### PR TITLE
Refactor BaseStrategyV1 and related contracts to replace Azorius module with Proposal Initializer

### DIFF
--- a/contracts/deployables/strategies/BaseStrategyV1.sol
+++ b/contracts/deployables/strategies/BaseStrategyV1.sol
@@ -20,22 +20,33 @@ abstract contract BaseStrategyV1 is
     ERC165
 {
     /** The Azorius contract address for this Strategy contract. */
-    address public azoriusModule;
+    address public proposalInitializer;
 
-    event AzoriusSet(address indexed azorius);
     event StrategySetUp(address indexed azorius, address indexed owner);
 
-    error AzoriusUnauthorizedAccount(address account);
+    error ProposalInitializerUnauthorizedAccount(address account);
+    error InvalidProposalInitializer(address initializer);
 
     /** Modifier that ensures transactions are being called only by Azorius. */
-    modifier onlyAzorius() {
-        if (msg.sender != azoriusModule)
-            revert AzoriusUnauthorizedAccount(msg.sender);
+    modifier onlyProposalInitializer() {
+        if (msg.sender != proposalInitializer)
+            revert ProposalInitializerUnauthorizedAccount(msg.sender);
         _;
     }
 
     constructor() {
         _disableInitializers();
+    }
+
+    function initialize(
+        address _owner,
+        address _proposalInitializer
+    ) public virtual initializer {
+        if (address(_proposalInitializer) == address(0))
+            revert InvalidProposalInitializer(_proposalInitializer);
+        __Ownable_init(_owner);
+        __UUPSUpgradeable_init();
+        proposalInitializer = _proposalInitializer;
     }
 
     /**
@@ -45,24 +56,6 @@ abstract contract BaseStrategyV1 is
     function _authorizeUpgrade(
         address newImplementation
     ) internal virtual override onlyOwner {}
-
-    /**
-     * Sets the azorius address that this strategy will provide voting information to.
-     * Must be called by the owner.
-     *
-     * @param _azoriusAddress The Azorius contract address
-     */
-    function setAzorius(address _azoriusAddress) external onlyOwner {
-        _setAzorius(_azoriusAddress);
-    }
-
-    /** Internal implementation of `setAzorius`. */
-    function _setAzorius(address _azoriusAddress) internal {
-        if (_azoriusAddress == address(0))
-            revert AzoriusUnauthorizedAccount(address(0));
-        azoriusModule = _azoriusAddress;
-        emit AzoriusSet(_azoriusAddress);
-    }
 
     /** @inheritdoc IBaseStrategyV1*/
     function initializeProposal(bytes memory _data) external virtual;

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -96,7 +96,7 @@ contract LinearERC20VotingV1 is
      *
      * @param _owner Address that will own the contract
      * @param _governanceToken The token used for voting
-     * @param _azoriusModule Address of the Azorius module contract
+     * @param _proposalInitializer Address that is allowed to initialize Proposals
      * @param _votingPeriod Time period for voting
      * @param _requiredProposerWeight Minimum weight to create proposals
      * @param _quorumNumerator Numerator for quorum calculation
@@ -105,7 +105,7 @@ contract LinearERC20VotingV1 is
     function initialize(
         address _owner,
         address _governanceToken,
-        address _azoriusModule,
+        address _proposalInitializer,
         uint32 _votingPeriod,
         uint256 _requiredProposerWeight,
         uint256 _quorumNumerator,
@@ -113,17 +113,16 @@ contract LinearERC20VotingV1 is
     ) public initializer {
         if (address(_governanceToken) == address(0))
             revert InvalidTokenAddress();
-
         governanceToken = IVotes(_governanceToken);
-        __Ownable_init(_owner);
-        __UUPSUpgradeable_init();
-        _setAzorius(_azoriusModule);
+
+        BaseStrategyV1.initialize(_owner, _proposalInitializer);
+
         _updateQuorumNumerator(_quorumNumerator);
         _updateBasisNumerator(_basisNumerator);
         _updateVotingPeriod(_votingPeriod);
         _updateRequiredProposerWeight(_requiredProposerWeight);
 
-        emit StrategySetUp(_azoriusModule, _owner);
+        emit StrategySetUp(_proposalInitializer, _owner);
     }
 
     /**
@@ -230,7 +229,7 @@ contract LinearERC20VotingV1 is
     /** @inheritdoc BaseStrategyV1*/
     function initializeProposal(
         bytes memory _data
-    ) public virtual override onlyAzorius {
+    ) public virtual override onlyProposalInitializer {
         uint32 proposalId = abi.decode(_data, (uint32));
         uint48 _votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
 

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -123,7 +123,7 @@ contract LinearERC721VotingV1 is
      * @param _owner The owner of the contract
      * @param _tokens Array of ERC-721 token addresses that can vote
      * @param _weights Array of voting weights for each token
-     * @param _azoriusModule The Azorius module address
+     * @param _proposalInitializer Address that is allowed to initialize Proposals
      * @param _votingPeriod The voting time period (in blocks)
      * @param _quorumThreshold Total voting weight required to achieve quorum
      * @param _proposerThreshold Required voting weight to submit proposals
@@ -133,7 +133,7 @@ contract LinearERC721VotingV1 is
         address _owner,
         address[] memory _tokens,
         uint256[] memory _weights,
-        address _azoriusModule,
+        address _proposalInitializer,
         uint32 _votingPeriod,
         uint256 _quorumThreshold,
         uint256 _proposerThreshold,
@@ -150,15 +150,14 @@ contract LinearERC721VotingV1 is
             }
         }
 
-        __Ownable_init(_owner);
-        __UUPSUpgradeable_init();
-        _setAzorius(_azoriusModule);
+        BaseStrategyV1.initialize(_owner, _proposalInitializer);
+
         _updateQuorumThreshold(_quorumThreshold);
         _updateProposerThreshold(_proposerThreshold);
         _updateBasisNumerator(_basisNumerator);
         _updateVotingPeriod(_votingPeriod);
 
-        emit StrategySetUp(_azoriusModule, _owner);
+        emit StrategySetUp(_proposalInitializer, _owner);
     }
 
     /**
@@ -346,7 +345,7 @@ contract LinearERC721VotingV1 is
     /** @inheritdoc BaseStrategyV1*/
     function initializeProposal(
         bytes memory _data
-    ) public virtual override onlyAzorius {
+    ) public virtual override onlyProposalInitializer {
         uint32 proposalId = abi.decode(_data, (uint32));
         uint48 _votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
 

--- a/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
@@ -13,14 +13,6 @@ pragma solidity ^0.8.28;
  */
 interface IBaseStrategyV1 {
     /**
-     * Sets the address of the [Azorius](../Azorius.md) contract this
-     * [BaseStrategy](../BaseStrategy.md) is being used on.
-     *
-     * @param _azoriusModule address of the Azorius Safe module
-     */
-    function setAzorius(address _azoriusModule) external;
-
-    /**
      * Called by the [Azorius](../Azorius.md) module. This notifies this
      * [BaseStrategy](../BaseStrategy.md) that a new Proposal has been created.
      *

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -14,8 +14,6 @@ contract MockVotingStrategy is IBaseStrategyV1 {
 
     // required by IBaseStrategyV1
 
-    function setAzorius(address _azoriusModule) external override {}
-
     function initializeProposal(bytes memory _data) external override {}
 
     function isPassed(uint32 proposalId) external view override returns (bool) {

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
@@ -12,29 +12,33 @@ contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
     /**
      * Sets up the concrete strategy contract.
      * @param _owner The owner of the contract
-     * @param _azoriusModule The Azorius module address
+     * @param _proposalInitializer Address that is allowed to initialize Proposals
      */
     function initialize(
         address _owner,
-        address _azoriusModule
-    ) public initializer {
-        __Ownable_init(_owner);
-        _setAzorius(_azoriusModule);
+        address _proposalInitializer
+    ) public override initializer {
+        BaseStrategyV1.initialize(_owner, _proposalInitializer);
 
-        emit StrategySetUp(_azoriusModule, _owner);
+        emit StrategySetUp(_proposalInitializer, _owner);
     }
 
     /**
      * A concrete function that uses the onlyAzorius modifier for testing.
      */
-    function concreteOnlyAzoriusFunction() external onlyAzorius {
+    function concreteOnlyProposalInitializerFunction()
+        external
+        onlyProposalInitializer
+    {
         emit ConcreteFunctionCalled();
     }
 
     /**
      * Concrete implementation of the abstract initializeProposal function.
      */
-    function initializeProposal(bytes memory) external override onlyAzorius {
+    function initializeProposal(
+        bytes memory
+    ) external override onlyProposalInitializer {
         emit ConcreteFunctionCalled();
     }
 

--- a/test/deployables/strategies/BaseStrategyV1.test.ts
+++ b/test/deployables/strategies/BaseStrategyV1.test.ts
@@ -17,7 +17,7 @@ describe('BaseStrategyV1', () => {
   let deployer: SignerWithAddress;
   let owner: SignerWithAddress;
   let nonOwner: SignerWithAddress;
-  let azoriusAddress: string;
+  let proposalInitializer: string;
   let azoriusSigner: SignerWithAddress;
 
   // Contracts
@@ -61,7 +61,7 @@ describe('BaseStrategyV1', () => {
     [deployer, owner, nonOwner, azoriusSigner] = await ethers.getSigners();
 
     // For the purpose of the test, we'll use the dedicated signer address as the Azorius address
-    azoriusAddress = await azoriusSigner.getAddress();
+    proposalInitializer = await azoriusSigner.getAddress();
 
     // Deploy the concrete strategy implementation
     concreteStrategyImplementation = await new ConcreteBaseStrategyV1__factory(deployer).deploy();
@@ -70,7 +70,7 @@ describe('BaseStrategyV1', () => {
     concreteStrategy = await deployConcreteStrategy(
       concreteStrategyImplementation,
       owner,
-      azoriusAddress,
+      proposalInitializer,
     );
   });
 
@@ -79,12 +79,12 @@ describe('BaseStrategyV1', () => {
       expect(await concreteStrategy.owner()).to.equal(owner.address);
     });
 
-    it('should initialize with correct Azorius module', async () => {
-      expect(await concreteStrategy.azoriusModule()).to.equal(azoriusAddress);
+    it('should initialize with correct proposal initializer', async () => {
+      expect(await concreteStrategy.proposalInitializer()).to.equal(proposalInitializer);
     });
 
     it('should not allow reinitialization', async () => {
-      await expect(concreteStrategy.initialize(owner.address, azoriusAddress)).to.be.reverted;
+      await expect(concreteStrategy.initialize(owner.address, proposalInitializer)).to.be.reverted;
     });
 
     it('should emit StrategySetUp event on initialization', async () => {
@@ -95,7 +95,7 @@ describe('BaseStrategyV1', () => {
       const fullInitData =
         ConcreteBaseStrategyV1__factory.createInterface().getFunction('initialize').selector +
         ethers.AbiCoder.defaultAbiCoder()
-          .encode(['address', 'address'], [owner.address, azoriusAddress])
+          .encode(['address', 'address'], [owner.address, proposalInitializer])
           .slice(2);
 
       // Deploy the factory
@@ -127,46 +127,25 @@ describe('BaseStrategyV1', () => {
         });
 
         // Check event parameters
-        expect(parsedLog?.args[0].toLowerCase()).to.equal(azoriusAddress.toLowerCase());
+        expect(parsedLog?.args[0].toLowerCase()).to.equal(proposalInitializer.toLowerCase());
         expect(parsedLog?.args[1].toLowerCase()).to.equal(owner.address.toLowerCase());
       }
-    });
-  });
-
-  describe('setAzorius', () => {
-    it('should allow owner to update Azorius address', async () => {
-      const newAzoriusAddress = await nonOwner.getAddress();
-      await concreteStrategy.connect(owner).setAzorius(newAzoriusAddress);
-      expect(await concreteStrategy.azoriusModule()).to.equal(newAzoriusAddress);
-    });
-
-    it('should emit AzoriusSet event when Azorius address is updated', async () => {
-      const newAzoriusAddress = await nonOwner.getAddress();
-      await expect(concreteStrategy.connect(owner).setAzorius(newAzoriusAddress))
-        .to.emit(concreteStrategy, 'AzoriusSet')
-        .withArgs(newAzoriusAddress);
-    });
-
-    it('should not allow non-owner to update Azorius address', async () => {
-      const newAzoriusAddress = await nonOwner.getAddress();
-      await expect(
-        concreteStrategy.connect(nonOwner).setAzorius(newAzoriusAddress),
-      ).to.be.revertedWithCustomError(concreteStrategy, 'OwnableUnauthorizedAccount');
     });
   });
 
   describe('onlyAzorius modifier', () => {
     it('should allow calls from Azorius address', async () => {
       // Call from the Azorius address should succeed
-      await expect(concreteStrategy.connect(azoriusSigner).concreteOnlyAzoriusFunction()).not.to.be
-        .reverted;
+      await expect(
+        concreteStrategy.connect(azoriusSigner).concreteOnlyProposalInitializerFunction(),
+      ).not.to.be.reverted;
     });
 
     it('should revert calls from non-Azorius address', async () => {
       // Call from a regular account should revert
       await expect(
-        concreteStrategy.connect(owner).concreteOnlyAzoriusFunction(),
-      ).to.be.revertedWithCustomError(concreteStrategy, 'AzoriusUnauthorizedAccount');
+        concreteStrategy.connect(owner).concreteOnlyProposalInitializerFunction(),
+      ).to.be.revertedWithCustomError(concreteStrategy, 'ProposalInitializerUnauthorizedAccount');
     });
   });
 

--- a/test/deployables/strategies/LinearERC20VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingV1.test.ts
@@ -24,7 +24,7 @@ describe('LinearERC20VotingV1', () => {
   let deployer: SignerWithAddress;
   let owner: SignerWithAddress;
   let nonOwner: SignerWithAddress;
-  let azoriusAddress: string;
+  let proposalInitializer: string;
   let tokenHolder1: SignerWithAddress;
   let tokenHolder2: SignerWithAddress;
   let tokenHolder3: SignerWithAddress;
@@ -55,7 +55,7 @@ describe('LinearERC20VotingV1', () => {
   ): Promise<LinearERC20VotingV1> {
     // Create the initialization data
     const initializeCalldata = LinearERC20VotingV1__factory.createInterface().encodeFunctionData(
-      'initialize',
+      'initialize(address,address,address,uint32,uint256,uint256,uint256)',
       [
         strategyOwner.address,
         governanceToken,
@@ -82,7 +82,7 @@ describe('LinearERC20VotingV1', () => {
       await ethers.getSigners();
 
     // Use nonOwner address as a mock azorius address for testing
-    azoriusAddress = await nonOwner.getAddress();
+    proposalInitializer = await nonOwner.getAddress();
 
     // Deploy MockERC20Votes token
     mockToken = await new MockERC20Votes__factory(deployer).deploy();
@@ -102,7 +102,7 @@ describe('LinearERC20VotingV1', () => {
     linearERC20Voting = await deployLinearERC20Voting(
       owner,
       await mockToken.getAddress(),
-      azoriusAddress,
+      proposalInitializer,
     );
   });
 
@@ -110,7 +110,7 @@ describe('LinearERC20VotingV1', () => {
     it('should initialize with correct parameters', async () => {
       expect(await linearERC20Voting.owner()).to.equal(owner.address);
       expect(await linearERC20Voting.governanceToken()).to.equal(await mockToken.getAddress());
-      expect(await linearERC20Voting.azoriusModule()).to.equal(azoriusAddress);
+      expect(await linearERC20Voting.proposalInitializer()).to.equal(proposalInitializer);
       expect(await linearERC20Voting.votingPeriod()).to.equal(VOTING_PERIOD);
       expect(await linearERC20Voting.requiredProposerWeight()).to.equal(REQUIRED_PROPOSER_WEIGHT);
       expect(await linearERC20Voting.quorumNumerator()).to.equal(QUORUM_NUMERATOR);
@@ -120,10 +120,10 @@ describe('LinearERC20VotingV1', () => {
     it('should not allow reinitialization', async () => {
       // Attempt to reinitialize - should revert
       await expect(
-        linearERC20Voting.initialize(
+        linearERC20Voting['initialize(address,address,address,uint32,uint256,uint256,uint256)'](
           owner.address,
           await mockToken.getAddress(),
-          azoriusAddress,
+          proposalInitializer,
           VOTING_PERIOD,
           REQUIRED_PROPOSER_WEIGHT,
           QUORUM_NUMERATOR,
@@ -135,11 +135,11 @@ describe('LinearERC20VotingV1', () => {
     it('should revert when initializing with zero token address', async () => {
       // Create initialization data with zero address for token
       const initializeCalldata = LinearERC20VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize',
+        'initialize(address,address,address,uint32,uint256,uint256,uint256)',
         [
           owner.address,
           ethers.ZeroAddress,
-          azoriusAddress,
+          proposalInitializer,
           VOTING_PERIOD,
           REQUIRED_PROPOSER_WEIGHT,
           QUORUM_NUMERATOR,
@@ -243,7 +243,7 @@ describe('LinearERC20VotingV1', () => {
       // Only Azorius can initialize proposals
       await expect(
         linearERC20Voting.connect(owner).initializeProposal(initializeData),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'AzoriusUnauthorizedAccount');
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'ProposalInitializerUnauthorizedAccount');
 
       // Test with Azorius signer
       await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);

--- a/test/deployables/strategies/LinearERC721VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingV1.test.ts
@@ -23,7 +23,7 @@ describe('LinearERC721VotingV1', () => {
   let deployer: SignerWithAddress;
   let owner: SignerWithAddress;
   let nonOwner: SignerWithAddress;
-  let azoriusAddress: string;
+  let proposalInitializer: string;
   let tokenHolder1: SignerWithAddress;
   let tokenHolder2: SignerWithAddress;
   let tokenHolder3: SignerWithAddress;
@@ -64,7 +64,7 @@ describe('LinearERC721VotingV1', () => {
 
     // Create the initialization data
     const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-      'initialize',
+      'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256)',
       [
         strategyOwner.address,
         tokenAddresses,
@@ -107,7 +107,7 @@ describe('LinearERC721VotingV1', () => {
       await ethers.getSigners();
 
     // Use nonOwner address as a mock azorius address for testing
-    azoriusAddress = await nonOwner.getAddress();
+    proposalInitializer = await nonOwner.getAddress();
 
     // Deploy MockERC721 tokens
     mockNFT1 = await new MockERC721__factory(deployer).deploy();
@@ -128,7 +128,7 @@ describe('LinearERC721VotingV1', () => {
         { tokenAddress: await mockNFT1.getAddress(), weight: TOKEN1_WEIGHT },
         { tokenAddress: await mockNFT2.getAddress(), weight: TOKEN2_WEIGHT },
       ],
-      azoriusAddress,
+      proposalInitializer,
     );
   });
 
@@ -146,7 +146,7 @@ describe('LinearERC721VotingV1', () => {
         TOKEN2_WEIGHT,
       );
 
-      expect(await linearERC721Voting.azoriusModule()).to.equal(azoriusAddress);
+      expect(await linearERC721Voting.proposalInitializer()).to.equal(proposalInitializer);
       expect(await linearERC721Voting.votingPeriod()).to.equal(VOTING_PERIOD);
       expect(await linearERC721Voting.quorumThreshold()).to.equal(QUORUM_THRESHOLD);
       expect(await linearERC721Voting.proposerThreshold()).to.equal(PROPOSER_THRESHOLD);
@@ -159,11 +159,13 @@ describe('LinearERC721VotingV1', () => {
 
       // Try to call initialize again - should revert
       await expect(
-        linearERC721Voting.initialize(
+        linearERC721Voting[
+          'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256)'
+        ](
           owner.address,
           tokenAddresses,
           tokenWeights,
-          azoriusAddress,
+          proposalInitializer,
           VOTING_PERIOD,
           QUORUM_THRESHOLD,
           PROPOSER_THRESHOLD,
@@ -178,12 +180,12 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with mismatched arrays
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256)',
         [
           owner.address,
           tokenAddresses,
           tokenWeights,
-          azoriusAddress,
+          proposalInitializer,
           VOTING_PERIOD,
           QUORUM_THRESHOLD,
           PROPOSER_THRESHOLD,
@@ -206,12 +208,12 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with invalid token weight
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256)',
         [
           owner.address,
           tokenAddresses,
           tokenWeights,
-          azoriusAddress,
+          proposalInitializer,
           VOTING_PERIOD,
           QUORUM_THRESHOLD,
           PROPOSER_THRESHOLD,
@@ -234,12 +236,12 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with empty token arrays
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256)',
         [
           owner.address,
           emptyTokenAddresses,
           emptyTokenWeights,
-          azoriusAddress,
+          proposalInitializer,
           VOTING_PERIOD,
           QUORUM_THRESHOLD,
           PROPOSER_THRESHOLD,
@@ -436,7 +438,7 @@ describe('LinearERC721VotingV1', () => {
       // Only Azorius can initialize proposals
       await expect(
         linearERC721Voting.connect(owner).initializeProposal(initializeData),
-      ).to.be.revertedWithCustomError(linearERC721Voting, 'AzoriusUnauthorizedAccount');
+      ).to.be.revertedWithCustomError(linearERC721Voting, 'ProposalInitializerUnauthorizedAccount');
 
       // Test with Azorius signer
       await linearERC721Voting.connect(nonOwner).initializeProposal(initializeData);
@@ -898,12 +900,12 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with non-ERC721 token
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256)',
         [
           owner.address,
           tokenAddresses,
           tokenWeights,
-          azoriusAddress,
+          proposalInitializer,
           VOTING_PERIOD,
           QUORUM_THRESHOLD,
           PROPOSER_THRESHOLD,


### PR DESCRIPTION
- Updated BaseStrategyV1 to use a proposalInitializer instead of azoriusModule for authorization.
- Removed the setAzorius function and associated event, replacing it with a new initialize function that accepts a proposalInitializer.
- Modified LinearERC20VotingV1 and LinearERC721VotingV1 to align with the new proposalInitializer logic.
- Updated tests to reflect changes in initialization and authorization checks.

These changes enhance the clarity and functionality of the strategy contracts, ensuring proper access control for proposal initialization.