### PR TITLE
DecentHats module

### DIFF
--- a/contracts/DecentHats.sol
+++ b/contracts/DecentHats.sol
@@ -19,22 +19,22 @@ contract DecentHats {
     }
 
     IHats public hats;
-    address public keyValuePairs;
-    IERC6551Registry public registry;
     address public hatsAccountImplementation;
+    IERC6551Registry public registry;
+    address public keyValuePairs;
 
     bytes32 public constant SALT = keccak256("DecentHats");
 
     constructor(
         IHats _hats,
-        address _keyValuePairs,
+        address _hatsAccountImplementation,
         IERC6551Registry _registry,
-        address _hatsAccountImplementation
+        address _keyValuePairs
     ) {
         hats = _hats;
-        keyValuePairs = _keyValuePairs;
-        registry = _registry;
         hatsAccountImplementation = _hatsAccountImplementation;
+        registry = _registry;
+        keyValuePairs = _keyValuePairs;
     }
 
     function createAndDeclareTree(

--- a/contracts/DecentHats.sol
+++ b/contracts/DecentHats.sol
@@ -23,7 +23,7 @@ contract DecentHats {
     IERC6551Registry public registry;
     address public hatsAccountImplementation;
 
-    bytes32 public constant SALT = bytes32(abi.encode(0xdece974a75));
+    bytes32 public constant SALT = keccak256("DecentHats");
 
     constructor(
         IHats _hats,

--- a/contracts/DecentHats.sol
+++ b/contracts/DecentHats.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.19;
 import {Enum} from "@gnosis.pm/zodiac/contracts/core/Module.sol";
 import {IAvatar} from "@gnosis.pm/zodiac/contracts/interfaces/IAvatar.sol";
 import {IHats} from "./interfaces/hats/IHats.sol";
+import {IERC6551Registry} from "./interfaces/IERC6551Registry.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 contract DecentHats {
@@ -19,10 +20,21 @@ contract DecentHats {
 
     IHats public hats;
     address public keyValuePairs;
+    IERC6551Registry public registry;
+    address public hatsAccountImplementation;
 
-    constructor(IHats _hats, address _keyValuePairs) {
+    bytes32 public constant SALT = bytes32(abi.encode(0xdece974a75));
+
+    constructor(
+        IHats _hats,
+        address _keyValuePairs,
+        IERC6551Registry _registry,
+        address _hatsAccountImplementation
+    ) {
         hats = _hats;
         keyValuePairs = _keyValuePairs;
+        registry = _registry;
+        hatsAccountImplementation = _hatsAccountImplementation;
     }
 
     function createAndDeclareTree(
@@ -35,6 +47,13 @@ contract DecentHats {
             msg.sender,
             _topHatDetails,
             _topHatImageURI
+        );
+        registry.createAccount(
+            hatsAccountImplementation,
+            SALT,
+            block.chainid,
+            address(hats),
+            topHatId
         );
 
         string[] memory keys = new string[](1);
@@ -63,6 +82,13 @@ contract DecentHats {
             _adminHat.isMutable,
             _adminHat.imageURI
         );
+        registry.createAccount(
+            hatsAccountImplementation,
+            SALT,
+            block.chainid,
+            address(hats),
+            adminHatId
+        );
 
         if (_adminHat.wearer != address(0)) {
             hats.mintHat(adminHatId, _adminHat.wearer);
@@ -78,6 +104,13 @@ contract DecentHats {
                 hat.toggle,
                 hat.isMutable,
                 hat.imageURI
+            );
+            registry.createAccount(
+                hatsAccountImplementation,
+                SALT,
+                block.chainid,
+                address(hats),
+                hatId
             );
 
             if (hat.wearer != address(0)) {

--- a/contracts/DecentHats.sol
+++ b/contracts/DecentHats.sol
@@ -44,7 +44,7 @@ contract DecentHats {
         Hat[] calldata _hats
     ) public {
         uint256 topHatId = hats.mintTopHat(
-            msg.sender,
+            address(this),
             _topHatDetails,
             _topHatImageURI
         );
@@ -121,5 +121,7 @@ contract DecentHats {
                 ++i;
             }
         }
+
+        hats.transferHat(topHatId, address(this), msg.sender);
     }
 }

--- a/contracts/DecentHats.sol
+++ b/contracts/DecentHats.sol
@@ -57,7 +57,7 @@ contract DecentHats {
         );
 
         string[] memory keys = new string[](1);
-        keys[0] = "hatsTreeId";
+        keys[0] = "topHatId";
 
         string[] memory values = new string[](1);
         values[0] = Strings.toString(topHatId);

--- a/contracts/DecentHats.sol
+++ b/contracts/DecentHats.sol
@@ -1,12 +1,22 @@
 //SPDX-License-Identifier: MIT
 pragma solidity =0.8.19;
 
-import { Enum } from "@gnosis.pm/zodiac/contracts/core/Module.sol";
-import { IAvatar } from "@gnosis.pm/zodiac/contracts/interfaces/IAvatar.sol";
-import { IHats } from "./interfaces/hats/IHats.sol";
-import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import {Enum} from "@gnosis.pm/zodiac/contracts/core/Module.sol";
+import {IAvatar} from "@gnosis.pm/zodiac/contracts/interfaces/IAvatar.sol";
+import {IHats} from "./interfaces/hats/IHats.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 contract DecentHats {
+    struct Hat {
+        address eligibility;
+        uint32 maxSupply;
+        address toggle;
+        string details;
+        string imageURI;
+        bool isMutable;
+        address wearer;
+    }
+
     IHats public hats;
     address public keyValuePairs;
 
@@ -15,8 +25,17 @@ contract DecentHats {
         keyValuePairs = _keyValuePairs;
     }
 
-    function createAndDeclareTree(string memory _details, string memory _imageURI) public returns (bool success) {
-        uint256 topHatId = hats.mintTopHat(msg.sender, _details, _imageURI);
+    function createAndDeclareTree(
+        string memory _topHatDetails,
+        string memory _topHatImageURI,
+        Hat calldata _adminHat,
+        Hat[] calldata _hats
+    ) public {
+        uint256 topHatId = hats.mintTopHat(
+            msg.sender,
+            _topHatDetails,
+            _topHatImageURI
+        );
 
         string[] memory keys = new string[](1);
         keys[0] = "hatsTreeId";
@@ -24,13 +43,50 @@ contract DecentHats {
         string[] memory values = new string[](1);
         values[0] = Strings.toString(topHatId);
 
-        success = IAvatar(msg.sender).execTransactionFromModule(
+        IAvatar(msg.sender).execTransactionFromModule(
             keyValuePairs,
             0,
-            abi.encodeWithSignature("updateValues(string[],string[])", keys, values),
+            abi.encodeWithSignature(
+                "updateValues(string[],string[])",
+                keys,
+                values
+            ),
             Enum.Operation.Call
         );
 
-        return success;
+        uint256 adminHatId = hats.createHat(
+            topHatId,
+            _adminHat.details,
+            _adminHat.maxSupply,
+            _adminHat.eligibility,
+            _adminHat.toggle,
+            _adminHat.isMutable,
+            _adminHat.imageURI
+        );
+
+        if (_adminHat.wearer != address(0)) {
+            hats.mintHat(adminHatId, _adminHat.wearer);
+        }
+
+        for (uint256 i = 0; i < _hats.length; ) {
+            Hat memory hat = _hats[i];
+            uint256 hatId = hats.createHat(
+                adminHatId,
+                hat.details,
+                hat.maxSupply,
+                hat.eligibility,
+                hat.toggle,
+                hat.isMutable,
+                hat.imageURI
+            );
+
+            if (hat.wearer != address(0)) {
+                hats.mintHat(hatId, hat.wearer);
+            }
+
+            unchecked {
+                ++i;
+            }
+        }
     }
 }

--- a/contracts/DecentHats.sol
+++ b/contracts/DecentHats.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity =0.8.19;
 
-import {Enum} from "@gnosis.pm/zodiac/contracts/core/Module.sol";
+import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IAvatar} from "@gnosis.pm/zodiac/contracts/interfaces/IAvatar.sol";
 import {IHats} from "./interfaces/hats/IHats.sol";
 import {IERC6551Registry} from "./interfaces/IERC6551Registry.sol";

--- a/contracts/DecentHats.sol
+++ b/contracts/DecentHats.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: MIT
+pragma solidity =0.8.19;
+
+import { Enum } from "@gnosis.pm/zodiac/contracts/core/Module.sol";
+import { IAvatar } from "@gnosis.pm/zodiac/contracts/interfaces/IAvatar.sol";
+import { IHats } from "./interfaces/hats/IHats.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+
+contract DecentHats {
+    IHats public hats;
+    address public keyValuePairs;
+
+    constructor(IHats _hats, address _keyValuePairs) {
+        hats = _hats;
+        keyValuePairs = _keyValuePairs;
+    }
+
+    function createAndDeclareTree(string memory _details, string memory _imageURI) public returns (bool success) {
+        uint256 topHatId = hats.mintTopHat(msg.sender, _details, _imageURI);
+
+        string[] memory keys = new string[](1);
+        keys[0] = "hatsTreeId";
+
+        string[] memory values = new string[](1);
+        values[0] = Strings.toString(topHatId);
+
+        success = IAvatar(msg.sender).execTransactionFromModule(
+            keyValuePairs,
+            0,
+            abi.encodeWithSignature("updateValues(string[],string[])", keys, values),
+            Enum.Operation.Call
+        );
+
+        return success;
+    }
+}

--- a/contracts/interfaces/IERC6551Registry.sol
+++ b/contracts/interfaces/IERC6551Registry.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface IERC6551Registry {
+    /**
+     * @dev The registry MUST emit the ERC6551AccountCreated event upon successful account creation.
+     */
+    event ERC6551AccountCreated(
+        address account,
+        address indexed implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address indexed tokenContract,
+        uint256 indexed tokenId
+    );
+
+    /**
+     * @dev The registry MUST revert with AccountCreationFailed error if the create2 operation fails.
+     */
+    error AccountCreationFailed();
+
+    /**
+     * @dev Creates a token bound account for a non-fungible token.
+     *
+     * If account has already been created, returns the account address without calling create2.
+     *
+     * Emits ERC6551AccountCreated event.
+     *
+     * @return account The address of the token bound account
+     */
+    function createAccount(
+        address implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) external returns (address account);
+
+    /**
+     * @dev Returns the computed token bound account address for a non-fungible token.
+     *
+     * @return account The address of the token bound account
+     */
+    function account(
+        address implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) external view returns (address account);
+}

--- a/contracts/interfaces/hats/IHats.sol
+++ b/contracts/interfaces/hats/IHats.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0
+// Copyright (C) 2023 Haberdasher Labs
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity >=0.8.13;
+
+interface IHats {
+    function mintTopHat(address _target, string memory _details, string memory _imageURI)
+        external
+        returns (uint256 topHatId);
+}

--- a/contracts/interfaces/hats/IHats.sol
+++ b/contracts/interfaces/hats/IHats.sol
@@ -37,4 +37,6 @@ interface IHats {
         uint256 _hatId,
         address _wearer
     ) external returns (bool success);
+
+    function transferHat(uint256 _hatId, address _from, address _to) external;
 }

--- a/contracts/interfaces/hats/IHats.sol
+++ b/contracts/interfaces/hats/IHats.sol
@@ -17,7 +17,24 @@
 pragma solidity >=0.8.13;
 
 interface IHats {
-    function mintTopHat(address _target, string memory _details, string memory _imageURI)
-        external
-        returns (uint256 topHatId);
+    function mintTopHat(
+        address _target,
+        string memory _details,
+        string memory _imageURI
+    ) external returns (uint256 topHatId);
+
+    function createHat(
+        uint256 _admin,
+        string calldata _details,
+        uint32 _maxSupply,
+        address _eligibility,
+        address _toggle,
+        bool _mutable,
+        string calldata _imageURI
+    ) external returns (uint256 newHatId);
+
+    function mintHat(
+        uint256 _hatId,
+        address _wearer
+    ) external returns (bool success);
 }

--- a/contracts/mock/ERC6551Registry.sol
+++ b/contracts/mock/ERC6551Registry.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface IERC6551Registry {
+    /**
+     * @dev The registry MUST emit the ERC6551AccountCreated event upon successful account creation.
+     */
+    event ERC6551AccountCreated(
+        address account,
+        address indexed implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address indexed tokenContract,
+        uint256 indexed tokenId
+    );
+
+    /**
+     * @dev The registry MUST revert with AccountCreationFailed error if the create2 operation fails.
+     */
+    error AccountCreationFailed();
+
+    /**
+     * @dev Creates a token bound account for a non-fungible token.
+     *
+     * If account has already been created, returns the account address without calling create2.
+     *
+     * Emits ERC6551AccountCreated event.
+     *
+     * @return account The address of the token bound account
+     */
+    function createAccount(
+        address implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) external returns (address account);
+
+    /**
+     * @dev Returns the computed token bound account address for a non-fungible token.
+     *
+     * @return account The address of the token bound account
+     */
+    function account(
+        address implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) external view returns (address account);
+}
+
+contract ERC6551Registry is IERC6551Registry {
+    function createAccount(
+        address implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) external returns (address) {
+        assembly {
+            // Memory Layout:
+            // ----
+            // 0x00   0xff                           (1 byte)
+            // 0x01   registry (address)             (20 bytes)
+            // 0x15   salt (bytes32)                 (32 bytes)
+            // 0x35   Bytecode Hash (bytes32)        (32 bytes)
+            // ----
+            // 0x55   ERC-1167 Constructor + Header  (20 bytes)
+            // 0x69   implementation (address)       (20 bytes)
+            // 0x5D   ERC-1167 Footer                (15 bytes)
+            // 0x8C   salt (uint256)                 (32 bytes)
+            // 0xAC   chainId (uint256)              (32 bytes)
+            // 0xCC   tokenContract (address)        (32 bytes)
+            // 0xEC   tokenId (uint256)              (32 bytes)
+
+            // Silence unused variable warnings
+            pop(chainId)
+
+            // Copy bytecode + constant data to memory
+            calldatacopy(0x8c, 0x24, 0x80) // salt, chainId, tokenContract, tokenId
+            mstore(0x6c, 0x5af43d82803e903d91602b57fd5bf3) // ERC-1167 footer
+            mstore(0x5d, implementation) // implementation
+            mstore(0x49, 0x3d60ad80600a3d3981f3363d3d373d3d3d363d73) // ERC-1167 constructor + header
+
+            // Copy create2 computation data to memory
+            mstore8(0x00, 0xff) // 0xFF
+            mstore(0x35, keccak256(0x55, 0xb7)) // keccak256(bytecode)
+            mstore(0x01, shl(96, address())) // registry address
+            mstore(0x15, salt) // salt
+
+            // Compute account address
+            let computed := keccak256(0x00, 0x55)
+
+            // If the account has not yet been deployed
+            if iszero(extcodesize(computed)) {
+                // Deploy account contract
+                let deployed := create2(0, 0x55, 0xb7, salt)
+
+                // Revert if the deployment fails
+                if iszero(deployed) {
+                    mstore(0x00, 0x20188a59) // `AccountCreationFailed()`
+                    revert(0x1c, 0x04)
+                }
+
+                // Store account address in memory before salt and chainId
+                mstore(0x6c, deployed)
+
+                // Emit the ERC6551AccountCreated event
+                log4(
+                    0x6c,
+                    0x60,
+                    // `ERC6551AccountCreated(address,address,bytes32,uint256,address,uint256)`
+                    0x79f19b3655ee38b1ce526556b7731a20c8f218fbda4a3990b6cc4172fdf88722,
+                    implementation,
+                    tokenContract,
+                    tokenId
+                )
+
+                // Return the account address
+                return(0x6c, 0x20)
+            }
+
+            // Otherwise, return the computed account address
+            mstore(0x00, shr(96, shl(96, computed)))
+            return(0x00, 0x20)
+        }
+    }
+
+    function account(
+        address implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) external view returns (address) {
+        assembly {
+            // Silence unused variable warnings
+            pop(chainId)
+            pop(tokenContract)
+            pop(tokenId)
+
+            // Copy bytecode + constant data to memory
+            calldatacopy(0x8c, 0x24, 0x80) // salt, chainId, tokenContract, tokenId
+            mstore(0x6c, 0x5af43d82803e903d91602b57fd5bf3) // ERC-1167 footer
+            mstore(0x5d, implementation) // implementation
+            mstore(0x49, 0x3d60ad80600a3d3981f3363d3d373d3d3d363d73) // ERC-1167 constructor + header
+
+            // Copy create2 computation data to memory
+            mstore8(0x00, 0xff) // 0xFF
+            mstore(0x35, keccak256(0x55, 0xb7)) // keccak256(bytecode)
+            mstore(0x01, shl(96, address())) // registry address
+            mstore(0x15, salt) // salt
+
+            // Store computed account address in memory
+            mstore(0x00, shr(96, shl(96, keccak256(0x00, 0x55))))
+
+            // Return computed account address
+            return(0x00, 0x20)
+        }
+    }
+}

--- a/contracts/mock/MockHats.sol
+++ b/contracts/mock/MockHats.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.19;
+
+import { IHats } from "../interfaces/hats/IHats.sol";
+
+contract MockHats is IHats {
+    uint256 count = 0;
+
+    function mintTopHat(address, string memory, string memory) external returns (uint256 topHatId) {
+        topHatId = count;
+        count++;
+    }
+}

--- a/contracts/mock/MockHats.sol
+++ b/contracts/mock/MockHats.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.19;
 import {IHats} from "../interfaces/hats/IHats.sol";
 
 contract MockHats is IHats {
-    uint256 count = 0;
+    uint256 public count = 0;
 
     function mintTopHat(
         address,

--- a/contracts/mock/MockHats.sol
+++ b/contracts/mock/MockHats.sol
@@ -1,13 +1,34 @@
 // SPDX-License-Identifier: MIT
 pragma solidity =0.8.19;
 
-import { IHats } from "../interfaces/hats/IHats.sol";
+import {IHats} from "../interfaces/hats/IHats.sol";
 
 contract MockHats is IHats {
     uint256 count = 0;
 
-    function mintTopHat(address, string memory, string memory) external returns (uint256 topHatId) {
+    function mintTopHat(
+        address,
+        string memory,
+        string memory
+    ) external returns (uint256 topHatId) {
         topHatId = count;
         count++;
+    }
+
+    function createHat(
+        uint256,
+        string calldata,
+        uint32,
+        address,
+        address,
+        bool,
+        string calldata
+    ) external returns (uint256 newHatId) {
+        newHatId = count;
+        count++;
+    }
+
+    function mintHat(uint256, address) external pure returns (bool success) {
+        success = true;
     }
 }

--- a/contracts/mock/MockHats.sol
+++ b/contracts/mock/MockHats.sol
@@ -31,4 +31,6 @@ contract MockHats is IHats {
     function mintHat(uint256, address) external pure returns (bool success) {
         success = true;
     }
+
+    function transferHat(uint256, address, address) external {}
 }

--- a/contracts/mock/MockHatsAccount.sol
+++ b/contracts/mock/MockHatsAccount.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.19;
+
+contract MockHatsAccount {
+    function tokenId() public view returns (uint256) {
+        bytes memory footer = new bytes(0x20);
+        assembly {
+            // copy 0x20 bytes from final word of footer
+            extcodecopy(address(), add(footer, 0x20), 0x8d, 0x20)
+        }
+        return abi.decode(footer, (uint256));
+    }
+
+    function tokenImplementation() public view returns (address) {
+        bytes memory footer = new bytes(0x20);
+        assembly {
+            // copy 0x20 bytes from third word of footer
+            extcodecopy(address(), add(footer, 0x20), 0x6d, 0x20)
+        }
+        return abi.decode(footer, (address));
+    }
+}

--- a/contracts/mock/MockHatsAccount.sol
+++ b/contracts/mock/MockHatsAccount.sol
@@ -2,6 +2,9 @@
 pragma solidity =0.8.19;
 
 contract MockHatsAccount {
+    // see https://github.com/Hats-Protocol/hats-account/blob/00650b3de756352d303ca08e4b024376f1d1db98/src/HatsAccountBase.sol#L41
+    // for my inspiration
+
     function tokenId() public view returns (uint256) {
         bytes memory footer = new bytes(0x20);
         assembly {

--- a/test/DecentHats.test.ts
+++ b/test/DecentHats.test.ts
@@ -296,7 +296,7 @@ describe("DecentHats", () => {
           salt = await decentHats.SALT();
         });
 
-        const getHatAccount = async (hatId: number) => {
+        const getHatAccount = async (hatId: bigint) => {
           const hatAccountAddress = await erc6551Registry.account(
             mockHatsAccountImplementationAddress,
             salt,
@@ -313,8 +313,10 @@ describe("DecentHats", () => {
           return hatAccount;
         };
 
-        it("Generates the correct Addresses for the three Hats", async () => {
-          for (let i = 0; i < 3; i++) {
+        it("Generates the correct Addresses for the current Hats", async () => {
+          const currentCount = await mockHats.count();
+
+          for (let i = 0n; i < currentCount; i++) {
             const topHatAccount = await getHatAccount(i);
             expect(await topHatAccount.tokenId()).eq(i);
             expect(await topHatAccount.tokenImplementation()).eq(

--- a/test/DecentHats.test.ts
+++ b/test/DecentHats.test.ts
@@ -100,9 +100,9 @@ describe("DecentHats", () => {
       await mockHatsAccountImplementation.getAddress();
     decentHats = await new DecentHats__factory(deployer).deploy(
       mockHatsAddress,
-      await keyValuePairs.getAddress(),
+      mockHatsAccountImplementationAddress,
       await erc6551Registry.getAddress(),
-      mockHatsAccountImplementationAddress
+      await keyValuePairs.getAddress()
     );
     decentHatsAddress = await decentHats.getAddress();
 

--- a/test/DecentHats.test.ts
+++ b/test/DecentHats.test.ts
@@ -237,7 +237,7 @@ describe("DecentHats", () => {
       it("Emits some hatsTreeId ValueUpdated events", async () => {
         await expect(createAndDeclareTreeTx)
           .to.emit(keyValuePairs, "ValueUpdated")
-          .withArgs(gnosisSafeAddress, "hatsTreeId", "0");
+          .withArgs(gnosisSafeAddress, "topHatId", "0");
       });
 
       describe("Multiple calls", () => {
@@ -285,7 +285,7 @@ describe("DecentHats", () => {
         it("Creates Top Hats with sequential IDs", async () => {
           await expect(createAndDeclareTreeTx2)
             .to.emit(keyValuePairs, "ValueUpdated")
-            .withArgs(gnosisSafeAddress, "hatsTreeId", "4");
+            .withArgs(gnosisSafeAddress, "topHatId", "4");
         });
       });
 

--- a/test/DecentHats.test.ts
+++ b/test/DecentHats.test.ts
@@ -61,8 +61,7 @@ const executeSafeTransaction = async ({
 };
 
 describe("DecentHats", () => {
-  let dao1: SignerWithAddress;
-  let dao2: SignerWithAddress;
+  let dao: SignerWithAddress;
 
   let keyValuePairs: KeyValuePairs;
   let gnosisSafe: GnosisSafeL2;
@@ -77,7 +76,7 @@ describe("DecentHats", () => {
   beforeEach(async () => {
     const signers = await hre.ethers.getSigners();
     const [deployer] = signers;
-    [, dao1, dao2] = signers;
+    [, dao] = signers;
 
     const hats = await new MockHats__factory(deployer).deploy();
     keyValuePairs = await new KeyValuePairs__factory(deployer).deploy();
@@ -94,7 +93,7 @@ describe("DecentHats", () => {
 
     const createGnosisSetupCalldata =
       GnosisSafeL2__factory.createInterface().encodeFunctionData("setup", [
-        [dao1.address],
+        [dao.address],
         1,
         ethers.ZeroAddress,
         ethers.ZeroHash,
@@ -136,7 +135,7 @@ describe("DecentHats", () => {
             "enableModule",
             [decentHatsAddress]
           ),
-        signers: [dao1],
+        signers: [dao],
       });
     });
 
@@ -160,9 +159,41 @@ describe("DecentHats", () => {
           transactionData:
             DecentHats__factory.createInterface().encodeFunctionData(
               "createAndDeclareTree",
-              ["", ""]
+              [
+                "",
+                "",
+                {
+                  eligibility: ethers.ZeroAddress,
+                  maxSupply: 1,
+                  toggle: ethers.ZeroAddress,
+                  details: "",
+                  imageURI: "",
+                  isMutable: false,
+                  wearer: ethers.ZeroAddress,
+                },
+                [
+                  {
+                    eligibility: ethers.ZeroAddress,
+                    maxSupply: 1,
+                    toggle: ethers.ZeroAddress,
+                    details: "",
+                    imageURI: "",
+                    isMutable: false,
+                    wearer: ethers.ZeroAddress,
+                  },
+                  {
+                    eligibility: ethers.ZeroAddress,
+                    maxSupply: 1,
+                    toggle: ethers.ZeroAddress,
+                    details: "",
+                    imageURI: "",
+                    isMutable: false,
+                    wearer: ethers.ZeroAddress,
+                  },
+                ],
+              ]
             ),
-          signers: [dao1],
+          signers: [dao],
         });
       });
 
@@ -179,7 +210,7 @@ describe("DecentHats", () => {
           .withArgs(decentHatsAddress);
       });
 
-      it("Emits a hatsTreeId ValueUpdated event", async () => {
+      it("Emits some hatsTreeId ValueUpdated events", async () => {
         await expect(createAndDeclareTreeTx)
           .to.emit(keyValuePairs, "ValueUpdated")
           .withArgs(gnosisSafeAddress, "hatsTreeId", "0");
@@ -195,9 +226,22 @@ describe("DecentHats", () => {
             transactionData:
               DecentHats__factory.createInterface().encodeFunctionData(
                 "createAndDeclareTree",
-                ["", ""]
+                [
+                  "",
+                  "",
+                  {
+                    eligibility: ethers.ZeroAddress,
+                    maxSupply: 1,
+                    toggle: ethers.ZeroAddress,
+                    details: "",
+                    imageURI: "",
+                    isMutable: false,
+                    wearer: ethers.ZeroAddress,
+                  },
+                  [],
+                ]
               ),
-            signers: [dao1],
+            signers: [dao],
           });
         });
 
@@ -217,7 +261,7 @@ describe("DecentHats", () => {
         it("Creates Top Hats with sequential IDs", async () => {
           await expect(createAndDeclareTreeTx2)
             .to.emit(keyValuePairs, "ValueUpdated")
-            .withArgs(gnosisSafeAddress, "hatsTreeId", "1");
+            .withArgs(gnosisSafeAddress, "hatsTreeId", "4");
         });
       });
     });

--- a/test/DecentHats.test.ts
+++ b/test/DecentHats.test.ts
@@ -1,0 +1,225 @@
+import {
+  GnosisSafeL2,
+  GnosisSafeL2__factory,
+  DecentHats__factory,
+  KeyValuePairs,
+  KeyValuePairs__factory,
+  MockHats__factory,
+} from "../typechain-types";
+
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { expect } from "chai";
+import { ethers } from "ethers";
+import hre from "hardhat";
+
+import {
+  getGnosisSafeL2Singleton,
+  getGnosisSafeProxyFactory,
+} from "./GlobalSafeDeployments.test";
+import {
+  buildSafeTransaction,
+  buildSignatureBytes,
+  predictGnosisSafeAddress,
+  safeSignTypedData,
+} from "./helpers";
+
+const executeSafeTransaction = async ({
+  safe,
+  to,
+  transactionData,
+  signers,
+}: {
+  safe: GnosisSafeL2;
+  to: string;
+  transactionData: string;
+  signers: SignerWithAddress[];
+}) => {
+  const safeTx = buildSafeTransaction({
+    to,
+    data: transactionData,
+    nonce: await safe.nonce(),
+  });
+
+  const sigs = await Promise.all(
+    signers.map(async (signer) => await safeSignTypedData(signer, safe, safeTx))
+  );
+
+  const tx = await safe.execTransaction(
+    safeTx.to,
+    safeTx.value,
+    safeTx.data,
+    safeTx.operation,
+    safeTx.safeTxGas,
+    safeTx.baseGas,
+    safeTx.gasPrice,
+    safeTx.gasToken,
+    safeTx.refundReceiver,
+    buildSignatureBytes(sigs)
+  );
+
+  return tx;
+};
+
+describe("DecentHats", () => {
+  let dao1: SignerWithAddress;
+  let dao2: SignerWithAddress;
+
+  let keyValuePairs: KeyValuePairs;
+  let gnosisSafe: GnosisSafeL2;
+
+  let gnosisSafeAddress: string;
+  let decentHatsAddress: string;
+
+  const saltNum = BigInt(
+    `0x${Buffer.from(ethers.randomBytes(32)).toString("hex")}`
+  );
+
+  beforeEach(async () => {
+    const signers = await hre.ethers.getSigners();
+    const [deployer] = signers;
+    [, dao1, dao2] = signers;
+
+    const hats = await new MockHats__factory(deployer).deploy();
+    keyValuePairs = await new KeyValuePairs__factory(deployer).deploy();
+    const decentHats = await new DecentHats__factory(deployer).deploy(
+      await hats.getAddress(),
+      await keyValuePairs.getAddress()
+    );
+    decentHatsAddress = await decentHats.getAddress();
+
+    const gnosisSafeProxyFactory = getGnosisSafeProxyFactory();
+    const gnosisSafeL2Singleton = getGnosisSafeL2Singleton();
+    const gnosisSafeL2SingletonAddress =
+      await gnosisSafeL2Singleton.getAddress();
+
+    const createGnosisSetupCalldata =
+      GnosisSafeL2__factory.createInterface().encodeFunctionData("setup", [
+        [dao1.address],
+        1,
+        ethers.ZeroAddress,
+        ethers.ZeroHash,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        0,
+        ethers.ZeroAddress,
+      ]);
+
+    const predictedGnosisSafeAddress = await predictGnosisSafeAddress(
+      createGnosisSetupCalldata,
+      saltNum,
+      gnosisSafeL2SingletonAddress,
+      gnosisSafeProxyFactory
+    );
+    gnosisSafeAddress = predictedGnosisSafeAddress;
+
+    await gnosisSafeProxyFactory.createProxyWithNonce(
+      gnosisSafeL2SingletonAddress,
+      createGnosisSetupCalldata,
+      saltNum
+    );
+
+    gnosisSafe = GnosisSafeL2__factory.connect(
+      predictedGnosisSafeAddress,
+      deployer
+    );
+  });
+
+  describe("DecentHats as a Module", () => {
+    let enableModuleTx: ethers.ContractTransactionResponse;
+
+    beforeEach(async () => {
+      enableModuleTx = await executeSafeTransaction({
+        safe: gnosisSafe,
+        to: gnosisSafeAddress,
+        transactionData:
+          GnosisSafeL2__factory.createInterface().encodeFunctionData(
+            "enableModule",
+            [decentHatsAddress]
+          ),
+        signers: [dao1],
+      });
+    });
+
+    it("Emits an ExecutionSuccess event", async () => {
+      await expect(enableModuleTx).to.emit(gnosisSafe, "ExecutionSuccess");
+    });
+
+    it("Emits an EnabledModule event", async () => {
+      await expect(enableModuleTx)
+        .to.emit(gnosisSafe, "EnabledModule")
+        .withArgs(decentHatsAddress);
+    });
+
+    describe("Creating a new Top Hat and Tree", () => {
+      let createAndDeclareTreeTx: ethers.ContractTransactionResponse;
+
+      beforeEach(async () => {
+        createAndDeclareTreeTx = await executeSafeTransaction({
+          safe: gnosisSafe,
+          to: decentHatsAddress,
+          transactionData:
+            DecentHats__factory.createInterface().encodeFunctionData(
+              "createAndDeclareTree",
+              ["", ""]
+            ),
+          signers: [dao1],
+        });
+      });
+
+      it("Emits an ExecutionSuccess event", async () => {
+        await expect(createAndDeclareTreeTx).to.emit(
+          gnosisSafe,
+          "ExecutionSuccess"
+        );
+      });
+
+      it("Emits an ExecutionFromModuleSuccess event", async () => {
+        await expect(createAndDeclareTreeTx)
+          .to.emit(gnosisSafe, "ExecutionFromModuleSuccess")
+          .withArgs(decentHatsAddress);
+      });
+
+      it("Emits a hatsTreeId ValueUpdated event", async () => {
+        await expect(createAndDeclareTreeTx)
+          .to.emit(keyValuePairs, "ValueUpdated")
+          .withArgs(gnosisSafeAddress, "hatsTreeId", "0");
+      });
+
+      describe("Multiple calls", () => {
+        let createAndDeclareTreeTx2: ethers.ContractTransactionResponse;
+
+        beforeEach(async () => {
+          createAndDeclareTreeTx2 = await executeSafeTransaction({
+            safe: gnosisSafe,
+            to: decentHatsAddress,
+            transactionData:
+              DecentHats__factory.createInterface().encodeFunctionData(
+                "createAndDeclareTree",
+                ["", ""]
+              ),
+            signers: [dao1],
+          });
+        });
+
+        it("Emits an ExecutionSuccess event", async () => {
+          await expect(createAndDeclareTreeTx2).to.emit(
+            gnosisSafe,
+            "ExecutionSuccess"
+          );
+        });
+
+        it("Emits an ExecutionFromModuleSuccess event", async () => {
+          await expect(createAndDeclareTreeTx2)
+            .to.emit(gnosisSafe, "ExecutionFromModuleSuccess")
+            .withArgs(decentHatsAddress);
+        });
+
+        it("Creates Top Hats with sequential IDs", async () => {
+          await expect(createAndDeclareTreeTx2)
+            .to.emit(keyValuePairs, "ValueUpdated")
+            .withArgs(gnosisSafeAddress, "hatsTreeId", "1");
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #92 
Closes #94 

See also https://github.com/decentdao/decent-contracts/pull/91

---

This PR implements a contract called `DecentHats` which will be temporarily added as a module to Safes, in order to create and configure a Hats tree for that Safe.

It also includes support for deploying instances of ERC6551 "Smart Accounts" for each new Hat.

In live environments, we'll use the `HatsAccount1ofN` implementation, which is deployed to various chains at address [0xfEf83A660b7C10a3EdaFdCF62DEee1fD8a875D29](https://github.com/Hats-Protocol/hats-account/releases/tag/0.1.0).

The `ERC6551Registry` also has a canonical address on all chains: [0x000000006551c19487814612e58FE06813775758](https://eips.ethereum.org/EIPS/eip-6551#registry).