### PR TITLE
Acl open role

### DIFF
--- a/contracts/AccessControlDAO.sol
+++ b/contracts/AccessControlDAO.sol
@@ -11,6 +11,7 @@ import "./interfaces/IAccessControlDAO.sol";
 /// @notice Use this contract for managing DAO role based permissions
 contract AccessControlDAO is IAccessControlDAO, ERC165, UUPSUpgradeable {
     string public constant DAO_ROLE = "DAO_ROLE";
+    string public constant OPEN_ROLE = "OPEN_ROLE";
 
     mapping(string => RoleData) private _roles;
     mapping(address => mapping(bytes4 => string[])) private _actionsToRoles;
@@ -216,7 +217,14 @@ contract AccessControlDAO is IAccessControlDAO, ERC165, UUPSUpgradeable {
         view
         returns (bool)
     {
-        return _roles[role].members[account];
+        if (
+            keccak256(bytes(role)) ==
+            keccak256(bytes(OPEN_ROLE))
+        ) {
+            return true;
+        } else {
+            return _roles[role].members[account];
+        }
     }
 
     /// @notice Returns the role that is the admin of the specified role

--- a/test/AccessControl.test.ts
+++ b/test/AccessControl.test.ts
@@ -27,6 +27,7 @@ describe("DAO Access Control Contract", function () {
 
   // Roles
   const daoRoleString = "DAO_ROLE";
+  const openRoleString = "OPEN_ROLE";
   const executorString = "EXECUTE";
   const roleAString = "roleA";
   const roleBString = "roleB";
@@ -132,6 +133,24 @@ describe("DAO Access Control Contract", function () {
       ).to.eq(true);
       expect(
         await daoAccessControl.hasRole(roleAString, roleAMember2.address)
+      ).to.eq(true);
+    });
+
+    it("Supports the Open Role", async () => {
+      expect(await daoAccessControl.hasRole(openRoleString, dao.address)).to.eq(
+        true
+      );
+      expect(
+        await daoAccessControl.hasRole(openRoleString, executor1.address)
+      ).to.eq(true);
+      expect(
+        await daoAccessControl.hasRole(openRoleString, roleAMember1.address)
+      ).to.eq(true);
+      expect(
+        await daoAccessControl.hasRole(openRoleString, user1.address)
+      ).to.eq(true);
+      expect(
+        await daoAccessControl.hasRole(openRoleString, user2.address)
       ).to.eq(true);
     });
   });


### PR DESCRIPTION
This PR adds a new role to the AccessControl contract called "OPEN_ROLE".
This role can be added to an action to give any address the ability to invoke that action.