### PR TITLE
Allow for proposals with 0 transactions

### DIFF
--- a/contracts/azorius/Azorius.sol
+++ b/contracts/azorius/Azorius.sol
@@ -120,10 +120,6 @@ contract Azorius is Module, IAzorius {
     ) external {
         require(isStrategyEnabled(_strategy), "Voting strategy is not enabled");
         require(
-            _transactions.length > 0,
-            "Proposal must contain at least one transaction"
-        );
-        require(
             IBaseStrategy(_strategy).isProposer(msg.sender),
             "Caller cannot submit proposals"
         );
@@ -318,6 +314,11 @@ contract Azorius is Module, IAzorius {
             return ProposalState.ACTIVE;
         } else if (!_strategy.isPassed(_proposalId)) {
             return ProposalState.FAILED;
+        } else if (_proposal.txHashes.length == 0) {
+            // a Proposal with 0 transactions goes straight to EXECUTED
+            // this allows for the potential for on-chain voting for 
+            // "off-chain" executed decisions
+            return ProposalState.EXECUTED;
         } else if (
             block.number <= votingEndBlock + _proposal.timelockPeriod
         ) {

--- a/contracts/azorius/Azorius.sol
+++ b/contracts/azorius/Azorius.sol
@@ -314,7 +314,7 @@ contract Azorius is Module, IAzorius {
             return ProposalState.ACTIVE;
         } else if (!_strategy.isPassed(_proposalId)) {
             return ProposalState.FAILED;
-        } else if (_proposal.txHashes.length == 0) {
+        } else if (_proposal.executionCounter == _proposal.txHashes.length) {
             // a Proposal with 0 transactions goes straight to EXECUTED
             // this allows for the potential for on-chain voting for 
             // "off-chain" executed decisions
@@ -323,8 +323,6 @@ contract Azorius is Module, IAzorius {
             block.number <= votingEndBlock + _proposal.timelockPeriod
         ) {
             return ProposalState.TIMELOCKED;
-        } else if (_proposal.executionCounter == _proposal.txHashes.length) {
-            return ProposalState.EXECUTED;
         } else if (
             block.number <=
             votingEndBlock +


### PR DESCRIPTION
## Description

Multiple beta feedback users have mentioned the desire to conduct votes on chain for things that do not necessarily involve transactions.

This change allows us to build such a feature into the frontend if we decide to do so, without adding any additional complexity to the contracts.
