### PR TITLE
Organize tests

### DIFF
--- a/test/deployables/Atomic-Deployment.test.ts
+++ b/test/deployables/Atomic-Deployment.test.ts
@@ -13,20 +13,20 @@ import {
   MultiSendCallOnly__factory,
   MultisigFreezeGuardV1,
   MultisigFreezeGuardV1__factory,
-} from '../typechain-types';
+} from '../../typechain-types';
 import {
   getGnosisSafeL2Singleton,
   getGnosisSafeProxyFactory,
   getModuleProxyFactory,
   getMultiSendCallOnly,
-} from './GlobalSafeDeployments.test';
+} from '../global/GlobalSafeDeployments.test';
 import {
   calculateProxyAddress,
   predictGnosisSafeAddress,
   buildContractCall,
   MetaTransaction,
   encodeMultiSend,
-} from './helpers';
+} from '../helpers';
 
 describe('Atomic Gnosis Safe Deployment', () => {
   // Factories

--- a/test/deployables/Azorius-LinearERC20Voting.test.ts
+++ b/test/deployables/Azorius-LinearERC20Voting.test.ts
@@ -15,21 +15,21 @@ import {
   VotesERC20V1__factory,
   ModuleProxyFactory,
   GnosisSafeL2__factory,
-} from '../typechain-types';
+} from '../../typechain-types';
 
 import {
   getGnosisSafeL2Singleton,
   getGnosisSafeProxyFactory,
   getModuleProxyFactory,
-} from './GlobalSafeDeployments.test';
+} from '../global/GlobalSafeDeployments.test';
 import {
   buildSignatureBytes,
   buildSafeTransaction,
   safeSignTypedData,
   predictGnosisSafeAddress,
   calculateProxyAddress,
-} from './helpers';
-import time from './time';
+} from '../helpers';
+import time from '../time';
 
 describe('Safe with Azorius module and linearERC20Voting', () => {
   // Deployed contracts

--- a/test/deployables/Azorius-LinearERC20VotingWithHatsProposalCreation.test.ts
+++ b/test/deployables/Azorius-LinearERC20VotingWithHatsProposalCreation.test.ts
@@ -15,20 +15,20 @@ import {
   VotesERC20V1__factory,
   ModuleProxyFactory,
   GnosisSafeL2__factory,
-} from '../typechain-types';
+} from '../../typechain-types';
 
 import {
   getGnosisSafeL2Singleton,
   getGnosisSafeProxyFactory,
   getModuleProxyFactory,
-} from './GlobalSafeDeployments.test';
+} from '../global/GlobalSafeDeployments.test';
 import {
   calculateProxyAddress,
   predictGnosisSafeAddress,
   buildSafeTransaction,
   safeSignTypedData,
   buildSignatureBytes,
-} from './helpers';
+} from '../helpers';
 
 describe('LinearERC20VotingWithHatsProposalCreation', () => {
   // Deployed contracts

--- a/test/deployables/Azorius-LinearERC721Voting.test.ts
+++ b/test/deployables/Azorius-LinearERC721Voting.test.ts
@@ -13,13 +13,13 @@ import {
   MockERC721__factory,
   MockContract__factory,
   GnosisSafeL2__factory,
-} from '../typechain-types';
+} from '../../typechain-types';
 import {
   getGnosisSafeL2Singleton,
   getGnosisSafeProxyFactory,
   getModuleProxyFactory,
   getMockContract,
-} from './GlobalSafeDeployments.test';
+} from '../global/GlobalSafeDeployments.test';
 import {
   buildSignatureBytes,
   buildSafeTransaction,
@@ -28,8 +28,8 @@ import {
   calculateProxyAddress,
   mockTransaction,
   mockRevertTransaction,
-} from './helpers';
-import time from './time';
+} from '../helpers';
+import time from '../time';
 
 describe('Safe with Azorius module and linearERC721Voting', () => {
   const abiCoder = new ethers.AbiCoder();

--- a/test/deployables/Azorius-LinearERC721VotingWithHatsProposalCreation.test.ts
+++ b/test/deployables/Azorius-LinearERC721VotingWithHatsProposalCreation.test.ts
@@ -15,20 +15,19 @@ import {
   MockERC721__factory,
   ModuleProxyFactory,
   GnosisSafeL2__factory,
-} from '../typechain-types';
-
+} from '../../typechain-types';
 import {
   getGnosisSafeL2Singleton,
   getGnosisSafeProxyFactory,
   getModuleProxyFactory,
-} from './GlobalSafeDeployments.test';
+} from '../global/GlobalSafeDeployments.test';
 import {
   calculateProxyAddress,
   predictGnosisSafeAddress,
   buildSafeTransaction,
   safeSignTypedData,
   buildSignatureBytes,
-} from './helpers';
+} from '../helpers';
 
 describe('LinearERC721VotingWithHatsProposalCreation', () => {
   // Deployed contracts

--- a/test/deployables/AzoriusFreezeGuard-ERC20FreezeVoting.test.ts
+++ b/test/deployables/AzoriusFreezeGuard-ERC20FreezeVoting.test.ts
@@ -17,22 +17,22 @@ import {
   VotesERC20V1__factory,
   ModuleProxyFactory,
   GnosisSafeL2__factory,
-} from '../typechain-types';
+} from '../../typechain-types';
 
 import {
   getGnosisSafeL2Singleton,
   getGnosisSafeProxyFactory,
   getModuleProxyFactory,
-} from './GlobalSafeDeployments.test';
+} from '../global/GlobalSafeDeployments.test';
 import {
   buildSignatureBytes,
   buildSafeTransaction,
   safeSignTypedData,
   predictGnosisSafeAddress,
   calculateProxyAddress,
-} from './helpers';
+} from '../helpers';
 
-import time from './time';
+import time from '../time';
 
 describe('Azorius Child DAO with Azorius Parent', () => {
   // Deployed contracts

--- a/test/deployables/AzoriusFreezeGuard-MultisigFreezeVoting.test.ts
+++ b/test/deployables/AzoriusFreezeGuard-MultisigFreezeVoting.test.ts
@@ -17,22 +17,22 @@ import {
   ModuleProxyFactory,
   GnosisSafeL2__factory,
   GnosisSafeL2,
-} from '../typechain-types';
+} from '../../typechain-types';
 
 import {
   getGnosisSafeL2Singleton,
   getGnosisSafeProxyFactory,
   getModuleProxyFactory,
-} from './GlobalSafeDeployments.test';
+} from '../global/GlobalSafeDeployments.test';
 import {
   buildSignatureBytes,
   buildSafeTransaction,
   safeSignTypedData,
   predictGnosisSafeAddress,
   calculateProxyAddress,
-} from './helpers';
+} from '../helpers';
 
-import time from './time';
+import time from '../time';
 
 describe('Azorius Child DAO with Multisig parent', () => {
   // Deployed contracts

--- a/test/deployables/ERC4337VoterSupport.test.ts
+++ b/test/deployables/ERC4337VoterSupport.test.ts
@@ -9,7 +9,7 @@ import {
   MockSmartAccount__factory,
   MockNonOwnership,
   MockNonOwnership__factory,
-} from '../typechain-types';
+} from '../../typechain-types';
 
 describe('ERC4337VoterSupport', () => {
   let smartAccount: MockSmartAccount;

--- a/test/deployables/Fractal-Module.test.ts
+++ b/test/deployables/Fractal-Module.test.ts
@@ -13,20 +13,20 @@ import {
   GnosisSafeL2__factory,
   MultiSendCallOnly__factory,
   MultiSendCallOnly,
-} from '../typechain-types';
+} from '../../typechain-types';
 import {
   getGnosisSafeL2Singleton,
   getGnosisSafeProxyFactory,
   getModuleProxyFactory,
   getMultiSendCallOnly,
-} from './GlobalSafeDeployments.test';
+} from '../global/GlobalSafeDeployments.test';
 import {
   calculateProxyAddress,
   predictGnosisSafeAddress,
   buildContractCall,
   MetaTransaction,
   encodeMultiSend,
-} from './helpers';
+} from '../helpers';
 
 describe('Fractal Module Tests', () => {
   let gnosisSafeProxyFactory: GnosisSafeProxyFactory;

--- a/test/deployables/HatsProposalCreationWhitelist.test.ts
+++ b/test/deployables/HatsProposalCreationWhitelist.test.ts
@@ -9,8 +9,8 @@ import {
   MockHatsProposalCreationWhitelist__factory,
   MockHats,
   MockHats__factory,
-} from '../typechain-types';
-import { topHatIdToHatId } from './helpers';
+} from '../../typechain-types';
+import { topHatIdToHatId } from '../helpers';
 
 describe('HatsProposalCreationWhitelist', () => {
   let mockHatsProposalCreationWhitelist: MockHatsProposalCreationWhitelist;

--- a/test/deployables/MultisigFreezeGuard-MultisigFreezeVoting.test.ts
+++ b/test/deployables/MultisigFreezeGuard-MultisigFreezeVoting.test.ts
@@ -11,21 +11,21 @@ import {
   MultisigFreezeGuardV1__factory,
   GnosisSafeL2__factory,
   GnosisSafeL2,
-} from '../typechain-types';
+} from '../../typechain-types';
 
 import {
   getGnosisSafeL2Singleton,
   getGnosisSafeProxyFactory,
   getModuleProxyFactory,
-} from './GlobalSafeDeployments.test';
+} from '../global/GlobalSafeDeployments.test';
 import {
   buildSignatureBytes,
   buildSafeTransaction,
   safeSignTypedData,
   predictGnosisSafeAddress,
   calculateProxyAddress,
-} from './helpers';
-import time from './time';
+} from '../helpers';
+import time from '../time';
 
 describe('Child Multisig DAO with Multisig Parent', () => {
   // Deployed contracts

--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -9,9 +9,9 @@ import {
   IPaymaster__factory,
   IDecentPaymasterV1__factory,
   DecentPaymasterV1__factory,
-} from '../typechain-types';
-import { getModuleProxyFactory } from './GlobalSafeDeployments.test';
-import { calculateProxyAddress } from './helpers';
+} from '../../../typechain-types';
+import { getModuleProxyFactory } from '../../global/GlobalSafeDeployments.test';
+import { calculateProxyAddress } from '../../helpers';
 
 interface PackedUserOperation {
   sender: string;

--- a/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
+++ b/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
@@ -10,9 +10,9 @@ import {
   MockHats__factory,
   MockHatsElectionsEligibility,
   MockHatsElectionsEligibility__factory,
-} from '../../typechain-types';
-import { topHatIdToHatId } from '../helpers';
-import { currentBlockTimestamp, setTime } from '../time';
+} from '../../../typechain-types';
+import { topHatIdToHatId } from '../../helpers';
+import { currentBlockTimestamp, setTime } from '../../time';
 
 describe('DecentAutonomousAdminHatV1', function () {
   // Signer accounts

--- a/test/global/GlobalSafeDeployments.test.ts
+++ b/test/global/GlobalSafeDeployments.test.ts
@@ -10,7 +10,7 @@ import {
   GnosisSafeL2__factory,
   MockContract,
   MockContract__factory,
-} from '../typechain-types';
+} from '../../typechain-types';
 
 let gnosisSafeProxyFactory: GnosisSafeProxyFactory;
 let moduleProxyFactory: ModuleProxyFactory;

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -6,11 +6,11 @@ import {
   ERC6551Registry,
   GnosisSafeL2,
   GnosisSafeProxyFactory,
-  IAzorius,
+  IAzoriusV1,
   MockContract__factory,
   MockHatsAccount__factory,
 } from '../typechain-types';
-import { getMockContract } from './GlobalSafeDeployments.test';
+import { getMockContract } from './global/GlobalSafeDeployments.test';
 
 export interface MetaTransaction {
   to: string;
@@ -181,7 +181,7 @@ export const encodeMultiSend = (txs: MetaTransaction[]): string => {
   );
 };
 
-export const mockTransaction = async (): Promise<IAzorius.TransactionStruct> => {
+export const mockTransaction = async (): Promise<IAzoriusV1.TransactionStruct> => {
   return {
     to: await getMockContract().getAddress(),
     value: 0n,
@@ -191,7 +191,7 @@ export const mockTransaction = async (): Promise<IAzorius.TransactionStruct> => 
   };
 };
 
-export const mockRevertTransaction = async (): Promise<IAzorius.TransactionStruct> => {
+export const mockRevertTransaction = async (): Promise<IAzoriusV1.TransactionStruct> => {
   return {
     to: await getMockContract().getAddress(),
     value: 0n,

--- a/test/singletons/KeyValuePairs.test.ts
+++ b/test/singletons/KeyValuePairs.test.ts
@@ -1,0 +1,60 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { KeyValuePairs, KeyValuePairs__factory } from '../../typechain-types';
+
+describe('KeyValuePairs', function () {
+  let keyValuePairs: KeyValuePairs;
+  let deployer: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  beforeEach(async function () {
+    [deployer, user] = await ethers.getSigners();
+    keyValuePairs = await new KeyValuePairs__factory(deployer).deploy();
+  });
+
+  describe('updateValues', function () {
+    it('should emit ValueUpdated events for each key-value pair', async function () {
+      const keys = ['name', 'age', 'city'];
+      const values = ['Alice', '25', 'New York'];
+
+      await expect(keyValuePairs.connect(user).updateValues(keys, values))
+        .to.emit(keyValuePairs, 'ValueUpdated')
+        .withArgs(user.address, 'name', 'Alice')
+        .to.emit(keyValuePairs, 'ValueUpdated')
+        .withArgs(user.address, 'age', '25')
+        .to.emit(keyValuePairs, 'ValueUpdated')
+        .withArgs(user.address, 'city', 'New York');
+    });
+
+    it('should work with a single key-value pair', async function () {
+      const keys = ['single'];
+      const values = ['value'];
+
+      await expect(keyValuePairs.connect(user).updateValues(keys, values))
+        .to.emit(keyValuePairs, 'ValueUpdated')
+        .withArgs(user.address, 'single', 'value');
+    });
+
+    it('should work with empty arrays', async function () {
+      const keys: string[] = [];
+      const values: string[] = [];
+
+      await expect(keyValuePairs.connect(user).updateValues(keys, values)).to.not.be.reverted;
+    });
+
+    it('should revert if keys and values arrays have different lengths', async function () {
+      const keys = ['key1', 'key2'];
+      const values = ['value1'];
+
+      await expect(
+        keyValuePairs.connect(user).updateValues(keys, values),
+      ).to.be.revertedWithCustomError(keyValuePairs, 'IncorrectValueCount');
+
+      const moreValues = ['value1', 'value2', 'value3'];
+      await expect(
+        keyValuePairs.connect(user).updateValues(keys, moreValues),
+      ).to.be.revertedWithCustomError(keyValuePairs, 'IncorrectValueCount');
+    });
+  });
+});

--- a/test/utilities/DecentHatsCreationModule.test.ts
+++ b/test/utilities/DecentHatsCreationModule.test.ts
@@ -29,7 +29,10 @@ import {
   ModuleProxyFactory__factory,
 } from '../../typechain-types';
 
-import { getGnosisSafeL2Singleton, getGnosisSafeProxyFactory } from '../GlobalSafeDeployments.test';
+import {
+  getGnosisSafeL2Singleton,
+  getGnosisSafeProxyFactory,
+} from '../global/GlobalSafeDeployments.test';
 import {
   executeSafeTransaction,
   getHatAccount,

--- a/test/utilities/DecentHatsModificationModule.test.ts
+++ b/test/utilities/DecentHatsModificationModule.test.ts
@@ -30,7 +30,10 @@ import {
   DecentHatsCreationModule,
 } from '../../typechain-types';
 
-import { getGnosisSafeL2Singleton, getGnosisSafeProxyFactory } from '../GlobalSafeDeployments.test';
+import {
+  getGnosisSafeL2Singleton,
+  getGnosisSafeProxyFactory,
+} from '../global/GlobalSafeDeployments.test';
 import {
   executeSafeTransaction,
   getHatAccount,

--- a/test/utilities/DecentHatsModuleUtils.test.ts
+++ b/test/utilities/DecentHatsModuleUtils.test.ts
@@ -23,7 +23,10 @@ import {
   KeyValuePairs__factory,
 } from '../../typechain-types';
 
-import { getGnosisSafeL2Singleton, getGnosisSafeProxyFactory } from '../GlobalSafeDeployments.test';
+import {
+  getGnosisSafeL2Singleton,
+  getGnosisSafeProxyFactory,
+} from '../global/GlobalSafeDeployments.test';
 
 import {
   getHatAccount,

--- a/test/utilities/DecentSablierStreamManagement.test.ts
+++ b/test/utilities/DecentSablierStreamManagement.test.ts
@@ -31,7 +31,10 @@ import {
   ModuleProxyFactory__factory,
 } from '../../typechain-types';
 
-import { getGnosisSafeProxyFactory, getGnosisSafeL2Singleton } from '../GlobalSafeDeployments.test';
+import {
+  getGnosisSafeProxyFactory,
+  getGnosisSafeL2Singleton,
+} from '../global/GlobalSafeDeployments.test';
 import {
   executeSafeTransaction,
   getHatAccount,


### PR DESCRIPTION
- Move test files into a more organized structure, mimicking the contracts
- Add tests for KeyValuePairs contract, of which there were none before