### PR TITLE
Migrate voting strategies from block-based to timestamp-based voting

### DIFF
--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -60,6 +60,14 @@ contract VotesERC20V1 is
         }
     }
 
+    function clock() public view override returns (uint48) {
+        return uint48(block.timestamp);
+    }
+
+    function CLOCK_MODE() public pure override returns (string memory) {
+        return "mode=timestamp";
+    }
+
     function _update(
         address from,
         address to,

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -55,10 +55,10 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version {
     /** Total number of submitted Proposals. */
     uint32 public totalProposalCount;
 
-    /** Delay (in blocks) between when a Proposal is passed and when it can be executed. */
+    /** Delay between when a Proposal is passed and when it can be executed. */
     uint32 public timelockPeriod;
 
-    /** Time (in blocks) between when timelock ends and the Proposal expires. */
+    /** Time between when timelock ends and the Proposal expires. */
     uint32 public executionPeriod;
 
     /** Proposals by `proposalId`. */
@@ -331,9 +331,9 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version {
 
         IBaseStrategyV1 _strategy = IBaseStrategyV1(_proposal.strategy);
 
-        uint256 votingEndBlock = _strategy.votingEndBlock(_proposalId);
+        uint256 votingEndTimestamp = _strategy.votingEndTimestamp(_proposalId);
 
-        if (block.number <= votingEndBlock) {
+        if (block.timestamp <= votingEndTimestamp) {
             return ProposalState.ACTIVE;
         } else if (!_strategy.isPassed(_proposalId)) {
             return ProposalState.FAILED;
@@ -342,11 +342,13 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version {
             // this allows for the potential for on-chain voting for
             // "off-chain" executed decisions
             return ProposalState.EXECUTED;
-        } else if (block.number <= votingEndBlock + _proposal.timelockPeriod) {
+        } else if (
+            block.timestamp <= votingEndTimestamp + _proposal.timelockPeriod
+        ) {
             return ProposalState.TIMELOCKED;
         } else if (
-            block.number <=
-            votingEndBlock +
+            block.timestamp <=
+            votingEndTimestamp +
                 _proposal.timelockPeriod +
                 _proposal.executionPeriod
         ) {
@@ -447,7 +449,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version {
     /**
      * Updates the `timelockPeriod` for future Proposals.
      *
-     * @param _timelockPeriod new timelock period (in blocks)
+     * @param _timelockPeriod new timelock period
      */
     function _updateTimelockPeriod(uint32 _timelockPeriod) internal {
         timelockPeriod = _timelockPeriod;
@@ -457,7 +459,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version {
     /**
      * Updates the `executionPeriod` for future Proposals.
      *
-     * @param _executionPeriod new execution period (in blocks)
+     * @param _executionPeriod new execution period
      */
     function _updateExecutionPeriod(uint32 _executionPeriod) internal {
         executionPeriod = _executionPeriod;

--- a/contracts/deployables/strategies/BaseStrategyV1.sol
+++ b/contracts/deployables/strategies/BaseStrategyV1.sol
@@ -52,9 +52,9 @@ abstract contract BaseStrategyV1 is
     function isProposer(address _address) external view virtual returns (bool);
 
     /** @inheritdoc IBaseStrategyV1*/
-    function votingEndBlock(
+    function votingEndTimestamp(
         uint32 _proposalId
-    ) external view virtual returns (uint32);
+    ) external view virtual returns (uint48);
 
     /**
      * Sets the address of the [Azorius](Azorius.md) module contract.

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -35,8 +35,8 @@ contract LinearERC20VotingV1 is
      * Defines the current state of votes on a particular Proposal.
      */
     struct ProposalVotes {
-        uint32 votingStartBlock; // block that voting starts at
-        uint32 votingEndBlock; // block that voting ends
+        uint48 votingStartTimestamp; // time that voting starts at
+        uint48 votingEndTimestamp; // time that voting ends
         uint256 noVotes; // current number of NO votes for the Proposal
         uint256 yesVotes; // current number of YES votes for the Proposal
         uint256 abstainVotes; // current number of ABSTAIN votes for the Proposal
@@ -45,7 +45,7 @@ contract LinearERC20VotingV1 is
 
     IVotes public governanceToken;
 
-    /** Number of blocks a new Proposal can be voted on. */
+    /** Time that a new Proposal can be voted on. */
     uint32 public votingPeriod;
 
     /** Voting weight required to be able to submit Proposals. */
@@ -56,7 +56,7 @@ contract LinearERC20VotingV1 is
 
     event VotingPeriodUpdated(uint32 votingPeriod);
     event RequiredProposerWeightUpdated(uint256 requiredProposerWeight);
-    event ProposalInitialized(uint32 proposalId, uint32 votingEndBlock);
+    event ProposalInitialized(uint32 proposalId, uint48 votingEndTimestamp);
     event Voted(
         address voter,
         uint32 proposalId,
@@ -152,8 +152,8 @@ contract LinearERC20VotingV1 is
      * @return noVotes current count of "NO" votes
      * @return yesVotes current count of "YES" votes
      * @return abstainVotes current count of "ABSTAIN" votes
-     * @return startBlock block number voting starts
-     * @return endBlock block number voting ends
+     * @return startTimestamp timestamp voting starts
+     * @return endTimestamp timestamp voting ends
      */
     function getProposalVotes(
         uint32 _proposalId
@@ -165,16 +165,16 @@ contract LinearERC20VotingV1 is
             uint256 noVotes,
             uint256 yesVotes,
             uint256 abstainVotes,
-            uint32 startBlock,
-            uint32 endBlock,
+            uint48 startTimestamp,
+            uint48 endTimestamp,
             uint256 votingSupply
         )
     {
         noVotes = proposalVotes[_proposalId].noVotes;
         yesVotes = proposalVotes[_proposalId].yesVotes;
         abstainVotes = proposalVotes[_proposalId].abstainVotes;
-        startBlock = proposalVotes[_proposalId].votingStartBlock;
-        endBlock = proposalVotes[_proposalId].votingEndBlock;
+        startTimestamp = proposalVotes[_proposalId].votingStartTimestamp;
+        endTimestamp = proposalVotes[_proposalId].votingEndTimestamp;
         votingSupply = getProposalVotingSupply(_proposalId);
     }
 
@@ -183,12 +183,14 @@ contract LinearERC20VotingV1 is
         bytes memory _data
     ) public virtual override onlyAzorius {
         uint32 proposalId = abi.decode(_data, (uint32));
-        uint32 _votingEndBlock = uint32(block.number) + votingPeriod;
+        uint48 _votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
 
-        proposalVotes[proposalId].votingEndBlock = _votingEndBlock;
-        proposalVotes[proposalId].votingStartBlock = uint32(block.number);
+        proposalVotes[proposalId].votingEndTimestamp = _votingEndTimestamp;
+        proposalVotes[proposalId].votingStartTimestamp = uint48(
+            block.timestamp
+        );
 
-        emit ProposalInitialized(proposalId, _votingEndBlock);
+        emit ProposalInitialized(proposalId, _votingEndTimestamp);
     }
 
     /**
@@ -209,7 +211,8 @@ contract LinearERC20VotingV1 is
     function isPassed(
         uint32 _proposalId
     ) public view virtual override returns (bool) {
-        return (block.number > proposalVotes[_proposalId].votingEndBlock && // voting period has ended
+        return (block.timestamp >
+            proposalVotes[_proposalId].votingEndTimestamp && // voting period has ended
             meetsQuorum(
                 getProposalVotingSupply(_proposalId),
                 proposalVotes[_proposalId].yesVotes,
@@ -234,7 +237,7 @@ contract LinearERC20VotingV1 is
     ) public view virtual returns (uint256) {
         return
             governanceToken.getPastTotalSupply(
-                proposalVotes[_proposalId].votingStartBlock
+                proposalVotes[_proposalId].votingStartTimestamp
             );
     }
 
@@ -252,7 +255,7 @@ contract LinearERC20VotingV1 is
         return
             governanceToken.getPastVotes(
                 _voter,
-                proposalVotes[_proposalId].votingStartBlock
+                proposalVotes[_proposalId].votingStartTimestamp
             );
     }
 
@@ -266,10 +269,10 @@ contract LinearERC20VotingV1 is
     }
 
     /** @inheritdoc BaseStrategyV1*/
-    function votingEndBlock(
+    function votingEndTimestamp(
         uint32 _proposalId
-    ) public view virtual override returns (uint32) {
-        return proposalVotes[_proposalId].votingEndBlock;
+    ) public view virtual override returns (uint48) {
+        return proposalVotes[_proposalId].votingEndTimestamp;
     }
 
     /** Internal implementation of `updateVotingPeriod`. */
@@ -301,9 +304,9 @@ contract LinearERC20VotingV1 is
         uint8 _voteType,
         uint256 _weight
     ) internal virtual {
-        if (proposalVotes[_proposalId].votingEndBlock == 0)
+        if (proposalVotes[_proposalId].votingEndTimestamp == 0)
             revert InvalidProposal();
-        if (block.number > proposalVotes[_proposalId].votingEndBlock)
+        if (block.timestamp > proposalVotes[_proposalId].votingEndTimestamp)
             revert VotingEnded();
         if (proposalVotes[_proposalId].hasVoted[_voter]) revert AlreadyVoted();
 

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -41,8 +41,8 @@ contract LinearERC721VotingV1 is
      * Defines the current state of votes on a particular Proposal.
      */
     struct ProposalVotes {
-        uint32 votingStartBlock; // block that voting starts at
-        uint32 votingEndBlock; // block that voting ends
+        uint48 votingStartTimestamp; // timestamp that voting starts at
+        uint48 votingEndTimestamp; // timestamp that voting ends
         uint256 noVotes; // current number of NO votes for the Proposal
         uint256 yesVotes; // current number of YES votes for the Proposal
         uint256 abstainVotes; // current number of ABSTAIN votes for the Proposal
@@ -80,7 +80,7 @@ contract LinearERC721VotingV1 is
     event VotingPeriodUpdated(uint32 votingPeriod);
     event QuorumThresholdUpdated(uint256 quorumThreshold);
     event ProposerThresholdUpdated(uint256 proposerThreshold);
-    event ProposalInitialized(uint32 proposalId, uint32 votingEndBlock);
+    event ProposalInitialized(uint32 proposalId, uint48 votingEndTimestamp);
     event Voted(
         address voter,
         uint32 proposalId,
@@ -222,8 +222,8 @@ contract LinearERC721VotingV1 is
      * @return noVotes current count of "NO" votes
      * @return yesVotes current count of "YES" votes
      * @return abstainVotes current count of "ABSTAIN" votes
-     * @return startBlock block number voting starts
-     * @return endBlock block number voting ends
+     * @return startTimestamp timestamp voting starts
+     * @return endTimestamp timestamp voting ends
      */
     function getProposalVotes(
         uint32 _proposalId
@@ -235,15 +235,15 @@ contract LinearERC721VotingV1 is
             uint256 noVotes,
             uint256 yesVotes,
             uint256 abstainVotes,
-            uint32 startBlock,
-            uint32 endBlock
+            uint48 startTimestamp,
+            uint48 endTimestamp
         )
     {
         noVotes = proposalVotes[_proposalId].noVotes;
         yesVotes = proposalVotes[_proposalId].yesVotes;
         abstainVotes = proposalVotes[_proposalId].abstainVotes;
-        startBlock = proposalVotes[_proposalId].votingStartBlock;
-        endBlock = proposalVotes[_proposalId].votingEndBlock;
+        startTimestamp = proposalVotes[_proposalId].votingStartTimestamp;
+        endTimestamp = proposalVotes[_proposalId].votingEndTimestamp;
     }
 
     /**
@@ -325,19 +325,22 @@ contract LinearERC721VotingV1 is
         bytes memory _data
     ) public virtual override onlyAzorius {
         uint32 proposalId = abi.decode(_data, (uint32));
-        uint32 _votingEndBlock = uint32(block.number) + votingPeriod;
+        uint48 _votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
 
-        proposalVotes[proposalId].votingEndBlock = _votingEndBlock;
-        proposalVotes[proposalId].votingStartBlock = uint32(block.number);
+        proposalVotes[proposalId].votingEndTimestamp = _votingEndTimestamp;
+        proposalVotes[proposalId].votingStartTimestamp = uint48(
+            block.timestamp
+        );
 
-        emit ProposalInitialized(proposalId, _votingEndBlock);
+        emit ProposalInitialized(proposalId, _votingEndTimestamp);
     }
 
     /** @inheritdoc BaseStrategyV1*/
     function isPassed(
         uint32 _proposalId
     ) public view virtual override returns (bool) {
-        return (block.number > proposalVotes[_proposalId].votingEndBlock && // voting period has ended
+        return (block.timestamp >
+            proposalVotes[_proposalId].votingEndTimestamp && // voting period has ended
             quorumThreshold <=
             proposalVotes[_proposalId].yesVotes +
                 proposalVotes[_proposalId].abstainVotes && // yes + abstain votes meets the quorum
@@ -365,10 +368,10 @@ contract LinearERC721VotingV1 is
     }
 
     /** @inheritdoc BaseStrategyV1*/
-    function votingEndBlock(
+    function votingEndTimestamp(
         uint32 _proposalId
-    ) public view virtual override returns (uint32) {
-        return proposalVotes[_proposalId].votingEndBlock;
+    ) public view virtual override returns (uint48) {
+        return proposalVotes[_proposalId].votingEndTimestamp;
     }
 
     /** Internal implementation of `addGovernanceToken` */
@@ -456,9 +459,9 @@ contract LinearERC721VotingV1 is
 
         ProposalVotes storage proposal = proposalVotes[_proposalId];
 
-        if (proposal.votingEndBlock == 0) revert InvalidProposal();
+        if (proposal.votingEndTimestamp == 0) revert InvalidProposal();
 
-        if (block.number > proposal.votingEndBlock) revert VotingEnded();
+        if (block.timestamp > proposal.votingEndTimestamp) revert VotingEnded();
 
         if (_voteType == uint8(VoteType.NO)) {
             proposal.noVotes += weight;

--- a/contracts/interfaces/decent/deployables/IAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IAzoriusV1.sol
@@ -50,8 +50,8 @@ interface IAzoriusV1 {
     /** Holds details pertaining to a single proposal. */
     struct Proposal {
         uint32 executionCounter; // count of transactions that have been executed within the proposal
-        uint32 timelockPeriod; // time (in blocks) this proposal will be timelocked for if it passes
-        uint32 executionPeriod; // time (in blocks) this proposal has to be executed after timelock ends before it is expired
+        uint32 timelockPeriod; // time this proposal will be timelocked for if it passes
+        uint32 executionPeriod; // time this proposal has to be executed after timelock ends before it is expired
         address strategy; // BaseStrategy contract this proposal was created on
         bytes32[] txHashes; // hashes of the transactions that are being proposed
     }
@@ -89,14 +89,14 @@ interface IAzoriusV1 {
      * Updates the `timelockPeriod` for newly created Proposals.
      * This has no effect on existing Proposals, either `ACTIVE` or completed.
      *
-     * @param _timelockPeriod timelockPeriod (in blocks) to be used for new Proposals
+     * @param _timelockPeriod new timelock period
      */
     function updateTimelockPeriod(uint32 _timelockPeriod) external;
 
     /**
      * Updates the execution period for future Proposals.
      *
-     * @param _executionPeriod new execution period (in blocks)
+     * @param _executionPeriod new execution period
      */
     function updateExecutionPeriod(uint32 _executionPeriod) external;
 
@@ -233,8 +233,8 @@ interface IAzoriusV1 {
      * @param _proposalId identifier of the Proposal
      * @return _strategy address of the BaseStrategy contract the Proposal is on
      * @return _txHashes hashes of the transactions the Proposal contains
-     * @return _timelockPeriod time (in blocks) the Proposal is timelocked for
-     * @return _executionPeriod time (in blocks) the Proposal must be executed within, after timelock ends
+     * @return _timelockPeriod time the Proposal is timelocked for
+     * @return _executionPeriod time the Proposal must be executed within, after timelock ends
      * @return _executionCounter counter of how many of the Proposals transactions have been executed
      */
     function getProposal(

--- a/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
@@ -50,10 +50,12 @@ interface IBaseStrategyV1 {
     function isProposer(address _address) external view returns (bool);
 
     /**
-     * Returns the block number voting ends on a given Proposal.
+     * Returns the absolute timestamp that voting ends on a given Proposal.
      *
      * @param _proposalId proposalId to check
-     * @return uint32 block number when voting ends on the Proposal
+     * @return uint48 timestamp when voting ends on the Proposal
      */
-    function votingEndBlock(uint32 _proposalId) external view returns (uint32);
+    function votingEndTimestamp(
+        uint32 _proposalId
+    ) external view returns (uint48);
 }

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -6,7 +6,7 @@ import {IBaseStrategyV1} from "../interfaces/decent/deployables/IBaseStrategyV1.
 contract MockVotingStrategy is IBaseStrategyV1 {
     address public proposer;
     mapping(uint32 => bool) private _isPassed;
-    mapping(uint32 => uint32) private _votingEndBlock;
+    mapping(uint32 => uint48) private _votingEndTimestamp;
 
     constructor(address _proposer) {
         proposer = _proposer;
@@ -28,16 +28,19 @@ contract MockVotingStrategy is IBaseStrategyV1 {
         return _proposer == proposer;
     }
 
-    function votingEndBlock(
+    function votingEndTimestamp(
         uint32 proposalId
-    ) external view override returns (uint32) {
-        return _votingEndBlock[proposalId];
+    ) external view override returns (uint48) {
+        return _votingEndTimestamp[proposalId];
     }
 
     // setters, for testing
 
-    function setVotingEndBlock(uint32 proposalId, uint32 endBlock) external {
-        _votingEndBlock[proposalId] = endBlock;
+    function setVotingEndTimestamp(
+        uint32 proposalId,
+        uint48 endTimestamp
+    ) external {
+        _votingEndTimestamp[proposalId] = endTimestamp;
     }
 
     function setIsPassed(uint32 proposalId, bool passed) external {

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
@@ -56,7 +56,9 @@ contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
     /**
      * Concrete implementation of the abstract votingEndBlock function.
      */
-    function votingEndBlock(uint32) external view override returns (uint32) {
-        return uint32(block.number + 100);
+    function votingEndTimestamp(
+        uint32
+    ) external view override returns (uint48) {
+        return uint48(block.timestamp) + 100;
     }
 }

--- a/test/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/deployables/erc20/VotesERC20V1.test.ts
@@ -1,4 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { mine, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -232,6 +233,48 @@ describe('VotesERC20V1', () => {
       const randomInterfaceId = '0x12345678';
       const supported = await votesERC20.supportsInterface(randomInterfaceId);
       void expect(supported).to.be.false;
+    });
+  });
+
+  describe('Timestamp-based clock functions', () => {
+    beforeEach(async () => {
+      votesERC20 = await deployVotesERC20Proxy(
+        votesERC20Mastercopy,
+        owner,
+        TOKEN_NAME,
+        TOKEN_SYMBOL,
+        [owner.address],
+        [ethers.parseEther('100')],
+      );
+    });
+
+    it('should return current timestamp from clock()', async () => {
+      const currentTime = await ethers.provider.getBlock('latest').then(b => b!.timestamp);
+      const clockTime = await votesERC20.clock();
+
+      // Allow small variance due to block mining time
+      expect(Number(clockTime)).to.be.closeTo(currentTime, 5);
+    });
+
+    it("should return 'mode=timestamp' from CLOCK_MODE()", async () => {
+      expect(await votesERC20.CLOCK_MODE()).to.equal('mode=timestamp');
+    });
+
+    it('should use timestamp for vote checkpoints', async () => {
+      // Delegate to another address
+      await votesERC20.connect(owner).delegate(alice.address);
+
+      // Mine a block to move forward in time
+      await mine(1);
+
+      // Get current timestamp which is now > the delegation timestamp
+      const currentTime = await time.latest();
+
+      // The voting power at the previous timestamp should be available
+      const votingPower = await votesERC20.getPastVotes(alice.address, currentTime - 1);
+
+      // Should match the owner's balance since we just delegated
+      expect(votingPower).to.equal(await votesERC20.balanceOf(owner.address));
     });
   });
 });

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -866,9 +866,9 @@ describe('AzoriusV1', () => {
         proposalId = 0;
 
         // Set voting end block to future block and mark as passed by default
-        const currentBlock = await time.latestBlock();
+        const currentBlockTimestamp = await time.latest();
 
-        await mockStrategy.setVotingEndBlock(proposalId, currentBlock + 10);
+        await mockStrategy.setVotingEndTimestamp(proposalId, currentBlockTimestamp + 10);
         await mockStrategy.setIsPassed(proposalId, true);
       });
 
@@ -877,7 +877,7 @@ describe('AzoriusV1', () => {
         expect(await azorius.proposalState(proposalId)).to.equal(0); // ACTIVE
 
         // End voting immediately
-        await mockStrategy.setVotingEndBlock(proposalId, await time.latestBlock());
+        await mockStrategy.setVotingEndTimestamp(proposalId, await time.latest());
 
         // Should be in timelock since we set isPassed to true in beforeEach
         expect(await azorius.proposalState(proposalId)).to.equal(1); // TIMELOCKED
@@ -900,7 +900,7 @@ describe('AzoriusV1', () => {
         await mockToken.mint(await avatar.getAddress(), 1000);
 
         // End voting immediately
-        await mockStrategy.setVotingEndBlock(proposalId, await time.latestBlock());
+        await mockStrategy.setVotingEndTimestamp(proposalId, await time.latest());
 
         // Move past timelock
         await mine(TIMELOCK_PERIOD);
@@ -923,7 +923,7 @@ describe('AzoriusV1', () => {
 
       it('should not execute proposal before timelock period', async () => {
         // Set voting to passed
-        await mockStrategy.setVotingEndBlock(proposalId, 0);
+        await mockStrategy.setVotingEndTimestamp(proposalId, 0);
         await mockStrategy.setIsPassed(proposalId, true);
 
         await expect(
@@ -939,7 +939,7 @@ describe('AzoriusV1', () => {
 
       it('should not execute proposal after execution period', async () => {
         // Set voting to passed
-        await mockStrategy.setVotingEndBlock(proposalId, 0);
+        await mockStrategy.setVotingEndTimestamp(proposalId, 0);
         await mockStrategy.setIsPassed(proposalId, true);
 
         // Move past timelock and execution period
@@ -954,6 +954,66 @@ describe('AzoriusV1', () => {
             [proposalTx.operation],
           ),
         ).to.be.revertedWithCustomError(azorius, 'ProposalNotExecutable');
+      });
+
+      describe('Timestamp-based proposal state transitions', () => {
+        beforeEach(async () => {
+          // Setup is already done in the parent beforeEach
+          // Just need to reset the proposal state for our tests
+          const currentTimestamp = await time.latest();
+
+          // Set a future voting end timestamp
+          await mockStrategy.setVotingEndTimestamp(proposalId, currentTimestamp + 100);
+          await mockStrategy.setIsPassed(proposalId, true);
+        });
+
+        it('should correctly transition between states based on timestamps', async () => {
+          const currentTimestamp = await time.latest();
+
+          // Initially active
+          expect(await azorius.proposalState(proposalId)).to.equal(0); // ACTIVE
+
+          // Advance time just past voting end
+          await time.increaseTo(currentTimestamp + 101);
+
+          // Verify state changes to TIMELOCKED
+          expect(await azorius.proposalState(proposalId)).to.equal(1); // TIMELOCKED
+
+          // Advance time past timelock period
+          await time.increaseTo(currentTimestamp + 101 + TIMELOCK_PERIOD);
+
+          // Verify state changes to EXECUTABLE
+          expect(await azorius.proposalState(proposalId)).to.equal(2); // EXECUTABLE
+
+          // Advance time past execution period
+          await time.increaseTo(currentTimestamp + 101 + TIMELOCK_PERIOD + EXECUTION_PERIOD);
+
+          // Verify state changes to EXPIRED
+          expect(await azorius.proposalState(proposalId)).to.equal(4); // EXPIRED
+        });
+
+        it('should handle exact boundary conditions in timestamp transitions', async () => {
+          const currentTimestamp = await time.latest();
+
+          // Set exact timestamps for voting end
+          await mockStrategy.setVotingEndTimestamp(proposalId, currentTimestamp + 100);
+
+          // At exactly the voting end time
+          await time.increaseTo(currentTimestamp + 100);
+          expect(await azorius.proposalState(proposalId)).to.equal(0); // Should still be ACTIVE at exactly the end timestamp
+
+          // One second after voting end
+          await time.increaseTo(currentTimestamp + 101);
+          expect(await azorius.proposalState(proposalId)).to.equal(1); // Should be TIMELOCKED after end timestamp
+
+          // At exactly the end of timelock period
+          await time.increaseTo(currentTimestamp + 101 + TIMELOCK_PERIOD);
+          expect(await azorius.proposalState(proposalId)).to.equal(2); // Should be EXECUTABLE
+
+          // At exactly the end of execution period
+          await time.increaseTo(currentTimestamp + 101 + TIMELOCK_PERIOD + EXECUTION_PERIOD);
+          expect(await azorius.proposalState(proposalId)).to.equal(4); // Should be EXPIRED at exactly end of execution period
+        });
       });
     });
 
@@ -992,7 +1052,7 @@ describe('AzoriusV1', () => {
           .submitProposal(await mockStrategy.getAddress(), '0x', [tx1, tx2], 'Test proposal');
 
         // Set voting to passed and move past timelock
-        await mockStrategy.setVotingEndBlock(0, 0);
+        await mockStrategy.setVotingEndTimestamp(0, 0);
         await mockStrategy.setIsPassed(0, true);
         await mine(TIMELOCK_PERIOD);
 
@@ -1004,9 +1064,9 @@ describe('AzoriusV1', () => {
       describe('Partial execution', () => {
         beforeEach(async () => {
           // Get current block number
-          const currentBlock = await time.latestBlock();
-          const votingEndBlock = currentBlock + 10;
-          await mockStrategy.setVotingEndBlock(0, votingEndBlock);
+          const currentBlockTimestamp = await time.latest();
+          const votingEndTimestamp = currentBlockTimestamp + 10;
+          await mockStrategy.setVotingEndTimestamp(0, votingEndTimestamp);
 
           // Move past voting and timelock period
           await mine(10 + TIMELOCK_PERIOD);
@@ -1063,9 +1123,9 @@ describe('AzoriusV1', () => {
           .submitProposal(await mockStrategy.getAddress(), '0x', [tx1, tx2], 'Test proposal');
 
         // Get current block number and set up proposal state
-        const currentBlock = await time.latestBlock();
-        const votingEndBlock = currentBlock + 10;
-        await mockStrategy.setVotingEndBlock(1, votingEndBlock);
+        const currentBlockTimestamp = await time.latest();
+        const votingEndBlockTimestamp = currentBlockTimestamp + 10;
+        await mockStrategy.setVotingEndTimestamp(1, votingEndBlockTimestamp);
         await mockStrategy.setIsPassed(1, true);
 
         // Move past voting and timelock period

--- a/test/deployables/strategies/LinearERC20VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingV1.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { mine, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -251,8 +251,8 @@ describe('LinearERC20VotingV1', () => {
       await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
 
       // Check that proposal was initialized correctly
-      const votingEndBlock = await linearERC20Voting.votingEndBlock(proposalId);
-      expect(votingEndBlock).to.not.equal(0);
+      const votingEndTimestamp = await linearERC20Voting.votingEndTimestamp(proposalId);
+      expect(votingEndTimestamp).to.not.equal(0);
     });
 
     it('should determine proposer status based on voting weight', async () => {
@@ -653,6 +653,105 @@ describe('LinearERC20VotingV1', () => {
       const randomInterfaceId = '0x12345678';
       const supported = await linearERC20Voting.supportsInterface(randomInterfaceId);
       void expect(supported).to.be.false;
+    });
+  });
+
+  describe('Timestamp-based voting', () => {
+    let proposalId: number;
+
+    beforeEach(async () => {
+      // Initialize a proposal
+      proposalId = 100;
+      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
+      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
+
+      // Mint tokens to a voter for testing
+      await mockToken.mint(tokenHolder1.address, 1000);
+      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+    });
+
+    it('should enforce voting end by timestamp', async () => {
+      // Get the voting end timestamp
+      const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
+
+      // Cast a vote before voting ends
+      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
+
+      // Advance time to just after voting end
+      await time.increaseTo(Number(endTimestamp) + 1);
+
+      // Try to vote after voting ended - should revert
+      await expect(
+        linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
+    });
+
+    it('should use timestamp for voting weight snapshot', async () => {
+      // Get the proposal start timestamp
+      const [, , , startTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
+
+      // Set the past votes to a specific value for testing at the proposal's start timestamp
+      await mockToken.setPastVotes(tokenHolder1.address, startTimestamp, 500);
+
+      // Check that the voting weight is determined by snapshot at start timestamp
+      const votingWeight = await linearERC20Voting.getVotingWeight(
+        tokenHolder1.address,
+        proposalId,
+      );
+      expect(votingWeight).to.equal(500);
+
+      // If user gets more tokens now, voting weight shouldn't change for this proposal
+      const oldBalance = await mockToken.balanceOf(tokenHolder1.address);
+      await mockToken.mint(tokenHolder1.address, 500);
+
+      // Verify total balance increased
+      expect(await mockToken.balanceOf(tokenHolder1.address)).to.be.gt(oldBalance);
+
+      // But voting weight for this proposal should remain the same
+      const newWeight = await linearERC20Voting.getVotingWeight(tokenHolder1.address, proposalId);
+      expect(newWeight).to.equal(500);
+    });
+
+    it('should determine proposal state based on timestamp', async () => {
+      // Set the past votes and total supply at the proposal's start timestamp
+      const [, , , startTimestamp, ,] = await linearERC20Voting.getProposalVotes(proposalId);
+      await mockToken.setPastVotes(tokenHolder1.address, startTimestamp, 600);
+      await mockToken.setPastTotalSupply(startTimestamp, 1000);
+
+      // Cast votes to meet quorum and basis requirements
+      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
+
+      // Before voting end, proposal should not be passed
+      void expect(await linearERC20Voting.isPassed(proposalId)).to.be.false;
+
+      // Get voting end timestamp
+      const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
+
+      // Advance time to just after voting end
+      await time.increaseTo(Number(endTimestamp) + 1);
+
+      // Proposal should pass
+      void expect(await linearERC20Voting.isPassed(proposalId)).to.be.true;
+    });
+
+    it('should handle exact boundary conditions for timestamps', async () => {
+      // Get voting end timestamp
+      const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
+
+      // Advance time to 2 seconds before the voting end timestamp
+      await time.increaseTo(Number(endTimestamp) - 2);
+
+      // Should still be able to vote before end timestamp
+      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
+
+      // Advance to end timestamp with a single mine operation
+      // This avoids the "same timestamp" error by using mine with a timestamp parameter
+      await ethers.provider.send('evm_mine', [Number(endTimestamp)]);
+
+      // Should no longer be able to vote at exactly the end timestamp
+      await expect(
+        linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
     });
   });
 });

--- a/test/deployables/strategies/LinearERC721VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingV1.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { mine, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -342,8 +342,8 @@ describe('LinearERC721VotingV1', () => {
       await linearERC721Voting.connect(nonOwner).initializeProposal(initializeData);
 
       // Check that proposal was initialized correctly
-      const votingEndBlock = await linearERC721Voting.votingEndBlock(proposalId);
-      expect(votingEndBlock).to.not.equal(0);
+      const votingEndTimestamp = await linearERC721Voting.votingEndTimestamp(proposalId);
+      expect(votingEndTimestamp).to.not.equal(0);
     });
 
     it('should determine proposer status based on NFT ownership', async () => {
@@ -840,13 +840,15 @@ describe('LinearERC721VotingV1', () => {
       const proposalId = 200;
       const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
 
-      // Get current block number to calculate expected end block
-      const currentBlockNumber = await ethers.provider.getBlockNumber();
-      const expectedEndBlock = currentBlockNumber + 1 + VOTING_PERIOD; // +1 because the proposal will be in the next block
+      // Get current block timestmp to calculate expected end timestamp
+      const currentBlockTimestamp = await time.latest();
+
+      // +1 because the proposal will be in the next block, and that block's timestamp will be increased by one second
+      const expectedEndTimestamp = currentBlockTimestamp + 1 + VOTING_PERIOD;
 
       await expect(linearERC721Voting.connect(nonOwner).initializeProposal(initializeData))
         .to.emit(linearERC721Voting, 'ProposalInitialized')
-        .withArgs(proposalId, expectedEndBlock);
+        .withArgs(proposalId, expectedEndTimestamp);
     });
   });
 
@@ -938,6 +940,105 @@ describe('LinearERC721VotingV1', () => {
       const randomInterfaceId = '0x12345678';
       const supported = await linearERC721Voting.supportsInterface(randomInterfaceId);
       void expect(supported).to.be.false;
+    });
+  });
+
+  describe('Timestamp-based voting', () => {
+    let proposalId: number;
+
+    beforeEach(async () => {
+      // Initialize a proposal
+      proposalId = 100;
+      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
+      await linearERC721Voting.connect(nonOwner).initializeProposal(initializeData);
+    });
+
+    it('should enforce voting end by timestamp', async () => {
+      // Get the voting end timestamp
+      const [, , , , endTimestamp] = await linearERC721Voting.getProposalVotes(proposalId);
+
+      // Cast a vote before voting ends
+      await linearERC721Voting
+        .connect(tokenHolder1)
+        .vote(proposalId, VoteType.YES, [await mockNFT1.getAddress()], [tokenHolder1Ids[0]]);
+
+      // Advance time to just after voting end
+      await time.increaseTo(Number(endTimestamp) + 1);
+
+      // Try to vote after voting ended - should revert
+      await expect(
+        linearERC721Voting
+          .connect(tokenHolder1)
+          .vote(proposalId, VoteType.YES, [await mockNFT1.getAddress()], [tokenHolder1Ids[1]]),
+      ).to.be.revertedWithCustomError(linearERC721Voting, 'VotingEnded');
+    });
+
+    it('should determine proposal state based on timestamp', async () => {
+      // Vote yes with several NFTs to ensure quorum and basis are met
+      await linearERC721Voting
+        .connect(tokenHolder1)
+        .vote(
+          proposalId,
+          VoteType.YES,
+          [await mockNFT1.getAddress(), await mockNFT1.getAddress()],
+          [tokenHolder1Ids[0], tokenHolder1Ids[1]],
+        );
+
+      // Add more votes to ensure quorum (we need at least 5 votes)
+      await linearERC721Voting
+        .connect(tokenHolder3)
+        .vote(
+          proposalId,
+          VoteType.YES,
+          [await mockNFT2.getAddress(), await mockNFT2.getAddress()],
+          [tokenHolder3Ids[0], tokenHolder3Ids[1]],
+        );
+
+      // Also add votes from tokenHolder2 to meet quorum
+      await linearERC721Voting
+        .connect(tokenHolder2)
+        .vote(proposalId, VoteType.YES, [await mockNFT1.getAddress()], [tokenHolder2Ids[0]]);
+
+      // Get voting end timestamp
+      const [, , , , endTimestamp] = await linearERC721Voting.getProposalVotes(proposalId);
+
+      // Before advancing time, proposal should not be passed
+      void expect(await linearERC721Voting.isPassed(proposalId)).to.be.false;
+
+      // Advance time to AFTER the voting end timestamp (critical for isPassed)
+      await ethers.provider.send('evm_mine', [Number(endTimestamp) + 1]);
+
+      // Now the proposal should pass (past end timestamp + meets quorum + meets basis)
+      void expect(await linearERC721Voting.isPassed(proposalId)).to.be.true;
+    });
+
+    it('should handle exact boundary conditions for timestamps', async () => {
+      // Get voting end timestamp
+      const [, , , , endTimestamp] = await linearERC721Voting.getProposalVotes(proposalId);
+
+      // Advance time to 3 seconds before the voting end timestamp
+      await time.increaseTo(Number(endTimestamp) - 3);
+
+      // Should still be able to vote before end timestamp
+      await linearERC721Voting
+        .connect(tokenHolder1)
+        .vote(proposalId, VoteType.YES, [await mockNFT1.getAddress()], [tokenHolder1Ids[0]]);
+
+      // Mine a block to ensure timestamp advances by 1 second
+      await mine(1);
+
+      // Now, jump directly to the end timestamp using evm_mine with a specific timestamp
+      // This approach avoids the "same timestamp" error by directly setting the block timestamp
+      const endTimeNum = Number(endTimestamp);
+      await ethers.provider.send('evm_setNextBlockTimestamp', [endTimeNum]);
+      await ethers.provider.send('evm_mine', []);
+
+      // Should no longer be able to vote at exactly the end timestamp
+      await expect(
+        linearERC721Voting
+          .connect(tokenHolder1)
+          .vote(proposalId, VoteType.YES, [await mockNFT1.getAddress()], [tokenHolder1Ids[1]]),
+      ).to.be.revertedWithCustomError(linearERC721Voting, 'VotingEnded');
     });
   });
 });


### PR DESCRIPTION
Refactors voting strategies to use timestamps instead of block numbers:
- Update VotesERC20V1 with timestamp-based clock functions
- Modify AzoriusV1 to use timestamps for proposal state transitions
- Adapt BaseStrategyV1, LinearERC20VotingV1, and LinearERC721VotingV1 to use timestamps
- Update interfaces and tests to support timestamp-based voting mechanics
- Improve voting precision and flexibility by using absolute timestamps

The changes provide a more consistent and reliable approach to tracking voting periods across different blockchain environments.

Read more about the background for these changes here: https://docs.openzeppelin.com/contracts/5.x/governance#timestamp_based_governance