### PR TITLE
Revert change to IHats

### DIFF
--- a/contracts/interfaces/hats/IHats.sol
+++ b/contracts/interfaces/hats/IHats.sol
@@ -39,9 +39,4 @@ interface IHats {
     ) external returns (bool success);
 
     function transferHat(uint256 _hatId, address _from, address _to) external;
-
-    function isWearerOfHat(
-        address _user,
-        uint256 _hatId
-    ) external view returns (bool isWearer);
 }


### PR DESCRIPTION
@DarksightKellar FYI, I don't want any changes to the IHats interface (after you deployed the new DecentHats_0_1_0 contract to all the networks), because then all of those latest deployments have become stale.