### PR TITLE
Add ERC4337VoterSupportV1 test suite with mock contracts

### DIFF
--- a/contracts/mocks/MockOwnership.sol
+++ b/contracts/mocks/MockOwnership.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {IOwnershipV1} from "../interfaces/decent/deployables/IOwnershipV1.sol";
+
+/**
+ * A mock contract implementing IOwnershipV1 for testing purposes.
+ */
+contract MockOwnership is IOwnershipV1 {
+    address private _owner;
+
+    constructor(address initialOwner) {
+        _owner = initialOwner;
+    }
+
+    /**
+     * Returns the owner of this contract.
+     */
+    function owner() external view override returns (address) {
+        return _owner;
+    }
+
+    /**
+     * Updates the owner address for testing.
+     */
+    function setOwner(address newOwner) external {
+        _owner = newOwner;
+    }
+}

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteERC4337VoterSupportV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteERC4337VoterSupportV1.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {ERC4337VoterSupportV1} from "../../../../deployables/strategies/ERC4337VoterSupportV1.sol";
+
+/**
+ * A concrete implementation of ERC4337VoterSupportV1 for testing purposes.
+ */
+contract ConcreteERC4337VoterSupportV1 is ERC4337VoterSupportV1 {
+    /**
+     * A public function that exposes the _voter function for testing.
+     */
+    function voter(address msgSender) public view returns (address) {
+        return _voter(msgSender);
+    }
+
+    /**
+     * Implementation of the getVersion function.
+     */
+    function getVersion() external pure override returns (uint16) {
+        return 1;
+    }
+}

--- a/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
+++ b/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
@@ -1,0 +1,74 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteERC4337VoterSupportV1,
+  ConcreteERC4337VoterSupportV1__factory,
+  MockOwnership,
+  MockOwnership__factory,
+} from '../../../typechain-types';
+
+describe('ERC4337VoterSupportV1', () => {
+  // Signers
+  let deployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  // Contracts
+  let concreteERC4337VoterSupport: ConcreteERC4337VoterSupportV1;
+  let mockOwnership: MockOwnership;
+
+  beforeEach(async () => {
+    [deployer, owner, user] = await ethers.getSigners();
+
+    // Deploy the ERC4337VoterSupport concrete
+    concreteERC4337VoterSupport = await new ConcreteERC4337VoterSupportV1__factory(
+      deployer,
+    ).deploy();
+
+    // Deploy a mock ownership contract with the owner address
+    mockOwnership = await new MockOwnership__factory(deployer).deploy(owner.address);
+  });
+
+  describe('voter', () => {
+    describe('when the msgSender is a smart account', () => {
+      it('should return the owner of the smart account', async () => {
+        // Test with our mock ownership contract
+        const voter = await concreteERC4337VoterSupport.voter(await mockOwnership.getAddress());
+        expect(voter).to.equal(owner.address);
+      });
+
+      it('should return address(0) when smart account owner is zero address', async () => {
+        // Set the owner to the zero address
+        await mockOwnership.setOwner(ethers.ZeroAddress);
+
+        const voter = await concreteERC4337VoterSupport.voter(await mockOwnership.getAddress());
+        expect(voter).to.equal(ethers.ZeroAddress);
+      });
+    });
+
+    describe('when the msgSender is an EOA', () => {
+      it('should return the msgSender', async () => {
+        // For EOAs, the voter function should just return the address itself
+        const eoaAddress = user.address;
+        const voter = await concreteERC4337VoterSupport.voter(eoaAddress);
+        expect(voter).to.equal(eoaAddress);
+      });
+    });
+
+    describe('when the msgSender is a contract that does not implement IOwnership', () => {
+      it('should return the contract address', async () => {
+        // Use the ConcreteRC4337VoterSupport contract itself as a contract that doesn't implement IOwnership
+        const contractAddress = await concreteERC4337VoterSupport.getAddress();
+        const voter = await concreteERC4337VoterSupport.voter(contractAddress);
+        expect(voter).to.equal(contractAddress);
+      });
+    });
+  });
+
+  describe('Version', () => {
+    it('should return correct version', async () => {
+      expect(await concreteERC4337VoterSupport.getVersion()).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/172

Introduces comprehensive test coverage for the ERC4337VoterSupportV1 contract, including:
- Voter determination for smart accounts
- Voter resolution for EOAs and contracts
- Handling of ownership-based voter identification
- Version verification

The test suite uses MockERC4337VoterSupportV1 and MockOwnership contracts to thoroughly test the ERC4337 voter support strategy's functionality.