### PR TITLE
Module names

### DIFF
--- a/contracts/DAO.sol
+++ b/contracts/DAO.sol
@@ -8,15 +8,12 @@ import "./ModuleBase.sol";
 
 /// @notice A minimum viable DAO contract
 contract DAO is IDAO, ModuleBase {
-    string public name;
-
     /// @notice Function for initializing the contract that can only be called once
     /// @param _accessControl The address of the access control contract
     /// @param _moduleFactoryBase The address of the module factory
     /// @param _name Name of the Dao
     function initialize(address _accessControl, address _moduleFactoryBase, string calldata _name) external initializer {
-        __initBase(_accessControl, _moduleFactoryBase);
-        name = _name;
+        __initBase(_accessControl, _moduleFactoryBase, _name);
     }
 
     /// @notice A function for executing function calls from the DAO

--- a/contracts/ModuleBase.sol
+++ b/contracts/ModuleBase.sol
@@ -8,7 +8,8 @@ import "./interfaces/IModuleBase.sol";
 /// @notice An abstract contract to be inherited by module contracts
 abstract contract ModuleBase is IModuleBase, UUPSUpgradeable, ERC165 {
     IAccessControlDAO public accessControl;
-    address public moduleFactoryBase;
+    address public moduleFactory;
+    string public name;
 
     /// @notice Requires that a function caller has the associated role
     modifier authorized() {
@@ -41,12 +42,15 @@ abstract contract ModuleBase is IModuleBase, UUPSUpgradeable, ERC165 {
 
     /// @notice Function for initializing the contract that can only be called once
     /// @param _accessControl The address of the access control contract
-    function __initBase(address _accessControl, address _moduleFactoryBase)
+    /// @param _moduleFactory The address of the factory deploying the module
+    /// @param _name Human readable string of the module name
+    function __initBase(address _accessControl, address _moduleFactory, string memory _name)
         internal
         onlyInitializing
     {
         accessControl = IAccessControlDAO(_accessControl);
-        moduleFactoryBase = _moduleFactoryBase;
+        moduleFactory = _moduleFactory;
+        name = _name;
         __UUPSUpgradeable_init();
     }
 

--- a/contracts/interfaces/IDAO.sol
+++ b/contracts/interfaces/IDAO.sol
@@ -1,3 +1,5 @@
+import "./IModuleBase.sol";
+
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
@@ -22,7 +24,4 @@ interface IDAO {
         uint256[] calldata values,
         bytes[] calldata calldatas
     ) external;
-
-    /// @return string The string "Name"
-    function name() external view returns (string memory);
 }

--- a/contracts/interfaces/IModuleBase.sol
+++ b/contracts/interfaces/IModuleBase.sol
@@ -13,4 +13,7 @@ interface IModuleBase {
     /// @param interfaceId An interface ID bytes4 as defined by ERC-165
     /// @return bool Indicates whether the interface is supported
     function supportsInterface(bytes4 interfaceId) external view returns (bool);
+
+    /// @return string The string "Name"
+    function name() external view returns (string memory);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractal-framework/core-contracts",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "files": [
     "contracts",
     "typechain-types"

--- a/test/DAOFactory.test.ts
+++ b/test/DAOFactory.test.ts
@@ -93,7 +93,7 @@ describe("DAOFactory", () => {
   });
 
   it("sets up moduleBase", async () => {
-    expect(await daoCreated.moduleFactoryBase()).to.equal(daoFactory.address);
+    expect(await daoCreated.moduleFactory()).to.equal(daoFactory.address);
   });
 
   it("Creates a DAO and AccessControl Contract", async () => {


### PR DESCRIPTION
This PR adds a human readable string to the ModuleBase contract that gets initialized upon module contract deployment.
This string will primarily be used by front end interfaces for identifying modules for users.