### PR TITLE
Add IVersion implementation to all non-abstract "deployable" contracts

### DIFF
--- a/contracts/deployables/account-abstraction/BasePaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/BasePaymasterV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.28;
 
+import "../../interfaces/decent/deployables/IVersion.sol";
 import "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import "@account-abstraction/contracts/core/UserOperationLib.sol";
@@ -12,7 +13,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
  * provides helper methods for staking.
  * Validates that the postOp is called only by the entryPoint.
  */
-abstract contract BasePaymasterV1 is IPaymaster, OwnableUpgradeable {
+abstract contract BasePaymasterV1 is IPaymaster, IVersion, OwnableUpgradeable {
     IEntryPoint public entryPoint;
 
     uint256 internal constant PAYMASTER_VALIDATION_GAS_OFFSET =
@@ -161,4 +162,7 @@ abstract contract BasePaymasterV1 is IPaymaster, OwnableUpgradeable {
     function _requireFromEntryPoint() internal virtual {
         require(msg.sender == address(entryPoint), "Sender not EntryPoint");
     }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -7,12 +7,7 @@ import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract DecentPaymasterV1 is
-    IDecentPaymasterV1,
-    IVersion,
-    BasePaymasterV1,
-    ERC165
-{
+contract DecentPaymasterV1 is IDecentPaymasterV1, BasePaymasterV1, ERC165 {
     // Mapping: strategy address => function selector => is approved
     mapping(address => mapping(bytes4 => bool)) public approvedFunctions;
 
@@ -116,7 +111,7 @@ contract DecentPaymasterV1 is
     }
 
     /// @inheritdoc IVersion
-    function getVersion() public pure override returns (uint16) {
+    function getVersion() public pure virtual override returns (uint16) {
         return 1;
     }
 }

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -2,12 +2,14 @@
 pragma solidity ^0.8.28;
 
 import {IHatsElectionsEligibility} from "../../interfaces/hats/modules/IHatsElectionsEligibility.sol";
+import {IDecentAutonomousAdminV1} from "../../interfaces/decent/deployables/IDecentAutonomousAdminV1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {IDecentAutonomousAdminV1} from "../../interfaces/decent/deployables/IDecentAutonomousAdminV1.sol";
 
 contract DecentAutonomousAdminV1 is
     IDecentAutonomousAdminV1,
+    IVersion,
     ERC165,
     FactoryFriendly
 {
@@ -41,5 +43,10 @@ contract DecentAutonomousAdminV1 is
         return
             interfaceId == type(IDecentAutonomousAdminV1).interfaceId ||
             super.supportsInterface(interfaceId);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16) {
+        return 1;
     }
 }

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {NoncesUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/NoncesUpgradeable.sol";
@@ -11,6 +12,7 @@ import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/
  * An implementation of the OpenZeppelin `IVotes` voting token standard.
  */
 contract VotesERC20V1 is
+    IVersion,
     ERC20VotesUpgradeable,
     ERC20PermitUpgradeable,
     FactoryFriendly
@@ -70,5 +72,10 @@ contract VotesERC20V1 is
         returns (uint256)
     {
         return super.nonces(owner);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16) {
+        return 1;
     }
 }

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
@@ -13,7 +14,7 @@ import {BaseGuard} from "@gnosis-guild/zodiac/contracts/guard/BaseGuard.sol";
  *
  * See https://docs.safe.global/learn/safe-core/safe-core-protocol/guards.
  */
-contract AzoriusFreezeGuardV1 is FactoryFriendly, IGuard, BaseGuard {
+contract AzoriusFreezeGuardV1 is IVersion, FactoryFriendly, IGuard, BaseGuard {
     /**
      * A reference to the freeze voting contract, which manages the freeze
      * voting process and maintains the frozen / unfrozen state of the DAO.
@@ -83,5 +84,10 @@ contract AzoriusFreezeGuardV1 is FactoryFriendly, IGuard, BaseGuard {
         bool
     ) external view override(BaseGuard, IGuard) {
         // not implementated
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16) {
+        return 1;
     }
 }

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IMultisigFreezeGuardV1} from "../../interfaces/decent/deployables/IMultisigFreezeGuardV1.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
@@ -13,6 +14,7 @@ import {BaseGuard} from "@gnosis-guild/zodiac/contracts/guard/BaseGuard.sol";
  * Implementation of [IMultisigFreezeGuard](./interfaces/IMultisigFreezeGuard.md).
  */
 contract MultisigFreezeGuardV1 is
+    IVersion,
     FactoryFriendly,
     IGuard,
     IMultisigFreezeGuardV1,
@@ -214,5 +216,10 @@ contract MultisigFreezeGuardV1 is
     function _updateExecutionPeriod(uint32 _executionPeriod) internal {
         executionPeriod = _executionPeriod;
         emit ExecutionPeriodUpdated(_executionPeriod);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16) {
+        return 1;
     }
 }

--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 
@@ -21,7 +22,11 @@ import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFree
  * Following a successful freeze vote, the childDAO will be unable to execute transactions, due to
  * a Safe Transaction Guard, until the `freezePeriod` has elapsed.
  */
-abstract contract BaseFreezeVotingV1 is FactoryFriendly, IBaseFreezeVotingV1 {
+abstract contract BaseFreezeVotingV1 is
+    IVersion,
+    FactoryFriendly,
+    IBaseFreezeVotingV1
+{
     /** Block number the freeze proposal was created at. */
     uint32 public freezeProposalCreatedBlock;
 
@@ -136,4 +141,7 @@ abstract contract BaseFreezeVotingV1 is FactoryFriendly, IBaseFreezeVotingV1 {
         freezePeriod = _freezePeriod;
         emit FreezePeriodUpdated(_freezePeriod);
     }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
@@ -88,5 +89,10 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1 {
         userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock] = true;
 
         emit FreezeVoteCast(msg.sender, userVotes);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual override returns (uint16) {
+        return 1;
     }
 }

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -113,5 +114,10 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1 {
         }
 
         return votes;
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual override returns (uint16) {
+        return 1;
     }
 }

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 
@@ -70,5 +71,10 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1 {
         userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock] = true;
 
         emit FreezeVoteCast(msg.sender, 1);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual override returns (uint16) {
+        return 1;
     }
 }

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
 import {IAzoriusV1, Enum} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
@@ -15,7 +16,7 @@ import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModu
  * All voting details are delegated to [BaseStrategy](./BaseStrategy.md) implementations, of which an Azorius DAO can
  * have any number.
  */
-contract AzoriusV1 is IAzoriusV1, GuardableModule {
+contract AzoriusV1 is IVersion, IAzoriusV1, GuardableModule {
     /**
      * The sentinel node of the linked list of enabled [BaseStrategies](./BaseStrategy.md).
      *
@@ -459,5 +460,10 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule {
     function _updateExecutionPeriod(uint32 _executionPeriod) internal {
         executionPeriod = _executionPeriod;
         emit ExecutionPeriodUpdated(_executionPeriod);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual override returns (uint16) {
+        return 1;
     }
 }

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IFractalModuleV1} from "../../interfaces/decent/deployables/IFractalModuleV1.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 
@@ -13,7 +14,7 @@ import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/Guardab
  * transactions on the Safe, which in our implementation is the set of parent
  * DAOs.
  */
-contract FractalModuleV1 is IFractalModuleV1, GuardableModule {
+contract FractalModuleV1 is IVersion, IFractalModuleV1, GuardableModule {
     /** Mapping of whether an address is a controller (typically a parentDAO). */
     mapping(address => bool) public controllers;
 
@@ -93,5 +94,10 @@ contract FractalModuleV1 is IFractalModuleV1, GuardableModule {
             }
         }
         emit ControllersAdded(_controllers);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual override returns (uint16) {
+        return 1;
     }
 }

--- a/contracts/deployables/strategies/BaseQuorumPercentV1.sol
+++ b/contracts/deployables/strategies/BaseQuorumPercentV1.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /**
  * An Azorius extension contract that enables percent based quorums.
  * Intended to be implemented by [BaseStrategy](./BaseStrategy.md) implementations.
  */
-abstract contract BaseQuorumPercentV1 is OwnableUpgradeable {
+abstract contract BaseQuorumPercentV1 is IVersion, OwnableUpgradeable {
     /** The numerator to use when calculating quorum (adjustable). */
     uint256 public quorumNumerator;
 
@@ -68,4 +69,7 @@ abstract contract BaseQuorumPercentV1 is OwnableUpgradeable {
     function quorumVotes(
         uint32 _proposalId
     ) public view virtual returns (uint256);
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/strategies/BaseStrategyV1.sol
+++ b/contracts/deployables/strategies/BaseStrategyV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IAzoriusV1} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
@@ -10,6 +11,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
  * The base abstract contract for all voting strategies in Azorius.
  */
 abstract contract BaseStrategyV1 is
+    IVersion,
     OwnableUpgradeable,
     FactoryFriendly,
     IBaseStrategyV1
@@ -63,4 +65,7 @@ abstract contract BaseStrategyV1 is
         azoriusModule = IAzoriusV1(_azoriusModule);
         emit AzoriusSet(_azoriusModule);
     }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/strategies/BaseVotingBasisPercentV1.sol
+++ b/contracts/deployables/strategies/BaseVotingBasisPercentV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /**
@@ -12,7 +13,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
  * See https://en.wikipedia.org/wiki/Voting#Voting_basis.
  * See https://en.wikipedia.org/wiki/Supermajority.
  */
-abstract contract BaseVotingBasisPercentV1 is OwnableUpgradeable {
+abstract contract BaseVotingBasisPercentV1 is IVersion, OwnableUpgradeable {
     /** The numerator to use when calculating basis (adjustable). */
     uint256 public basisNumerator;
 
@@ -61,4 +62,7 @@ abstract contract BaseVotingBasisPercentV1 is OwnableUpgradeable {
             _yesVotes >
             ((_yesVotes + _noVotes) * basisNumerator) / BASIS_DENOMINATOR;
     }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IOwnershipV1} from "../../interfaces/decent/deployables/IOwnershipV1.sol";
 
-abstract contract ERC4337VoterSupportV1 {
+abstract contract ERC4337VoterSupportV1 is IVersion {
     /**
      * Returns the address of the voter which owns the voting weight
      * @param _msgSender address of the sender. It can be the wallet address, or the smart account address with EOA as owner
@@ -30,4 +31,7 @@ abstract contract ERC4337VoterSupportV1 {
             return _msgSender;
         }
     }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
+++ b/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IHats} from "../../interfaces/hats/IHats.sol";
 
-abstract contract HatsProposalCreationWhitelistV1 is OwnableUpgradeable {
+abstract contract HatsProposalCreationWhitelistV1 is
+    IVersion,
+    OwnableUpgradeable
+{
     event HatWhitelisted(uint256 hatId);
     event HatRemovedFromWhitelist(uint256 hatId);
 
@@ -102,4 +106,7 @@ abstract contract HatsProposalCreationWhitelistV1 is OwnableUpgradeable {
     function getWhitelistedHatIds() public view returns (uint256[] memory) {
         return whitelistedHatIds;
     }
+
+    /// @inheritdoc IVersion
+    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {BaseStrategyV1} from "./BaseStrategyV1.sol";
 import {BaseQuorumPercentV1} from "./BaseQuorumPercentV1.sol";
 import {BaseVotingBasisPercentV1} from "./BaseVotingBasisPercentV1.sol";
@@ -325,5 +326,21 @@ contract LinearERC20VotingV1 is
         return
             (quorumNumerator * getProposalVotingSupply(_proposalId)) /
             QUORUM_DENOMINATOR;
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion()
+        external
+        pure
+        virtual
+        override(
+            BaseQuorumPercentV1,
+            BaseStrategyV1,
+            BaseVotingBasisPercentV1,
+            ERC4337VoterSupportV1
+        )
+        returns (uint16)
+    {
+        return 1;
     }
 }

--- a/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {LinearERC20VotingV1} from "./LinearERC20VotingV1.sol";
 import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1.sol";
 import {IHats} from "../../interfaces/hats/IHats.sol";
@@ -75,5 +76,16 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
         returns (bool)
     {
         return HatsProposalCreationWhitelistV1.isProposer(_address);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion()
+        external
+        pure
+        virtual
+        override(HatsProposalCreationWhitelistV1, LinearERC20VotingV1)
+        returns (uint16)
+    {
+        return 1;
     }
 }

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
 import {BaseVotingBasisPercentV1} from "./BaseVotingBasisPercentV1.sol";
 import {IAzoriusV1} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
@@ -468,5 +469,20 @@ contract LinearERC721VotingV1 is
         }
 
         emit Voted(_voter, _proposalId, _voteType, _tokenAddresses, _tokenIds);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion()
+        external
+        pure
+        virtual
+        override(
+            BaseStrategyV1,
+            BaseVotingBasisPercentV1,
+            ERC4337VoterSupportV1
+        )
+        returns (uint16)
+    {
+        return 1;
     }
 }

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {LinearERC721VotingV1} from "./LinearERC721VotingV1.sol";
 import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1.sol";
 import {IHats} from "../../interfaces/hats/IHats.sol";
@@ -78,5 +79,16 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
         returns (bool)
     {
         return HatsProposalCreationWhitelistV1.isProposer(_address);
+    }
+
+    /// @inheritdoc IVersion
+    function getVersion()
+        external
+        pure
+        virtual
+        override(HatsProposalCreationWhitelistV1, LinearERC721VotingV1)
+        returns (uint16)
+    {
+        return 1;
     }
 }

--- a/contracts/mocks/MockERC4337VoterSupport.sol
+++ b/contracts/mocks/MockERC4337VoterSupport.sol
@@ -8,4 +8,8 @@ contract MockERC4337VoterSupport is ERC4337VoterSupportV1 {
     function voter(address _msgSender) external view returns (address) {
         return _voter(_msgSender);
     }
+
+    function getVersion() external pure override returns (uint16) {
+        return 1;
+    }
 }

--- a/contracts/mocks/MockHatsProposalCreationWhitelist.sol
+++ b/contracts/mocks/MockHatsProposalCreationWhitelist.sol
@@ -8,4 +8,8 @@ contract MockHatsProposalCreationWhitelist is HatsProposalCreationWhitelistV1 {
         __Ownable_init(msg.sender);
         super.setUp(initializeParams);
     }
+
+    function getVersion() external pure override returns (uint16) {
+        return 1;
+    }
 }

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -39,4 +39,8 @@ contract MockVotingStrategy is BaseStrategyV1 {
     function votingEndBlock(uint32) external pure override returns (uint32) {
         return 0;
     }
+
+    function getVersion() external pure override returns (uint16) {
+        return 1;
+    }
 }

--- a/test/deployables/Atomic-Deployment.test.ts
+++ b/test/deployables/Atomic-Deployment.test.ts
@@ -552,4 +552,35 @@ describe('Atomic Gnosis Safe Deployment', () => {
       expect(await gnosisSafe.getThreshold()).eq(threshold);
     });
   });
+
+  describe('Version', function () {
+    it('Fractal module should have a version', async function () {
+      const txs: MetaTransaction[] = [
+        await buildContractCall(
+          gnosisSafeProxyFactory,
+          'createProxyWithNonce',
+          [await gnosisSafeL2Singleton.getAddress(), createGnosisSetupCalldata, saltNum],
+          0,
+          false,
+        ),
+        await buildContractCall(
+          moduleProxyFactory,
+          'deployModule',
+          [await fractalModuleSingleton.getAddress(), setModuleCalldata, '10031021'],
+          0,
+          false,
+        ),
+      ];
+      const safeTx = encodeMultiSend(txs);
+      await multiSendCallOnly.multiSend(safeTx);
+
+      const version = await fractalModule.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Freeze guard should have a version', async function () {
+      const version = await freezeGuardImplementation.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/Azorius-LinearERC20Voting.test.ts
+++ b/test/deployables/Azorius-LinearERC20Voting.test.ts
@@ -1729,4 +1729,21 @@ describe('Safe with Azorius module and linearERC20Voting', () => {
       expect(await linearERC20Voting.isPassed(0)).to.eq(false);
     });
   });
+
+  describe('Version', function () {
+    it('Azorius module should have a version', async function () {
+      const version = await azorius.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Linear ERC20 voting should have a version', async function () {
+      const version = await linearERC20Voting.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Votes ERC20 should have a version', async function () {
+      const version = await votesERC20.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/Azorius-LinearERC20VotingWithHatsProposalCreation.test.ts
+++ b/test/deployables/Azorius-LinearERC20VotingWithHatsProposalCreation.test.ts
@@ -267,4 +267,21 @@ describe('LinearERC20VotingWithHatsProposalCreation', () => {
       'InvalidInitialization',
     );
   });
+
+  describe('Version', function () {
+    it('Azorius module should have a version', async function () {
+      const version = await azorius.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Linear ERC20 voting with hats should have a version', async function () {
+      const version = await linearERC20VotingWithHats.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Votes ERC20 should have a version', async function () {
+      const version = await votesERC20.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/Azorius-LinearERC721Voting.test.ts
+++ b/test/deployables/Azorius-LinearERC721Voting.test.ts
@@ -1035,4 +1035,16 @@ describe('Safe with Azorius module and linearERC721Voting', () => {
       expect(await linearERC721Voting.isPassed(0)).to.eq(false);
     });
   });
+
+  describe('Version', function () {
+    it('Azorius module should have a version', async function () {
+      const version = await azorius.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Linear ERC721 voting should have a version', async function () {
+      const version = await linearERC721Voting.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/Azorius-LinearERC721VotingWithHatsProposalCreation.test.ts
+++ b/test/deployables/Azorius-LinearERC721VotingWithHatsProposalCreation.test.ts
@@ -258,4 +258,16 @@ describe('LinearERC721VotingWithHatsProposalCreation', () => {
       'InvalidInitialization',
     );
   });
+
+  describe('Version', function () {
+    it('Azorius module should have a version', async function () {
+      const version = await azorius.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Linear ERC721 voting with hats should have a version', async function () {
+      const version = await linearERC721VotingWithHats.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/AzoriusFreezeGuard-ERC20FreezeVoting.test.ts
+++ b/test/deployables/AzoriusFreezeGuard-ERC20FreezeVoting.test.ts
@@ -1123,4 +1123,36 @@ describe('Azorius Child DAO with Azorius Parent', () => {
       freezeVoting.connect(childTokenHolder1).castFreezeVote(),
     ).to.be.revertedWithCustomError(freezeVoting, 'NoVotes()');
   });
+
+  describe('Version', function () {
+    it('Azorius module should have a version', async function () {
+      const version = await azoriusModule.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Linear ERC20 voting should have a version', async function () {
+      const version = await linearERC20Voting.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Freeze voting should have a version', async function () {
+      const version = await freezeVoting.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Freeze guard should have a version', async function () {
+      const version = await freezeGuard.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Parent votes ERC20 should have a version', async function () {
+      const version = await parentVotesERC20.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Child votes ERC20 should have a version', async function () {
+      const version = await childVotesERC20.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/AzoriusFreezeGuard-MultisigFreezeVoting.test.ts
+++ b/test/deployables/AzoriusFreezeGuard-MultisigFreezeVoting.test.ts
@@ -1122,4 +1122,31 @@ describe('Azorius Child DAO with Multisig parent', () => {
       expect(await freezeVoting.isFrozen()).to.eq(false);
     });
   });
+
+  describe('Version', function () {
+    it('Azorius module should have a version', async function () {
+      const version = await azoriusModule.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Linear ERC20 voting should have a version', async function () {
+      const version = await linearERC20Voting.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Freeze voting should have a version', async function () {
+      const version = await freezeVoting.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Freeze guard should have a version', async function () {
+      const version = await freezeGuard.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Child votes ERC20 should have a version', async function () {
+      const version = await childVotesERC20.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/ERC4337VoterSupport.test.ts
+++ b/test/deployables/ERC4337VoterSupport.test.ts
@@ -62,4 +62,11 @@ describe('ERC4337VoterSupport', () => {
       });
     });
   });
+
+  describe('Version', function () {
+    it('ERC4337 voter support should have a version', async function () {
+      const version = await erc4337VoterSupport.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/Fractal-Module.test.ts
+++ b/test/deployables/Fractal-Module.test.ts
@@ -329,4 +329,35 @@ describe('Fractal Module Tests', () => {
       expect(await votesERC20.balanceOf(owner1.address)).to.eq(1000);
     });
   });
+
+  describe('Version', function () {
+    it('Fractal module should have a version', async function () {
+      const txs: MetaTransaction[] = [
+        await buildContractCall(
+          gnosisSafeProxyFactory,
+          'createProxyWithNonce',
+          [await gnosisSafeL2Singleton.getAddress(), createGnosisSetupCalldata, saltNum],
+          0,
+          false,
+        ),
+        await buildContractCall(
+          moduleProxyFactory,
+          'deployModule',
+          [await moduleImpl.getAddress(), setModuleCalldata, '10031021'],
+          0,
+          false,
+        ),
+      ];
+      const safeTx = encodeMultiSend(txs);
+      await multiSendCallOnly.multiSend(safeTx);
+
+      const version = await fractalModule.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Freeze guard should have a version', async function () {
+      const version = await freezeGuard.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/HatsProposalCreationWhitelist.test.ts
+++ b/test/deployables/HatsProposalCreationWhitelist.test.ts
@@ -183,4 +183,11 @@ describe('HatsProposalCreationWhitelist', () => {
       (await mockHatsProposalCreationWhitelist.getWhitelistedHatIds()).includes(proposerHatId),
     ).to.equal(false);
   });
+
+  describe('Version', function () {
+    it('Hats proposal creation whitelist should have a version', async function () {
+      const version = await mockHatsProposalCreationWhitelist.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/MultisigFreezeGuard-ERC20FreezeVoting.test.ts
+++ b/test/deployables/MultisigFreezeGuard-ERC20FreezeVoting.test.ts
@@ -757,4 +757,21 @@ describe('Child Multisig DAO with Azorius Parent', () => {
       ).to.be.revertedWithCustomError(freezeGuard, 'OwnableUnauthorizedAccount');
     });
   });
+
+  describe('Version', function () {
+    it('Freeze guard should have a version', async function () {
+      const version = await freezeGuard.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Freeze voting should have a version', async function () {
+      const version = await freezeVoting.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Votes ERC20 should have a version', async function () {
+      const version = await votesERC20.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/MultisigFreezeGuard-ERC721FreezeVoting.test.ts
+++ b/test/deployables/MultisigFreezeGuard-ERC721FreezeVoting.test.ts
@@ -821,4 +821,26 @@ describe('Child Multisig DAO with Azorius Parent', () => {
       ).to.be.revertedWithCustomError(freezeGuard, 'OwnableUnauthorizedAccount');
     });
   });
+
+  describe('Version', function () {
+    it('Freeze guard should have a version', async function () {
+      const version = await freezeGuard.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Freeze voting should have a version', async function () {
+      const version = await freezeVoting.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Votes ERC721 should have a version', async function () {
+      const version = await linearERC721Voting.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Azorius module should have a version', async function () {
+      const version = await azorius.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/MultisigFreezeGuard-MultisigFreezeVoting.test.ts
+++ b/test/deployables/MultisigFreezeGuard-MultisigFreezeVoting.test.ts
@@ -1177,4 +1177,21 @@ describe('Child Multisig DAO with Multisig Parent', () => {
       ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
     });
   });
+
+  describe('Version', function () {
+    it('Freeze guard should have a version', async function () {
+      const version = await freezeGuard.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Freeze voting should have a version', async function () {
+      const version = await freezeVoting.getVersion();
+      void expect(version).to.equal(1);
+    });
+
+    it('Votes ERC20 should have a version', async function () {
+      const version = await votesERC20.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -443,4 +443,11 @@ describe('DecentPaymasterV1', function () {
       void expect(supported).to.be.false;
     });
   });
+
+  describe('Version', function () {
+    it('Should have a version', async function () {
+      const version = await decentPaymaster.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });

--- a/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
+++ b/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
@@ -169,4 +169,11 @@ describe('DecentAutonomousAdminHatV1', function () {
       });
     });
   });
+
+  describe('Version', function () {
+    it('Should have a version', async function () {
+      const version = await decentAutonomousAdminInstance.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
"Deployable" contracts are those that are the class of contracts that are instantiated once per DAO and are long lived and hold state.

We don't need IVersion support for:
- singletons (for obvious reasons -- we can never really touch these)
- utilities (these can be updated and redeployed on the fly, they are ephemeral and only used to implement logic that must run on-chain in the middle of a transaction, and don't hold state. the frontend will never need to know about multiple implementations/interfaces for these.)