### PR TITLE
Introduce Version abstract contract and standardize versioning across contracts

### DIFF
--- a/contracts/deployables/Version.sol
+++ b/contracts/deployables/Version.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {IVersion} from "../interfaces/decent/deployables/IVersion.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+/**
+ * @title Version
+ * @dev Abstract contract providing standardized contract identification
+ *
+ * Inheriting contracts MUST implement:
+ * - getVersion()
+ */
+abstract contract Version is IVersion, ERC165 {
+    /**
+     * @dev Returns the version number of this contract implementation
+     * Inheriting contracts MUST override this function.
+     */
+    function getVersion() public view virtual returns (uint16);
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -3,16 +3,13 @@ pragma solidity ^0.8.28;
 
 import {BasePaymasterV1, IEntryPoint} from "./BasePaymasterV1.sol";
 import {IDecentPaymasterV1} from "../../interfaces/decent/deployables/IDecentPaymasterV1.sol";
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract DecentPaymasterV1 is
-    IDecentPaymasterV1,
-    IVersion,
-    BasePaymasterV1,
-    ERC165
-{
+contract DecentPaymasterV1 is IDecentPaymasterV1, Version, BasePaymasterV1 {
+    uint16 private constant VERSION = 1;
+
     // Mapping: strategy address => function selector => is approved
     mapping(address => mapping(bytes4 => bool)) public approvedFunctions;
 
@@ -105,19 +102,17 @@ contract DecentPaymasterV1 is
         return (abi.encode(), 0);
     }
 
-    /// @inheritdoc ERC165
+    /// @inheritdoc Version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
+    }
+
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IDecentPaymasterV1).interfaceId ||
             interfaceId == type(IPaymaster).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    /// @inheritdoc IVersion
-    function getVersion() public pure virtual override returns (uint16) {
-        return 1;
     }
 }

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -3,16 +3,17 @@ pragma solidity ^0.8.28;
 
 import {IHatsElectionsEligibility} from "../../interfaces/hats/modules/IHatsElectionsEligibility.sol";
 import {IDecentAutonomousAdminV1} from "../../interfaces/decent/deployables/IDecentAutonomousAdminV1.sol";
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract DecentAutonomousAdminV1 is
     IDecentAutonomousAdminV1,
-    IVersion,
-    ERC165,
+    Version,
     FactoryFriendly
 {
+    uint16 private constant VERSION = 1;
+
     // //////////////////////////////////////////////////////////////
     //                         initializer
     // //////////////////////////////////////////////////////////////
@@ -37,17 +38,16 @@ contract DecentAutonomousAdminV1 is
         }
     }
 
+    /// @inheritdoc Version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
+    }
+
     function supportsInterface(
         bytes4 interfaceId
     ) public view override returns (bool) {
         return
             interfaceId == type(IDecentAutonomousAdminV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16) {
-        return 1;
     }
 }

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -16,12 +16,13 @@ import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/
  * An implementation of the OpenZeppelin `IVotes` voting token standard.
  */
 contract VotesERC20V1 is
-    IVersion,
+    Version,
     ERC20VotesUpgradeable,
     ERC20PermitUpgradeable,
-    FactoryFriendly,
-    ERC165
+    FactoryFriendly
 {
+    uint16 private constant VERSION = 1;
+
     constructor() {
         _disableInitializers();
     }
@@ -79,20 +80,18 @@ contract VotesERC20V1 is
         return super.nonces(owner);
     }
 
-    /// @inheritdoc ERC165
+    /// @inheritdoc Version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
+    }
+
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IVersion).interfaceId ||
             interfaceId == type(IERC20).interfaceId ||
             interfaceId == type(IERC20Permit).interfaceId ||
             interfaceId == type(IVotes).interfaceId ||
             super.supportsInterface(interfaceId);
-    }
-
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16) {
-        return 1;
     }
 }

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {BaseGuardV1} from "./BaseGuardV1.sol";
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
@@ -13,7 +13,9 @@ import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
  *
  * See https://docs.safe.global/learn/safe-core/safe-core-protocol/guards.
  */
-contract AzoriusFreezeGuardV1 is IVersion, BaseGuardV1, FactoryFriendly {
+contract AzoriusFreezeGuardV1 is Version, BaseGuardV1, FactoryFriendly {
+    uint16 private constant VERSION = 1;
+
     /**
      * A reference to the freeze voting contract, which manages the freeze
      * voting process and maintains the frozen / unfrozen state of the DAO.
@@ -85,16 +87,14 @@ contract AzoriusFreezeGuardV1 is IVersion, BaseGuardV1, FactoryFriendly {
         // not implementated
     }
 
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual override returns (uint16) {
-        return 1;
+    /// @inheritdoc Version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
     }
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override returns (bool) {
-        return
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+    ) public view virtual override(BaseGuardV1, Version) returns (bool) {
+        return super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {BaseGuardV1} from "./BaseGuardV1.sol";
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {IMultisigFreezeGuardV1} from "../../interfaces/decent/deployables/IMultisigFreezeGuardV1.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
@@ -14,10 +14,12 @@ import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
  */
 contract MultisigFreezeGuardV1 is
     IMultisigFreezeGuardV1,
-    IVersion,
+    Version,
     BaseGuardV1,
     FactoryFriendly
 {
+    uint16 private constant VERSION = 1;
+
     /** Timelock period (in blocks). */
     uint32 public timelockPeriod;
 
@@ -216,17 +218,16 @@ contract MultisigFreezeGuardV1 is
         emit ExecutionPeriodUpdated(_executionPeriod);
     }
 
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual override returns (uint16) {
-        return 1;
+    /// @inheritdoc Version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
     }
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override returns (bool) {
+    ) public view virtual override(BaseGuardV1, Version) returns (bool) {
         return
             interfaceId == type(IMultisigFreezeGuardV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -24,7 +23,6 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  * a Safe Transaction Guard, until the `freezePeriod` has elapsed.
  */
 abstract contract BaseFreezeVotingV1 is
-    IVersion,
     FactoryFriendly,
     IBaseFreezeVotingV1,
     ERC165
@@ -144,16 +142,11 @@ abstract contract BaseFreezeVotingV1 is
         emit FreezePeriodUpdated(_freezePeriod);
     }
 
-    /// @inheritdoc ERC165
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IBaseFreezeVotingV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
-
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual override returns (uint16);
 }

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
+import {Version} from "../Version.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 
 /**
  * A [BaseFreezeVoting](./BaseFreezeVoting.md) implementation which handles
  * freezes on ERC20 based token voting DAOs.
  */
-contract ERC20FreezeVotingV1 is BaseFreezeVotingV1 {
+contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
+    uint16 private constant VERSION = 1;
+
     /** A reference to the ERC20 voting token of the subDAO. */
     IVotes public votesERC20;
 
@@ -90,8 +92,14 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1 {
         emit FreezeVoteCast(msg.sender, userVotes);
     }
 
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual override returns (uint16) {
-        return 1;
+    /// Implementation for the version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(BaseFreezeVotingV1, Version) returns (bool) {
+        return super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
+import {Version} from "../Version.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
  * A [BaseFreezeVoting](./BaseFreezeVoting.md) implementation which handles
  * freezes on ERC721 based token voting DAOs.
  */
-contract ERC721FreezeVotingV1 is BaseFreezeVotingV1 {
+contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
+    uint16 private constant VERSION = 1;
+
     /** A reference to the voting strategy of the parent DAO. */
     IERC721VotingStrategyV1 public strategy;
 
@@ -116,8 +118,14 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1 {
         return votes;
     }
 
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual override returns (uint16) {
-        return 1;
+    /// Implementation for the version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(BaseFreezeVotingV1, Version) returns (bool) {
+        return super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
+import {Version} from "../Version.sol";
 
 /**
  * A BaseFreezeVoting implementation which handles freezes on multi-sig (Safe) based DAOs.
  */
-contract MultisigFreezeVotingV1 is BaseFreezeVotingV1 {
-    ISafe public parentGnosisSafe;
+contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
+    uint16 private constant VERSION = 1;
+
+    ISafe public parentSafe;
 
     event MultisigFreezeVotingSetup(
         address indexed owner,
-        address indexed parentGnosisSafe
+        address indexed parentSafe
     );
 
     error NotOwner();
@@ -24,7 +26,7 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1 {
      *
      * @param initializeParams encoded initialization parameters: `address _owner`,
      * `uint256 _freezeVotesThreshold`, `uint256 _freezeProposalPeriod`, `uint256 _freezePeriod`,
-     * `address _parentGnosisSafe`
+     * `address _parentSafeSafe`
      */
     function setUp(bytes memory initializeParams) public override initializer {
         (
@@ -32,7 +34,7 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1 {
             uint256 _freezeVotesThreshold,
             uint32 _freezeProposalPeriod,
             uint32 _freezePeriod,
-            address _parentGnosisSafe
+            address _parentSafe
         ) = abi.decode(
                 initializeParams,
                 (address, uint256, uint32, uint32, address)
@@ -42,14 +44,14 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1 {
         _updateFreezeVotesThreshold(_freezeVotesThreshold);
         _updateFreezeProposalPeriod(_freezeProposalPeriod);
         _updateFreezePeriod(_freezePeriod);
-        parentGnosisSafe = ISafe(_parentGnosisSafe);
+        parentSafe = ISafe(_parentSafe);
 
-        emit MultisigFreezeVotingSetup(_owner, _parentGnosisSafe);
+        emit MultisigFreezeVotingSetup(_owner, _parentSafe);
     }
 
     /** @inheritdoc BaseFreezeVotingV1*/
     function castFreezeVote() external override {
-        if (!parentGnosisSafe.isOwner(msg.sender)) revert NotOwner();
+        if (!parentSafe.isOwner(msg.sender)) revert NotOwner();
 
         if (block.number > freezeProposalCreatedBlock + freezeProposalPeriod) {
             // create a new freeze proposal and count the caller's vote
@@ -73,8 +75,14 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1 {
         emit FreezeVoteCast(msg.sender, 1);
     }
 
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual override returns (uint16) {
-        return 1;
+    /// Implementation for the version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(BaseFreezeVotingV1, Version) returns (bool) {
+        return super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
 import {IAzoriusV1, Enum} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
  * A Safe module which allows for composable governance.
@@ -17,7 +16,9 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  * All voting details are delegated to [BaseStrategy](./BaseStrategy.md) implementations, of which an Azorius DAO can
  * have any number.
  */
-contract AzoriusV1 is IVersion, IAzoriusV1, GuardableModule, ERC165 {
+contract AzoriusV1 is IAzoriusV1, GuardableModule, Version {
+    uint16 private constant VERSION = 1;
+
     /**
      * The sentinel node of the linked list of enabled [BaseStrategies](./BaseStrategy.md).
      *
@@ -463,20 +464,16 @@ contract AzoriusV1 is IVersion, IAzoriusV1, GuardableModule, ERC165 {
         emit ExecutionPeriodUpdated(_executionPeriod);
     }
 
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual override returns (uint16) {
-        return 1;
+    /// Implementation for the version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
     }
 
-    /**
-     * Implementation of ERC165 for this contract.
-     */
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IAzoriusV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {IFractalModuleV1} from "../../interfaces/decent/deployables/IFractalModuleV1.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
  * Implementation of [IFractalModule](./interfaces/IFractalModule.md).
@@ -15,12 +14,9 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  * transactions on the Safe, which in our implementation is the set of parent
  * DAOs.
  */
-contract FractalModuleV1 is
-    IVersion,
-    IFractalModuleV1,
-    GuardableModule,
-    ERC165
-{
+contract FractalModuleV1 is IFractalModuleV1, GuardableModule, Version {
+    uint16 private constant VERSION = 1;
+
     /** Mapping of whether an address is a controller (typically a parentDAO). */
     mapping(address => bool) public controllers;
 
@@ -102,9 +98,9 @@ contract FractalModuleV1 is
         emit ControllersAdded(_controllers);
     }
 
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual override returns (uint16) {
-        return 1;
+    /// Implementation for the version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
     }
 
     /**
@@ -115,7 +111,6 @@ contract FractalModuleV1 is
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IFractalModuleV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/BaseQuorumPercentV1.sol
+++ b/contracts/deployables/strategies/BaseQuorumPercentV1.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IBaseQuorumPercentV1} from "../../interfaces/decent/deployables/IBaseQuorumPercentV1.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -12,7 +11,6 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  */
 abstract contract BaseQuorumPercentV1 is
     IBaseQuorumPercentV1,
-    IVersion,
     OwnableUpgradeable,
     ERC165
 {
@@ -72,16 +70,11 @@ abstract contract BaseQuorumPercentV1 is
         uint32 _proposalId
     ) public view virtual returns (uint256);
 
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16);
-
-    /// @inheritdoc ERC165
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IBaseQuorumPercentV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/BaseStrategyV1.sol
+++ b/contracts/deployables/strategies/BaseStrategyV1.sol
@@ -1,19 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IAzoriusV1} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
 import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
  * The base abstract contract for all voting strategies in Azorius.
  */
 abstract contract BaseStrategyV1 is
     IBaseStrategyV1,
-    IVersion,
     OwnableUpgradeable,
     FactoryFriendly,
     ERC165
@@ -68,16 +66,11 @@ abstract contract BaseStrategyV1 is
         emit AzoriusSet(_azoriusModule);
     }
 
-    /// @inheritdoc ERC165
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IBaseStrategyV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
-
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual override returns (uint16);
 }

--- a/contracts/deployables/strategies/BaseVotingBasisPercentV1.sol
+++ b/contracts/deployables/strategies/BaseVotingBasisPercentV1.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IBaseVotingBasisPercentV1} from "../../interfaces/decent/deployables/IBaseVotingBasisPercentV1.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -17,7 +16,6 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  */
 abstract contract BaseVotingBasisPercentV1 is
     IBaseVotingBasisPercentV1,
-    IVersion,
     OwnableUpgradeable,
     ERC165
 {
@@ -66,18 +64,11 @@ abstract contract BaseVotingBasisPercentV1 is
             ((_yesVotes + _noVotes) * basisNumerator) / BASIS_DENOMINATOR;
     }
 
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16);
-
-    /**
-     * @inheritdoc ERC165
-     */
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IBaseVotingBasisPercentV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IOwnershipV1} from "../../interfaces/decent/deployables/IOwnershipV1.sol";
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-abstract contract ERC4337VoterSupportV1 is IVersion, ERC165 {
+/**
+ * Functionality to support ERC4337 (Account Abstraction) by properly identifying the voter
+ * when a contract account is used to interact with the voting system.
+ */
+abstract contract ERC4337VoterSupportV1 {
     /**
      * Returns the address of the voter which owns the voting weight
      * @param _msgSender address of the sender. It can be the wallet address, or the smart account address with EOA as owner
@@ -32,16 +34,4 @@ abstract contract ERC4337VoterSupportV1 is IVersion, ERC165 {
             return _msgSender;
         }
     }
-
-    /// @inheritdoc ERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override returns (bool) {
-        return
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
-    }
-
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
+++ b/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IHatsProposalCreationWhitelistV1} from "../../interfaces/decent/deployables/IHatsProposalCreationWhitelistV1.sol";
 import {IHats} from "../../interfaces/hats/IHats.sol";
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 abstract contract HatsProposalCreationWhitelistV1 is
     IHatsProposalCreationWhitelistV1,
-    IVersion,
     OwnableUpgradeable,
     ERC165
 {
@@ -103,16 +101,11 @@ abstract contract HatsProposalCreationWhitelistV1 is
         return whitelistedHatIds;
     }
 
-    /// @inheritdoc ERC165
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IHatsProposalCreationWhitelistV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
-
-    /// @inheritdoc IVersion
-    function getVersion() external pure virtual returns (uint16);
 }

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {BaseStrategyV1} from "./BaseStrategyV1.sol";
 import {BaseQuorumPercentV1} from "./BaseQuorumPercentV1.sol";
 import {BaseVotingBasisPercentV1} from "./BaseVotingBasisPercentV1.sol";
@@ -17,8 +17,11 @@ contract LinearERC20VotingV1 is
     BaseStrategyV1,
     BaseQuorumPercentV1,
     BaseVotingBasisPercentV1,
-    ERC4337VoterSupportV1
+    ERC4337VoterSupportV1,
+    Version
 {
+    uint16 private constant VERSION = 1;
+
     /**
      * The voting options for a Proposal.
      */
@@ -328,20 +331,11 @@ contract LinearERC20VotingV1 is
             QUORUM_DENOMINATOR;
     }
 
-    /// @inheritdoc IVersion
-    function getVersion()
-        external
-        pure
-        virtual
-        override(
-            BaseQuorumPercentV1,
-            BaseStrategyV1,
-            BaseVotingBasisPercentV1,
-            ERC4337VoterSupportV1
-        )
-        returns (uint16)
-    {
-        return 1;
+    /**
+     * Implementation of version
+     */
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
     }
 
     function supportsInterface(
@@ -354,7 +348,7 @@ contract LinearERC20VotingV1 is
             BaseQuorumPercentV1,
             BaseStrategyV1,
             BaseVotingBasisPercentV1,
-            ERC4337VoterSupportV1
+            Version
         )
         returns (bool)
     {

--- a/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {LinearERC20VotingV1} from "./LinearERC20VotingV1.sol";
 import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1.sol";
 
@@ -14,6 +14,8 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
     HatsProposalCreationWhitelistV1,
     LinearERC20VotingV1
 {
+    uint16 private constant VERSION = 1;
+
     /**
      * Sets up the contract with its initial parameters.
      *
@@ -24,7 +26,11 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
      */
     function setUp(
         bytes memory initializeParams
-    ) public override(HatsProposalCreationWhitelistV1, LinearERC20VotingV1) {
+    )
+        public
+        virtual
+        override(HatsProposalCreationWhitelistV1, LinearERC20VotingV1)
+    {
         (
             address _owner,
             address _governanceToken,
@@ -71,21 +77,18 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
     )
         public
         view
+        virtual
         override(HatsProposalCreationWhitelistV1, LinearERC20VotingV1)
         returns (bool)
     {
         return HatsProposalCreationWhitelistV1.isProposer(_address);
     }
 
-    /// @inheritdoc IVersion
-    function getVersion()
-        external
-        pure
-        virtual
-        override(HatsProposalCreationWhitelistV1, LinearERC20VotingV1)
-        returns (uint16)
-    {
-        return 1;
+    /**
+     * Implementation of version
+     */
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
     }
 
     function supportsInterface(

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
 import {BaseVotingBasisPercentV1} from "./BaseVotingBasisPercentV1.sol";
 import {BaseStrategyV1} from "./BaseStrategyV1.sol";
@@ -23,8 +23,11 @@ contract LinearERC721VotingV1 is
     BaseStrategyV1,
     BaseVotingBasisPercentV1,
     IERC721VotingStrategyV1,
-    ERC4337VoterSupportV1
+    ERC4337VoterSupportV1,
+    Version
 {
+    uint16 private constant VERSION = 1;
+
     /**
      * The voting options for a Proposal.
      */
@@ -470,19 +473,11 @@ contract LinearERC721VotingV1 is
         emit Voted(_voter, _proposalId, _voteType, _tokenAddresses, _tokenIds);
     }
 
-    /// @inheritdoc IVersion
-    function getVersion()
-        external
-        pure
-        virtual
-        override(
-            BaseStrategyV1,
-            BaseVotingBasisPercentV1,
-            ERC4337VoterSupportV1
-        )
-        returns (uint16)
-    {
-        return 1;
+    /**
+     * Implementation of version
+     */
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
     }
 
     function supportsInterface(
@@ -491,11 +486,7 @@ contract LinearERC721VotingV1 is
         public
         view
         virtual
-        override(
-            BaseStrategyV1,
-            BaseVotingBasisPercentV1,
-            ERC4337VoterSupportV1
-        )
+        override(BaseStrategyV1, BaseVotingBasisPercentV1, Version)
         returns (bool)
     {
         return

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {LinearERC721VotingV1} from "./LinearERC721VotingV1.sol";
 import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1.sol";
 
@@ -14,6 +14,8 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
     HatsProposalCreationWhitelistV1,
     LinearERC721VotingV1
 {
+    uint16 private constant VERSION = 1;
+
     /**
      * Sets up the contract with its initial parameters.
      *
@@ -24,7 +26,11 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
      */
     function setUp(
         bytes memory initializeParams
-    ) public override(HatsProposalCreationWhitelistV1, LinearERC721VotingV1) {
+    )
+        public
+        virtual
+        override(HatsProposalCreationWhitelistV1, LinearERC721VotingV1)
+    {
         (
             address _owner,
             address[] memory _tokens,
@@ -74,21 +80,18 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
     )
         public
         view
+        virtual
         override(HatsProposalCreationWhitelistV1, LinearERC721VotingV1)
         returns (bool)
     {
         return HatsProposalCreationWhitelistV1.isProposer(_address);
     }
 
-    /// @inheritdoc IVersion
-    function getVersion()
-        external
-        pure
-        virtual
-        override(HatsProposalCreationWhitelistV1, LinearERC721VotingV1)
-        returns (uint16)
-    {
-        return 1;
+    /**
+     * Implementation of version
+     */
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
     }
 
     function supportsInterface(

--- a/contracts/interfaces/decent/deployables/IVersion.sol
+++ b/contracts/interfaces/decent/deployables/IVersion.sol
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-/**
- * Interface of functions for versioned contracts
- */
 interface IVersion {
-    /**
-     * Returns the current version of the contract
-     */
-    function getVersion() external pure returns (uint16);
+    function getVersion() external view returns (uint16);
 }

--- a/contracts/mocks/concretes/deployables/ConcreteVersion.sol
+++ b/contracts/mocks/concretes/deployables/ConcreteVersion.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {Version} from "../../../deployables/Version.sol";
+
+contract ConcreteVersion is Version {
+    uint16 private _version;
+
+    function setVersion(uint16 newVersion) public {
+        _version = newVersion;
+    }
+
+    function getVersion()
+        public
+        view
+        virtual
+        override(Version)
+        returns (uint16)
+    {
+        return _version;
+    }
+}

--- a/contracts/mocks/concretes/deployables/freeze-voting/ConcreteBaseFreezeVotingV1.sol
+++ b/contracts/mocks/concretes/deployables/freeze-voting/ConcreteBaseFreezeVotingV1.sol
@@ -61,11 +61,4 @@ contract ConcreteBaseFreezeVotingV1 is BaseFreezeVotingV1 {
 
         emit FreezeVoteCast(msg.sender, _mockVotePower);
     }
-
-    /**
-     * Returns the version of the contract.
-     */
-    function getVersion() external pure override returns (uint16) {
-        return 1;
-    }
 }

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteBaseQuorumPercentV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteBaseQuorumPercentV1.sol
@@ -33,11 +33,4 @@ contract ConcreteBaseQuorumPercentV1 is BaseQuorumPercentV1 {
         uint256 totalSupply = 1000000; // Concrete fixed total supply
         return (totalSupply * quorumNumerator) / QUORUM_DENOMINATOR;
     }
-
-    /**
-     * Concrete implementation of the abstract getVersion function.
-     */
-    function getVersion() external pure override returns (uint16) {
-        return 1;
-    }
 }

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
@@ -59,11 +59,4 @@ contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
     function votingEndBlock(uint32) external view override returns (uint32) {
         return uint32(block.number + 100);
     }
-
-    /**
-     * Concrete implementation of the abstract getVersion function.
-     */
-    function getVersion() external pure override returns (uint16) {
-        return 1;
-    }
 }

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteBaseVotingBasisPercentV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteBaseVotingBasisPercentV1.sol
@@ -24,11 +24,4 @@ contract ConcreteBaseVotingBasisPercentV1 is BaseVotingBasisPercentV1 {
         __Ownable_init(_owner);
         _updateBasisNumerator(_basisNumerator);
     }
-
-    /**
-     * Concrete implementation of the abstract getVersion function.
-     */
-    function getVersion() external pure override returns (uint16) {
-        return 1;
-    }
 }

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteERC4337VoterSupportV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteERC4337VoterSupportV1.sol
@@ -13,11 +13,4 @@ contract ConcreteERC4337VoterSupportV1 is ERC4337VoterSupportV1 {
     function voter(address msgSender) public view returns (address) {
         return _voter(msgSender);
     }
-
-    /**
-     * Implementation of the getVersion function.
-     */
-    function getVersion() external pure override returns (uint16) {
-        return 1;
-    }
 }

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteHatsProposalCreationWhitelistV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteHatsProposalCreationWhitelistV1.sol
@@ -17,11 +17,4 @@ contract ConcreteHatsProposalCreationWhitelistV1 is
         __Ownable_init(msg.sender);
         super.setUp(initializeParams);
     }
-
-    /**
-     * Implementation of the abstract getVersion function.
-     */
-    function getVersion() external pure override returns (uint16) {
-        return 1;
-    }
 }

--- a/test/deployables/Version.test.ts
+++ b/test/deployables/Version.test.ts
@@ -1,0 +1,76 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteVersion,
+  ConcreteVersion__factory,
+  IERC165__factory,
+  IVersion__factory,
+} from '../../typechain-types';
+import { calculateInterfaceId } from '../helpers/utils';
+
+describe('Version', () => {
+  // Signers
+  let deployer: SignerWithAddress;
+
+  // Contracts
+  let concreteVersion: ConcreteVersion;
+
+  beforeEach(async () => {
+    [deployer] = await ethers.getSigners();
+
+    // Deploy the concrete version implementation
+    concreteVersion = await new ConcreteVersion__factory(deployer).deploy();
+  });
+
+  describe('Version Identification', () => {
+    it('should return version value that matches what was set', async () => {
+      const version = 123;
+
+      await concreteVersion.setVersion(version);
+
+      expect(await concreteVersion.getVersion()).to.equal(version);
+    });
+
+    it('should update version when setter is called', async () => {
+      const oldVersion = 1;
+      const newVersion = 2;
+
+      await concreteVersion.setVersion(oldVersion);
+      expect(await concreteVersion.getVersion()).to.equal(oldVersion);
+
+      await concreteVersion.setVersion(newVersion);
+      expect(await concreteVersion.getVersion()).to.equal(newVersion);
+    });
+  });
+
+  describe('ERC165', () => {
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async () => {
+      // Dynamically calculate interface IDs
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('should support IERC165 interface', async () => {
+      const supported = await concreteVersion.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('should support IVersion interface', async () => {
+      const supported = await concreteVersion.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('should not support random interface', async () => {
+      const randomInterfaceId = '0x12345678';
+      const supported = await concreteVersion.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
+    });
+  });
+});

--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -457,10 +457,9 @@ describe('DecentPaymasterV1', function () {
     });
   });
 
-  describe('Version', function () {
-    it('Should have a version', async function () {
-      const version = await decentPaymaster.getVersion();
-      void expect(version).to.equal(1);
+  describe('Version', () => {
+    it('should return the correct version number', async () => {
+      expect(await decentPaymaster.getVersion()).to.equal(1);
     });
   });
 });

--- a/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
+++ b/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
@@ -68,10 +68,9 @@ describe('DecentAutonomousAdminV1', function () {
     });
   });
 
-  describe('getVersion', function () {
-    it('should return version 1', async function () {
-      const version = await decentAutonomousAdminInstance.getVersion();
-      void expect(version).to.equal(1);
+  describe('Version', () => {
+    it('should return the correct version number', async () => {
+      expect(await decentAutonomousAdminInstance.getVersion()).to.equal(1);
     });
   });
 });

--- a/test/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/deployables/erc20/VotesERC20V1.test.ts
@@ -161,7 +161,8 @@ describe('VotesERC20V1', () => {
       );
     });
 
-    it('should return correct version', async () => {
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await votesERC20.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
@@ -221,7 +221,8 @@ describe('AzoriusFreezeGuardV1', () => {
       );
     });
 
-    it('should return correct version', async () => {
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await azoriusFreezeGuard.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
@@ -499,7 +499,8 @@ describe('MultisigFreezeGuardV1', () => {
   });
 
   describe('Version', () => {
-    it('should return correct version', async () => {
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await multisigFreezeGuard.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
@@ -7,7 +7,6 @@ import {
   ConcreteBaseFreezeVotingV1__factory,
   IBaseFreezeVotingV1__factory,
   IERC165__factory,
-  IVersion__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
 import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
@@ -380,24 +379,14 @@ describe('BaseFreezeVotingV1', () => {
     });
   });
 
-  describe('Version', () => {
-    it('should return correct version', async () => {
-      expect(await freezeVoting.getVersion()).to.equal(1);
-    });
-  });
-
   describe('ERC165', function () {
     let iBaseFreezeVotingV1InterfaceId: string;
-    let iVersionInterfaceId: string;
     let iERC165InterfaceId: string;
 
     beforeEach(async function () {
       // Dynamically calculate interface IDs
       const IBaseFreezeVotingV1Interface = IBaseFreezeVotingV1__factory.createInterface();
       iBaseFreezeVotingV1InterfaceId = calculateInterfaceId(IBaseFreezeVotingV1Interface);
-
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
 
       const IERC165Interface = IERC165__factory.createInterface();
       iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
@@ -412,11 +401,6 @@ describe('BaseFreezeVotingV1', () => {
 
     it('Should support IBaseFreezeVotingV1 interface', async function () {
       const supported = await freezeVoting.supportsInterface(iBaseFreezeVotingV1InterfaceId);
-      void expect(supported).to.be.true;
-    });
-
-    it('Should support IVersion interface', async function () {
-      const supported = await freezeVoting.supportsInterface(iVersionInterfaceId);
       void expect(supported).to.be.true;
     });
 

--- a/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
@@ -472,7 +472,8 @@ describe('ERC20FreezeVotingV1', () => {
   });
 
   describe('Version', () => {
-    it('should return correct version', async () => {
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await freezeVoting.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
@@ -575,7 +575,8 @@ describe('ERC721FreezeVotingV1', () => {
   });
 
   describe('Version', () => {
-    it('should return correct version', async () => {
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await freezeVoting.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
@@ -101,7 +101,7 @@ describe('MultisigFreezeVotingV1', () => {
       expect(await freezeVoting.freezeVotesThreshold()).to.equal(FREEZE_VOTES_THRESHOLD);
       expect(await freezeVoting.freezeProposalPeriod()).to.equal(FREEZE_PROPOSAL_PERIOD);
       expect(await freezeVoting.freezePeriod()).to.equal(FREEZE_PERIOD);
-      expect(await freezeVoting.parentGnosisSafe()).to.equal(await mockSafe.getAddress());
+      expect(await freezeVoting.parentSafe()).to.equal(await mockSafe.getAddress());
     });
 
     it('should not allow reinitialization', async () => {
@@ -475,7 +475,8 @@ describe('MultisigFreezeVotingV1', () => {
   });
 
   describe('Version', () => {
-    it('should return correct version', async () => {
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await freezeVoting.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -1128,8 +1128,10 @@ describe('AzoriusV1', () => {
   });
 
   describe('Version', () => {
-    it('should return correct version number', async () => {
-      const azorius = await deployAzoriusProxy(
+    let azorius: AzoriusV1;
+
+    beforeEach(async () => {
+      azorius = await deployAzoriusProxy(
         azoriusMastercopy,
         owner,
         ethers.ZeroAddress,
@@ -1138,7 +1140,10 @@ describe('AzoriusV1', () => {
         0,
         0,
       );
+    });
 
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await azorius.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/modules/FractalModuleV1.test.ts
+++ b/test/deployables/modules/FractalModuleV1.test.ts
@@ -549,15 +549,20 @@ describe('FractalModuleV1', () => {
   });
 
   describe('Version', () => {
-    it('should return correct version number', async () => {
-      const fractalModule = await deployFractalModuleProxy(
+    let fractalModule: FractalModuleV1;
+
+    beforeEach(async () => {
+      fractalModule = await deployFractalModuleProxy(
         fractalModuleMastercopy,
         owner,
         ethers.ZeroAddress,
         ethers.ZeroAddress,
         [],
       );
+    });
 
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await fractalModule.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/strategies/BaseQuorumPercentV1.test.ts
+++ b/test/deployables/strategies/BaseQuorumPercentV1.test.ts
@@ -6,7 +6,6 @@ import {
   ConcreteBaseQuorumPercentV1__factory,
   IBaseQuorumPercentV1__factory,
   IERC165__factory,
-  IVersion__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
 import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
@@ -182,30 +181,21 @@ describe('BaseQuorumPercentV1', () => {
 
   describe('quorumVotes', () => {
     it('should return correct quorum votes value', async () => {
-      // concrete implementation uses a fixed total supply of 1000000
-      const expectedQuorumVotes = (1000000 * INITIAL_QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
-      expect(await concreteQuorumPercent.quorumVotes(1)).to.equal(expectedQuorumVotes);
-    });
-  });
-
-  describe('Version', () => {
-    it('should return correct version', async () => {
-      expect(await concreteQuorumPercent.getVersion()).to.equal(1);
+      const totalSupply = 1000000; // Value from mock
+      const result = await concreteQuorumPercent.quorumVotes(1);
+      const expected = (totalSupply * INITIAL_QUORUM_NUMERATOR) / QUORUM_DENOMINATOR;
+      expect(result).to.equal(expected);
     });
   });
 
   describe('ERC165', function () {
     let iBaseQuorumPercentV1InterfaceId: string;
-    let iVersionInterfaceId: string;
     let iERC165InterfaceId: string;
 
     beforeEach(async function () {
       // Dynamically calculate interface IDs
       const IBaseQuorumPercentV1Interface = IBaseQuorumPercentV1__factory.createInterface();
       iBaseQuorumPercentV1InterfaceId = calculateInterfaceId(IBaseQuorumPercentV1Interface);
-
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
 
       const IERC165Interface = IERC165__factory.createInterface();
       iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
@@ -220,11 +210,6 @@ describe('BaseQuorumPercentV1', () => {
       const supported = await concreteQuorumPercent.supportsInterface(
         iBaseQuorumPercentV1InterfaceId,
       );
-      void expect(supported).to.be.true;
-    });
-
-    it('Should support IVersion interface', async function () {
-      const supported = await concreteQuorumPercent.supportsInterface(iVersionInterfaceId);
       void expect(supported).to.be.true;
     });
 

--- a/test/deployables/strategies/BaseStrategyV1.test.ts
+++ b/test/deployables/strategies/BaseStrategyV1.test.ts
@@ -6,7 +6,6 @@ import {
   ConcreteBaseStrategyV1__factory,
   IBaseStrategyV1__factory,
   IERC165__factory,
-  IVersion__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
 import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
@@ -162,9 +161,8 @@ describe('BaseStrategyV1', () => {
 
   describe('onlyAzorius modifier', () => {
     it('should allow calls from Azorius address', async () => {
-      // Use the dedicated Azorius signer directly
-      // Call a function that uses the onlyAzorius modifier
-      await expect(concreteStrategy.connect(azoriusSigner).concreteOnlyAzoriusFunction()).to.not.be
+      // Call from the Azorius address should succeed
+      await expect(concreteStrategy.connect(azoriusSigner).concreteOnlyAzoriusFunction()).not.to.be
         .reverted;
     });
 
@@ -176,24 +174,14 @@ describe('BaseStrategyV1', () => {
     });
   });
 
-  describe('Version', () => {
-    it('should return correct version', async () => {
-      expect(await concreteStrategy.getVersion()).to.equal(1);
-    });
-  });
-
   describe('ERC165', function () {
     let iBaseStrategyV1InterfaceId: string;
-    let iVersionInterfaceId: string;
     let iERC165InterfaceId: string;
 
     beforeEach(async function () {
       // Dynamically calculate interface IDs
       const IBaseStrategyV1Interface = IBaseStrategyV1__factory.createInterface();
       iBaseStrategyV1InterfaceId = calculateInterfaceId(IBaseStrategyV1Interface);
-
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
 
       const IERC165Interface = IERC165__factory.createInterface();
       iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
@@ -206,11 +194,6 @@ describe('BaseStrategyV1', () => {
 
     it('Should support IBaseStrategyV1 interface', async function () {
       const supported = await concreteStrategy.supportsInterface(iBaseStrategyV1InterfaceId);
-      void expect(supported).to.be.true;
-    });
-
-    it('Should support IVersion interface', async function () {
-      const supported = await concreteStrategy.supportsInterface(iVersionInterfaceId);
       void expect(supported).to.be.true;
     });
 

--- a/test/deployables/strategies/BaseVotingBasisPercentV1.test.ts
+++ b/test/deployables/strategies/BaseVotingBasisPercentV1.test.ts
@@ -6,7 +6,6 @@ import {
   ConcreteBaseVotingBasisPercentV1__factory,
   IBaseVotingBasisPercentV1__factory,
   IERC165__factory,
-  IVersion__factory,
 } from '../../../typechain-types';
 import { getModuleProxyFactory } from '../../helpers/globals.test';
 import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
@@ -204,15 +203,8 @@ describe('BaseVotingBasisPercentV1', () => {
     });
   });
 
-  describe('Version', () => {
-    it('should return correct version', async () => {
-      expect(await concreteVotingBasis.getVersion()).to.equal(1);
-    });
-  });
-
   describe('ERC165', function () {
     let iBaseVotingBasisPercentV1InterfaceId: string;
-    let iVersionInterfaceId: string;
     let iERC165InterfaceId: string;
 
     beforeEach(async function () {
@@ -222,9 +214,6 @@ describe('BaseVotingBasisPercentV1', () => {
       iBaseVotingBasisPercentV1InterfaceId = calculateInterfaceId(
         IBaseVotingBasisPercentV1Interface,
       );
-
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
 
       const IERC165Interface = IERC165__factory.createInterface();
       iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
@@ -239,11 +228,6 @@ describe('BaseVotingBasisPercentV1', () => {
       const supported = await concreteVotingBasis.supportsInterface(
         iBaseVotingBasisPercentV1InterfaceId,
       );
-      void expect(supported).to.be.true;
-    });
-
-    it('Should support IVersion interface', async function () {
-      const supported = await concreteVotingBasis.supportsInterface(iVersionInterfaceId);
       void expect(supported).to.be.true;
     });
 

--- a/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
+++ b/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
@@ -4,12 +4,9 @@ import { ethers } from 'hardhat';
 import {
   ConcreteERC4337VoterSupportV1,
   ConcreteERC4337VoterSupportV1__factory,
-  IERC165__factory,
-  IVersion__factory,
   MockOwnership,
   MockOwnership__factory,
 } from '../../../typechain-types';
-import { calculateInterfaceId } from '../../helpers/utils';
 
 describe('ERC4337VoterSupportV1', () => {
   // Signers
@@ -66,43 +63,6 @@ describe('ERC4337VoterSupportV1', () => {
         const voter = await concreteERC4337VoterSupport.voter(contractAddress);
         expect(voter).to.equal(contractAddress);
       });
-    });
-  });
-
-  describe('Version', () => {
-    it('should return correct version', async () => {
-      expect(await concreteERC4337VoterSupport.getVersion()).to.equal(1);
-    });
-  });
-
-  describe('ERC165', function () {
-    // Interface IDs
-    let iVersionInterfaceId: string;
-    let iERC165InterfaceId: string;
-
-    beforeEach(async function () {
-      // Dynamically calculate interface IDs for standard interfaces
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
-
-      const IERC165Interface = IERC165__factory.createInterface();
-      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
-    });
-
-    it('Should support IERC165 interface', async function () {
-      const supported = await concreteERC4337VoterSupport.supportsInterface(iERC165InterfaceId);
-      void expect(supported).to.be.true;
-    });
-
-    it('Should support IVersion interface', async function () {
-      const supported = await concreteERC4337VoterSupport.supportsInterface(iVersionInterfaceId);
-      void expect(supported).to.be.true;
-    });
-
-    it('Should not support random interface', async function () {
-      const randomInterfaceId = '0x12345678';
-      const supported = await concreteERC4337VoterSupport.supportsInterface(randomInterfaceId);
-      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/HatsProposalCreationWhitelistV1.test.ts
+++ b/test/deployables/strategies/HatsProposalCreationWhitelistV1.test.ts
@@ -6,7 +6,6 @@ import {
   ConcreteHatsProposalCreationWhitelistV1__factory,
   IERC165__factory,
   IHatsProposalCreationWhitelistV1__factory,
-  IVersion__factory,
   MockHats,
   MockHats__factory,
 } from '../../../typechain-types';
@@ -183,16 +182,17 @@ describe('HatsProposalCreationWhitelistV1', () => {
     });
   });
 
-  // Use the shared test utility for isProposer tests
-  runHatsProposerTests({
-    getMockHats: () => mockHats,
-    getContract: () => concreteHatsProposalCreationWhitelist,
-    hatWearer: () => hatWearer,
-    nonHatWearer: () => nonHatWearer,
-    tokenHolder: () => nonOwner, // Using nonOwner as tokenHolder since we don't have tokens in this test
-    owner: () => owner,
-    proposerHatId: proposerHatId1,
-    nonProposerHatId,
+  describe('isProposer override', () => {
+    runHatsProposerTests({
+      getMockHats: () => mockHats,
+      getContract: () => concreteHatsProposalCreationWhitelist,
+      hatWearer: () => hatWearer,
+      nonHatWearer: () => nonHatWearer,
+      tokenHolder: () => nonOwner, // Using nonOwner as tokenHolder since we don't have tokens in this test
+      owner: () => owner,
+      proposerHatId: proposerHatId1,
+      nonProposerHatId,
+    });
   });
 
   describe('getWhitelistedHatIds', () => {
@@ -222,15 +222,8 @@ describe('HatsProposalCreationWhitelistV1', () => {
     });
   });
 
-  describe('Version', () => {
-    it('should return correct version', async () => {
-      expect(await concreteHatsProposalCreationWhitelist.getVersion()).to.equal(1);
-    });
-  });
-
   describe('ERC165', function () {
     let iHatsProposalCreationWhitelistV1InterfaceId: string;
-    let iVersionInterfaceId: string;
     let iERC165InterfaceId: string;
 
     beforeEach(async function () {
@@ -240,9 +233,6 @@ describe('HatsProposalCreationWhitelistV1', () => {
       iHatsProposalCreationWhitelistV1InterfaceId = calculateInterfaceId(
         IHatsProposalCreationWhitelistV1Interface,
       );
-
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
 
       const IERC165Interface = IERC165__factory.createInterface();
       iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
@@ -258,12 +248,6 @@ describe('HatsProposalCreationWhitelistV1', () => {
       const supported = await concreteHatsProposalCreationWhitelist.supportsInterface(
         iHatsProposalCreationWhitelistV1InterfaceId,
       );
-      void expect(supported).to.be.true;
-    });
-
-    it('Should support IVersion interface', async function () {
-      const supported =
-        await concreteHatsProposalCreationWhitelist.supportsInterface(iVersionInterfaceId);
       void expect(supported).to.be.true;
     });
 

--- a/test/deployables/strategies/LinearERC20VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingV1.test.ts
@@ -406,7 +406,8 @@ describe('LinearERC20VotingV1', () => {
   });
 
   describe('Version', () => {
-    it('should return correct version', async () => {
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await linearERC20Voting.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.test.ts
@@ -184,22 +184,23 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
       });
     });
 
-    // Use the shared test utility for isProposer tests
-    runHatsProposerTests({
-      getMockHats: () => mockHats,
-      getContract: () => linearERC20VotingWithHatsProposalCreation,
-      hatWearer: () => hatWearer,
-      nonHatWearer: () => nonHatWearer,
-      tokenHolder: () => tokenHolder1,
-      owner: () => owner,
-      proposerHatId: proposerHatId1,
-      nonProposerHatId,
+    describe('isProposer override', () => {
+      runHatsProposerTests({
+        getMockHats: () => mockHats,
+        getContract: () => linearERC20VotingWithHatsProposalCreation,
+        hatWearer: () => hatWearer,
+        nonHatWearer: () => nonHatWearer,
+        tokenHolder: () => tokenHolder1,
+        owner: () => owner,
+        proposerHatId: proposerHatId1,
+        nonProposerHatId,
+      });
     });
 
     describe('getVersion override', () => {
-      it('should return correct version', async () => {
-        const version = await linearERC20VotingWithHatsProposalCreation.getVersion();
-        expect(version).to.equal(1);
+      // Use the shared version test utility
+      it('should return the correct version number', async () => {
+        expect(await linearERC20VotingWithHatsProposalCreation.getVersion()).to.equal(1);
       });
     });
   });

--- a/test/deployables/strategies/LinearERC721VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingV1.test.ts
@@ -871,7 +871,8 @@ describe('LinearERC721VotingV1', () => {
   });
 
   describe('Version', () => {
-    it('should return correct version', async () => {
+    // Use the shared version test utility
+    it('should return the correct version number', async () => {
       expect(await linearERC721Voting.getVersion()).to.equal(1);
     });
   });

--- a/test/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.test.ts
@@ -221,22 +221,23 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
       });
     });
 
-    // Use the shared test utility for isProposer tests
-    runHatsProposerTests({
-      getMockHats: () => mockHats,
-      getContract: () => linearERC721VotingWithHatsProposalCreation,
-      hatWearer: () => hatWearer,
-      nonHatWearer: () => nonHatWearer,
-      tokenHolder: () => tokenHolder1,
-      owner: () => owner,
-      proposerHatId: proposerHatId1,
-      nonProposerHatId,
+    describe('isProposer override', () => {
+      runHatsProposerTests({
+        getMockHats: () => mockHats,
+        getContract: () => linearERC721VotingWithHatsProposalCreation,
+        hatWearer: () => hatWearer,
+        nonHatWearer: () => nonHatWearer,
+        tokenHolder: () => tokenHolder1,
+        owner: () => owner,
+        proposerHatId: proposerHatId1,
+        nonProposerHatId,
+      });
     });
 
     describe('getVersion override', () => {
-      it('should return correct version', async () => {
-        const version = await linearERC721VotingWithHatsProposalCreation.getVersion();
-        expect(version).to.equal(1);
+      // Use the shared version test utility
+      it('should return the correct version number', async () => {
+        expect(await linearERC721VotingWithHatsProposalCreation.getVersion()).to.equal(1);
       });
     });
 

--- a/test/helpers/hatsProposerTests.ts
+++ b/test/helpers/hatsProposerTests.ts
@@ -10,7 +10,7 @@ import { MockHats } from '../../typechain-types';
 /**
  * Interface for any contract that implements the isProposer and whitelistHat methods
  */
-export interface HatsProposerTester {
+interface HatsProposerTester {
   isProposer(address: string): Promise<boolean>;
   whitelistHat(hatId: bigint): Promise<any>;
   connect(signer: SignerWithAddress): HatsProposerTester;
@@ -19,7 +19,7 @@ export interface HatsProposerTester {
 /**
  * Parameters for running the isProposer tests
  */
-export interface HatsProposerTestParams {
+interface HatsProposerTestParams {
   getMockHats: () => MockHats;
   getContract: () => HatsProposerTester;
   hatWearer: () => SignerWithAddress;
@@ -37,53 +37,51 @@ export interface HatsProposerTestParams {
  * @param params The test parameters
  */
 export function runHatsProposerTests(params: HatsProposerTestParams): void {
-  describe('isProposer override', () => {
-    beforeEach(async () => {
-      await params
-        .getMockHats()
-        .setWearerStatus(params.hatWearer().address, params.proposerHatId, true);
-      await params
-        .getMockHats()
-        .setWearerStatus(params.nonHatWearer().address, params.nonProposerHatId, true);
-    });
+  beforeEach(async () => {
+    await params
+      .getMockHats()
+      .setWearerStatus(params.hatWearer().address, params.proposerHatId, true);
+    await params
+      .getMockHats()
+      .setWearerStatus(params.nonHatWearer().address, params.nonProposerHatId, true);
+  });
 
-    it('should return true for an address wearing a whitelisted hat', async () => {
-      // hatWearer has proposerHatId, which is whitelisted
-      const isHatWearerProposer = await params.getContract().isProposer(params.hatWearer().address);
-      void expect(isHatWearerProposer).to.be.true;
-    });
+  it('should return true for an address wearing a whitelisted hat', async () => {
+    // hatWearer has proposerHatId, which is whitelisted
+    const isHatWearerProposer = await params.getContract().isProposer(params.hatWearer().address);
+    void expect(isHatWearerProposer).to.be.true;
+  });
 
-    it('should return false for an address wearing a non-whitelisted hat', async () => {
-      // nonHatWearer has nonProposerHatId, which is not whitelisted
-      const isNonHatWearerProposer = await params
-        .getContract()
-        .isProposer(params.nonHatWearer().address);
-      void expect(isNonHatWearerProposer).to.be.false;
-    });
+  it('should return false for an address wearing a non-whitelisted hat', async () => {
+    // nonHatWearer has nonProposerHatId, which is not whitelisted
+    const isNonHatWearerProposer = await params
+      .getContract()
+      .isProposer(params.nonHatWearer().address);
+    void expect(isNonHatWearerProposer).to.be.false;
+  });
 
-    it('should return false for an address not wearing any hat even if they have tokens/NFTs', async () => {
-      // tokenHolder has no hats at all, but has tokens/NFTs
-      const isTokenHolderProposer = await params
-        .getContract()
-        .isProposer(params.tokenHolder().address);
-      void expect(isTokenHolderProposer).to.be.false;
-    });
+  it('should return false for an address not wearing any hat even if they have tokens/NFTs', async () => {
+    // tokenHolder has no hats at all, but has tokens/NFTs
+    const isTokenHolderProposer = await params
+      .getContract()
+      .isProposer(params.tokenHolder().address);
+    void expect(isTokenHolderProposer).to.be.false;
+  });
 
-    it('should return true after adding a previously non-whitelisted hat to the whitelist', async () => {
-      // First verify nonHatWearer is not a proposer initially
-      const isNonHatWearerProposerBefore = await params
-        .getContract()
-        .isProposer(params.nonHatWearer().address);
-      void expect(isNonHatWearerProposerBefore).to.be.false;
+  it('should return true after adding a previously non-whitelisted hat to the whitelist', async () => {
+    // First verify nonHatWearer is not a proposer initially
+    const isNonHatWearerProposerBefore = await params
+      .getContract()
+      .isProposer(params.nonHatWearer().address);
+    void expect(isNonHatWearerProposerBefore).to.be.false;
 
-      // Adding nonProposerHatId to the whitelist
-      await params.getContract().connect(params.owner()).whitelistHat(params.nonProposerHatId);
+    // Adding nonProposerHatId to the whitelist
+    await params.getContract().connect(params.owner()).whitelistHat(params.nonProposerHatId);
 
-      // Now nonHatWearer should be a proposer
-      const isNonHatWearerProposerAfterWhitelist = await params
-        .getContract()
-        .isProposer(params.nonHatWearer().address);
-      void expect(isNonHatWearerProposerAfterWhitelist).to.be.true;
-    });
+    // Now nonHatWearer should be a proposer
+    const isNonHatWearerProposerAfterWhitelist = await params
+      .getContract()
+      .isProposer(params.nonHatWearer().address);
+    void expect(isNonHatWearerProposerAfterWhitelist).to.be.true;
   });
 }


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/184

Implements a new Version abstract contract to provide a consistent versioning mechanism:
- Create Version contract with ERC165 interface support
- Replace IVersion interface with a more flexible implementation
- Update multiple contracts to inherit from Version
- Modify getVersion method to be view instead of pure
- Remove redundant IVersion interface checks in supportsInterface methods
- Add comprehensive test suite for Version contract

The changes improve contract versioning, enhance interface support, and provide a more flexible approach to contract identification and introspection.
