### PR TITLE
Use interface in contract

### DIFF
--- a/contracts/interfaces/zodiac/IModuleProxyFactory.sol
+++ b/contracts/interfaces/zodiac/IModuleProxyFactory.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+interface IModuleProxyFactory {
+    event ModuleProxyCreation(
+        address indexed proxy,
+        address indexed masterCopy
+    );
+
+    /// `target` can not be zero.
+    error ZeroAddress(address target);
+
+    /// `target` has no code deployed.
+    error TargetHasNoCode(address target);
+
+    /// `address_` is already taken.
+    error TakenAddress(address address_);
+
+    /// @notice Initialization failed.
+    error FailedInitialization();
+
+    function deployModule(
+        address masterCopy,
+        bytes memory initializer,
+        uint256 saltNonce
+    ) external returns (address proxy);
+}

--- a/contracts/utilities/DecentHatsCreationModule.sol
+++ b/contracts/utilities/DecentHatsCreationModule.sol
@@ -7,7 +7,7 @@ import {IHats} from "../interfaces/hats/IHats.sol";
 import {IHatsModuleFactory} from "../interfaces/hats/IHatsModuleFactory.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IAvatar} from "@gnosis-guild/zodiac/contracts/interfaces/IAvatar.sol";
-import {ModuleProxyFactory} from "@gnosis-guild/zodiac/contracts/factory/ModuleProxyFactory.sol";
+import {IModuleProxyFactory} from "../interfaces/zodiac/IModuleProxyFactory.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 contract DecentHatsCreationModule is DecentHatsModuleUtils {
@@ -26,7 +26,7 @@ contract DecentHatsCreationModule is DecentHatsModuleUtils {
         IHats hatsProtocol;
         IERC6551Registry erc6551Registry;
         IHatsModuleFactory hatsModuleFactory;
-        ModuleProxyFactory moduleProxyFactory;
+        IModuleProxyFactory moduleProxyFactory;
         address keyValuePairs;
         address decentAutonomousAdminImplementation;
         address hatsAccountImplementation;
@@ -164,7 +164,7 @@ contract DecentHatsCreationModule is DecentHatsModuleUtils {
         address hatsAccountImplementation,
         uint256 topHatId,
         address topHatAccount,
-        ModuleProxyFactory moduleProxyFactory,
+        IModuleProxyFactory moduleProxyFactory,
         address decentAutonomousAdminImplementation,
         AdminHatParams calldata adminHat
     ) internal returns (uint256 adminHatId) {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -29,6 +29,7 @@ const config: HardhatUserConfig = {
       '@gnosis.pm/safe-contracts/contracts/libraries/MultiSendCallOnly.sol',
       '@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol',
       '@gnosis.pm/safe-contracts/contracts/GnosisSafeL2.sol',
+      '@gnosis-guild/zodiac/contracts/factory/ModuleProxyFactory.sol',
     ],
   },
   namedAccounts: {


### PR DESCRIPTION
Noticed that the `DecentHatsCreationModule` contract didn't need the entire contract code of the `ModuleProxyFactory`, since it was only making calls over to an existing instance of it.

- Created an `IModuleProxyFactory` interface
- Use that interface in `DecentHatsCreationModule`

As a side effect, that reference to `ModuleProxyFactory` in `DecentHatsCreationModule` was the only place in our codebase where we referenced that contract, which forces the hardhat compiler to compile it.

In many of our tests, we use the ModuleProxyFactory, and expect those contract typechain files to be created during compilation.

So, this required me to explicitly declare that this contract _should be compiled_ despite none of our contract code relying on it (but our tests do, hence).

If you want to see for yourself, comment out line 32 in hardhat.config.ts and then `npm run clean` (to delete compiled artifacts), then `npm run compile` and `npm run test` and notice all the missing imports for ModuleProxyFactory.