### PR TITLE
ENG-172 ERC4337 Get owner

### DIFF
--- a/contracts/azorius/strategies/v2/ERC4337VoterSupport.sol
+++ b/contracts/azorius/strategies/v2/ERC4337VoterSupport.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity =0.8.19;
+
+/**
+ * Interface to get the owner of a smart account
+ */
+interface IOwnership {
+    /**
+     * Returns the owner address, could be EOA for regular voters, but could be DAO Safe or other smart contract
+     *
+     */
+    function owner() external pure returns (address);
+}
+
+abstract contract ERC4337VoterSupport {
+    /**
+     * Returns the address of the voter which owns the voting weight
+     * @param _msgSender address of the sender. It can be the wallet address, or the smart account address with EOA as owner
+     * 
+     */
+    function _voter(address _msgSender) internal virtual returns (address) {
+        try IOwnership(_msgSender).owner()  returns (address _value) {
+            return (_value);
+        } catch  {
+            return _msgSender;
+        }
+    }
+}

--- a/contracts/azorius/strategies/v2/ERC4337VoterSupport.sol
+++ b/contracts/azorius/strategies/v2/ERC4337VoterSupport.sol
@@ -1,16 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity =0.8.19;
 
-/**
- * Interface to get the owner of a smart account
- */
-interface IOwnership {
-    /**
-     * Returns the owner address, could be EOA for regular voters, but could be DAO Safe or other smart contract
-     *
-     */
-    function owner() external pure returns (address);
-}
+import {IOwnership} from "../../../interfaces/IOwnership.sol";
 
 abstract contract ERC4337VoterSupport {
     /**

--- a/contracts/azorius/strategies/v2/ERC4337VoterSupport.sol
+++ b/contracts/azorius/strategies/v2/ERC4337VoterSupport.sol
@@ -16,12 +16,12 @@ abstract contract ERC4337VoterSupport {
     /**
      * Returns the address of the voter which owns the voting weight
      * @param _msgSender address of the sender. It can be the wallet address, or the smart account address with EOA as owner
-     * 
+     * @return address of the voter
      */
     function _voter(address _msgSender) internal virtual returns (address) {
-        try IOwnership(_msgSender).owner()  returns (address _value) {
+        try IOwnership(_msgSender).owner() returns (address _value) {
             return (_value);
-        } catch  {
+        } catch {
             return _msgSender;
         }
     }

--- a/contracts/azorius/strategies/v2/ERC4337VoterSupport.sol
+++ b/contracts/azorius/strategies/v2/ERC4337VoterSupport.sol
@@ -9,9 +9,23 @@ abstract contract ERC4337VoterSupport {
      * @param _msgSender address of the sender. It can be the wallet address, or the smart account address with EOA as owner
      * @return address of the voter
      */
-    function _voter(address _msgSender) internal virtual returns (address) {
+    function _voter(
+        address _msgSender
+    ) internal view virtual returns (address) {
+        // First check if the address has code (is a contract)
+        uint256 size;
+        assembly {
+            size := extcodesize(_msgSender)
+        }
+
+        // If it's an EOA (no code), return the address directly
+        if (size == 0) {
+            return _msgSender;
+        }
+
+        // If it's a contract, try to get its owner
         try IOwnership(_msgSender).owner() returns (address _value) {
-            return (_value);
+            return _value;
         } catch {
             return _msgSender;
         }

--- a/contracts/azorius/strategies/v2/LinearERC20VotingV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC20VotingV2.sol
@@ -3,16 +3,28 @@ pragma solidity =0.8.19;
 
 import {LinearERC20VotingExtensible} from "../LinearERC20VotingExtensible.sol";
 import {IVersion} from "../../../interfaces/IVersion.sol";
-
+import {ERC4337VoterSupport} from "./ERC4337VoterSupport.sol";
 /**
  * An [Azorius](./Azorius.md) [BaseStrategy](./BaseStrategy.md) implementation that
  * enables linear (i.e. 1 to 1) token voting. Each token delegated to a given address
  * in an `ERC20Votes` token equals 1 vote for a Proposal.
  */
-contract LinearERC20VotingV2 is LinearERC20VotingExtensible, IVersion {
+
+contract LinearERC20VotingV2 is LinearERC20VotingExtensible, IVersion, ERC4337VoterSupport {
     /** @inheritdoc IVersion*/
     function getVersion() external pure virtual returns (uint16) {
         // This should be incremented whenever the contract is modified
         return 2;
+    }
+
+    /** @inheritdoc LinearERC20VotingExtensible*/
+    function vote(uint32 _proposalId, uint8 _voteType) external virtual override {
+        address voter = _voter(msg.sender);
+        _vote(
+            _proposalId,
+            voter,
+            _voteType,
+            getVotingWeight(voter, _proposalId)
+        );
     }
 }

--- a/contracts/azorius/strategies/v2/LinearERC20VotingV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC20VotingV2.sol
@@ -4,13 +4,17 @@ pragma solidity =0.8.19;
 import {LinearERC20VotingExtensible} from "../LinearERC20VotingExtensible.sol";
 import {IVersion} from "../../../interfaces/IVersion.sol";
 import {ERC4337VoterSupport} from "./ERC4337VoterSupport.sol";
+
 /**
  * An [Azorius](./Azorius.md) [BaseStrategy](./BaseStrategy.md) implementation that
  * enables linear (i.e. 1 to 1) token voting. Each token delegated to a given address
  * in an `ERC20Votes` token equals 1 vote for a Proposal.
  */
-
-contract LinearERC20VotingV2 is LinearERC20VotingExtensible, IVersion, ERC4337VoterSupport {
+contract LinearERC20VotingV2 is
+    LinearERC20VotingExtensible,
+    IVersion,
+    ERC4337VoterSupport
+{
     /** @inheritdoc IVersion*/
     function getVersion() external pure virtual returns (uint16) {
         // This should be incremented whenever the contract is modified
@@ -18,7 +22,10 @@ contract LinearERC20VotingV2 is LinearERC20VotingExtensible, IVersion, ERC4337Vo
     }
 
     /** @inheritdoc LinearERC20VotingExtensible*/
-    function vote(uint32 _proposalId, uint8 _voteType) external virtual override {
+    function vote(
+        uint32 _proposalId,
+        uint8 _voteType
+    ) external virtual override {
         address voter = _voter(msg.sender);
         _vote(
             _proposalId,

--- a/contracts/azorius/strategies/v2/LinearERC20VotingWithHatsProposalCreationV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC20VotingWithHatsProposalCreationV2.sol
@@ -24,7 +24,10 @@ contract LinearERC20VotingWithHatsProposalCreationV2 is
     }
 
     /** @inheritdoc LinearERC20VotingExtensible*/
-    function vote(uint32 _proposalId, uint8 _voteType) external virtual override {
+    function vote(
+        uint32 _proposalId,
+        uint8 _voteType
+    ) external virtual override {
         address voter = _voter(msg.sender);
         _vote(
             _proposalId,

--- a/contracts/azorius/strategies/v2/LinearERC20VotingWithHatsProposalCreationV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC20VotingWithHatsProposalCreationV2.sol
@@ -2,7 +2,9 @@
 pragma solidity =0.8.19;
 
 import {LinearERC20VotingWithHatsProposalCreation} from "../LinearERC20VotingWithHatsProposalCreation.sol";
+import {LinearERC20VotingExtensible} from "../LinearERC20VotingExtensible.sol";
 import {IVersion} from "../../../interfaces/IVersion.sol";
+import {ERC4337VoterSupport} from "./ERC4337VoterSupport.sol";
 
 /**
  * An [Azorius](./Azorius.md) [BaseStrategy](./BaseStrategy.md) implementation that
@@ -11,12 +13,24 @@ import {IVersion} from "../../../interfaces/IVersion.sol";
  */
 contract LinearERC20VotingWithHatsProposalCreationV2 is
     LinearERC20VotingWithHatsProposalCreation,
-    IVersion
+    IVersion,
+    ERC4337VoterSupport
 {
     /** @inheritdoc IVersion*/
     function getVersion() external pure override returns (uint16) {
         // Although this function is implemented by parent class, we want them to have independent versionings
         // This should be incremented whenever the contract is modified
         return 2;
+    }
+
+    /** @inheritdoc LinearERC20VotingExtensible*/
+    function vote(uint32 _proposalId, uint8 _voteType) external virtual override {
+        address voter = _voter(msg.sender);
+        _vote(
+            _proposalId,
+            voter,
+            _voteType,
+            getVotingWeight(voter, _proposalId)
+        );
     }
 }

--- a/contracts/azorius/strategies/v2/LinearERC721VotingV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC721VotingV2.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.19;
 
 import {LinearERC721VotingExtensible} from "../LinearERC721VotingExtensible.sol";
 import {IVersion} from "../../../interfaces/IVersion.sol";
+import {ERC4337VoterSupport} from "./ERC4337VoterSupport.sol";
 
 /**
  * An Azorius strategy that allows multiple ERC721 tokens to be registered as governance tokens,
@@ -15,10 +16,22 @@ import {IVersion} from "../../../interfaces/IVersion.sol";
  * total supply of NFTs is not knowable within the IERC721 interface.  This is similar to a multisig
  * "total signers" required, rather than a percentage of the tokens.
  */
-contract LinearERC721VotingV2 is LinearERC721VotingExtensible, IVersion {
+contract LinearERC721VotingV2 is LinearERC721VotingExtensible, IVersion, ERC4337VoterSupport {
     /** @inheritdoc IVersion*/
     function getVersion() external pure virtual returns (uint16) {
         // This should be incremented whenever the contract is modified
         return 2;
+    }
+
+    /** @inheritdoc LinearERC721VotingExtensible*/
+    function vote(
+        uint32 _proposalId,
+        uint8 _voteType,
+        address[] memory _tokenAddresses,
+        uint256[] memory _tokenIds
+    ) external virtual override {
+        if (_tokenAddresses.length != _tokenIds.length) revert InvalidParams();
+        address voter = _voter(msg.sender);
+        _vote(_proposalId, voter, _voteType, _tokenAddresses, _tokenIds);
     }
 }

--- a/contracts/azorius/strategies/v2/LinearERC721VotingV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC721VotingV2.sol
@@ -31,7 +31,6 @@ contract LinearERC721VotingV2 is LinearERC721VotingExtensible, IVersion, ERC4337
         uint256[] memory _tokenIds
     ) external virtual override {
         if (_tokenAddresses.length != _tokenIds.length) revert InvalidParams();
-        address voter = _voter(msg.sender);
-        _vote(_proposalId, voter, _voteType, _tokenAddresses, _tokenIds);
+        _vote(_proposalId, _voter(msg.sender), _voteType, _tokenAddresses, _tokenIds);
     }
 }

--- a/contracts/azorius/strategies/v2/LinearERC721VotingV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC721VotingV2.sol
@@ -16,7 +16,11 @@ import {ERC4337VoterSupport} from "./ERC4337VoterSupport.sol";
  * total supply of NFTs is not knowable within the IERC721 interface.  This is similar to a multisig
  * "total signers" required, rather than a percentage of the tokens.
  */
-contract LinearERC721VotingV2 is LinearERC721VotingExtensible, IVersion, ERC4337VoterSupport {
+contract LinearERC721VotingV2 is
+    LinearERC721VotingExtensible,
+    IVersion,
+    ERC4337VoterSupport
+{
     /** @inheritdoc IVersion*/
     function getVersion() external pure virtual returns (uint16) {
         // This should be incremented whenever the contract is modified
@@ -31,6 +35,12 @@ contract LinearERC721VotingV2 is LinearERC721VotingExtensible, IVersion, ERC4337
         uint256[] memory _tokenIds
     ) external virtual override {
         if (_tokenAddresses.length != _tokenIds.length) revert InvalidParams();
-        _vote(_proposalId, _voter(msg.sender), _voteType, _tokenAddresses, _tokenIds);
+        _vote(
+            _proposalId,
+            _voter(msg.sender),
+            _voteType,
+            _tokenAddresses,
+            _tokenIds
+        );
     }
 }

--- a/contracts/azorius/strategies/v2/LinearERC721VotingWithHatsProposalCreationV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC721VotingWithHatsProposalCreationV2.sol
@@ -31,6 +31,12 @@ contract LinearERC721VotingWithHatsProposalCreationV2 is
         uint256[] memory _tokenIds
     ) external virtual override {
         if (_tokenAddresses.length != _tokenIds.length) revert InvalidParams();
-        _vote(_proposalId, _voter(msg.sender), _voteType, _tokenAddresses, _tokenIds);
+        _vote(
+            _proposalId,
+            _voter(msg.sender),
+            _voteType,
+            _tokenAddresses,
+            _tokenIds
+        );
     }
 }

--- a/contracts/azorius/strategies/v2/LinearERC721VotingWithHatsProposalCreationV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC721VotingWithHatsProposalCreationV2.sol
@@ -31,7 +31,6 @@ contract LinearERC721VotingWithHatsProposalCreationV2 is
         uint256[] memory _tokenIds
     ) external virtual override {
         if (_tokenAddresses.length != _tokenIds.length) revert InvalidParams();
-        address voter = _voter(msg.sender);
-        _vote(_proposalId, voter, _voteType, _tokenAddresses, _tokenIds);
+        _vote(_proposalId, _voter(msg.sender), _voteType, _tokenAddresses, _tokenIds);
     }
 }

--- a/contracts/azorius/strategies/v2/LinearERC721VotingWithHatsProposalCreationV2.sol
+++ b/contracts/azorius/strategies/v2/LinearERC721VotingWithHatsProposalCreationV2.sol
@@ -2,7 +2,9 @@
 pragma solidity =0.8.19;
 
 import {LinearERC721VotingWithHatsProposalCreation} from "../LinearERC721VotingWithHatsProposalCreation.sol";
+import {LinearERC721VotingExtensible} from "../LinearERC721VotingExtensible.sol";
 import {IVersion} from "../../../interfaces/IVersion.sol";
+import {ERC4337VoterSupport} from "./ERC4337VoterSupport.sol";
 
 /**
  * An [Azorius](./Azorius.md) [BaseStrategy](./BaseStrategy.md) implementation that
@@ -11,12 +13,25 @@ import {IVersion} from "../../../interfaces/IVersion.sol";
  */
 contract LinearERC721VotingWithHatsProposalCreationV2 is
     LinearERC721VotingWithHatsProposalCreation,
-    IVersion
+    IVersion,
+    ERC4337VoterSupport
 {
     /** @inheritdoc IVersion*/
     function getVersion() external pure override returns (uint16) {
         // Although this function is implemented by parent class, we want them to have independent versionings
         // This should be incremented whenever the contract is modified
         return 2;
+    }
+
+    /** @inheritdoc LinearERC721VotingExtensible*/
+    function vote(
+        uint32 _proposalId,
+        uint8 _voteType,
+        address[] memory _tokenAddresses,
+        uint256[] memory _tokenIds
+    ) external virtual override {
+        if (_tokenAddresses.length != _tokenIds.length) revert InvalidParams();
+        address voter = _voter(msg.sender);
+        _vote(_proposalId, voter, _voteType, _tokenAddresses, _tokenIds);
     }
 }

--- a/contracts/interfaces/IOwnership.sol
+++ b/contracts/interfaces/IOwnership.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.19;
+
+/**
+ * Interface to get the owner of a smart account
+ */
+interface IOwnership {
+    /**
+     * @notice Returns the owner address of this contract
+     * @dev This can return either an EOA address for regular voters, or a smart contract address like a DAO Safe
+     * @return The address of the owner
+     */
+    function owner() external view returns (address);
+}

--- a/contracts/mocks/MockERC4337VoterSupport.sol
+++ b/contracts/mocks/MockERC4337VoterSupport.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {ERC4337VoterSupport} from "../azorius/strategies/v2/ERC4337VoterSupport.sol";
+
+contract MockERC4337VoterSupport is ERC4337VoterSupport {
+    // Expose the internal _voter function for testing
+    function voter(address _msgSender) external view returns (address) {
+        return _voter(_msgSender);
+    }
+}

--- a/contracts/mocks/MockNonOwnership.sol
+++ b/contracts/mocks/MockNonOwnership.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+contract MockNonOwnership {
+    // This contract intentionally does not implement IOwnership
+    // It's used to test the catch block in ERC4337VoterSupport._voter
+
+    function someFunction() external pure returns (bool) {
+        return true;
+    }
+}

--- a/contracts/mocks/MockSmartAccount.sol
+++ b/contracts/mocks/MockSmartAccount.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IOwnership} from "../interfaces/IOwnership.sol";
+
+contract MockSmartAccount is IOwnership {
+    address public owner;
+
+    constructor(address _owner) {
+        owner = _owner;
+    }
+}

--- a/test/ERC4337VoterSupport.test.ts
+++ b/test/ERC4337VoterSupport.test.ts
@@ -1,0 +1,65 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+import {
+  MockERC4337VoterSupport,
+  MockERC4337VoterSupport__factory,
+  MockSmartAccount,
+  MockSmartAccount__factory,
+  MockNonOwnership,
+  MockNonOwnership__factory,
+} from '../typechain-types';
+
+describe('ERC4337VoterSupport', () => {
+  let smartAccount: MockSmartAccount;
+  let erc4337VoterSupport: MockERC4337VoterSupport;
+  let nonOwnershipContract: MockNonOwnership;
+  let zeroOwnerSmartAccount: MockSmartAccount;
+
+  let deployer: SignerWithAddress;
+  let smartAccountOwner: SignerWithAddress;
+  let eoa: SignerWithAddress;
+
+  beforeEach(async () => {
+    const signers = await hre.ethers.getSigners();
+    [deployer, smartAccountOwner, eoa] = signers;
+
+    // Deploy mock contracts
+    smartAccount = await new MockSmartAccount__factory(deployer).deploy(smartAccountOwner.address);
+    zeroOwnerSmartAccount = await new MockSmartAccount__factory(deployer).deploy(
+      hre.ethers.ZeroAddress,
+    );
+    erc4337VoterSupport = await new MockERC4337VoterSupport__factory(deployer).deploy();
+    nonOwnershipContract = await new MockNonOwnership__factory(deployer).deploy();
+  });
+
+  describe('voter', () => {
+    describe('when the msgSender is a smart account', () => {
+      it('should return the owner of the smart account', async () => {
+        expect(await erc4337VoterSupport.voter(await smartAccount.getAddress())).to.equal(
+          smartAccountOwner.address,
+        );
+      });
+
+      it('should return address(0) when smart account owner is zero address', async () => {
+        expect(await erc4337VoterSupport.voter(await zeroOwnerSmartAccount.getAddress())).to.equal(
+          hre.ethers.ZeroAddress,
+        );
+      });
+    });
+
+    describe('when the msgSender is an EOA', () => {
+      it('should return the msgSender', async () => {
+        expect(await erc4337VoterSupport.voter(eoa.address)).to.equal(eoa.address);
+      });
+    });
+
+    describe('when the msgSender is a contract that does not implement IOwnership', () => {
+      it('should return the contract address', async () => {
+        const contractAddress = await nonOwnershipContract.getAddress();
+        expect(await erc4337VoterSupport.voter(contractAddress)).to.equal(contractAddress);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Changed voting strategy to get owner from the msg.sender if it is the smart account.

```
  ERC4337VoterSupport
    voter
      when the msgSender is a smart account
        ✔ should return the owner of the smart account
        ✔ should return address(0) when smart account owner is zero address
      when the msgSender is an EOA
        ✔ should return the msgSender
      when the msgSender is a contract that does not implement IOwnership
        ✔ should return the contract address
```