### PR TITLE
Remove IDecentVersion interface and all implementations

### DIFF
--- a/contracts/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -20,10 +20,6 @@ contract DecentAutonomousAdminV1 is
     // //////////////////////////////////////////////////////////////
     //                         Public Functions
     // //////////////////////////////////////////////////////////////
-    function version() external pure override returns (uint32) {
-        return 1;
-    }
-
     function triggerStartNextTerm(TriggerStartArgs calldata args) public {
         IHatsElectionsEligibility hatsElectionModule = IHatsElectionsEligibility(
                 args.hatsProtocol.getHatEligibilityModule(args.hatId)

--- a/contracts/interfaces/IDecentVersion.sol
+++ b/contracts/interfaces/IDecentVersion.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity >=0.8.28;
-
-interface IDecentVersion {
-    function version() external view returns (uint32);
-}

--- a/contracts/interfaces/autonomous-admin/IDecentAutonomousAdminV1.sol
+++ b/contracts/interfaces/autonomous-admin/IDecentAutonomousAdminV1.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IDecentVersion} from "../IDecentVersion.sol";
 import {IHats} from "../hats/IHats.sol";
 
-interface IDecentAutonomousAdminV1 is IDecentVersion {
+interface IDecentAutonomousAdminV1 {
     error NotCurrentWearer();
 
     struct TriggerStartArgs {

--- a/test/autonomous-admin/DecentAutonomousAdminV1.test.ts
+++ b/test/autonomous-admin/DecentAutonomousAdminV1.test.ts
@@ -93,12 +93,6 @@ describe('DecentAutonomousAdminHatV1', function () {
     await hatsElectionModule.elect(nextTermEnd, [await secondWearer.getAddress()]);
   });
 
-  describe('version', function () {
-    it('should return the correct version', async () => {
-      expect(await decentAutonomousAdminInstance.version()).to.equal(1);
-    });
-  });
-
   describe('triggerStartNextTerm', function () {
     describe('before the first term is over', function () {
       it('should have correct wearers', async () => {


### PR DESCRIPTION
This interface/implementation was originally added as a helper, so that "we" (Decent's frontend) could more quickly (in terms of network round trips) identify what version of contract the implementer of this interface is.

The same thing could be done with the implementer's contract's ERC165 interface, but my original (incorrect) assumption was that ERC165 checks would be O(n) complexity (in terms of network requests), while calling `version()` is O(1). That assumption was incorrect because we can use the multicall contract to bundle all of those `supportsInterface` checks into a single request.

Another thing I don't love about the `IDecentVersion` interface is that it adds tight coupling between clients and contracts. In order for the client to properly utilize this `version()` call, it needs to make an assumption about what functions are available on the contract. Relying on ERC165 just about guarantees that not only the functions we expect to be there are there (because we ask the contract directly if they are there -- that's what ERC165 is), but also we are now using a common pattern for _other_ teams to be able to deploy and use their own versions of these contracts if they so desire, and as long as they implement the interface, our frontend should work. This only requires the other team to understand how ERC165 works, and _not_ need to understand what our custom version schema is.