### PR TITLE
Refactor AzoriusV1 contract to improve strategy retrieval logic

### DIFF
--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -88,6 +88,8 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
     event ExecutionPeriodUpdated(uint32 executionPeriod);
 
     error InvalidStrategy();
+    error InvalidStartAddress();
+    error InvalidCount();
     error StrategyEnabled();
     error StrategyDisabled();
     error InvalidProposal();
@@ -269,22 +271,37 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         address _startAddress,
         uint256 _count
     ) external view returns (address[] memory _strategies, address _next) {
+        if (
+            _startAddress != SENTINEL_STRATEGY &&
+            !isStrategyEnabled(_startAddress)
+        ) {
+            revert InvalidStartAddress();
+        }
+
+        if (_count == 0) {
+            revert InvalidCount();
+        }
+
         // init array with max page size
         _strategies = new address[](_count);
 
         // populate return array
         uint256 strategyCount = 0;
-        address currentStrategy = strategies[_startAddress];
+        _next = strategies[_startAddress];
+
         while (
-            currentStrategy != address(0x0) &&
-            currentStrategy != SENTINEL_STRATEGY &&
+            _next != address(0) &&
+            _next != SENTINEL_STRATEGY &&
             strategyCount < _count
         ) {
-            _strategies[strategyCount] = currentStrategy;
-            currentStrategy = strategies[currentStrategy];
+            _strategies[strategyCount] = _next;
+            _next = strategies[_next];
             strategyCount++;
         }
-        _next = currentStrategy;
+
+        if (_next != SENTINEL_STRATEGY) {
+            _next = _strategies[strategyCount - 1];
+        }
         // set correct size of returned array
         assembly {
             mstore(_strategies, strategyCount)

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -217,7 +217,7 @@ describe('AzoriusV1', () => {
             200,
           );
 
-          const [strategies, next] = await azorius.getStrategies(SENTINEL_STRATEGY, 0);
+          const [strategies, next] = await azorius.getStrategies(SENTINEL_STRATEGY, 1);
           expect(strategies.length).to.equal(0);
           expect(next).to.equal(SENTINEL_STRATEGY);
         });
@@ -673,12 +673,13 @@ describe('AzoriusV1', () => {
         }
       });
 
-      it('should return empty array when starting from non-existent strategy', async () => {
+      it('should revert with InvalidStartAddress when using a non-existent strategy', async () => {
         const nonExistentStrategy = '0x0000000000000000000000000000000000000002';
-        const [returnedStrategies, next] = await azorius.getStrategies(nonExistentStrategy, 10);
 
-        expect(returnedStrategies.length).to.equal(0);
-        expect(next).to.equal('0x0000000000000000000000000000000000000000');
+        await expect(azorius.getStrategies(nonExistentStrategy, 10)).to.be.revertedWithCustomError(
+          azorius,
+          'InvalidStartAddress',
+        );
       });
 
       it('should handle pagination with large numbers of strategies', async () => {
@@ -789,6 +790,87 @@ describe('AzoriusV1', () => {
             }
           }
         }
+      });
+
+      it('should revert with InvalidCount when count is zero', async () => {
+        await expect(azorius.getStrategies(SENTINEL_STRATEGY, 0)).to.be.revertedWithCustomError(
+          azorius,
+          'InvalidCount',
+        );
+      });
+
+      it('should return last strategy as _next when not all strategies fit in the array', async () => {
+        // First, clear any existing strategies (from previous tests)
+        // and create a fresh Azorius instance
+        const mockAvatar = await new MockAvatar__factory(proxyDeployer).deploy();
+        azorius = await deployAzoriusProxy(
+          proxyDeployer,
+          masterCopy,
+          owner,
+          await mockAvatar.getAddress(),
+          await mockAvatar.getAddress(),
+          [], // empty strategies array
+          100,
+          200,
+        );
+
+        // Enable three strategies
+        const strategy1 = await new MockVotingStrategy__factory(proxyDeployer).deploy(
+          proposer.address,
+        );
+        const strategy2 = await new MockVotingStrategy__factory(proxyDeployer).deploy(
+          proposer.address,
+        );
+        const strategy3 = await new MockVotingStrategy__factory(proxyDeployer).deploy(
+          proposer.address,
+        );
+
+        await azorius.enableStrategy(await strategy1.getAddress());
+        await azorius.enableStrategy(await strategy2.getAddress());
+        await azorius.enableStrategy(await strategy3.getAddress());
+
+        // Request only 2 strategies when there are 3 total
+        const [returnedStrategies, next] = await azorius.getStrategies(SENTINEL_STRATEGY, 2);
+
+        // Verify the behavior
+        expect(returnedStrategies.length).to.equal(2);
+
+        // The _next pointer should equal the last returned strategy when there are more strategies
+        // This matches the updated contract logic
+        expect(next).to.equal(returnedStrategies[1]);
+      });
+
+      it('should handle the case where all strategies are returned correctly', async () => {
+        // First, clear any existing strategies (from previous tests)
+        // and create a fresh Azorius instance
+        const mockAvatar = await new MockAvatar__factory(proxyDeployer).deploy();
+        azorius = await deployAzoriusProxy(
+          proxyDeployer,
+          masterCopy,
+          owner,
+          await mockAvatar.getAddress(),
+          await mockAvatar.getAddress(),
+          [], // empty strategies array
+          100,
+          200,
+        );
+
+        // Enable just one strategy
+        const strategy = await new MockVotingStrategy__factory(proxyDeployer).deploy(
+          proposer.address,
+        );
+        await azorius.enableStrategy(await strategy.getAddress());
+
+        // Request strategies with count>1 to ensure we get all strategies
+        const [returnedStrategies, next] = await azorius.getStrategies(SENTINEL_STRATEGY, 2);
+
+        // Verify returned data
+        expect(returnedStrategies.length).to.equal(1);
+        expect(returnedStrategies[0]).to.equal(await strategy.getAddress());
+
+        // Since _next becomes SENTINEL_STRATEGY in the loop (we've reached the end of the list),
+        // it should remain SENTINEL_STRATEGY as per the contract logic
+        expect(next).to.equal(SENTINEL_STRATEGY);
       });
     });
   });


### PR DESCRIPTION
- Added error handling for invalid start addresses and zero counts in the `getStrategies` function.
- Updated the logic to correctly return the next strategy when not all strategies fit in the returned array.
- Enhanced tests to validate new error handling and pagination behavior.

These changes enhance the robustness and clarity of the strategy management functionality in the AzoriusV1 contract.