### PR TITLE
Add Version contract and supporting utilities for contract versioning

### DIFF
--- a/contracts/Version.sol
+++ b/contracts/Version.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {IVersion} from "./interfaces/IVersion.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+/**
+ * @title Version
+ * @dev Abstract contract providing standardized contract identification
+ *
+ * Inheriting contracts MUST implement:
+ * - getVersion()
+ */
+abstract contract Version is IVersion, ERC165 {
+    /**
+     * @dev Returns the version number of this contract implementation
+     * Inheriting contracts MUST override this function.
+     */
+    function getVersion() public view virtual returns (uint16);
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/interfaces/IVersion.sol
+++ b/contracts/interfaces/IVersion.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+interface IVersion {
+    function getVersion() external view returns (uint16);
+}

--- a/contracts/mocks/ConcreteVersion.sol
+++ b/contracts/mocks/ConcreteVersion.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {Version} from "../Version.sol";
+
+contract ConcreteVersion is Version {
+    uint16 private _version;
+
+    function setVersion(uint16 newVersion) public {
+        _version = newVersion;
+    }
+
+    function getVersion()
+        public
+        view
+        virtual
+        override(Version)
+        returns (uint16)
+    {
+        return _version;
+    }
+}

--- a/test/Version.test.ts
+++ b/test/Version.test.ts
@@ -1,0 +1,76 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteVersion,
+  ConcreteVersion__factory,
+  IERC165__factory,
+  IVersion__factory,
+} from '../typechain-types';
+import { calculateInterfaceId } from './helpers/utils';
+
+describe('Version', () => {
+  // Signers
+  let deployer: SignerWithAddress;
+
+  // Contracts
+  let concreteVersion: ConcreteVersion;
+
+  beforeEach(async () => {
+    [deployer] = await ethers.getSigners();
+
+    // Deploy the concrete version implementation
+    concreteVersion = await new ConcreteVersion__factory(deployer).deploy();
+  });
+
+  describe('Version Identification', () => {
+    it('should return version value that matches what was set', async () => {
+      const version = 123;
+
+      await concreteVersion.setVersion(version);
+
+      expect(await concreteVersion.getVersion()).to.equal(version);
+    });
+
+    it('should update version when setter is called', async () => {
+      const oldVersion = 1;
+      const newVersion = 2;
+
+      await concreteVersion.setVersion(oldVersion);
+      expect(await concreteVersion.getVersion()).to.equal(oldVersion);
+
+      await concreteVersion.setVersion(newVersion);
+      expect(await concreteVersion.getVersion()).to.equal(newVersion);
+    });
+  });
+
+  describe('ERC165', () => {
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async () => {
+      // Dynamically calculate interface IDs
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('should support IERC165 interface', async () => {
+      const supported = await concreteVersion.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('should support IVersion interface', async () => {
+      const supported = await concreteVersion.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('should not support random interface', async () => {
+      const randomInterfaceId = '0x12345678';
+      const supported = await concreteVersion.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
+    });
+  });
+});

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -1,0 +1,30 @@
+import type { FunctionFragment, Interface } from 'ethers';
+
+/**
+ * Calculate an interface ID from an ethers Interface object.
+ * The interface ID is the XOR of all function selectors in the interface.
+ * @param interfaceObj An ethers Interface object
+ * @returns The interface ID as a hex string with 0x prefix
+ */
+export function calculateInterfaceId(interfaceObj: Interface): string {
+  // Get all function fragments from the interface
+  const fragments = interfaceObj.fragments.filter(
+    (fragment): fragment is FunctionFragment => fragment.type === 'function',
+  );
+
+  if (fragments.length === 0) {
+    throw new Error('Interface has no functions');
+  }
+
+  // XOR all function selectors
+  let interfaceId = BigInt(0);
+  for (const fragment of fragments) {
+    // Get the selector by using the function's signature
+    const selector = interfaceObj.getFunction(fragment.selector)?.selector;
+    if (selector) {
+      interfaceId = interfaceId ^ BigInt(selector);
+    }
+  }
+
+  return '0x' + interfaceId.toString(16).padStart(8, '0');
+}


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/205

- Introduced Version abstract contract and IVersion interface for standardized version management
- Added getVersion function for version retrieval and supportsInterface for ERC165 support
- Created ConcreteVersion mock contract for testing version management functionality
- Added utility function calculateInterfaceId to compute interface IDs from ethers Interface objects
- Implemented comprehensive test suite for version management and interface validation