### PR TITLE
Implement UUPS upgradeability in freeze guard contracts

### DIFF
--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -34,20 +34,32 @@ contract AzoriusFreezeGuardV1 is Version, BaseFreezeGuardV1 {
     }
 
     /**
-     * Initialize function, will be triggered when a new instance is deployed.
+     * Initialize function for the proxy deployment. This standardizes the initialization
+     * to better work with ProxyFactory.
      *
-     * @param initializeParams encoded initialization parameters: `address _owner`,
-     * `address _freezeVoting`
+     * @param _owner Address that will own the proxy and be able to upgrade it
+     * @param _freezeVoting Address of the freeze voting contract
      */
-    function setUp(bytes memory initializeParams) public override initializer {
-        (address _owner, address _freezeVoting) = abi.decode(
-            initializeParams,
-            (address, address)
-        );
-        __Ownable_init(_owner);
+    function initialize(
+        address _owner,
+        address _freezeVoting
+    ) public initializer {
+        super.initialize(_owner);
         freezeVoting = IBaseFreezeVotingV1(_freezeVoting);
 
         emit AzoriusFreezeGuardSetUp(msg.sender, _owner, _freezeVoting);
+    }
+
+    /**
+     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
+     * Called by {upgradeTo} and {upgradeToAndCall}.
+     *
+     * Reverts if the sender is not the owner of the contract.
+     */
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal virtual override onlyOwner {
+        // Authorization is handled by the onlyOwner modifier
     }
 
     /**

--- a/contracts/deployables/freeze-guard/BaseFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/BaseFreezeGuardV1.sol
@@ -4,11 +4,40 @@ pragma solidity ^0.8.28;
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {FactoryFriendly} from "@gnosis-guild/zodiac/contracts/factory/FactoryFriendly.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
-abstract contract BaseFreezeGuardV1 is IGuard, ERC165, FactoryFriendly {
+abstract contract BaseFreezeGuardV1 is
+    IGuard,
+    ERC165,
+    OwnableUpgradeable,
+    UUPSUpgradeable
+{
     constructor() {
         _disableInitializers();
+    }
+
+    /**
+     * Initialize function for the proxy deployment. This standardizes the initialization
+     * to better work with ProxyFactory.
+     *
+     * @param _owner Address that will own the proxy and be able to upgrade it
+     */
+    function initialize(address _owner) public initializer {
+        __Ownable_init(_owner);
+        __UUPSUpgradeable_init();
+    }
+
+    /**
+     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
+     * Called by {upgradeTo} and {upgradeToAndCall}.
+     *
+     * Reverts if the sender is not the owner of the contract.
+     */
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal virtual override onlyOwner {
+        // Authorization is handled by the onlyOwner modifier
     }
 
     function supportsInterface(

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -7,6 +7,8 @@ import {IMultisigFreezeGuardV1} from "../../interfaces/decent/deployables/IMulti
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 /**
  * Implementation of [IMultisigFreezeGuard](./interfaces/IMultisigFreezeGuard.md).
@@ -63,24 +65,22 @@ contract MultisigFreezeGuardV1 is
     /**
      * Initialize function, will be triggered when a new instance is deployed.
      *
-     * @param initializeParams encoded initialization parameters: `uint256 _timelockPeriod`,
-     * `uint256 _executionPeriod`, `address _owner`, `address _freezeVoting`, `address _childGnosisSafe`
+     * @param _timelockPeriod The timelock period in blocks
+     * @param _executionPeriod The execution period in blocks
+     * @param _owner The owner of the contract
+     * @param _freezeVoting The address of the freeze voting contract
+     * @param _childGnosisSafe The address of the child Gnosis Safe
      */
-    function setUp(bytes memory initializeParams) public override initializer {
-        (
-            uint32 _timelockPeriod,
-            uint32 _executionPeriod,
-            address _owner,
-            address _freezeVoting,
-            address _childGnosisSafe
-        ) = abi.decode(
-                initializeParams,
-                (uint32, uint32, address, address, address)
-            );
-
+    function initialize(
+        uint32 _timelockPeriod,
+        uint32 _executionPeriod,
+        address _owner,
+        address _freezeVoting,
+        address _childGnosisSafe
+    ) public initializer {
+        super.initialize(_owner);
         _updateTimelockPeriod(_timelockPeriod);
         _updateExecutionPeriod(_executionPeriod);
-        __Ownable_init(_owner);
         freezeVoting = IBaseFreezeVotingV1(_freezeVoting);
         childGnosisSafe = ISafe(_childGnosisSafe);
 
@@ -91,6 +91,14 @@ contract MultisigFreezeGuardV1 is
             _childGnosisSafe
         );
     }
+
+    /**
+     * @dev Function that authorizes an upgrade. Only the owner can upgrade the implementation.
+     * @param newImplementation The address of the new implementation
+     */
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal virtual override onlyOwner {}
 
     /** @inheritdoc IMultisigFreezeGuardV1*/
     function timelockTransaction(

--- a/contracts/mocks/concretes/deployables/freeze-guard/ConcreteBaseFreezeGuardV1.sol
+++ b/contracts/mocks/concretes/deployables/freeze-guard/ConcreteBaseFreezeGuardV1.sol
@@ -8,11 +8,6 @@ import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
  * A concrete implementation of BaseGuardV1 for testing
  */
 contract ConcreteBaseFreezeGuardV1 is BaseFreezeGuardV1 {
-    function setUp(bytes memory initializeParams) public override initializer {
-        address _owner = abi.decode(initializeParams, (address));
-        __Ownable_init(_owner);
-    }
-
     function checkTransaction(
         address,
         uint256,

--- a/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
@@ -4,45 +4,35 @@ import { ethers } from 'hardhat';
 import {
   AzoriusFreezeGuardV1,
   AzoriusFreezeGuardV1__factory,
+  ERC1967Proxy__factory,
   IERC165__factory,
   IVersion__factory,
   MockFreezeVoting,
   MockFreezeVoting__factory,
 } from '../../../typechain-types';
-import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId } from '../../helpers/utils';
+import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
-// Helper function for deploying AzoriusFreezeGuardV1 instances
+// Helper function for deploying AzoriusFreezeGuardV1 instances using ERC1967Proxy
 async function deployAzoriusFreezeGuardProxy(
-  azoriusFreezeGuardMastercopy: AzoriusFreezeGuardV1,
+  proxyDeployer: SignerWithAddress,
+  implementation: string,
   owner: SignerWithAddress,
   freezeVoting: string,
 ): Promise<AzoriusFreezeGuardV1> {
-  const moduleProxyFactory = getModuleProxyFactory();
-  const salt = ethers.hexlify(ethers.randomBytes(32));
+  // Create initialization data with function selector
+  const fullInitData =
+    AzoriusFreezeGuardV1__factory.createInterface().getFunction('initialize(address,address)')
+      .selector +
+    ethers.AbiCoder.defaultAbiCoder()
+      .encode(['address', 'address'], [owner.address, freezeVoting])
+      .slice(2);
 
-  const azoriusFreezeGuardSetupCalldata =
-    AzoriusFreezeGuardV1__factory.createInterface().encodeFunctionData('setUp', [
-      ethers.AbiCoder.defaultAbiCoder().encode(
-        ['address', 'address'],
-        [owner.address, freezeVoting],
-      ),
-    ]);
+  // Deploy the proxy with the implementation
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
-  await moduleProxyFactory.deployModule(
-    await azoriusFreezeGuardMastercopy.getAddress(),
-    azoriusFreezeGuardSetupCalldata,
-    salt,
-  );
-
-  const predictedAzoriusFreezeGuardAddress = await calculateProxyAddress(
-    moduleProxyFactory,
-    await azoriusFreezeGuardMastercopy.getAddress(),
-    azoriusFreezeGuardSetupCalldata,
-    salt,
-  );
-
-  return AzoriusFreezeGuardV1__factory.connect(predictedAzoriusFreezeGuardAddress, owner);
+  // Return a contract instance connected to the proxy
+  return AzoriusFreezeGuardV1__factory.connect(await proxy.getAddress(), owner);
 }
 
 describe('AzoriusFreezeGuardV1', () => {
@@ -52,20 +42,23 @@ describe('AzoriusFreezeGuardV1', () => {
   };
 
   // signers
+  let proxyDeployer: SignerWithAddress;
   let owner: SignerWithAddress;
   let user: SignerWithAddress;
+  let nonOwner: SignerWithAddress;
 
   // contracts
-  let azoriusFreezeGuardMastercopy: AzoriusFreezeGuardV1;
+  let masterCopy: string;
   let azoriusFreezeGuard: AzoriusFreezeGuardV1;
   let mockFreezeVoting: MockFreezeVoting;
 
   beforeEach(async () => {
     // Get signers
-    [owner, user] = await ethers.getSigners();
+    [proxyDeployer, owner, user, nonOwner] = await ethers.getSigners();
 
-    // Deploy mastercopy
-    azoriusFreezeGuardMastercopy = await new AzoriusFreezeGuardV1__factory(owner).deploy();
+    // Deploy implementation
+    const implementation = await new AzoriusFreezeGuardV1__factory(proxyDeployer).deploy();
+    masterCopy = await implementation.getAddress();
 
     // Deploy mock contracts
     mockFreezeVoting = await new MockFreezeVoting__factory(owner).deploy();
@@ -74,7 +67,8 @@ describe('AzoriusFreezeGuardV1', () => {
   describe('Initialization', () => {
     it('should initialize with correct owner and freezeVoting address', async () => {
       azoriusFreezeGuard = await deployAzoriusFreezeGuardProxy(
-        azoriusFreezeGuardMastercopy,
+        proxyDeployer,
+        masterCopy,
         owner,
         await mockFreezeVoting.getAddress(),
       );
@@ -86,68 +80,68 @@ describe('AzoriusFreezeGuardV1', () => {
     it('should emit AzoriusFreezeGuardSetUp event on initialization', async () => {
       const freezeVotingAddress = await mockFreezeVoting.getAddress();
 
-      // Deploy proxy and check if event is emitted
-      const factoryInstance = getModuleProxyFactory();
-      const salt = ethers.hexlify(ethers.randomBytes(32));
-
-      const azoriusFreezeGuardSetupCalldata =
-        AzoriusFreezeGuardV1__factory.createInterface().encodeFunctionData('setUp', [
-          ethers.AbiCoder.defaultAbiCoder().encode(
-            ['address', 'address'],
-            [owner.address, freezeVotingAddress],
-          ),
-        ]);
-
-      // Calculate the proxy address to use for event filtering
-      const predictedAddress = await calculateProxyAddress(
-        factoryInstance,
-        await azoriusFreezeGuardMastercopy.getAddress(),
-        azoriusFreezeGuardSetupCalldata,
-        salt,
+      // Deploy via our helper
+      const tx = await deployAzoriusFreezeGuardProxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+        freezeVotingAddress,
       );
-
-      const tx = await factoryInstance.deployModule(
-        await azoriusFreezeGuardMastercopy.getAddress(),
-        azoriusFreezeGuardSetupCalldata,
-        salt,
-      );
-
-      // Connect to the deployed contract
-      const deployedGuard = AzoriusFreezeGuardV1__factory.connect(predictedAddress, owner);
 
       // Check event emission
-      const receipt = await tx.wait();
-
-      // Filter events from the proxy address after deployment
-      const filter = deployedGuard.filters.AzoriusFreezeGuardSetUp;
-      const events = await deployedGuard.queryFilter(
-        filter,
-        receipt?.blockNumber,
-        receipt?.blockNumber,
-      );
+      const filter = tx.filters.AzoriusFreezeGuardSetUp;
+      const events = await tx.queryFilter(filter);
 
       expect(events.length).to.equal(1);
-      expect(events[0].args[0]).to.equal(await factoryInstance.getAddress()); // creator
       expect(events[0].args[1]).to.equal(owner.address); // owner
       expect(events[0].args[2]).to.equal(freezeVotingAddress); // freezeVoting
     });
 
     it('should not allow reinitialization', async () => {
       azoriusFreezeGuard = await deployAzoriusFreezeGuardProxy(
-        azoriusFreezeGuardMastercopy,
+        proxyDeployer,
+        masterCopy,
         owner,
         await mockFreezeVoting.getAddress(),
       );
 
-      const setupData = ethers.AbiCoder.defaultAbiCoder().encode(
-        ['address', 'address'],
-        [user.address, ethers.ZeroAddress],
+      await expect(
+        azoriusFreezeGuard['initialize(address,address)'](user.address, ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(azoriusFreezeGuard, 'InvalidInitialization');
+    });
+
+    it('Should have initialization disabled in the implementation', async function () {
+      const implementationContract = AzoriusFreezeGuardV1__factory.connect(
+        masterCopy,
+        proxyDeployer,
       );
 
-      await expect(azoriusFreezeGuard.setUp(setupData)).to.be.revertedWithCustomError(
-        azoriusFreezeGuard,
-        'InvalidInitialization',
+      await expect(
+        implementationContract['initialize(address,address)'](owner.address, ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
+    });
+  });
+
+  describe('Ownership', function () {
+    beforeEach(async () => {
+      azoriusFreezeGuard = await deployAzoriusFreezeGuardProxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+        await mockFreezeVoting.getAddress(),
       );
+    });
+
+    it('Should allow owner to call owner-only functions', async function () {
+      // The transfer ownership function is an example of an owner-only function
+      await azoriusFreezeGuard.connect(owner).transferOwnership(user.address);
+      expect(await azoriusFreezeGuard.owner()).to.equal(user.address);
+    });
+
+    it('Should prevent non-owners from calling owner-only functions', async function () {
+      await expect(
+        azoriusFreezeGuard.connect(user).transferOwnership(user.address),
+      ).to.be.revertedWithCustomError(azoriusFreezeGuard, 'OwnableUnauthorizedAccount');
     });
   });
 
@@ -155,7 +149,8 @@ describe('AzoriusFreezeGuardV1', () => {
     beforeEach(async () => {
       // Deploy the guard with the mock freeze voting
       azoriusFreezeGuard = await deployAzoriusFreezeGuardProxy(
-        azoriusFreezeGuardMastercopy,
+        proxyDeployer,
+        masterCopy,
         owner,
         await mockFreezeVoting.getAddress(),
       );
@@ -215,7 +210,8 @@ describe('AzoriusFreezeGuardV1', () => {
   describe('Version', () => {
     beforeEach(async () => {
       azoriusFreezeGuard = await deployAzoriusFreezeGuardProxy(
-        azoriusFreezeGuardMastercopy,
+        proxyDeployer,
+        masterCopy,
         owner,
         await mockFreezeVoting.getAddress(),
       );
@@ -232,6 +228,13 @@ describe('AzoriusFreezeGuardV1', () => {
     let iERC165InterfaceId: string;
 
     beforeEach(async function () {
+      azoriusFreezeGuard = await deployAzoriusFreezeGuardProxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+        await mockFreezeVoting.getAddress(),
+      );
+
       // Dynamically calculate interface IDs
       const IVersionInterface = IVersion__factory.createInterface();
       iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
@@ -254,6 +257,29 @@ describe('AzoriusFreezeGuardV1', () => {
       const randomInterfaceId = '0x12345678';
       const supported = await azoriusFreezeGuard.supportsInterface(randomInterfaceId);
       void expect(supported).to.be.false;
+    });
+  });
+
+  describe('AzoriusFreezeGuardV1 UUPS Upgradeability', function () {
+    beforeEach(async function () {
+      // Deploy proxy
+      azoriusFreezeGuard = await deployAzoriusFreezeGuardProxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+        await mockFreezeVoting.getAddress(),
+      );
+    });
+
+    // Run UUPS upgradeability tests
+    runUUPSUpgradeabilityTests({
+      getContract: () => azoriusFreezeGuard,
+      createNewImplementation: async () => {
+        const newImplementation = await new AzoriusFreezeGuardV1__factory(owner).deploy();
+        return newImplementation;
+      },
+      owner: () => owner,
+      nonOwner: () => nonOwner,
     });
   });
 });

--- a/test/deployables/freeze-guard/BaseFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/BaseFreezeGuardV1.test.ts
@@ -4,23 +4,47 @@ import { ethers } from 'hardhat';
 import {
   ConcreteBaseFreezeGuardV1,
   ConcreteBaseFreezeGuardV1__factory,
+  ERC1967Proxy__factory,
   IERC165__factory,
   IGuard__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
+import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
+
+/**
+ * Deploy a ConcreteBaseFreezeGuardV1 instance using a proxy
+ */
+async function deployConcreteBaseFreezeGuardProxy(
+  proxyDeployer: SignerWithAddress,
+  implementation: string,
+  owner: SignerWithAddress,
+): Promise<ConcreteBaseFreezeGuardV1> {
+  // Combine selector and encoded params
+  const fullInitData =
+    ConcreteBaseFreezeGuardV1__factory.createInterface().getFunction('initialize').selector +
+    ethers.AbiCoder.defaultAbiCoder().encode(['address'], [owner.address]).slice(2);
+
+  // Deploy the proxy with the implementation
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+
+  // Return a contract instance connected to the proxy
+  return ConcreteBaseFreezeGuardV1__factory.connect(await proxy.getAddress(), owner);
+}
 
 describe('BaseFreezeGuardV1', () => {
   // Signers
-  let deployer: SignerWithAddress;
+  let proxyDeployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+  let nonOwner: SignerWithAddress;
 
   // Contracts
   let concreteBaseFreezeGuard: ConcreteBaseFreezeGuardV1;
+  let masterCopy: string;
 
   beforeEach(async () => {
-    [deployer] = await ethers.getSigners();
-
+    [proxyDeployer, owner, nonOwner] = await ethers.getSigners();
     // Deploy MockBaseGuardV1
-    concreteBaseFreezeGuard = await new ConcreteBaseFreezeGuardV1__factory(deployer).deploy();
+    concreteBaseFreezeGuard = await new ConcreteBaseFreezeGuardV1__factory(proxyDeployer).deploy();
   });
 
   describe('ERC165', function () {
@@ -50,6 +74,32 @@ describe('BaseFreezeGuardV1', () => {
       const randomInterfaceId = '0x12345678';
       const supported = await concreteBaseFreezeGuard.supportsInterface(randomInterfaceId);
       void expect(supported).to.be.false;
+    });
+  });
+
+  describe('UUPS Upgradeability', function () {
+    beforeEach(async function () {
+      // Deploy mastercopy
+      const implementation = await new ConcreteBaseFreezeGuardV1__factory(proxyDeployer).deploy();
+      masterCopy = await implementation.getAddress();
+
+      // Deploy proxy
+      concreteBaseFreezeGuard = await deployConcreteBaseFreezeGuardProxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+      );
+    });
+
+    // Run UUPS upgradeability tests
+    runUUPSUpgradeabilityTests({
+      getContract: () => concreteBaseFreezeGuard,
+      createNewImplementation: async () => {
+        const newImplementation = await new ConcreteBaseFreezeGuardV1__factory(owner).deploy();
+        return newImplementation;
+      },
+      owner: () => owner,
+      nonOwner: () => nonOwner,
     });
   });
 });

--- a/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
@@ -3,6 +3,7 @@ import { mine } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
+  ERC1967Proxy__factory,
   IERC165__factory,
   IMultisigFreezeGuardV1__factory,
   IVersion__factory,
@@ -13,43 +14,31 @@ import {
   MultisigFreezeGuardV1,
   MultisigFreezeGuardV1__factory,
 } from '../../../typechain-types';
-import { getModuleProxyFactory } from '../../helpers/globals.test';
-import { calculateInterfaceId, calculateProxyAddress } from '../../helpers/utils';
+import { calculateInterfaceId } from '../../helpers/utils';
+import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
-// Helper function for deploying MultisigFreezeGuardV1 instances
+// Helper function for deploying MultisigFreezeGuardV1 instances using ERC1967Proxy
 async function deployMultisigFreezeGuardProxy(
-  multisigFreezeGuardMastercopy: MultisigFreezeGuardV1,
+  proxyDeployer: SignerWithAddress,
+  implementation: string,
   owner: SignerWithAddress,
   timelockPeriod: number,
   executionPeriod: number,
   freezeVoting: string,
   childGnosisSafe: string,
 ): Promise<MultisigFreezeGuardV1> {
-  const moduleProxyFactory = getModuleProxyFactory();
-  const salt = ethers.hexlify(ethers.randomBytes(32));
-
-  const multisigFreezeGuardSetupCalldata =
-    MultisigFreezeGuardV1__factory.createInterface().encodeFunctionData('setUp', [
-      ethers.AbiCoder.defaultAbiCoder().encode(
-        ['uint32', 'uint32', 'address', 'address', 'address'],
-        [timelockPeriod, executionPeriod, owner.address, freezeVoting, childGnosisSafe],
-      ),
-    ]);
-
-  await moduleProxyFactory.deployModule(
-    await multisigFreezeGuardMastercopy.getAddress(),
-    multisigFreezeGuardSetupCalldata,
-    salt,
+  // Create initialization data with function selector
+  const initializeInterface = MultisigFreezeGuardV1__factory.createInterface();
+  const fullInitData = initializeInterface.encodeFunctionData(
+    'initialize(uint32,uint32,address,address,address)',
+    [timelockPeriod, executionPeriod, owner.address, freezeVoting, childGnosisSafe],
   );
 
-  const predictedMultisigFreezeGuardAddress = await calculateProxyAddress(
-    moduleProxyFactory,
-    await multisigFreezeGuardMastercopy.getAddress(),
-    multisigFreezeGuardSetupCalldata,
-    salt,
-  );
+  // Deploy the proxy with the implementation
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
-  return MultisigFreezeGuardV1__factory.connect(predictedMultisigFreezeGuardAddress, owner);
+  // Return a contract instance connected to the proxy
+  return MultisigFreezeGuardV1__factory.connect(await proxy.getAddress(), owner);
 }
 
 describe('MultisigFreezeGuardV1', () => {
@@ -59,11 +48,13 @@ describe('MultisigFreezeGuardV1', () => {
   };
 
   // signers
+  let proxyDeployer: SignerWithAddress;
   let owner: SignerWithAddress;
   let user: SignerWithAddress;
+  let nonOwner: SignerWithAddress;
 
   // contracts
-  let multisigFreezeGuardMastercopy: MultisigFreezeGuardV1;
+  let masterCopy: string;
   let multisigFreezeGuard: MultisigFreezeGuardV1;
   let mockFreezeVoting: MockFreezeVoting;
   let mockSafe: MockSafe;
@@ -78,10 +69,11 @@ describe('MultisigFreezeGuardV1', () => {
 
   beforeEach(async () => {
     // Get signers
-    [owner, user] = await ethers.getSigners();
+    [proxyDeployer, owner, user, nonOwner] = await ethers.getSigners();
 
-    // Deploy mastercopy
-    multisigFreezeGuardMastercopy = await new MultisigFreezeGuardV1__factory(owner).deploy();
+    // Deploy implementation
+    const implementation = await new MultisigFreezeGuardV1__factory(proxyDeployer).deploy();
+    masterCopy = await implementation.getAddress();
 
     // Deploy mock contracts
     mockFreezeVoting = await new MockFreezeVoting__factory(owner).deploy();
@@ -89,7 +81,8 @@ describe('MultisigFreezeGuardV1', () => {
 
     // Deploy MultisigFreezeGuard with mock dependencies
     multisigFreezeGuard = await deployMultisigFreezeGuardProxy(
-      multisigFreezeGuardMastercopy,
+      proxyDeployer,
+      masterCopy,
       owner,
       TIMELOCK_PERIOD,
       EXECUTION_PERIOD,
@@ -113,69 +106,59 @@ describe('MultisigFreezeGuardV1', () => {
       const freezeVotingAddress = await mockFreezeVoting.getAddress();
       const mockSafeAddress = await mockSafe.getAddress();
 
-      // Deploy proxy and check if event is emitted
-      const factoryInstance = getModuleProxyFactory();
-      const salt = ethers.hexlify(ethers.randomBytes(32));
-
-      const multisigFreezeGuardSetupCalldata =
-        MultisigFreezeGuardV1__factory.createInterface().encodeFunctionData('setUp', [
-          ethers.AbiCoder.defaultAbiCoder().encode(
-            ['uint32', 'uint32', 'address', 'address', 'address'],
-            [
-              TIMELOCK_PERIOD,
-              EXECUTION_PERIOD,
-              owner.address,
-              freezeVotingAddress,
-              mockSafeAddress,
-            ],
-          ),
-        ]);
-
-      // Calculate the proxy address to use for event filtering
-      const predictedAddress = await calculateProxyAddress(
-        factoryInstance,
-        await multisigFreezeGuardMastercopy.getAddress(),
-        multisigFreezeGuardSetupCalldata,
-        salt,
+      // Create initialization data
+      const initializeInterface = MultisigFreezeGuardV1__factory.createInterface();
+      const fullInitData = initializeInterface.encodeFunctionData(
+        'initialize(uint32,uint32,address,address,address)',
+        [TIMELOCK_PERIOD, EXECUTION_PERIOD, owner.address, freezeVotingAddress, mockSafeAddress],
       );
 
-      const tx = await factoryInstance.deployModule(
-        await multisigFreezeGuardMastercopy.getAddress(),
-        multisigFreezeGuardSetupCalldata,
-        salt,
-      );
+      // Deploy the proxy directly
+      const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(masterCopy, fullInitData);
+
+      const proxyAddress = await proxy.getAddress();
 
       // Connect to the deployed contract
-      const deployedGuard = MultisigFreezeGuardV1__factory.connect(predictedAddress, owner);
+      const deployedGuard = MultisigFreezeGuardV1__factory.connect(proxyAddress, owner);
 
       // Check event emission
-      const receipt = await tx.wait();
-
-      // Filter events from the proxy address after deployment
       const filter = deployedGuard.filters.MultisigFreezeGuardSetup;
-      const events = await deployedGuard.queryFilter(
-        filter,
-        receipt?.blockNumber,
-        receipt?.blockNumber,
-      );
+      const events = await deployedGuard.queryFilter(filter);
 
       expect(events.length).to.equal(1);
-      expect(events[0].args[0]).to.equal(await factoryInstance.getAddress()); // creator
+      expect(events[0].args[0]).to.equal(proxyDeployer.address); // creator
       expect(events[0].args[1]).to.equal(owner.address); // owner
       expect(events[0].args[2]).to.equal(freezeVotingAddress); // freezeVoting
       expect(events[0].args[3]).to.equal(mockSafeAddress); // childGnosisSafe
     });
 
     it('should not allow reinitialization', async () => {
-      const setupData = ethers.AbiCoder.defaultAbiCoder().encode(
-        ['uint32', 'uint32', 'address', 'address', 'address'],
-        [50, 100, user.address, ethers.ZeroAddress, ethers.ZeroAddress],
+      await expect(
+        multisigFreezeGuard['initialize(uint32,uint32,address,address,address)'](
+          50,
+          100,
+          user.address,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+        ),
+      ).to.be.revertedWithCustomError(multisigFreezeGuard, 'InvalidInitialization');
+    });
+
+    it('Should have initialization disabled in the implementation', async function () {
+      const implementationContract = MultisigFreezeGuardV1__factory.connect(
+        masterCopy,
+        proxyDeployer,
       );
 
-      await expect(multisigFreezeGuard.setUp(setupData)).to.be.revertedWithCustomError(
-        multisigFreezeGuard,
-        'InvalidInitialization',
-      );
+      await expect(
+        implementationContract['initialize(uint32,uint32,address,address,address)'](
+          50,
+          100,
+          owner.address,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+        ),
+      ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
     });
   });
 
@@ -543,6 +526,18 @@ describe('MultisigFreezeGuardV1', () => {
       const randomInterfaceId = '0x12345678';
       const supported = await multisigFreezeGuard.supportsInterface(randomInterfaceId);
       void expect(supported).to.be.false;
+    });
+  });
+
+  describe('UUPS Upgradeability', function () {
+    runUUPSUpgradeabilityTests({
+      getContract: () => multisigFreezeGuard,
+      createNewImplementation: async () => {
+        const newImplementation = await new MultisigFreezeGuardV1__factory(owner).deploy();
+        return newImplementation;
+      },
+      owner: () => owner,
+      nonOwner: () => nonOwner,
     });
   });
 });


### PR DESCRIPTION
- Integrated UUPSUpgradeable and OwnableUpgradeable into AzoriusFreezeGuardV1, BaseFreezeGuardV1, and MultisigFreezeGuardV1 for enhanced upgradeability.
- Refactored initialization functions to standardize the setup process for proxy deployment, replacing the previous `setUp` method with `initialize`.
- Added authorization functions for contract upgrades, ensuring only the owner can initiate upgrades.
- Updated tests to validate the new initialization process, ownership functionalities, and UUPS upgradeability.

These changes improve the contracts' upgradeability and security, aligning with best practices in smart contract development.