### PR TITLE
Bump all pragma solidity declarations to "^0.8.28;"

### DIFF
--- a/contracts/deployables/account-abstraction/BasePaymaster.sol
+++ b/contracts/deployables/account-abstraction/BasePaymaster.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {BasePaymaster, IEntryPoint} from "./BasePaymaster.sol";
 import {IDecentPaymasterV1} from "../../interfaces/decent/IDecentPaymasterV1.sol";

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {IHatsElectionsEligibility} from "../../interfaces/hats/modules/IHatsElectionsEligibility.sol";
 import {FactoryFriendly} from "@gnosis.pm/zodiac/contracts/factory/FactoryFriendly.sol";

--- a/contracts/deployables/erc20/VotesERC20.sol
+++ b/contracts/deployables/erc20/VotesERC20.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {FactoryFriendly} from "@gnosis.pm/zodiac/contracts/factory/FactoryFriendly.sol";
 import {ERC20VotesUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuard.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuard.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IBaseFreezeVoting} from "../../interfaces/decent/IBaseFreezeVoting.sol";
 import {IGuard} from "@gnosis.pm/zodiac/contracts/interfaces/IGuard.sol";

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuard.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuard.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IMultisigFreezeGuard} from "../../interfaces/decent/IMultisigFreezeGuard.sol";
 import {IBaseFreezeVoting} from "../../interfaces/decent/IBaseFreezeVoting.sol";

--- a/contracts/deployables/freeze-voting/BaseFreezeVoting.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVoting.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {FactoryFriendly} from "@gnosis.pm/zodiac/contracts/factory/FactoryFriendly.sol";
 import {IBaseFreezeVoting} from "../../interfaces/decent/IBaseFreezeVoting.sol";

--- a/contracts/deployables/freeze-voting/ERC20FreezeVoting.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVoting.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {BaseFreezeVoting, IBaseFreezeVoting} from "./BaseFreezeVoting.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";

--- a/contracts/deployables/freeze-voting/ERC721FreezeVoting.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVoting.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IERC721VotingStrategy} from "../../interfaces/decent/IERC721VotingStrategy.sol";
 import {BaseFreezeVoting, IBaseFreezeVoting} from "./BaseFreezeVoting.sol";

--- a/contracts/deployables/freeze-voting/MultisigFreezeVoting.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVoting.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {BaseFreezeVoting, IBaseFreezeVoting} from "./BaseFreezeVoting.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";

--- a/contracts/deployables/modules/Azorius.sol
+++ b/contracts/deployables/modules/Azorius.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IBaseStrategy} from "../../interfaces/decent/IBaseStrategy.sol";
 import {IAzorius, Enum} from "../../interfaces/decent/IAzorius.sol";

--- a/contracts/deployables/modules/FractalModule.sol
+++ b/contracts/deployables/modules/FractalModule.sol
@@ -1,8 +1,8 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
-import {Module, Enum} from "@gnosis.pm/zodiac/contracts/core/Module.sol";
 import {IFractalModule} from "../../interfaces/decent/IFractalModule.sol";
+import {Module, Enum} from "@gnosis.pm/zodiac/contracts/core/Module.sol";
 
 /**
  * Implementation of [IFractalModule](./interfaces/IFractalModule.md).

--- a/contracts/deployables/strategies/BaseQuorumPercent.sol
+++ b/contracts/deployables/strategies/BaseQuorumPercent.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/contracts/deployables/strategies/BaseStrategy.sol
+++ b/contracts/deployables/strategies/BaseStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IAzorius} from "../../interfaces/decent/IAzorius.sol";
 import {IBaseStrategy} from "../../interfaces/decent/IBaseStrategy.sol";

--- a/contracts/deployables/strategies/BaseVotingBasisPercent.sol
+++ b/contracts/deployables/strategies/BaseVotingBasisPercent.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/contracts/deployables/strategies/ERC4337VoterSupport.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupport.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IOwnership} from "../../interfaces/IOwnership.sol";
 

--- a/contracts/deployables/strategies/HatsProposalCreationWhitelist.sol
+++ b/contracts/deployables/strategies/HatsProposalCreationWhitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IHats} from "../../interfaces/hats/IHats.sol";

--- a/contracts/deployables/strategies/LinearERC20Voting.sol
+++ b/contracts/deployables/strategies/LinearERC20Voting.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {BaseStrategy, IBaseStrategy} from "./BaseStrategy.sol";
 import {BaseQuorumPercent} from "./BaseQuorumPercent.sol";

--- a/contracts/deployables/strategies/LinearERC20VotingV2.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/IVersion.sol";
 import {LinearERC20Voting} from "./LinearERC20Voting.sol";

--- a/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreation.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {LinearERC20Voting} from "./LinearERC20Voting.sol";
 import {HatsProposalCreationWhitelist} from "./HatsProposalCreationWhitelist.sol";

--- a/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV2.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {LinearERC20Voting} from "./LinearERC20Voting.sol";
 import {ERC4337VoterSupport} from "./ERC4337VoterSupport.sol";

--- a/contracts/deployables/strategies/LinearERC721Voting.sol
+++ b/contracts/deployables/strategies/LinearERC721Voting.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IERC721VotingStrategy} from "../../interfaces/decent/IERC721VotingStrategy.sol";
 import {BaseVotingBasisPercent} from "./BaseVotingBasisPercent.sol";

--- a/contracts/deployables/strategies/LinearERC721VotingV2.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/IVersion.sol";
 import {ERC4337VoterSupport} from "./ERC4337VoterSupport.sol";

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreation.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {LinearERC721Voting} from "./LinearERC721Voting.sol";
 import {HatsProposalCreationWhitelist} from "./HatsProposalCreationWhitelist.sol";

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV2.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {LinearERC721Voting} from "./LinearERC721Voting.sol";
 import {ERC4337VoterSupport} from "./ERC4337VoterSupport.sol";

--- a/contracts/interfaces/IOwnership.sol
+++ b/contracts/interfaces/IOwnership.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity 0.8.19;
+pragma solidity ^0.8.28;
 
 /**
  * Interface to get the owner of a smart account

--- a/contracts/interfaces/decent/IAzorius.sol
+++ b/contracts/interfaces/decent/IAzorius.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 

--- a/contracts/interfaces/decent/IBaseFreezeVoting.sol
+++ b/contracts/interfaces/decent/IBaseFreezeVoting.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 

--- a/contracts/interfaces/decent/IBaseStrategy.sol
+++ b/contracts/interfaces/decent/IBaseStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 /**
  * The specification for a voting strategy in Azorius.

--- a/contracts/interfaces/decent/IDecentAutonomousAdminV1.sol
+++ b/contracts/interfaces/decent/IDecentAutonomousAdminV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {IHats} from "../hats/IHats.sol";
 

--- a/contracts/interfaces/decent/IDecentPaymasterV1.sol
+++ b/contracts/interfaces/decent/IDecentPaymasterV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 interface IDecentPaymasterV1 {
     function setStrategyFunctionApproval(

--- a/contracts/interfaces/decent/IERC721VotingStrategy.sol
+++ b/contracts/interfaces/decent/IERC721VotingStrategy.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 /**
  * Interface of functions required for ERC-721 freeze voting associated with an ERC-721

--- a/contracts/interfaces/decent/IFractalModule.sol
+++ b/contracts/interfaces/decent/IFractalModule.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/contracts/interfaces/decent/IKeyValuePairs.sol
+++ b/contracts/interfaces/decent/IKeyValuePairs.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 /**
  * A utility contract to log key / value pair events for the calling address.

--- a/contracts/interfaces/decent/IMultisigFreezeGuard.sol
+++ b/contracts/interfaces/decent/IMultisigFreezeGuard.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 

--- a/contracts/interfaces/decent/IVersion.sol
+++ b/contracts/interfaces/decent/IVersion.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.28;
 
 /**
  * Interface of functions for versioned contracts

--- a/contracts/interfaces/erc6551/IERC6551Registry.sol
+++ b/contracts/interfaces/erc6551/IERC6551Registry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.28;
 
 interface IERC6551Registry {
     /**

--- a/contracts/interfaces/sablier/IERC4096.sol
+++ b/contracts/interfaces/sablier/IERC4096.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC4906.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.28;
 
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/interfaces/safe/ISafe.sol
+++ b/contracts/interfaces/safe/ISafe.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 

--- a/contracts/mocks/ERC6551Registry.sol
+++ b/contracts/mocks/ERC6551Registry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.28;
 
 interface IERC6551Registry {
     /**

--- a/contracts/mocks/MockContract.sol
+++ b/contracts/mocks/MockContract.sol
@@ -1,6 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.28;
 
 /**
  * Mock contract for testing

--- a/contracts/mocks/MockDecentHatsUtils.sol
+++ b/contracts/mocks/MockDecentHatsUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {DecentHatsModuleUtils} from "../utilities/DecentHatsModuleUtils.sol";
 

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/MockERC4337VoterSupport.sol
+++ b/contracts/mocks/MockERC4337VoterSupport.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.28;
 
 import {ERC4337VoterSupport} from "../deployables/strategies/ERC4337VoterSupport.sol";
 

--- a/contracts/mocks/MockERC721.sol
+++ b/contracts/mocks/MockERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/contracts/mocks/MockEntryPoint.sol
+++ b/contracts/mocks/MockEntryPoint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/contracts/mocks/MockHats.sol
+++ b/contracts/mocks/MockHats.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IHats} from "../interfaces/hats/IHats.sol";
 import {IHatsIdUtilities} from "../interfaces/hats/IHatsIdUtilities.sol";

--- a/contracts/mocks/MockHatsAccount.sol
+++ b/contracts/mocks/MockHatsAccount.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 contract MockHatsAccount {
     // see https://github.com/Hats-Protocol/hats-account/blob/00650b3de756352d303ca08e4b024376f1d1db98/src/HatsAccountBase.sol#L41

--- a/contracts/mocks/MockHatsElectionsEligibility.sol
+++ b/contracts/mocks/MockHatsElectionsEligibility.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.28;
+
 import {IHatsElectionsEligibility} from "../interfaces/hats/modules/IHatsElectionsEligibility.sol";
 
 contract MockHatsElectionsEligibility is IHatsElectionsEligibility {

--- a/contracts/mocks/MockHatsModuleFactory.sol
+++ b/contracts/mocks/MockHatsModuleFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.28;
 
 import {IHatsModuleFactory} from "../interfaces/hats/IHatsModuleFactory.sol";
 import {MockHatsElectionsEligibility} from "./MockHatsElectionsEligibility.sol";

--- a/contracts/mocks/MockHatsProposalCreationWhitelist.sol
+++ b/contracts/mocks/MockHatsProposalCreationWhitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import "../deployables/strategies/HatsProposalCreationWhitelist.sol";
 

--- a/contracts/mocks/MockLockupLinear.sol
+++ b/contracts/mocks/MockLockupLinear.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.28;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/mocks/MockNonOwnership.sol
+++ b/contracts/mocks/MockNonOwnership.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.28;
 
 contract MockNonOwnership {
     // This contract intentionally does not implement IOwnership

--- a/contracts/mocks/MockSablierV2LockupLinear.sol
+++ b/contracts/mocks/MockSablierV2LockupLinear.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.22;
+pragma solidity ^0.8.28;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ISablierV2LockupLinear} from "../interfaces/sablier/ISablierV2LockupLinear.sol";

--- a/contracts/mocks/MockSmartAccount.sol
+++ b/contracts/mocks/MockSmartAccount.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.28;
 
 import {IOwnership} from "../interfaces/IOwnership.sol";
 

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {BaseStrategy, IBaseStrategy} from "../deployables/strategies/BaseStrategy.sol";
 

--- a/contracts/singletons/KeyValuePairs.sol
+++ b/contracts/singletons/KeyValuePairs.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity =0.8.19;
+pragma solidity ^0.8.28;
 
 import {IKeyValuePairs} from "../interfaces/decent/IKeyValuePairs.sol";
 

--- a/contracts/utilities/DecentHatsCreationModule.sol
+++ b/contracts/utilities/DecentHatsCreationModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {DecentHatsModuleUtils} from "./DecentHatsModuleUtils.sol";
 import {IERC6551Registry} from "../interfaces/erc6551/IERC6551Registry.sol";

--- a/contracts/utilities/DecentHatsModificationModule.sol
+++ b/contracts/utilities/DecentHatsModificationModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {DecentHatsModuleUtils} from "./DecentHatsModuleUtils.sol";
 

--- a/contracts/utilities/DecentHatsModuleUtils.sol
+++ b/contracts/utilities/DecentHatsModuleUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.28;
+pragma solidity ^0.8.28;
 
 import {IERC6551Registry} from "../interfaces/erc6551/IERC6551Registry.sol";
 import {IHats} from "../interfaces/hats/IHats.sol";

--- a/contracts/utilities/DecentSablierStreamManagementModule.sol
+++ b/contracts/utilities/DecentSablierStreamManagementModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.28;
+pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IAvatar} from "@gnosis.pm/zodiac/contracts/interfaces/IAvatar.sol";

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -14,15 +14,6 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.19',
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 200,
-          },
-        },
-      },
-      {
         version: '0.8.28',
         settings: {
           optimizer: {


### PR DESCRIPTION
- Remove 0.8.19 compiler in hardhat.config.ts
- Update all `pragma solidity` declarations to `^0.8.28` (current solidity version)