### PR TITLE
Refactor freeze guard contracts to use BaseFreezeGuardV1

### DIFF
--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {BaseGuardV1} from "./BaseGuardV1.sol";
+import {BaseFreezeGuardV1} from "./BaseFreezeGuardV1.sol";
 import {Version} from "../Version.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
-import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 /**
@@ -13,7 +12,7 @@ import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
  *
  * See https://docs.safe.global/learn/safe-core/safe-core-protocol/guards.
  */
-contract AzoriusFreezeGuardV1 is Version, BaseGuardV1, FactoryFriendly {
+contract AzoriusFreezeGuardV1 is Version, BaseFreezeGuardV1 {
     uint16 private constant VERSION = 1;
 
     /**
@@ -70,7 +69,7 @@ contract AzoriusFreezeGuardV1 is Version, BaseGuardV1, FactoryFriendly {
         address payable,
         bytes memory,
         address
-    ) external view override(BaseGuardV1) {
+    ) external view override(BaseFreezeGuardV1) {
         // if the DAO is currently frozen, revert
         // see BaseFreezeVoting for freeze voting details
         if (freezeVoting.isFrozen()) revert DAOFrozen();
@@ -83,7 +82,7 @@ contract AzoriusFreezeGuardV1 is Version, BaseGuardV1, FactoryFriendly {
     function checkAfterExecution(
         bytes32,
         bool
-    ) external view override(BaseGuardV1) {
+    ) external view override(BaseFreezeGuardV1) {
         // not implementated
     }
 
@@ -94,7 +93,7 @@ contract AzoriusFreezeGuardV1 is Version, BaseGuardV1, FactoryFriendly {
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(BaseGuardV1, Version) returns (bool) {
+    ) public view virtual override(BaseFreezeGuardV1, Version) returns (bool) {
         return super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-guard/BaseFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/BaseFreezeGuardV1.sol
@@ -4,8 +4,13 @@ pragma solidity ^0.8.28;
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 
-abstract contract BaseGuardV1 is IGuard, ERC165 {
+abstract contract BaseFreezeGuardV1 is IGuard, ERC165, FactoryFriendly {
+    constructor() {
+        _disableInitializers();
+    }
+
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {BaseGuardV1} from "./BaseGuardV1.sol";
+import {BaseFreezeGuardV1} from "./BaseFreezeGuardV1.sol";
 import {Version} from "../Version.sol";
 import {IMultisigFreezeGuardV1} from "../../interfaces/decent/deployables/IMultisigFreezeGuardV1.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
-import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 /**
@@ -15,8 +14,7 @@ import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 contract MultisigFreezeGuardV1 is
     IMultisigFreezeGuardV1,
     Version,
-    BaseGuardV1,
-    FactoryFriendly
+    BaseFreezeGuardV1
 {
     uint16 private constant VERSION = 1;
 
@@ -167,7 +165,7 @@ contract MultisigFreezeGuardV1 is
         address payable,
         bytes memory signatures,
         address
-    ) external view override(BaseGuardV1) {
+    ) external view override(BaseFreezeGuardV1) {
         bytes32 signaturesHash = keccak256(signatures);
 
         if (transactionTimelockedBlock[signaturesHash] == 0)
@@ -195,7 +193,7 @@ contract MultisigFreezeGuardV1 is
     function checkAfterExecution(
         bytes32,
         bool
-    ) external view override(BaseGuardV1) {
+    ) external view override(BaseFreezeGuardV1) {
         // not implementated
     }
 
@@ -225,7 +223,7 @@ contract MultisigFreezeGuardV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(BaseGuardV1, Version) returns (bool) {
+    ) public view virtual override(BaseFreezeGuardV1, Version) returns (bool) {
         return
             interfaceId == type(IMultisigFreezeGuardV1).interfaceId ||
             super.supportsInterface(interfaceId);

--- a/contracts/mocks/concretes/deployables/freeze-guard/ConcreteBaseFreezeGuardV1.sol
+++ b/contracts/mocks/concretes/deployables/freeze-guard/ConcreteBaseFreezeGuardV1.sol
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {BaseGuardV1} from "../../../../deployables/freeze-guard/BaseGuardV1.sol";
+import {BaseFreezeGuardV1} from "../../../../deployables/freeze-guard/BaseFreezeGuardV1.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 /**
  * A concrete implementation of BaseGuardV1 for testing
  */
-contract ConcreteBaseGuardV1 is BaseGuardV1 {
+contract ConcreteBaseFreezeGuardV1 is BaseFreezeGuardV1 {
+    function setUp(bytes memory initializeParams) public override initializer {
+        address _owner = abi.decode(initializeParams, (address));
+        __Ownable_init(_owner);
+    }
+
     function checkTransaction(
         address,
         uint256,

--- a/test/deployables/freeze-guard/BaseFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/BaseFreezeGuardV1.test.ts
@@ -2,25 +2,25 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  ConcreteBaseGuardV1,
-  ConcreteBaseGuardV1__factory,
+  ConcreteBaseFreezeGuardV1,
+  ConcreteBaseFreezeGuardV1__factory,
   IERC165__factory,
   IGuard__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
 
-describe('BaseGuardV1', () => {
+describe('BaseFreezeGuardV1', () => {
   // Signers
   let deployer: SignerWithAddress;
 
   // Contracts
-  let concreteBaseGuard: ConcreteBaseGuardV1;
+  let concreteBaseFreezeGuard: ConcreteBaseFreezeGuardV1;
 
   beforeEach(async () => {
     [deployer] = await ethers.getSigners();
 
     // Deploy MockBaseGuardV1
-    concreteBaseGuard = await new ConcreteBaseGuardV1__factory(deployer).deploy();
+    concreteBaseFreezeGuard = await new ConcreteBaseFreezeGuardV1__factory(deployer).deploy();
   });
 
   describe('ERC165', function () {
@@ -37,18 +37,18 @@ describe('BaseGuardV1', () => {
     });
 
     it('Should support IERC165 interface', async function () {
-      const supported = await concreteBaseGuard.supportsInterface(iERC165InterfaceId);
+      const supported = await concreteBaseFreezeGuard.supportsInterface(iERC165InterfaceId);
       void expect(supported).to.be.true;
     });
 
     it('Should support IGuard interface', async function () {
-      const supported = await concreteBaseGuard.supportsInterface(iGuardInterfaceId);
+      const supported = await concreteBaseFreezeGuard.supportsInterface(iGuardInterfaceId);
       void expect(supported).to.be.true;
     });
 
     it('Should not support random interface', async function () {
       const randomInterfaceId = '0x12345678';
-      const supported = await concreteBaseGuard.supportsInterface(randomInterfaceId);
+      const supported = await concreteBaseFreezeGuard.supportsInterface(randomInterfaceId);
       void expect(supported).to.be.false;
     });
   });


### PR DESCRIPTION
- Updated AzoriusFreezeGuardV1 and MultisigFreezeGuardV1 to inherit from BaseFreezeGuardV1 instead of BaseGuardV1.
- Introduced BaseFreezeGuardV1 as an abstract contract implementing IGuard and ERC165.
- Added ConcreteBaseFreezeGuardV1 for testing purposes with mock implementations of required functions.
- Created tests for BaseFreezeGuardV1 to ensure proper ERC165 interface support.

These changes enhance the modularity and testability of the freeze guard contracts.