### PR TITLE
License cleanup

### DIFF
--- a/contracts/deployables/account-abstraction/BasePaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/BasePaymasterV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {BasePaymasterV1, IEntryPoint} from "./BasePaymasterV1.sol";

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IHatsElectionsEligibility} from "../../interfaces/hats/modules/IHatsElectionsEligibility.sol";

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/strategies/BaseQuorumPercentV1.sol
+++ b/contracts/deployables/strategies/BaseQuorumPercentV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/strategies/BaseStrategyV1.sol
+++ b/contracts/deployables/strategies/BaseStrategyV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/strategies/BaseVotingBasisPercentV1.sol
+++ b/contracts/deployables/strategies/BaseVotingBasisPercentV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
+++ b/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";

--- a/contracts/interfaces/decent/deployables/IAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IAzoriusV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";

--- a/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";

--- a/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 /**

--- a/contracts/interfaces/decent/deployables/IDecentAutonomousAdminV1.sol
+++ b/contracts/interfaces/decent/deployables/IDecentAutonomousAdminV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IHats} from "../../hats/IHats.sol";

--- a/contracts/interfaces/decent/deployables/IDecentPaymasterV1.sol
+++ b/contracts/interfaces/decent/deployables/IDecentPaymasterV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 interface IDecentPaymasterV1 {

--- a/contracts/interfaces/decent/deployables/IERC721VotingStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC721VotingStrategyV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 /**

--- a/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
+++ b/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";

--- a/contracts/interfaces/decent/deployables/IMultisigFreezeGuardV1.sol
+++ b/contracts/interfaces/decent/deployables/IMultisigFreezeGuardV1.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";

--- a/contracts/interfaces/decent/deployables/IOwnershipV1.sol
+++ b/contracts/interfaces/decent/deployables/IOwnershipV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 /**

--- a/contracts/interfaces/decent/deployables/IVersion.sol
+++ b/contracts/interfaces/decent/deployables/IVersion.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 /**

--- a/contracts/interfaces/decent/singletons/IKeyValuePairs.sol
+++ b/contracts/interfaces/decent/singletons/IKeyValuePairs.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 /**

--- a/contracts/interfaces/erc6551/IERC6551Registry.sol
+++ b/contracts/interfaces/erc6551/IERC6551Registry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 interface IERC6551Registry {

--- a/contracts/interfaces/hats/IHatsModuleFactory.sol
+++ b/contracts/interfaces/hats/IHatsModuleFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.19;
 
 interface IHatsModuleFactory {

--- a/contracts/interfaces/hats/modules/IHatsElectionsEligibility.sol
+++ b/contracts/interfaces/hats/modules/IHatsElectionsEligibility.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity >=0.8.13;
 
 interface IHatsElectionsEligibility {

--- a/contracts/interfaces/sablier/IERC4096.sol
+++ b/contracts/interfaces/sablier/IERC4096.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 // OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC4906.sol)
 
 pragma solidity ^0.8.28;

--- a/contracts/interfaces/safe/ISafe.sol
+++ b/contracts/interfaces/safe/ISafe.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";

--- a/contracts/mocks/ERC6551Registry.sol
+++ b/contracts/mocks/ERC6551Registry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 interface IERC6551Registry {

--- a/contracts/mocks/MockContract.sol
+++ b/contracts/mocks/MockContract.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 /**

--- a/contracts/mocks/MockDecentHatsUtils.sol
+++ b/contracts/mocks/MockDecentHatsUtils.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {DecentHatsModuleUtils} from "../utilities/DecentHatsModuleUtils.sol";

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/mocks/MockERC4337VoterSupport.sol
+++ b/contracts/mocks/MockERC4337VoterSupport.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {ERC4337VoterSupportV1} from "../deployables/strategies/ERC4337VoterSupportV1.sol";

--- a/contracts/mocks/MockERC721.sol
+++ b/contracts/mocks/MockERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/contracts/mocks/MockEntryPoint.sol
+++ b/contracts/mocks/MockEntryPoint.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";

--- a/contracts/mocks/MockHats.sol
+++ b/contracts/mocks/MockHats.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IHats} from "../interfaces/hats/IHats.sol";

--- a/contracts/mocks/MockHatsAccount.sol
+++ b/contracts/mocks/MockHatsAccount.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 contract MockHatsAccount {

--- a/contracts/mocks/MockHatsElectionsEligibility.sol
+++ b/contracts/mocks/MockHatsElectionsEligibility.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IHatsElectionsEligibility} from "../interfaces/hats/modules/IHatsElectionsEligibility.sol";

--- a/contracts/mocks/MockHatsModuleFactory.sol
+++ b/contracts/mocks/MockHatsModuleFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IHatsModuleFactory} from "../interfaces/hats/IHatsModuleFactory.sol";

--- a/contracts/mocks/MockHatsProposalCreationWhitelist.sol
+++ b/contracts/mocks/MockHatsProposalCreationWhitelist.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import "../deployables/strategies/HatsProposalCreationWhitelistV1.sol";

--- a/contracts/mocks/MockLockupLinear.sol
+++ b/contracts/mocks/MockLockupLinear.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/mocks/MockNonOwnership.sol
+++ b/contracts/mocks/MockNonOwnership.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 contract MockNonOwnership {

--- a/contracts/mocks/MockSablierV2LockupLinear.sol
+++ b/contracts/mocks/MockSablierV2LockupLinear.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/mocks/MockSmartAccount.sol
+++ b/contracts/mocks/MockSmartAccount.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IOwnershipV1} from "../interfaces/decent/deployables/IOwnershipV1.sol";

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {BaseStrategyV1} from "../deployables/strategies/BaseStrategyV1.sol";

--- a/contracts/singletons/KeyValuePairs.sol
+++ b/contracts/singletons/KeyValuePairs.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IKeyValuePairs} from "../interfaces/decent/singletons/IKeyValuePairs.sol";

--- a/contracts/utilities/DecentHatsCreationModule.sol
+++ b/contracts/utilities/DecentHatsCreationModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {DecentHatsModuleUtils} from "./DecentHatsModuleUtils.sol";

--- a/contracts/utilities/DecentHatsModificationModule.sol
+++ b/contracts/utilities/DecentHatsModificationModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {DecentHatsModuleUtils} from "./DecentHatsModuleUtils.sol";

--- a/contracts/utilities/DecentHatsModuleUtils.sol
+++ b/contracts/utilities/DecentHatsModuleUtils.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {IERC6551Registry} from "../interfaces/erc6551/IERC6551Registry.sol";

--- a/contracts/utilities/DecentSablierStreamManagementModule.sol
+++ b/contracts/utilities/DecentSablierStreamManagementModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";


### PR DESCRIPTION
- Modify all contracts to use `// SPDX-License-Identifier: AGPL-3.0`
  - AGPL-3.0 was originally used in some of the Hats interfaces (directly copy/pasted into this project), and is pretty restrictive, so if we want to utilize this code in our codebase we need to at least match it.
  - Technically we can make _only_ the contracts which inherit from Hats be this AGPL-3.0 license, and then use a less restrictive one for other contracts, but in the spirit of consistency why not just make em all the same yanno.
- Doesn't touch some of the Sablier interfaces (which were straight copy/pasted into this project), which have a `// SPDX-License-Identifier: GPL-3.0-or-later` identifier, and is compatible with AGPL-3.0
