### PR TITLE
use IVotes interface rather than ERC20Votes in LinearERC20Voting

### DIFF
--- a/contracts/azorius/LinearERC20Voting.sol
+++ b/contracts/azorius/LinearERC20Voting.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity =0.8.19;
 
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import "./BaseStrategy.sol";
 import "./BaseQuorumPercent.sol";
 
@@ -32,7 +32,7 @@ contract LinearERC20Voting is BaseStrategy, BaseQuorumPercent {
         mapping(address => bool) hasVoted; // whether a given address has voted yet or not
     }
 
-    ERC20Votes public governanceToken;
+    IVotes public governanceToken;
 
     /** Number of blocks a new Proposal can be voted on. */
     uint256 public votingPeriod;
@@ -58,13 +58,13 @@ contract LinearERC20Voting is BaseStrategy, BaseQuorumPercent {
     function setUp(bytes memory initParams) public override initializer {
         (
             address _owner,
-            ERC20Votes _governanceToken,
+            IVotes _governanceToken,
             address _azoriusModule,
             uint256 _votingPeriod,
             uint256 _quorumNumerator
         ) = abi.decode(
                 initParams,
-                (address, ERC20Votes, address, uint256, uint256)
+                (address, IVotes, address, uint256, uint256)
             );
         if (address(_governanceToken) == address(0))
             revert InvalidTokenAddress();


### PR DESCRIPTION
## Description

The `LinearERC20Voting` strategy assumes an `ERC20Votes` token, which is an OZ implementation, but our token isn't actually an `ERC20Votes`, it's our own "VotesERC20" token.

This only happens to work because it conforms to the methods in IVotes that we need (getPastTotalSupply, getPastVotes), and we don't call anything ERC20Votes specific.

This just updates the code to use the base interface we need, rather than a token contract we don't use.