### PR TITLE
Rename getProposal to getProposalVotes and fix shadow warning error

### DIFF
--- a/contracts/azorius/LinearERC20Voting.sol
+++ b/contracts/azorius/LinearERC20Voting.sol
@@ -199,23 +199,23 @@ contract LinearERC20Voting is BaseStrategy, BaseQuorumPercent {
      * @return noVotes current count of "NO" votes
      * @return yesVotes current count of "YES" votes
      * @return abstainVotes current count of "ABSTAIN" votes
-     * @return votingStartBlock block number voting starts
-     * @return votingEndBlock block number voting ends
+     * @return startBlock block number voting starts
+     * @return endBlock block number voting ends
      */
-    function getProposal(uint256 _proposalId) external view
+    function getProposalVotes(uint256 _proposalId) external view
         returns (
             uint256 noVotes,
             uint256 yesVotes,
             uint256 abstainVotes,
-            uint256 votingStartBlock,
-            uint256 votingEndBlock
+            uint256 startBlock,
+            uint256 endBlock
         )
     {
         noVotes = proposalVotes[_proposalId].noVotes;
         yesVotes = proposalVotes[_proposalId].yesVotes;
         abstainVotes = proposalVotes[_proposalId].abstainVotes;
-        votingStartBlock = proposalVotes[_proposalId].votingStartBlock;
-        votingEndBlock = proposalVotes[_proposalId].votingEndBlock;
+        startBlock = proposalVotes[_proposalId].votingStartBlock;
+        endBlock = proposalVotes[_proposalId].votingEndBlock;
     }
 
     /**

--- a/test/Azorius-LinearERC20Voting.test.ts
+++ b/test/Azorius-LinearERC20Voting.test.ts
@@ -444,22 +444,22 @@ describe("Safe with Azorius module and linearERC20Voting", () => {
       // Proposal is active
       expect(await azorius.proposalState(0)).to.eq(0);
 
-      expect((await linearERC20Voting.getProposal(0)).yesVotes).to.eq(0);
+      expect((await linearERC20Voting.getProposalVotes(0)).yesVotes).to.eq(0);
 
       // Token holder 1 votes but does not have any voting weight
       await linearERC20Voting.connect(tokenHolder1).vote(0, 1, [0]);
 
-      expect((await linearERC20Voting.getProposal(0)).yesVotes).to.eq(0);
+      expect((await linearERC20Voting.getProposalVotes(0)).yesVotes).to.eq(0);
 
       // Token holder 2 votes with voting weight of 300
       await linearERC20Voting.connect(tokenHolder2).vote(0, 1, [0]);
 
-      expect((await linearERC20Voting.getProposal(0)).yesVotes).to.eq(300);
+      expect((await linearERC20Voting.getProposalVotes(0)).yesVotes).to.eq(300);
 
       // Token holder 3 votes with voting weight of 300
       await linearERC20Voting.connect(tokenHolder3).vote(0, 1, [0]);
 
-      expect((await linearERC20Voting.getProposal(0)).yesVotes).to.eq(600);
+      expect((await linearERC20Voting.getProposalVotes(0)).yesVotes).to.eq(600);
     });
 
     it("Correctly counts proposal No votes", async () => {
@@ -486,22 +486,22 @@ describe("Safe with Azorius module and linearERC20Voting", () => {
       // Proposal is active
       expect(await azorius.proposalState(0)).to.eq(0);
 
-      expect((await linearERC20Voting.getProposal(0)).noVotes).to.eq(0);
+      expect((await linearERC20Voting.getProposalVotes(0)).noVotes).to.eq(0);
 
       // Token holder 1 votes but does not have any voting weight
       await linearERC20Voting.connect(tokenHolder1).vote(0, 0, [0]);
 
-      expect((await linearERC20Voting.getProposal(0)).noVotes).to.eq(0);
+      expect((await linearERC20Voting.getProposalVotes(0)).noVotes).to.eq(0);
 
       // Token holder 2 votes with voting weight of 300
       await linearERC20Voting.connect(tokenHolder2).vote(0, 0, [0]);
 
-      expect((await linearERC20Voting.getProposal(0)).noVotes).to.eq(300);
+      expect((await linearERC20Voting.getProposalVotes(0)).noVotes).to.eq(300);
 
       // Token holder 3 votes with voting weight of 300
       await linearERC20Voting.connect(tokenHolder3).vote(0, 0, [0]);
 
-      expect((await linearERC20Voting.getProposal(0)).noVotes).to.eq(600);
+      expect((await linearERC20Voting.getProposalVotes(0)).noVotes).to.eq(600);
     });
 
     it("Correctly counts proposal Abstain votes", async () => {
@@ -528,22 +528,30 @@ describe("Safe with Azorius module and linearERC20Voting", () => {
       // Proposal is active
       expect(await azorius.proposalState(0)).to.eq(0);
 
-      expect((await linearERC20Voting.getProposal(0)).abstainVotes).to.eq(0);
+      expect((await linearERC20Voting.getProposalVotes(0)).abstainVotes).to.eq(
+        0
+      );
 
       // Token holder 1 votes but does not have any voting weight
       await linearERC20Voting.connect(tokenHolder1).vote(0, 2, [0]);
 
-      expect((await linearERC20Voting.getProposal(0)).abstainVotes).to.eq(0);
+      expect((await linearERC20Voting.getProposalVotes(0)).abstainVotes).to.eq(
+        0
+      );
 
       // Token holder 2 votes with voting weight of 300
       await linearERC20Voting.connect(tokenHolder2).vote(0, 2, [0]);
 
-      expect((await linearERC20Voting.getProposal(0)).abstainVotes).to.eq(300);
+      expect((await linearERC20Voting.getProposalVotes(0)).abstainVotes).to.eq(
+        300
+      );
 
       // Token holder 3 votes with voting weight of 300
       await linearERC20Voting.connect(tokenHolder3).vote(0, 2, [0]);
 
-      expect((await linearERC20Voting.getProposal(0)).abstainVotes).to.eq(600);
+      expect((await linearERC20Voting.getProposalVotes(0)).abstainVotes).to.eq(
+        600
+      );
     });
 
     it("A proposal is passed with enough Yes votes and quorum", async () => {


### PR DESCRIPTION
## Description

Renames the `getProposal` function to a clearer `getProposalVotes`, and fix the parameter shadow error by renaming the returned value from `votingEndBlock` to just `endBlock`
