### PR TITLE
Add ERC165 support across multiple contracts

### DIFF
--- a/contracts/deployables/account-abstraction/BasePaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/BasePaymasterV1.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {UserOperationLib, PackedUserOperation} from "@account-abstraction/contracts/core/UserOperationLib.sol";
@@ -13,7 +12,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
  * provides helper methods for staking.
  * Validates that the postOp is called only by the entryPoint.
  */
-abstract contract BasePaymasterV1 is IPaymaster, IVersion, OwnableUpgradeable {
+abstract contract BasePaymasterV1 is IPaymaster, OwnableUpgradeable {
     IEntryPoint public entryPoint;
 
     uint256 internal constant PAYMASTER_VALIDATION_GAS_OFFSET =
@@ -162,7 +161,4 @@ abstract contract BasePaymasterV1 is IPaymaster, IVersion, OwnableUpgradeable {
     function _requireFromEntryPoint() internal virtual {
         require(msg.sender == address(entryPoint), "Sender not EntryPoint");
     }
-
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -7,7 +7,12 @@ import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract DecentPaymasterV1 is IDecentPaymasterV1, BasePaymasterV1, ERC165 {
+contract DecentPaymasterV1 is
+    IDecentPaymasterV1,
+    IVersion,
+    BasePaymasterV1,
+    ERC165
+{
     // Mapping: strategy address => function selector => is approved
     mapping(address => mapping(bytes4 => bool)) public approvedFunctions;
 
@@ -103,10 +108,11 @@ contract DecentPaymasterV1 is IDecentPaymasterV1, BasePaymasterV1, ERC165 {
     /// @inheritdoc ERC165
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IPaymaster).interfaceId ||
             interfaceId == type(IDecentPaymasterV1).interfaceId ||
+            interfaceId == type(IPaymaster).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
+import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {NoncesUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/NoncesUpgradeable.sol";
 import {ERC20VotesUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
@@ -15,7 +19,8 @@ contract VotesERC20V1 is
     IVersion,
     ERC20VotesUpgradeable,
     ERC20PermitUpgradeable,
-    FactoryFriendly
+    FactoryFriendly,
+    ERC165
 {
     constructor() {
         _disableInitializers();
@@ -72,6 +77,18 @@ contract VotesERC20V1 is
         returns (uint256)
     {
         return super.nonces(owner);
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IVersion).interfaceId ||
+            interfaceId == type(IERC20).interfaceId ||
+            interfaceId == type(IERC20Permit).interfaceId ||
+            interfaceId == type(IVotes).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /// @inheritdoc IVersion

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
+import {BaseGuardV1} from "./BaseGuardV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
-import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
-import {BaseGuard} from "@gnosis-guild/zodiac/contracts/guard/BaseGuard.sol";
 
 /**
  * A Safe Transaction Guard contract that prevents an [Azorius](./azorius/Azorius.md)
@@ -14,7 +13,7 @@ import {BaseGuard} from "@gnosis-guild/zodiac/contracts/guard/BaseGuard.sol";
  *
  * See https://docs.safe.global/learn/safe-core/safe-core-protocol/guards.
  */
-contract AzoriusFreezeGuardV1 is IVersion, FactoryFriendly, IGuard, BaseGuard {
+contract AzoriusFreezeGuardV1 is IVersion, BaseGuardV1, FactoryFriendly {
     /**
      * A reference to the freeze voting contract, which manages the freeze
      * voting process and maintains the frozen / unfrozen state of the DAO.
@@ -69,7 +68,7 @@ contract AzoriusFreezeGuardV1 is IVersion, FactoryFriendly, IGuard, BaseGuard {
         address payable,
         bytes memory,
         address
-    ) external view override(BaseGuard, IGuard) {
+    ) external view override(BaseGuardV1) {
         // if the DAO is currently frozen, revert
         // see BaseFreezeVoting for freeze voting details
         if (freezeVoting.isFrozen()) revert DAOFrozen();
@@ -82,12 +81,20 @@ contract AzoriusFreezeGuardV1 is IVersion, FactoryFriendly, IGuard, BaseGuard {
     function checkAfterExecution(
         bytes32,
         bool
-    ) external view override(BaseGuard, IGuard) {
+    ) external view override(BaseGuardV1) {
         // not implementated
     }
 
     /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16) {
+    function getVersion() external pure virtual override returns (uint16) {
         return 1;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-guard/BaseGuardV1.sol
+++ b/contracts/deployables/freeze-guard/BaseGuardV1.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+abstract contract BaseGuardV1 is IGuard, ERC165 {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IGuard).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Module transactions only use the first four parameters: to, value, data, and operation.
+    /// Module.sol hardcodes the remaining parameters as 0 since they are not used for module transactions.
+    /// @notice This interface is used to maintain compatibilty with Gnosis Safe transaction guards.
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures,
+        address msgSender
+    ) external virtual;
+
+    function checkAfterExecution(bytes32 txHash, bool success) external virtual;
+}

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -1,24 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
+import {BaseGuardV1} from "./BaseGuardV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IMultisigFreezeGuardV1} from "../../interfaces/decent/deployables/IMultisigFreezeGuardV1.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
-import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
-import {BaseGuard} from "@gnosis-guild/zodiac/contracts/guard/BaseGuard.sol";
 
 /**
  * Implementation of [IMultisigFreezeGuard](./interfaces/IMultisigFreezeGuard.md).
  */
 contract MultisigFreezeGuardV1 is
-    IVersion,
-    FactoryFriendly,
-    IGuard,
     IMultisigFreezeGuardV1,
-    BaseGuard
+    IVersion,
+    BaseGuardV1,
+    FactoryFriendly
 {
     /** Timelock period (in blocks). */
     uint32 public timelockPeriod;
@@ -167,7 +165,7 @@ contract MultisigFreezeGuardV1 is
         address payable,
         bytes memory signatures,
         address
-    ) external view override(BaseGuard, IGuard) {
+    ) external view override(BaseGuardV1) {
         bytes32 signaturesHash = keccak256(signatures);
 
         if (transactionTimelockedBlock[signaturesHash] == 0)
@@ -195,7 +193,7 @@ contract MultisigFreezeGuardV1 is
     function checkAfterExecution(
         bytes32,
         bool
-    ) external view override(BaseGuard, IGuard) {
+    ) external view override(BaseGuardV1) {
         // not implementated
     }
 
@@ -219,7 +217,16 @@ contract MultisigFreezeGuardV1 is
     }
 
     /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16) {
+    function getVersion() external pure virtual override returns (uint16) {
         return 1;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IMultisigFreezeGuardV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -2,8 +2,9 @@
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
-import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
+import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
  * The base abstract contract which holds the state of a vote to freeze a childDAO.
@@ -25,7 +26,8 @@ import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFree
 abstract contract BaseFreezeVotingV1 is
     IVersion,
     FactoryFriendly,
-    IBaseFreezeVotingV1
+    IBaseFreezeVotingV1,
+    ERC165
 {
     /** Block number the freeze proposal was created at. */
     uint32 public freezeProposalCreatedBlock;
@@ -142,6 +144,16 @@ abstract contract BaseFreezeVotingV1 is
         emit FreezePeriodUpdated(_freezePeriod);
     }
 
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IBaseFreezeVotingV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
     /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16);
+    function getVersion() external pure virtual override returns (uint16);
 }

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -5,6 +5,7 @@ import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
 import {IAzoriusV1, Enum} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
  * A Safe module which allows for composable governance.
@@ -16,7 +17,7 @@ import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModu
  * All voting details are delegated to [BaseStrategy](./BaseStrategy.md) implementations, of which an Azorius DAO can
  * have any number.
  */
-contract AzoriusV1 is IVersion, IAzoriusV1, GuardableModule {
+contract AzoriusV1 is IVersion, IAzoriusV1, GuardableModule, ERC165 {
     /**
      * The sentinel node of the linked list of enabled [BaseStrategies](./BaseStrategy.md).
      *
@@ -465,5 +466,17 @@ contract AzoriusV1 is IVersion, IAzoriusV1, GuardableModule {
     /// @inheritdoc IVersion
     function getVersion() external pure virtual override returns (uint16) {
         return 1;
+    }
+
+    /**
+     * Implementation of ERC165 for this contract.
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IAzoriusV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IFractalModuleV1} from "../../interfaces/decent/deployables/IFractalModuleV1.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
  * Implementation of [IFractalModule](./interfaces/IFractalModule.md).
@@ -14,7 +15,12 @@ import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/Guardab
  * transactions on the Safe, which in our implementation is the set of parent
  * DAOs.
  */
-contract FractalModuleV1 is IVersion, IFractalModuleV1, GuardableModule {
+contract FractalModuleV1 is
+    IVersion,
+    IFractalModuleV1,
+    GuardableModule,
+    ERC165
+{
     /** Mapping of whether an address is a controller (typically a parentDAO). */
     mapping(address => bool) public controllers;
 
@@ -99,5 +105,17 @@ contract FractalModuleV1 is IVersion, IFractalModuleV1, GuardableModule {
     /// @inheritdoc IVersion
     function getVersion() external pure virtual override returns (uint16) {
         return 1;
+    }
+
+    /**
+     * Implementation of ERC165 for this contract.
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IFractalModuleV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/BaseQuorumPercentV1.sol
+++ b/contracts/deployables/strategies/BaseQuorumPercentV1.sol
@@ -2,23 +2,25 @@
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {IBaseQuorumPercentV1} from "../../interfaces/decent/deployables/IBaseQuorumPercentV1.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
  * An Azorius extension contract that enables percent based quorums.
  * Intended to be implemented by [BaseStrategy](./BaseStrategy.md) implementations.
  */
-abstract contract BaseQuorumPercentV1 is IVersion, OwnableUpgradeable {
+abstract contract BaseQuorumPercentV1 is
+    IBaseQuorumPercentV1,
+    IVersion,
+    OwnableUpgradeable,
+    ERC165
+{
     /** The numerator to use when calculating quorum (adjustable). */
     uint256 public quorumNumerator;
 
     /** The denominator to use when calculating quorum (1,000,000). */
     uint256 public constant QUORUM_DENOMINATOR = 1_000_000;
-
-    /** Ensures the numerator cannot be larger than the denominator. */
-    error InvalidQuorumNumerator();
-
-    event QuorumNumeratorUpdated(uint256 quorumNumerator);
 
     /**
      * Updates the quorum required for future Proposals.
@@ -72,4 +74,14 @@ abstract contract BaseQuorumPercentV1 is IVersion, OwnableUpgradeable {
 
     /// @inheritdoc IVersion
     function getVersion() external pure virtual returns (uint16);
+
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IBaseQuorumPercentV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/deployables/strategies/BaseStrategyV1.sol
+++ b/contracts/deployables/strategies/BaseStrategyV1.sol
@@ -5,16 +5,18 @@ import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IAzoriusV1} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /**
  * The base abstract contract for all voting strategies in Azorius.
  */
 abstract contract BaseStrategyV1 is
+    IBaseStrategyV1,
     IVersion,
     OwnableUpgradeable,
     FactoryFriendly,
-    IBaseStrategyV1
+    ERC165
 {
     event AzoriusSet(address indexed azoriusModule);
     event StrategySetUp(address indexed azoriusModule, address indexed owner);
@@ -66,6 +68,16 @@ abstract contract BaseStrategyV1 is
         emit AzoriusSet(_azoriusModule);
     }
 
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IBaseStrategyV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
     /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16);
+    function getVersion() external pure virtual override returns (uint16);
 }

--- a/contracts/deployables/strategies/BaseVotingBasisPercentV1.sol
+++ b/contracts/deployables/strategies/BaseVotingBasisPercentV1.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {IBaseVotingBasisPercentV1} from "../../interfaces/decent/deployables/IBaseVotingBasisPercentV1.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
  * An Azorius extension contract that enables percent based voting basis calculations.
@@ -13,16 +15,17 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
  * See https://en.wikipedia.org/wiki/Voting#Voting_basis.
  * See https://en.wikipedia.org/wiki/Supermajority.
  */
-abstract contract BaseVotingBasisPercentV1 is IVersion, OwnableUpgradeable {
+abstract contract BaseVotingBasisPercentV1 is
+    IBaseVotingBasisPercentV1,
+    IVersion,
+    OwnableUpgradeable,
+    ERC165
+{
     /** The numerator to use when calculating basis (adjustable). */
     uint256 public basisNumerator;
 
     /** The denominator to use when calculating basis (1,000,000). */
     uint256 public constant BASIS_DENOMINATOR = 1_000_000;
-
-    error InvalidBasisNumerator();
-
-    event BasisNumeratorUpdated(uint256 basisNumerator);
 
     /**
      * Updates the `basisNumerator` for future Proposals.
@@ -65,4 +68,16 @@ abstract contract BaseVotingBasisPercentV1 is IVersion, OwnableUpgradeable {
 
     /// @inheritdoc IVersion
     function getVersion() external pure virtual returns (uint16);
+
+    /**
+     * @inheritdoc ERC165
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IBaseVotingBasisPercentV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IOwnershipV1} from "../../interfaces/decent/deployables/IOwnershipV1.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-abstract contract ERC4337VoterSupportV1 is IVersion {
+abstract contract ERC4337VoterSupportV1 is IVersion, ERC165 {
     /**
      * Returns the address of the voter which owns the voting weight
      * @param _msgSender address of the sender. It can be the wallet address, or the smart account address with EOA as owner
@@ -30,6 +31,15 @@ abstract contract ERC4337VoterSupportV1 is IVersion {
         } catch {
             return _msgSender;
         }
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /// @inheritdoc IVersion

--- a/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
+++ b/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
@@ -2,25 +2,21 @@
 pragma solidity ^0.8.28;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {IHatsProposalCreationWhitelistV1} from "../../interfaces/decent/deployables/IHatsProposalCreationWhitelistV1.sol";
 import {IHats} from "../../interfaces/hats/IHats.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 abstract contract HatsProposalCreationWhitelistV1 is
+    IHatsProposalCreationWhitelistV1,
     IVersion,
-    OwnableUpgradeable
+    OwnableUpgradeable,
+    ERC165
 {
-    event HatWhitelisted(uint256 hatId);
-    event HatRemovedFromWhitelist(uint256 hatId);
-
     IHats public hatsContract;
 
     /** Array to store whitelisted Hat IDs. */
     uint256[] private whitelistedHatIds;
-
-    error InvalidHatsContract();
-    error NoHatsWhitelisted();
-    error HatAlreadyWhitelisted();
-    error HatNotWhitelisted();
 
     /**
      * Sets up the contract with its initial parameters.
@@ -105,6 +101,16 @@ abstract contract HatsProposalCreationWhitelistV1 is
      */
     function getWhitelistedHatIds() public view returns (uint256[] memory) {
         return whitelistedHatIds;
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IHatsProposalCreationWhitelistV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /// @inheritdoc IVersion

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -343,4 +343,21 @@ contract LinearERC20VotingV1 is
     {
         return 1;
     }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    )
+        public
+        view
+        virtual
+        override(
+            BaseQuorumPercentV1,
+            BaseStrategyV1,
+            BaseVotingBasisPercentV1,
+            ERC4337VoterSupportV1
+        )
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
@@ -87,4 +87,16 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
     {
         return 1;
     }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    )
+        public
+        view
+        virtual
+        override(HatsProposalCreationWhitelistV1, LinearERC20VotingV1)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -484,4 +484,22 @@ contract LinearERC721VotingV1 is
     {
         return 1;
     }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    )
+        public
+        view
+        virtual
+        override(
+            BaseStrategyV1,
+            BaseVotingBasisPercentV1,
+            ERC4337VoterSupportV1
+        )
+        returns (bool)
+    {
+        return
+            interfaceId == type(IERC721VotingStrategyV1).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -90,4 +90,16 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
     {
         return 1;
     }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    )
+        public
+        view
+        virtual
+        override(HatsProposalCreationWhitelistV1, LinearERC721VotingV1)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/interfaces/decent/deployables/IBaseQuorumPercentV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseQuorumPercentV1.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+/**
+ * @title IBaseQuorumPercentV1
+ * @dev Interface for BaseQuorumPercentV1 contract that enables percent based quorums.
+ * Intended to be implemented by BaseStrategy implementations.
+ */
+interface IBaseQuorumPercentV1 {
+    /**
+     * @dev Emitted when the quorum numerator is updated.
+     */
+    event QuorumNumeratorUpdated(uint256 quorumNumerator);
+
+    /**
+     * @dev Error thrown when the numerator exceeds the denominator.
+     */
+    error InvalidQuorumNumerator();
+
+    /**
+     * @dev Returns the current quorum numerator.
+     * @return The current quorum numerator.
+     */
+    function quorumNumerator() external view returns (uint256);
+
+    /**
+     * @dev Returns the quorum denominator, which is a constant (1,000,000).
+     * @return The quorum denominator.
+     */
+    function QUORUM_DENOMINATOR() external view returns (uint256);
+
+    /**
+     * @dev Updates the quorum required for future Proposals.
+     * @param _quorumNumerator numerator to use when calculating quorum (over 1,000,000)
+     */
+    function updateQuorumNumerator(uint256 _quorumNumerator) external;
+
+    /**
+     * @dev Calculates whether a vote meets quorum. This is calculated based on yes votes + abstain votes.
+     * @param _totalSupply the total supply of tokens
+     * @param _yesVotes number of votes in favor
+     * @param _abstainVotes number of votes abstaining
+     * @return Whether the total number of yes votes + abstain meets the quorum
+     */
+    function meetsQuorum(
+        uint256 _totalSupply,
+        uint256 _yesVotes,
+        uint256 _abstainVotes
+    ) external view returns (bool);
+
+    /**
+     * @dev Calculates the total number of votes required for a proposal to meet quorum.
+     * @param _proposalId The ID of the proposal to get quorum votes for
+     * @return The quantity of votes required to meet quorum
+     */
+    function quorumVotes(uint32 _proposalId) external view returns (uint256);
+}

--- a/contracts/interfaces/decent/deployables/IBaseVotingBasisPercentV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseVotingBasisPercentV1.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+/**
+ * @title IBaseVotingBasisPercentV1
+ * @dev Interface for BaseVotingBasisPercentV1 contract that enables percent based voting basis calculations.
+ *
+ * Intended to be implemented by BaseStrategy implementations, this allows for voting strategies
+ * to dictate any basis strategy for passing a Proposal between >50% (simple majority) to 100%.
+ *
+ * See https://en.wikipedia.org/wiki/Voting#Voting_basis.
+ * See https://en.wikipedia.org/wiki/Supermajority.
+ */
+interface IBaseVotingBasisPercentV1 {
+    /**
+     * @dev Emitted when the basis numerator is updated.
+     */
+    event BasisNumeratorUpdated(uint256 basisNumerator);
+
+    /**
+     * @dev Error thrown when the numerator is invalid (out of allowed range).
+     */
+    error InvalidBasisNumerator();
+
+    /**
+     * @dev Returns the current basis numerator.
+     * @return The current basis numerator.
+     */
+    function basisNumerator() external view returns (uint256);
+
+    /**
+     * @dev Returns the basis denominator, which is a constant (1,000,000).
+     * @return The basis denominator.
+     */
+    function BASIS_DENOMINATOR() external view returns (uint256);
+
+    /**
+     * @dev Updates the `basisNumerator` for future Proposals.
+     * @param _basisNumerator numerator to use
+     */
+    function updateBasisNumerator(uint256 _basisNumerator) external;
+
+    /**
+     * @dev Calculates whether a vote meets its basis.
+     * @param _yesVotes number of votes in favor
+     * @param _noVotes number of votes against
+     * @return Whether the yes votes meets the set basis
+     */
+    function meetsBasis(
+        uint256 _yesVotes,
+        uint256 _noVotes
+    ) external view returns (bool);
+}

--- a/contracts/interfaces/decent/deployables/IHatsProposalCreationWhitelistV1.sol
+++ b/contracts/interfaces/decent/deployables/IHatsProposalCreationWhitelistV1.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {IHats} from "../../hats/IHats.sol";
+
+/**
+ * @title IHatsProposalCreationWhitelistV1
+ * @dev Interface for HatsProposalCreationWhitelistV1 contract that manages proposal creation permissions
+ * based on Hats Protocol.
+ */
+interface IHatsProposalCreationWhitelistV1 {
+    /**
+     * @dev Emitted when a Hat is added to the whitelist.
+     */
+    event HatWhitelisted(uint256 hatId);
+
+    /**
+     * @dev Emitted when a Hat is removed from the whitelist.
+     */
+    event HatRemovedFromWhitelist(uint256 hatId);
+
+    /**
+     * @dev Error thrown when the Hats contract address is invalid.
+     */
+    error InvalidHatsContract();
+
+    /**
+     * @dev Error thrown when no Hats are whitelisted.
+     */
+    error NoHatsWhitelisted();
+
+    /**
+     * @dev Error thrown when attempting to whitelist a Hat that is already whitelisted.
+     */
+    error HatAlreadyWhitelisted();
+
+    /**
+     * @dev Error thrown when attempting to remove a Hat that is not whitelisted.
+     */
+    error HatNotWhitelisted();
+
+    /**
+     * @dev Returns the Hats contract.
+     * @return The Hats contract interface.
+     */
+    function hatsContract() external view returns (IHats);
+
+    /**
+     * @dev Adds a Hat to the whitelist for proposal creation.
+     * @param _hatId The ID of the Hat to whitelist
+     */
+    function whitelistHat(uint256 _hatId) external;
+
+    /**
+     * @dev Removes a Hat from the whitelist for proposal creation.
+     * @param _hatId The ID of the Hat to remove from the whitelist
+     */
+    function removeHatFromWhitelist(uint256 _hatId) external;
+
+    /**
+     * @dev Checks if an address is authorized to create proposals.
+     * @param _address The address to check for proposal creation authorization.
+     * @return Returns true if the address is wearing any of the whitelisted Hats, false otherwise.
+     */
+    function isProposer(address _address) external view returns (bool);
+
+    /**
+     * @dev Returns the IDs of all whitelisted Hats.
+     * @return An array of whitelisted Hat IDs.
+     */
+    function getWhitelistedHatIds() external view returns (uint256[] memory);
+}

--- a/contracts/mocks/concretes/deployables/freeze-guard/ConcreteBaseGuardV1.sol
+++ b/contracts/mocks/concretes/deployables/freeze-guard/ConcreteBaseGuardV1.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {BaseGuardV1} from "../../../../deployables/freeze-guard/BaseGuardV1.sol";
+import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+
+/**
+ * A concrete implementation of BaseGuardV1 for testing
+ */
+contract ConcreteBaseGuardV1 is BaseGuardV1 {
+    function checkTransaction(
+        address,
+        uint256,
+        bytes memory,
+        Enum.Operation,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        address payable,
+        bytes memory,
+        address
+    ) external view override {
+        // Mock implementation
+    }
+
+    function checkAfterExecution(bytes32, bool) external view override {
+        // Mock implementation
+    }
+}

--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -5,12 +5,14 @@ import {
   DecentPaymasterV1,
   DecentPaymasterV1__factory,
   IDecentPaymasterV1__factory,
+  IERC165__factory,
   IPaymaster__factory,
+  IVersion__factory,
   MockEntryPoint,
   MockEntryPoint__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 interface PackedUserOperation {
   sender: string;
@@ -404,39 +406,32 @@ describe('DecentPaymasterV1', function () {
   });
 
   describe('ERC165', function () {
+    // Interface IDs
     let iPaymasterInterfaceId: string;
     let iDecentPaymasterInterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
 
     beforeEach(async function () {
       // Calculate IPaymaster interface ID
       const IPaymasterInterface = IPaymaster__factory.createInterface();
-      const validatePaymasterUserOpSelector =
-        IPaymasterInterface.getFunction('validatePaymasterUserOp').selector;
-      const postOpSelector = IPaymasterInterface.getFunction('postOp').selector;
-      iPaymasterInterfaceId = ethers.hexlify(
-        ethers.toBeArray(BigInt(validatePaymasterUserOpSelector) ^ BigInt(postOpSelector)),
-      );
+      iPaymasterInterfaceId = calculateInterfaceId(IPaymasterInterface);
 
       // Calculate IDecentPaymaster interface ID
       const IDecentPaymasterInterface = IDecentPaymasterV1__factory.createInterface();
-      const setStrategyFunctionApprovalSelector = IDecentPaymasterInterface.getFunction(
-        'setStrategyFunctionApproval',
-      ).selector;
-      const isFunctionApprovedSelector =
-        IDecentPaymasterInterface.getFunction('isFunctionApproved').selector;
-      const setUpSelector = IDecentPaymasterInterface.getFunction('setUp').selector;
-      iDecentPaymasterInterfaceId = ethers.hexlify(
-        ethers.toBeArray(
-          BigInt(setStrategyFunctionApprovalSelector) ^
-            BigInt(isFunctionApprovedSelector) ^
-            BigInt(setUpSelector),
-        ),
-      );
+      iDecentPaymasterInterfaceId = calculateInterfaceId(IDecentPaymasterInterface);
+
+      // Calculate IVersion interface ID
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      // Calculate IERC165 interface ID
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
     });
 
     it('Should support IERC165 interface', async function () {
-      const IERC165InterfaceId = '0x01ffc9a7';
-      const supported = await decentPaymaster.supportsInterface(IERC165InterfaceId);
+      const supported = await decentPaymaster.supportsInterface(iERC165InterfaceId);
       void expect(supported).to.be.true;
     });
 
@@ -447,6 +442,11 @@ describe('DecentPaymasterV1', function () {
 
     it('Should support IDecentPaymaster interface', async function () {
       const supported = await decentPaymaster.supportsInterface(iDecentPaymasterInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await decentPaymaster.supportsInterface(iVersionInterfaceId);
       void expect(supported).to.be.true;
     });
 

--- a/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
+++ b/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
@@ -5,8 +5,10 @@ import {
   DecentAutonomousAdminV1,
   DecentAutonomousAdminV1__factory,
   IDecentAutonomousAdminV1__factory,
+  IERC165__factory,
   IVersion__factory,
 } from '../../../typechain-types';
+import { calculateInterfaceId } from '../../helpers/utils';
 
 describe('DecentAutonomousAdminV1', function () {
   // Signer accounts
@@ -23,44 +25,46 @@ describe('DecentAutonomousAdminV1', function () {
     decentAutonomousAdminInstance = await new DecentAutonomousAdminV1__factory(deployer).deploy();
   });
 
-  describe('supportsInterface', function () {
-    it('should support IDecentAutonomousAdminV1 interface', async function () {
-      // Get the interface ID from the factory
-      const decentAdminInterfaceId =
-        IDecentAutonomousAdminV1__factory.createInterface().getFunction(
-          'triggerStartNextTerm',
-        ).selector;
+  describe('ERC165', function () {
+    let iDecentAutonomousAdminV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
 
-      // Check if the contract supports this interface
-      const supports =
-        await decentAutonomousAdminInstance.supportsInterface(decentAdminInterfaceId);
-      void expect(supports).to.be.true;
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IDecentAutonomousAdminV1Interface = IDecentAutonomousAdminV1__factory.createInterface();
+      iDecentAutonomousAdminV1InterfaceId = calculateInterfaceId(IDecentAutonomousAdminV1Interface);
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
     });
 
-    it('should support IVersion interface', async function () {
-      // Get the interface ID from the factory
-      const versionInterfaceId =
-        IVersion__factory.createInterface().getFunction('getVersion').selector;
-
-      // Check if the contract supports this interface
-      const supports = await decentAutonomousAdminInstance.supportsInterface(versionInterfaceId);
-      void expect(supports).to.be.true;
+    it('Should support IERC165 interface', async function () {
+      const supported = await decentAutonomousAdminInstance.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
     });
 
-    it('should support ERC165 interface', async function () {
-      // ERC165 interface id is well-known
-      const erc165InterfaceId = '0x01ffc9a7';
+    it('Should support IDecentAutonomousAdminV1 interface', async function () {
+      const supported = await decentAutonomousAdminInstance.supportsInterface(
+        iDecentAutonomousAdminV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
 
-      const supports = await decentAutonomousAdminInstance.supportsInterface(erc165InterfaceId);
-      void expect(supports).to.be.true;
+    it('Should support IVersion interface', async function () {
+      const supported = await decentAutonomousAdminInstance.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
     });
 
     it('should not support random interface', async function () {
       // Random interface id
       const randomInterfaceId = '0x12345678';
 
-      const supports = await decentAutonomousAdminInstance.supportsInterface(randomInterfaceId);
-      void expect(supports).to.be.false;
+      const supported = await decentAutonomousAdminInstance.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 

--- a/test/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/deployables/erc20/VotesERC20V1.test.ts
@@ -1,9 +1,17 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { VotesERC20V1, VotesERC20V1__factory } from '../../../typechain-types';
+import {
+  IERC165__factory,
+  IERC20__factory,
+  IERC20Permit__factory,
+  IVersion__factory,
+  IVotes__factory,
+  VotesERC20V1,
+  VotesERC20V1__factory,
+} from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 // Helper function for deploying VotesERC20V1 instances
 async function deployVotesERC20Proxy(
@@ -155,6 +163,74 @@ describe('VotesERC20V1', () => {
 
     it('should return correct version', async () => {
       expect(await votesERC20.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    // Interface IDs
+    let iVersionInterfaceId: string;
+    let iERC20InterfaceId: string;
+    let iERC20PermitInterfaceId: string;
+    let iVotesInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Deploy VotesERC20 for this test section
+      votesERC20 = await deployVotesERC20Proxy(
+        votesERC20Mastercopy,
+        owner,
+        TOKEN_NAME,
+        TOKEN_SYMBOL,
+        [],
+        [],
+      );
+
+      // Calculate interface IDs
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC20Interface = IERC20__factory.createInterface();
+      iERC20InterfaceId = calculateInterfaceId(IERC20Interface);
+
+      const IERC20PermitInterface = IERC20Permit__factory.createInterface();
+      iERC20PermitInterfaceId = calculateInterfaceId(IERC20PermitInterface);
+
+      const IVotesInterface = IVotes__factory.createInterface();
+      iVotesInterfaceId = calculateInterfaceId(IVotesInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await votesERC20.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await votesERC20.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IERC20 interface', async function () {
+      const supported = await votesERC20.supportsInterface(iERC20InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IERC20Permit interface', async function () {
+      const supported = await votesERC20.supportsInterface(iERC20PermitInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVotes interface', async function () {
+      const supported = await votesERC20.supportsInterface(iVotesInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await votesERC20.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
@@ -4,11 +4,13 @@ import { ethers } from 'hardhat';
 import {
   AzoriusFreezeGuardV1,
   AzoriusFreezeGuardV1__factory,
+  IERC165__factory,
+  IVersion__factory,
   MockFreezeVoting,
   MockFreezeVoting__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 // Helper function for deploying AzoriusFreezeGuardV1 instances
 async function deployAzoriusFreezeGuardProxy(
@@ -221,6 +223,36 @@ describe('AzoriusFreezeGuardV1', () => {
 
     it('should return correct version', async () => {
       expect(await azoriusFreezeGuard.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await azoriusFreezeGuard.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await azoriusFreezeGuard.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await azoriusFreezeGuard.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/freeze-guard/BaseGuardV1.test.ts
+++ b/test/deployables/freeze-guard/BaseGuardV1.test.ts
@@ -1,0 +1,55 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteBaseGuardV1,
+  ConcreteBaseGuardV1__factory,
+  IERC165__factory,
+  IGuard__factory,
+} from '../../../typechain-types';
+import { calculateInterfaceId } from '../../helpers/utils';
+
+describe('BaseGuardV1', () => {
+  // Signers
+  let deployer: SignerWithAddress;
+
+  // Contracts
+  let concreteBaseGuard: ConcreteBaseGuardV1;
+
+  beforeEach(async () => {
+    [deployer] = await ethers.getSigners();
+
+    // Deploy MockBaseGuardV1
+    concreteBaseGuard = await new ConcreteBaseGuardV1__factory(deployer).deploy();
+  });
+
+  describe('ERC165', function () {
+    let iGuardInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IGuardInterface = IGuard__factory.createInterface();
+      iGuardInterfaceId = calculateInterfaceId(IGuardInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await concreteBaseGuard.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IGuard interface', async function () {
+      const supported = await concreteBaseGuard.supportsInterface(iGuardInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await concreteBaseGuard.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
+    });
+  });
+});

--- a/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
@@ -3,6 +3,9 @@ import { mine } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
+  IERC165__factory,
+  IMultisigFreezeGuardV1__factory,
+  IVersion__factory,
   MockFreezeVoting,
   MockFreezeVoting__factory,
   MockSafe,
@@ -11,7 +14,7 @@ import {
   MultisigFreezeGuardV1__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 // Helper function for deploying MultisigFreezeGuardV1 instances
 async function deployMultisigFreezeGuardProxy(
@@ -498,6 +501,47 @@ describe('MultisigFreezeGuardV1', () => {
   describe('Version', () => {
     it('should return correct version', async () => {
       expect(await multisigFreezeGuard.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let iVersionInterfaceId: string;
+    let iMultisigFreezeGuardV1InterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IMultisigFreezeGuardV1Interface = IMultisigFreezeGuardV1__factory.createInterface();
+      iMultisigFreezeGuardV1InterfaceId = calculateInterfaceId(IMultisigFreezeGuardV1Interface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await multisigFreezeGuard.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await multisigFreezeGuard.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IMultisigFreezeGuardV1 interface', async function () {
+      const supported = await multisigFreezeGuard.supportsInterface(
+        iMultisigFreezeGuardV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await multisigFreezeGuard.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
@@ -5,9 +5,12 @@ import { ethers } from 'hardhat';
 import {
   ConcreteBaseFreezeVotingV1,
   ConcreteBaseFreezeVotingV1__factory,
+  IBaseFreezeVotingV1__factory,
+  IERC165__factory,
+  IVersion__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 // Helper function for deploying ConcreteBaseFreezeVoting instances
 async function deployConcreteBaseFreezeVotingProxy(
@@ -380,6 +383,47 @@ describe('BaseFreezeVotingV1', () => {
   describe('Version', () => {
     it('should return correct version', async () => {
       expect(await freezeVoting.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let iBaseFreezeVotingV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IBaseFreezeVotingV1Interface = IBaseFreezeVotingV1__factory.createInterface();
+      iBaseFreezeVotingV1InterfaceId = calculateInterfaceId(IBaseFreezeVotingV1Interface);
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      // Cast the freezeVoting instance to any type to bypass TypeScript checking
+      // since we know the actual contract implements supportsInterface
+      const supported = await freezeVoting.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseFreezeVotingV1 interface', async function () {
+      const supported = await freezeVoting.supportsInterface(iBaseFreezeVotingV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await freezeVoting.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await freezeVoting.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -5,6 +5,9 @@ import { ethers } from 'hardhat';
 import {
   AzoriusV1,
   AzoriusV1__factory,
+  IAzoriusV1__factory,
+  IERC165__factory,
+  IVersion__factory,
   MockAvatar,
   MockAvatar__factory,
   MockERC20Votes,
@@ -13,7 +16,7 @@ import {
   MockVotingStrategy__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 // Helper functions for deploying AzoriusV1 instances
 async function deployAzoriusProxy(
@@ -1137,6 +1140,57 @@ describe('AzoriusV1', () => {
       );
 
       expect(await azorius.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let azoriusInstance: AzoriusV1;
+    let iAzoriusV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Deploy a new instance for testing
+      azoriusInstance = await deployAzoriusProxy(
+        azoriusMastercopy,
+        owner,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        [],
+        0,
+        0,
+      );
+
+      // Dynamically calculate interface IDs
+      const IAzoriusV1Interface = IAzoriusV1__factory.createInterface();
+      iAzoriusV1InterfaceId = calculateInterfaceId(IAzoriusV1Interface);
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await azoriusInstance.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IAzoriusV1 interface', async function () {
+      const supported = await azoriusInstance.supportsInterface(iAzoriusV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await azoriusInstance.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await azoriusInstance.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/modules/FractalModuleV1.test.ts
+++ b/test/deployables/modules/FractalModuleV1.test.ts
@@ -4,13 +4,16 @@ import { ethers } from 'hardhat';
 import {
   FractalModuleV1,
   FractalModuleV1__factory,
+  IERC165__factory,
+  IFractalModuleV1__factory,
+  IVersion__factory,
   MockAvatar,
   MockAvatar__factory,
   MockERC20Votes,
   MockERC20Votes__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 // Helper functions for deploying FractalModuleV1 instances
 async function deployFractalModuleProxy(
@@ -556,6 +559,55 @@ describe('FractalModuleV1', () => {
       );
 
       expect(await fractalModule.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let fractalModuleInstance: FractalModuleV1;
+    let iFractalModuleV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Deploy a new instance for testing
+      fractalModuleInstance = await deployFractalModuleProxy(
+        fractalModuleMastercopy,
+        owner,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        [],
+      );
+
+      // Dynamically calculate interface IDs
+      const IFractalModuleV1Interface = IFractalModuleV1__factory.createInterface();
+      iFractalModuleV1InterfaceId = calculateInterfaceId(IFractalModuleV1Interface);
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await fractalModuleInstance.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IFractalModuleV1 interface', async function () {
+      const supported = await fractalModuleInstance.supportsInterface(iFractalModuleV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await fractalModuleInstance.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await fractalModuleInstance.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/BaseQuorumPercentV1.test.ts
+++ b/test/deployables/strategies/BaseQuorumPercentV1.test.ts
@@ -4,9 +4,12 @@ import { ethers } from 'hardhat';
 import {
   ConcreteBaseQuorumPercentV1,
   ConcreteBaseQuorumPercentV1__factory,
+  IBaseQuorumPercentV1__factory,
+  IERC165__factory,
+  IVersion__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 describe('BaseQuorumPercentV1', () => {
   // Signers
@@ -188,6 +191,47 @@ describe('BaseQuorumPercentV1', () => {
   describe('Version', () => {
     it('should return correct version', async () => {
       expect(await concreteQuorumPercent.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let iBaseQuorumPercentV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IBaseQuorumPercentV1Interface = IBaseQuorumPercentV1__factory.createInterface();
+      iBaseQuorumPercentV1InterfaceId = calculateInterfaceId(IBaseQuorumPercentV1Interface);
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await concreteQuorumPercent.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseQuorumPercentV1 interface', async function () {
+      const supported = await concreteQuorumPercent.supportsInterface(
+        iBaseQuorumPercentV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await concreteQuorumPercent.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await concreteQuorumPercent.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/BaseStrategyV1.test.ts
+++ b/test/deployables/strategies/BaseStrategyV1.test.ts
@@ -1,9 +1,15 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { ConcreteBaseStrategyV1, ConcreteBaseStrategyV1__factory } from '../../../typechain-types';
+import {
+  ConcreteBaseStrategyV1,
+  ConcreteBaseStrategyV1__factory,
+  IBaseStrategyV1__factory,
+  IERC165__factory,
+  IVersion__factory,
+} from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 describe('BaseStrategyV1', () => {
   // Signers
@@ -173,6 +179,45 @@ describe('BaseStrategyV1', () => {
   describe('Version', () => {
     it('should return correct version', async () => {
       expect(await concreteStrategy.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let iBaseStrategyV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IBaseStrategyV1Interface = IBaseStrategyV1__factory.createInterface();
+      iBaseStrategyV1InterfaceId = calculateInterfaceId(IBaseStrategyV1Interface);
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await concreteStrategy.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseStrategyV1 interface', async function () {
+      const supported = await concreteStrategy.supportsInterface(iBaseStrategyV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await concreteStrategy.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await concreteStrategy.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/BaseVotingBasisPercentV1.test.ts
+++ b/test/deployables/strategies/BaseVotingBasisPercentV1.test.ts
@@ -4,9 +4,12 @@ import { ethers } from 'hardhat';
 import {
   ConcreteBaseVotingBasisPercentV1,
   ConcreteBaseVotingBasisPercentV1__factory,
+  IBaseVotingBasisPercentV1__factory,
+  IERC165__factory,
+  IVersion__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 describe('BaseVotingBasisPercentV1', () => {
   // Signers
@@ -204,6 +207,50 @@ describe('BaseVotingBasisPercentV1', () => {
   describe('Version', () => {
     it('should return correct version', async () => {
       expect(await concreteVotingBasis.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let iBaseVotingBasisPercentV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IBaseVotingBasisPercentV1Interface =
+        IBaseVotingBasisPercentV1__factory.createInterface();
+      iBaseVotingBasisPercentV1InterfaceId = calculateInterfaceId(
+        IBaseVotingBasisPercentV1Interface,
+      );
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await concreteVotingBasis.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseVotingBasisPercentV1 interface', async function () {
+      const supported = await concreteVotingBasis.supportsInterface(
+        iBaseVotingBasisPercentV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await concreteVotingBasis.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await concreteVotingBasis.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
+++ b/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
@@ -4,9 +4,12 @@ import { ethers } from 'hardhat';
 import {
   ConcreteERC4337VoterSupportV1,
   ConcreteERC4337VoterSupportV1__factory,
+  IERC165__factory,
+  IVersion__factory,
   MockOwnership,
   MockOwnership__factory,
 } from '../../../typechain-types';
+import { calculateInterfaceId } from '../../helpers/utils';
 
 describe('ERC4337VoterSupportV1', () => {
   // Signers
@@ -69,6 +72,37 @@ describe('ERC4337VoterSupportV1', () => {
   describe('Version', () => {
     it('should return correct version', async () => {
       expect(await concreteERC4337VoterSupport.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    // Interface IDs
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs for standard interfaces
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await concreteERC4337VoterSupport.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await concreteERC4337VoterSupport.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await concreteERC4337VoterSupport.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/HatsProposalCreationWhitelistV1.test.ts
+++ b/test/deployables/strategies/HatsProposalCreationWhitelistV1.test.ts
@@ -4,10 +4,14 @@ import { ethers } from 'hardhat';
 import {
   ConcreteHatsProposalCreationWhitelistV1,
   ConcreteHatsProposalCreationWhitelistV1__factory,
+  IERC165__factory,
+  IHatsProposalCreationWhitelistV1__factory,
+  IVersion__factory,
   MockHats,
   MockHats__factory,
 } from '../../../typechain-types';
 import { runHatsProposerTests } from '../../helpers/hatsProposerTests';
+import { calculateInterfaceId } from '../../helpers/utils';
 
 describe('HatsProposalCreationWhitelistV1', () => {
   // Signers
@@ -221,6 +225,53 @@ describe('HatsProposalCreationWhitelistV1', () => {
   describe('Version', () => {
     it('should return correct version', async () => {
       expect(await concreteHatsProposalCreationWhitelist.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let iHatsProposalCreationWhitelistV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IHatsProposalCreationWhitelistV1Interface =
+        IHatsProposalCreationWhitelistV1__factory.createInterface();
+      iHatsProposalCreationWhitelistV1InterfaceId = calculateInterfaceId(
+        IHatsProposalCreationWhitelistV1Interface,
+      );
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported =
+        await concreteHatsProposalCreationWhitelist.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IHatsProposalCreationWhitelistV1 interface', async function () {
+      const supported = await concreteHatsProposalCreationWhitelist.supportsInterface(
+        iHatsProposalCreationWhitelistV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported =
+        await concreteHatsProposalCreationWhitelist.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported =
+        await concreteHatsProposalCreationWhitelist.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/LinearERC20VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingV1.test.ts
@@ -3,6 +3,11 @@ import { mine } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
+  IBaseQuorumPercentV1__factory,
+  IBaseStrategyV1__factory,
+  IBaseVotingBasisPercentV1__factory,
+  IERC165__factory,
+  IVersion__factory,
   LinearERC20VotingV1,
   LinearERC20VotingV1__factory,
   MockERC20Votes,
@@ -11,7 +16,7 @@ import {
   MockOwnership__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 describe('LinearERC20VotingV1', () => {
   // Signers
@@ -44,7 +49,7 @@ describe('LinearERC20VotingV1', () => {
 
   async function deployLinearERC20Voting(
     strategyOwner: SignerWithAddress,
-    governanceToken: MockERC20Votes,
+    governanceToken: string,
     azoriusAddr: string,
   ): Promise<LinearERC20VotingV1> {
     const salt = ethers.hexlify(ethers.randomBytes(32));
@@ -52,7 +57,7 @@ describe('LinearERC20VotingV1', () => {
       ['address', 'address', 'address', 'uint32', 'uint256', 'uint256', 'uint256'],
       [
         strategyOwner.address,
-        await governanceToken.getAddress(),
+        governanceToken,
         azoriusAddr,
         VOTING_PERIOD,
         REQUIRED_PROPOSER_WEIGHT,
@@ -105,7 +110,11 @@ describe('LinearERC20VotingV1', () => {
     linearERC20VotingMastercopy = await new LinearERC20VotingV1__factory(deployer).deploy();
 
     // Deploy LinearERC20Voting strategy
-    linearERC20Voting = await deployLinearERC20Voting(owner, mockToken, azoriusAddress);
+    linearERC20Voting = await deployLinearERC20Voting(
+      owner,
+      await mockToken.getAddress(),
+      azoriusAddress,
+    );
   });
 
   describe('Initialization', () => {
@@ -581,6 +590,68 @@ describe('LinearERC20VotingV1', () => {
       void expect(await linearERC20Voting.hasVoted(proposalId2, tokenHolder1.address)).to.be.true;
       void expect(await linearERC20Voting.hasVoted(proposalId1, tokenHolder2.address)).to.be.true;
       void expect(await linearERC20Voting.hasVoted(proposalId2, tokenHolder2.address)).to.be.true;
+    });
+  });
+
+  describe('ERC165', function () {
+    let iBaseStrategyV1InterfaceId: string;
+    let iBaseQuorumPercentV1InterfaceId: string;
+    let iBaseVotingBasisPercentV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IBaseQuorumPercentV1Interface = IBaseQuorumPercentV1__factory.createInterface();
+      iBaseQuorumPercentV1InterfaceId = calculateInterfaceId(IBaseQuorumPercentV1Interface);
+
+      const IBaseVotingBasisPercentV1Interface =
+        IBaseVotingBasisPercentV1__factory.createInterface();
+      iBaseVotingBasisPercentV1InterfaceId = calculateInterfaceId(
+        IBaseVotingBasisPercentV1Interface,
+      );
+
+      const IBaseStrategyV1Interface = IBaseStrategyV1__factory.createInterface();
+      iBaseStrategyV1InterfaceId = calculateInterfaceId(IBaseStrategyV1Interface);
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await linearERC20Voting.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseQuorumPercentV1 interface', async function () {
+      const supported = await linearERC20Voting.supportsInterface(iBaseQuorumPercentV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseVotingBasisPercentV1 interface', async function () {
+      const supported = await linearERC20Voting.supportsInterface(
+        iBaseVotingBasisPercentV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseStrategyV1 interface', async function () {
+      const supported = await linearERC20Voting.supportsInterface(iBaseStrategyV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await linearERC20Voting.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await linearERC20Voting.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.test.ts
@@ -2,6 +2,12 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
+  IBaseQuorumPercentV1__factory,
+  IBaseStrategyV1__factory,
+  IBaseVotingBasisPercentV1__factory,
+  IERC165__factory,
+  IHatsProposalCreationWhitelistV1__factory,
+  IVersion__factory,
   LinearERC20VotingWithHatsProposalCreationV1,
   LinearERC20VotingWithHatsProposalCreationV1__factory,
   MockERC20Votes,
@@ -11,7 +17,7 @@ import {
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
 import { runHatsProposerTests } from '../../helpers/hatsProposerTests';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 /**
  * This test file only covers the specific functionality of LinearERC20VotingWithHatsProposalCreationV1,
@@ -195,6 +201,89 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
         const version = await linearERC20VotingWithHatsProposalCreation.getVersion();
         expect(version).to.equal(1);
       });
+    });
+  });
+
+  describe('ERC165', function () {
+    let iHatsProposalCreationWhitelistV1InterfaceId: string;
+    let iBaseStrategyV1InterfaceId: string;
+    let iBaseQuorumPercentV1InterfaceId: string;
+    let iBaseVotingBasisPercentV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IBaseVotingBasisPercentV1Interface =
+        IBaseVotingBasisPercentV1__factory.createInterface();
+      iBaseVotingBasisPercentV1InterfaceId = calculateInterfaceId(
+        IBaseVotingBasisPercentV1Interface,
+      );
+
+      const IBaseQuorumPercentV1Interface = IBaseQuorumPercentV1__factory.createInterface();
+      iBaseQuorumPercentV1InterfaceId = calculateInterfaceId(IBaseQuorumPercentV1Interface);
+
+      const IBaseStrategyV1Interface = IBaseStrategyV1__factory.createInterface();
+      iBaseStrategyV1InterfaceId = calculateInterfaceId(IBaseStrategyV1Interface);
+
+      const IHatsProposalCreationWhitelistV1Interface =
+        IHatsProposalCreationWhitelistV1__factory.createInterface();
+      iHatsProposalCreationWhitelistV1InterfaceId = calculateInterfaceId(
+        IHatsProposalCreationWhitelistV1Interface,
+      );
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported =
+        await linearERC20VotingWithHatsProposalCreation.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseVotingBasisPercentV1 interface', async function () {
+      const supported = await linearERC20VotingWithHatsProposalCreation.supportsInterface(
+        iBaseVotingBasisPercentV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseQuorumPercentV1 interface', async function () {
+      const supported = await linearERC20VotingWithHatsProposalCreation.supportsInterface(
+        iBaseQuorumPercentV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseStrategyV1 interface', async function () {
+      const supported = await linearERC20VotingWithHatsProposalCreation.supportsInterface(
+        iBaseStrategyV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IHatsProposalCreationWhitelistV1 interface', async function () {
+      const supported = await linearERC20VotingWithHatsProposalCreation.supportsInterface(
+        iHatsProposalCreationWhitelistV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported =
+        await linearERC20VotingWithHatsProposalCreation.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported =
+        await linearERC20VotingWithHatsProposalCreation.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/LinearERC721VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingV1.test.ts
@@ -3,6 +3,11 @@ import { mine } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
+  IBaseStrategyV1__factory,
+  IBaseVotingBasisPercentV1__factory,
+  IERC165__factory,
+  IERC721VotingStrategyV1__factory,
+  IVersion__factory,
   LinearERC721VotingV1,
   LinearERC721VotingV1__factory,
   MockERC721,
@@ -10,7 +15,7 @@ import {
   MockOwnership__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 describe('LinearERC721VotingV1', () => {
   // Signers
@@ -868,6 +873,70 @@ describe('LinearERC721VotingV1', () => {
   describe('Version', () => {
     it('should return correct version', async () => {
       expect(await linearERC721Voting.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let iERC721VotingStrategyV1InterfaceId: string;
+    let iBaseStrategyV1InterfaceId: string;
+    let iBaseVotingBasisPercentV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Dynamically calculate interface IDs
+      const IERC721VotingStrategyV1Interface = IERC721VotingStrategyV1__factory.createInterface();
+      iERC721VotingStrategyV1InterfaceId = calculateInterfaceId(IERC721VotingStrategyV1Interface);
+
+      const IBaseVotingBasisPercentV1Interface =
+        IBaseVotingBasisPercentV1__factory.createInterface();
+      iBaseVotingBasisPercentV1InterfaceId = calculateInterfaceId(
+        IBaseVotingBasisPercentV1Interface,
+      );
+
+      const IBaseStrategyV1Interface = IBaseStrategyV1__factory.createInterface();
+      iBaseStrategyV1InterfaceId = calculateInterfaceId(IBaseStrategyV1Interface);
+
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC721VotingStrategyV1 interface', async function () {
+      const supported = await linearERC721Voting.supportsInterface(
+        iERC721VotingStrategyV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await linearERC721Voting.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseVotingBasisPercentV1 interface', async function () {
+      const supported = await linearERC721Voting.supportsInterface(
+        iBaseVotingBasisPercentV1InterfaceId,
+      );
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IBaseStrategyV1 interface', async function () {
+      const supported = await linearERC721Voting.supportsInterface(iBaseStrategyV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await linearERC721Voting.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await linearERC721Voting.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.test.ts
@@ -2,6 +2,12 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
+  IBaseStrategyV1__factory,
+  IBaseVotingBasisPercentV1__factory,
+  IERC165__factory,
+  IERC721VotingStrategyV1__factory,
+  IHatsProposalCreationWhitelistV1__factory,
+  IVersion__factory,
   LinearERC721VotingWithHatsProposalCreationV1,
   LinearERC721VotingWithHatsProposalCreationV1__factory,
   MockERC721,
@@ -11,7 +17,7 @@ import {
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
 import { runHatsProposerTests } from '../../helpers/hatsProposerTests';
-import { calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
 
 /**
  * This test file only covers the specific functionality of LinearERC721VotingWithHatsProposalCreationV1,
@@ -231,6 +237,89 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
       it('should return correct version', async () => {
         const version = await linearERC721VotingWithHatsProposalCreation.getVersion();
         expect(version).to.equal(1);
+      });
+    });
+
+    describe('ERC165', function () {
+      let iERC721VotingStrategyV1InterfaceId: string;
+      let iBaseVotingBasisPercentV1InterfaceId: string;
+      let iBaseStrategyV1InterfaceId: string;
+      let iHatsProposalCreationWhitelistV1InterfaceId: string;
+      let iVersionInterfaceId: string;
+      let iERC165InterfaceId: string;
+
+      beforeEach(async function () {
+        // Dynamically calculate interface IDs
+        const IERC721VotingStrategyV1Interface = IERC721VotingStrategyV1__factory.createInterface();
+        iERC721VotingStrategyV1InterfaceId = calculateInterfaceId(IERC721VotingStrategyV1Interface);
+
+        const IBaseVotingBasisPercentV1Interface =
+          IBaseVotingBasisPercentV1__factory.createInterface();
+        iBaseVotingBasisPercentV1InterfaceId = calculateInterfaceId(
+          IBaseVotingBasisPercentV1Interface,
+        );
+
+        const IBaseStrategyV1Interface = IBaseStrategyV1__factory.createInterface();
+        iBaseStrategyV1InterfaceId = calculateInterfaceId(IBaseStrategyV1Interface);
+
+        const IHatsProposalCreationWhitelistV1Interface =
+          IHatsProposalCreationWhitelistV1__factory.createInterface();
+        iHatsProposalCreationWhitelistV1InterfaceId = calculateInterfaceId(
+          IHatsProposalCreationWhitelistV1Interface,
+        );
+
+        const IVersionInterface = IVersion__factory.createInterface();
+        iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+        const IERC165Interface = IERC165__factory.createInterface();
+        iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+      });
+
+      it('Should support IERC165 interface', async function () {
+        const supported =
+          await linearERC721VotingWithHatsProposalCreation.supportsInterface(iERC165InterfaceId);
+        void expect(supported).to.be.true;
+      });
+
+      it('Should support IERC721VotingStrategyV1 interface', async function () {
+        const supported = await linearERC721VotingWithHatsProposalCreation.supportsInterface(
+          iERC721VotingStrategyV1InterfaceId,
+        );
+        void expect(supported).to.be.true;
+      });
+
+      it('Should support IHatsProposalCreationWhitelistV1 interface', async function () {
+        const supported = await linearERC721VotingWithHatsProposalCreation.supportsInterface(
+          iHatsProposalCreationWhitelistV1InterfaceId,
+        );
+        void expect(supported).to.be.true;
+      });
+
+      it('Should support IBaseVotingBasisPercentV1 interface', async function () {
+        const supported = await linearERC721VotingWithHatsProposalCreation.supportsInterface(
+          iBaseVotingBasisPercentV1InterfaceId,
+        );
+        void expect(supported).to.be.true;
+      });
+
+      it('Should support IBaseStrategyV1 interface', async function () {
+        const supported = await linearERC721VotingWithHatsProposalCreation.supportsInterface(
+          iBaseStrategyV1InterfaceId,
+        );
+        void expect(supported).to.be.true;
+      });
+
+      it('Should support IVersion interface', async function () {
+        const supported =
+          await linearERC721VotingWithHatsProposalCreation.supportsInterface(iVersionInterfaceId);
+        void expect(supported).to.be.true;
+      });
+
+      it('Should not support random interface', async function () {
+        const randomInterfaceId = '0x12345678';
+        const supported =
+          await linearERC721VotingWithHatsProposalCreation.supportsInterface(randomInterfaceId);
+        void expect(supported).to.be.false;
       });
     });
   });

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -1,4 +1,4 @@
-import type { BaseContract } from 'ethers';
+import type { BaseContract, FunctionFragment, Interface } from 'ethers';
 import { ethers } from 'hardhat';
 
 export const calculateProxyAddress = async (
@@ -30,3 +30,32 @@ export const topHatIdToHatId = (topHatId: bigint): bigint => {
   // Shift left by 224 bits (same as in Solidity)
   return topHatId << 224n;
 };
+
+/**
+ * Calculate an interface ID from an ethers Interface object.
+ * The interface ID is the XOR of all function selectors in the interface.
+ * @param interfaceObj An ethers Interface object
+ * @returns The interface ID as a hex string with 0x prefix
+ */
+export function calculateInterfaceId(interfaceObj: Interface): string {
+  // Get all function fragments from the interface
+  const fragments = interfaceObj.fragments.filter(
+    (fragment): fragment is FunctionFragment => fragment.type === 'function',
+  );
+
+  if (fragments.length === 0) {
+    throw new Error('Interface has no functions');
+  }
+
+  // XOR all function selectors
+  let interfaceId = BigInt(0);
+  for (const fragment of fragments) {
+    // Get the selector by using the function's signature
+    const selector = interfaceObj.getFunction(fragment.selector)?.selector;
+    if (selector) {
+      interfaceId = interfaceId ^ BigInt(selector);
+    }
+  }
+
+  return '0x' + interfaceId.toString(16).padStart(8, '0');
+}


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/183

Implements comprehensive ERC165 interface support for various contracts:
- Add `supportsInterface` method to multiple contracts
- Dynamically calculate and support interface IDs
- Enhance contract interoperability and introspection capabilities
- Update test suites to validate interface support
- Add utility function for calculating interface IDs

The changes improve contract flexibility and provide a standardized way to query supported interfaces across the project's contracts.