### PR TITLE
Add account abstraction contracts with paymaster functionality and testing utilities

### DIFF
--- a/contracts/account-abstraction/BasePaymasterV1.sol
+++ b/contracts/account-abstraction/BasePaymasterV1.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {UserOperationLib, PackedUserOperation} from "@account-abstraction/contracts/core/UserOperationLib.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+/**
+ * Helper class for creating a paymaster.
+ * provides helper methods for staking.
+ * Validates that the postOp is called only by the entryPoint.
+ */
+abstract contract BasePaymasterV1 is IPaymaster, OwnableUpgradeable {
+    IEntryPoint public entryPoint;
+
+    uint256 internal constant PAYMASTER_VALIDATION_GAS_OFFSET =
+        UserOperationLib.PAYMASTER_VALIDATION_GAS_OFFSET;
+    uint256 internal constant PAYMASTER_POSTOP_GAS_OFFSET =
+        UserOperationLib.PAYMASTER_POSTOP_GAS_OFFSET;
+    uint256 internal constant PAYMASTER_DATA_OFFSET =
+        UserOperationLib.PAYMASTER_DATA_OFFSET;
+
+    function __BasePaymaster_init(
+        address _owner,
+        IEntryPoint _entryPoint
+    ) internal onlyInitializing {
+        __Ownable_init();
+        _transferOwnership(_owner);
+        _validateEntryPointInterface(_entryPoint);
+        entryPoint = _entryPoint;
+    }
+
+    //sanity check: make sure this EntryPoint was compiled against the same
+    // IEntryPoint of this paymaster
+    function _validateEntryPointInterface(
+        IEntryPoint _entryPoint
+    ) internal virtual {
+        require(
+            IERC165(address(_entryPoint)).supportsInterface(
+                type(IEntryPoint).interfaceId
+            ),
+            "IEntryPoint interface mismatch"
+        );
+    }
+
+    /// @inheritdoc IPaymaster
+    function validatePaymasterUserOp(
+        PackedUserOperation calldata userOp,
+        bytes32 userOpHash,
+        uint256 maxCost
+    ) external override returns (bytes memory context, uint256 validationData) {
+        _requireFromEntryPoint();
+        return _validatePaymasterUserOp(userOp, userOpHash, maxCost);
+    }
+
+    /**
+     * Validate a user operation.
+     * @param userOp     - The user operation.
+     * @param userOpHash - The hash of the user operation.
+     * @param maxCost    - The maximum cost of the user operation.
+     */
+    function _validatePaymasterUserOp(
+        PackedUserOperation calldata userOp,
+        bytes32 userOpHash,
+        uint256 maxCost
+    ) internal virtual returns (bytes memory context, uint256 validationData);
+
+    /// @inheritdoc IPaymaster
+    function postOp(
+        PostOpMode mode,
+        bytes calldata context,
+        uint256 actualGasCost,
+        uint256 actualUserOpFeePerGas
+    ) external override {
+        _requireFromEntryPoint();
+        _postOp(mode, context, actualGasCost, actualUserOpFeePerGas);
+    }
+
+    /**
+     * Post-operation handler.
+     * (verified to be called only through the entryPoint)
+     * @dev If subclass returns a non-empty context from validatePaymasterUserOp,
+     *      it must also implement this method.
+     * @param mode          - Enum with the following options:
+     *                        opSucceeded - User operation succeeded.
+     *                        opReverted  - User op reverted. The paymaster still has to pay for gas.
+     *                        postOpReverted - never passed in a call to postOp().
+     * @param context       - The context value returned by validatePaymasterUserOp
+     * @param actualGasCost - Actual gas used so far (without this postOp call).
+     * @param actualUserOpFeePerGas - the gas price this UserOp pays. This value is based on the UserOp's maxFeePerGas
+     *                        and maxPriorityFee (and basefee)
+     *                        It is not the same as tx.gasprice, which is what the bundler pays.
+     */
+    function _postOp(
+        PostOpMode mode,
+        bytes calldata context,
+        uint256 actualGasCost,
+        uint256 actualUserOpFeePerGas
+    ) internal virtual {
+        (mode, context, actualGasCost, actualUserOpFeePerGas); // unused params
+        // subclass must override this method if validatePaymasterUserOp returns a context
+        revert("must override");
+    }
+
+    /**
+     * Add a deposit for this paymaster, used for paying for transaction fees.
+     */
+    function deposit() public payable {
+        entryPoint.depositTo{value: msg.value}(address(this));
+    }
+
+    /**
+     * Withdraw value from the deposit.
+     * @param withdrawAddress - Target to send to.
+     * @param amount          - Amount to withdraw.
+     */
+    function withdrawTo(
+        address payable withdrawAddress,
+        uint256 amount
+    ) public onlyOwner {
+        entryPoint.withdrawTo(withdrawAddress, amount);
+    }
+
+    /**
+     * Add stake for this paymaster.
+     * This method can also carry eth value to add to the current stake.
+     * @param unstakeDelaySec - The unstake delay for this paymaster. Can only be increased.
+     */
+    function addStake(uint32 unstakeDelaySec) external payable onlyOwner {
+        entryPoint.addStake{value: msg.value}(unstakeDelaySec);
+    }
+
+    /**
+     * Return current paymaster's deposit on the entryPoint.
+     */
+    function getDeposit() public view returns (uint256) {
+        return entryPoint.balanceOf(address(this));
+    }
+
+    /**
+     * Unlock the stake, in order to withdraw it.
+     * The paymaster can't serve requests once unlocked, until it calls addStake again
+     */
+    function unlockStake() external onlyOwner {
+        entryPoint.unlockStake();
+    }
+
+    /**
+     * Withdraw the entire paymaster's stake.
+     * stake must be unlocked first (and then wait for the unstakeDelay to be over)
+     * @param withdrawAddress - The address to send withdrawn value.
+     */
+    function withdrawStake(address payable withdrawAddress) external onlyOwner {
+        entryPoint.withdrawStake(withdrawAddress);
+    }
+
+    /**
+     * Validate the call is made from a valid entrypoint
+     */
+    function _requireFromEntryPoint() internal virtual {
+        require(msg.sender == address(entryPoint), "Sender not EntryPoint");
+    }
+}

--- a/contracts/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/account-abstraction/DecentPaymasterV1.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {BasePaymasterV1, IEntryPoint} from "./BasePaymasterV1.sol";
+import {IDecentPaymasterV1} from "../interfaces/account-abstraction/IDecentPaymasterV1.sol";
+import {Version} from "../Version.sol";
+import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+contract DecentPaymasterV1 is
+    IDecentPaymasterV1,
+    Version,
+    BasePaymasterV1,
+    UUPSUpgradeable
+{
+    uint16 private constant VERSION = 1;
+
+    // Mapping: strategy address => function selector => is approved
+    mapping(address => mapping(bytes4 => bool)) private _approvedFunctions;
+
+    event FunctionApproved(address strategy, bytes4 selector, bool approved);
+
+    error UnauthorizedStrategy();
+    error InvalidCallDataLength();
+    error ZeroAddressStrategy();
+    error InvalidArrayLength();
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * Initialize function for the proxy deployment. This standardizes the initialization
+     * to better work with ProxyFactory.
+     *
+     * @param _owner Address that will own the proxy and be able to upgrade it
+     * @param _entryPoint The EntryPoint address this paymaster will work with
+     */
+    function initialize(
+        address _owner,
+        address _entryPoint
+    ) public initializer {
+        __BasePaymaster_init(_owner, IEntryPoint(_entryPoint));
+        __UUPSUpgradeable_init();
+    }
+
+    /**
+     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
+     * Called by {upgradeTo} and {upgradeToAndCall}.
+     *
+     * Reverts if the sender is not the owner of the contract.
+     */
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal virtual override onlyOwner {
+        // Authorization is handled by the onlyOwner modifier
+    }
+
+    /**
+     * Add or remove approved functions for a strategy contract
+     * @param contractAddress The contract address that will be whitelisted
+     * @param selectors Array of function selectors to approve/disapprove
+     * @param approved Whether to approve or remove approval for the selectors
+     */
+    function whitelistFunctions(
+        address contractAddress,
+        bytes4[] calldata selectors,
+        bool[] calldata approved
+    ) external onlyOwner {
+        if (contractAddress == address(0)) revert ZeroAddressStrategy();
+        if (selectors.length != approved.length) revert InvalidArrayLength();
+        for (uint256 i = 0; i < selectors.length; i++) {
+            _approvedFunctions[contractAddress][selectors[i]] = approved[i];
+            emit FunctionApproved(contractAddress, selectors[i], approved[i]);
+        }
+    }
+
+    /**
+     * Check if a function is approved for a strategy
+     * @param contractAddress The contract address
+     * @param selector The function selector to check
+     * @return bool Whether the function is approved
+     */
+    function isFunctionWhitelisted(
+        address contractAddress,
+        bytes4 selector
+    ) public view returns (bool) {
+        return _approvedFunctions[contractAddress][selector];
+    }
+
+    /// @inheritdoc BasePaymasterV1
+    function _validatePaymasterUserOp(
+        PackedUserOperation calldata userOp,
+        bytes32,
+        uint256
+    )
+        internal
+        view
+        override
+        returns (bytes memory context, uint256 validationData)
+    {
+        bytes calldata callData = userOp.callData;
+
+        // Require minimum length for selector and target address
+        if (callData.length < 24) {
+            revert InvalidCallDataLength();
+        }
+
+        // Extract function selector and target address
+        bytes4 selector = bytes4(callData[:4]);
+        address target;
+        assembly {
+            target := shr(96, calldataload(add(callData.offset, 4)))
+        }
+
+        // Verify the function is approved for this strategy
+        if (!isFunctionWhitelisted(target, selector)) {
+            revert UnauthorizedStrategy();
+        }
+
+        return (abi.encode(), 0);
+    }
+
+    /// @inheritdoc Version
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IDecentPaymasterV1).interfaceId ||
+            interfaceId == type(IPaymaster).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/interfaces/account-abstraction/IDecentPaymasterV1.sol
+++ b/contracts/interfaces/account-abstraction/IDecentPaymasterV1.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+interface IDecentPaymasterV1 {
+    function whitelistFunctions(
+        address contractAddress,
+        bytes4[] calldata selectors,
+        bool[] calldata approved
+    ) external;
+
+    function isFunctionWhitelisted(
+        address contractAddress,
+        bytes4 selector
+    ) external view returns (bool);
+}

--- a/contracts/mocks/MockEntryPoint.sol
+++ b/contracts/mocks/MockEntryPoint.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+contract MockEntryPoint is IEntryPoint, IERC165 {
+    mapping(address => uint256) public balances;
+    mapping(address => uint256) public stakes;
+    mapping(address => uint256) public unstakeDelaySecs;
+    mapping(address => mapping(uint192 => uint256)) public nonces;
+    mapping(address => IStakeManager.DepositInfo) public deposits;
+
+    function depositTo(address account) external payable {
+        balances[account] += msg.value;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return balances[account];
+    }
+
+    function addStake(uint32 unstakeDelaySec) external payable {
+        stakes[msg.sender] = msg.value;
+        unstakeDelaySecs[msg.sender] = unstakeDelaySec;
+    }
+
+    function unlockStake() external {
+        // Mock implementation
+    }
+
+    function withdrawStake(address payable withdrawAddress) external {
+        uint256 stake = stakes[msg.sender];
+        require(stake > 0, "No stake to withdraw");
+        stakes[msg.sender] = 0;
+        (bool success, ) = withdrawAddress.call{value: stake}("");
+        require(success, "Transfer failed");
+    }
+
+    function withdrawTo(
+        address payable withdrawAddress,
+        uint256 amount
+    ) external {
+        require(balances[msg.sender] >= amount, "Insufficient balance");
+        balances[msg.sender] -= amount;
+        (bool success, ) = withdrawAddress.call{value: amount}("");
+        require(success, "Transfer failed");
+    }
+
+    function handleOps(
+        PackedUserOperation[] calldata,
+        address payable
+    ) external pure {
+        // Mock implementation
+    }
+
+    function handleAggregatedOps(
+        UserOpsPerAggregator[] calldata,
+        address payable
+    ) external pure {
+        // Mock implementation
+    }
+
+    function simulateValidation(PackedUserOperation calldata) external pure {
+        // Mock implementation
+    }
+
+    function simulateHandleOp(
+        PackedUserOperation calldata,
+        address,
+        bytes calldata
+    ) external pure {
+        // Mock implementation
+    }
+
+    function getNonce(
+        address sender,
+        uint192 key
+    ) external view returns (uint256) {
+        return nonces[sender][key];
+    }
+
+    function incrementNonce(uint192 key) external {
+        nonces[msg.sender][key]++;
+    }
+
+    function getUserOpHash(
+        PackedUserOperation calldata
+    ) external pure returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function getDepositInfo(
+        address account
+    ) external view returns (IStakeManager.DepositInfo memory) {
+        return deposits[account];
+    }
+
+    function getSenderAddress(bytes memory) external pure {
+        // Mock implementation
+    }
+
+    function delegateAndRevert(address, bytes calldata) external pure {
+        // Mock implementation
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external pure returns (bool) {
+        return
+            interfaceId == type(IEntryPoint).interfaceId ||
+            interfaceId == type(IERC165).interfaceId;
+    }
+
+    receive() external payable {
+        // Accept ETH transfers
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
+        "@account-abstraction/contracts": "^0.7.0",
         "@gnosis.pm/zodiac": "^1.1.4",
         "@nomicfoundation/hardhat-ethers": "^3.0.5",
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
@@ -29,6 +30,20 @@
         "prettier": "^3.3.3",
         "solidity-docgen": "^0.6.0-beta.36"
       }
+    },
+    "node_modules/@account-abstraction/contracts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@account-abstraction/contracts/-/contracts-0.7.0.tgz",
+      "integrity": "sha512-Bt/66ilu3u8I9+vFZ9fTd+cWs55fdb9J5YKfrhsrFafH1drkzwuCSL/xEot1GGyXXNJLQuXbMRztQPyelNbY1A==",
+      "dependencies": {
+        "@openzeppelin/contracts": "^5.0.0",
+        "@uniswap/v3-periphery": "^1.4.3"
+      }
+    },
+    "node_modules/@account-abstraction/contracts/node_modules/@openzeppelin/contracts": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.2.0.tgz",
+      "integrity": "sha512-bxjNie5z89W1Ea0NZLZluFh8PrFNn9DH8DQlujEok2yjsOlraUPKID5p1Wk3qdNbf6XkQ1Os2RvfiHrrXLHWKA=="
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
@@ -2312,6 +2327,50 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
+    "node_modules/@uniswap/lib": {
+      "version": "4.0.1-alpha",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz",
+      "integrity": "sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v2-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.1.tgz",
+      "integrity": "sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.1.tgz",
+      "integrity": "sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-periphery": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@uniswap/v3-periphery/-/v3-periphery-1.4.4.tgz",
+      "integrity": "sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==",
+      "dependencies": {
+        "@openzeppelin/contracts": "3.4.2-solc-0.7",
+        "@uniswap/lib": "^4.0.1-alpha",
+        "@uniswap/v2-core": "^1.0.1",
+        "@uniswap/v3-core": "^1.0.0",
+        "base64-sol": "1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v3-periphery/node_modules/@openzeppelin/contracts": {
+      "version": "3.4.2-solc-0.7",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
+      "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA=="
+    },
     "node_modules/abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -2732,6 +2791,11 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/base64-sol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz",
+      "integrity": "sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg=="
     },
     "node_modules/bech32": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/decentdao/fractal-contracts/issues"
   },
   "dependencies": {
+    "@account-abstraction/contracts": "^0.7.0",
     "@gnosis.pm/zodiac": "^1.1.4",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",

--- a/test/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/account-abstraction/DecentPaymasterV1.test.ts
@@ -1,0 +1,458 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  DecentPaymasterV1,
+  DecentPaymasterV1__factory,
+  ERC1967Proxy__factory,
+  IDecentPaymasterV1__factory,
+  IERC165__factory,
+  IPaymaster__factory,
+  IVersion__factory,
+  MockEntryPoint,
+  MockEntryPoint__factory,
+} from '../../typechain-types';
+import { calculateInterfaceId } from '../helpers/utils';
+import { runUUPSUpgradeabilityTests } from '../helpers/uupsUpgradeabilityTests';
+
+interface PackedUserOperation {
+  sender: string;
+  nonce: bigint;
+  initCode: string;
+  callData: string;
+  accountGasLimits: string;
+  preVerificationGas: bigint;
+  gasFees: string;
+  paymasterAndData: string;
+  signature: string;
+}
+
+// Helper function for deploying DecentPaymasterV1 instances using ERC1967Proxy
+async function deployDecentPaymasterProxy(
+  proxyDeployer: SignerWithAddress,
+  implementation: string,
+  owner: SignerWithAddress,
+  entryPoint: string,
+): Promise<DecentPaymasterV1> {
+  // Encode initialization parameters
+  const initializeParams = ethers.AbiCoder.defaultAbiCoder().encode(
+    ['address', 'address'],
+    [owner.address, entryPoint],
+  );
+
+  // Create full initialization data with function selector
+  const fullInitData =
+    DecentPaymasterV1__factory.createInterface().getFunction('initialize').selector +
+    initializeParams.slice(2);
+
+  // Deploy the proxy with the implementation
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+
+  // Return a contract instance connected to the proxy
+  return DecentPaymasterV1__factory.connect(await proxy.getAddress(), owner);
+}
+
+describe('DecentPaymasterV1', function () {
+  // contracts
+  let decentPaymaster: DecentPaymasterV1;
+  let masterCopy: string;
+  let entryPoint: MockEntryPoint;
+
+  // signers
+  let owner: SignerWithAddress;
+  let proxyDeployer: SignerWithAddress;
+  let strategy: SignerWithAddress;
+  let nonOwner: SignerWithAddress;
+
+  // test data
+  let mockUserOp: PackedUserOperation;
+  const MOCK_FUNCTION_SELECTOR = '0x12345678';
+  const MOCK_FUNCTION_SELECTOR_2 = '0x87654321';
+  const MOCK_FUNCTION_SELECTOR_3 = '0x11223344';
+  const MOCK_INVALID_SELECTOR = '0x99999999';
+
+  beforeEach(async function () {
+    // Get signers
+    [proxyDeployer, owner, strategy, nonOwner] = await ethers.getSigners();
+
+    // Deploy mock EntryPoint
+    entryPoint = await new MockEntryPoint__factory(owner).deploy();
+
+    // Deploy DecentPaymaster implementation
+    masterCopy = await (await new DecentPaymasterV1__factory(owner).deploy()).getAddress();
+
+    // Deploy DecentPaymaster proxy
+    decentPaymaster = await deployDecentPaymasterProxy(
+      proxyDeployer,
+      masterCopy,
+      owner,
+      await entryPoint.getAddress(),
+    );
+
+    // Create mock UserOperation
+    const mockCallData = ethers.concat([
+      MOCK_FUNCTION_SELECTOR,
+      strategy.address,
+      '0x', // empty data
+    ]);
+
+    mockUserOp = {
+      sender: ethers.ZeroAddress,
+      nonce: 0n,
+      initCode: '0x',
+      callData: mockCallData,
+      accountGasLimits: ethers.ZeroHash,
+      preVerificationGas: 0n,
+      gasFees: ethers.ZeroHash,
+      paymasterAndData: '0x',
+      signature: '0x',
+    };
+  });
+
+  describe('Initialization', function () {
+    it('Should set the entry point address', async function () {
+      expect(await decentPaymaster.entryPoint()).to.equal(await entryPoint.getAddress());
+    });
+
+    it('Should set the owner', async function () {
+      expect(await decentPaymaster.owner()).to.equal(owner.address);
+    });
+
+    it('Should not allow reinitialization', async function () {
+      await expect(
+        decentPaymaster.initialize(owner.address, await entryPoint.getAddress()),
+      ).to.be.revertedWith('Initializable: contract is already initialized');
+    });
+
+    it('Should have a version', async function () {
+      const version = await decentPaymaster.getVersion();
+      void expect(version).to.equal(1);
+    });
+  });
+
+  describe('Function Approval', function () {
+    it('Should allow owner to approve functions', async function () {
+      const selectors = [MOCK_FUNCTION_SELECTOR];
+      const approved = [true];
+
+      await expect(decentPaymaster.whitelistFunctions(strategy.address, selectors, approved))
+        .to.emit(decentPaymaster, 'FunctionApproved')
+        .withArgs(strategy.address, MOCK_FUNCTION_SELECTOR, true);
+
+      const isApproved = await decentPaymaster.isFunctionWhitelisted(
+        strategy.address,
+        MOCK_FUNCTION_SELECTOR,
+      );
+      void expect(isApproved).to.be.true;
+    });
+
+    it('Should allow owner to revoke function approval', async function () {
+      const selectors = [MOCK_FUNCTION_SELECTOR];
+      const approved = [true];
+
+      await decentPaymaster.whitelistFunctions(strategy.address, selectors, approved);
+
+      await decentPaymaster.whitelistFunctions(strategy.address, selectors, [false]);
+      const isApproved = await decentPaymaster.isFunctionWhitelisted(
+        strategy.address,
+        MOCK_FUNCTION_SELECTOR,
+      );
+      void expect(isApproved).to.be.false;
+    });
+
+    it('Should revert when non-owner tries to set approval', async function () {
+      const selectors = [MOCK_FUNCTION_SELECTOR];
+      const approved = [true];
+
+      await expect(
+        decentPaymaster.connect(nonOwner).whitelistFunctions(strategy.address, selectors, approved),
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it('Should revert when arrays have different lengths', async function () {
+      const selectors = [MOCK_FUNCTION_SELECTOR];
+      const approved: boolean[] = [];
+
+      await expect(
+        decentPaymaster.whitelistFunctions(strategy.address, selectors, approved),
+      ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidArrayLength');
+    });
+
+    it('Should approve multiple functions in a single call', async function () {
+      const selectors = [
+        MOCK_FUNCTION_SELECTOR,
+        MOCK_FUNCTION_SELECTOR_2,
+        MOCK_FUNCTION_SELECTOR_3,
+      ];
+      const approved = [true, true, true];
+
+      await decentPaymaster.whitelistFunctions(strategy.address, selectors, approved);
+
+      for (const selector of selectors) {
+        const isApproved = await decentPaymaster.isFunctionWhitelisted(strategy.address, selector);
+        void expect(isApproved).to.be.true;
+      }
+    });
+
+    it('Should handle empty arrays', async function () {
+      const selectors: string[] = [];
+      const approved: boolean[] = [];
+
+      await decentPaymaster.whitelistFunctions(strategy.address, selectors, approved);
+      // Should not revert and should not modify any state
+    });
+
+    it('Should revert when using zero address as strategy', async function () {
+      const selectors = [MOCK_FUNCTION_SELECTOR];
+      const approved = [true];
+
+      await expect(
+        decentPaymaster.whitelistFunctions(ethers.ZeroAddress, selectors, approved),
+      ).to.be.revertedWithCustomError(decentPaymaster, 'ZeroAddressStrategy');
+    });
+  });
+
+  describe('Validation', function () {
+    beforeEach(async function () {
+      // Approve the function for the strategy
+      const selectors = [MOCK_FUNCTION_SELECTOR];
+      const approved = [true];
+      await decentPaymaster.whitelistFunctions(strategy.address, selectors, approved);
+
+      // Fund the impersonated signer
+      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
+      await owner.sendTransaction({
+        to: await entryPointSigner.getAddress(),
+        value: ethers.parseEther('1'),
+      });
+    });
+
+    it('Should validate approved function calls', async function () {
+      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
+      const result = await decentPaymaster
+        .connect(entryPointSigner)
+        .validatePaymasterUserOp.staticCall(mockUserOp, ethers.ZeroHash, 0);
+
+      expect(result[1]).to.equal(0n); // validationData
+      expect(result[0]).to.equal('0x'); // context
+    });
+
+    it('Should revert on unauthorized function calls', async function () {
+      const unauthorizedCallData = ethers.concat([
+        MOCK_INVALID_SELECTOR,
+        ethers.zeroPadValue(strategy.address, 20),
+        '0x',
+      ]);
+
+      const unauthorizedUserOp = { ...mockUserOp, callData: unauthorizedCallData };
+
+      await expect(
+        decentPaymaster
+          .connect(await ethers.getImpersonatedSigner(await entryPoint.getAddress()))
+          .validatePaymasterUserOp.staticCall(unauthorizedUserOp, ethers.ZeroHash, 0),
+      ).to.be.revertedWithCustomError(decentPaymaster, 'UnauthorizedStrategy');
+    });
+
+    it('Should revert on invalid calldata length', async function () {
+      const invalidCallData = '0x1234'; // Too short
+      const invalidUserOp = { ...mockUserOp, callData: invalidCallData };
+
+      await expect(
+        decentPaymaster
+          .connect(await ethers.getImpersonatedSigner(await entryPoint.getAddress()))
+          .validatePaymasterUserOp.staticCall(invalidUserOp, ethers.ZeroHash, 0),
+      ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidCallDataLength');
+    });
+
+    it('Should validate with exactly 24 bytes of calldata', async function () {
+      const exactCallData = ethers.concat([
+        MOCK_FUNCTION_SELECTOR,
+        ethers.zeroPadValue(strategy.address, 20),
+      ]);
+
+      const userOp = { ...mockUserOp, callData: exactCallData };
+      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
+
+      const result = await decentPaymaster
+        .connect(entryPointSigner)
+        .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0);
+
+      expect(result[1]).to.equal(0n);
+      expect(result[0]).to.equal('0x');
+    });
+
+    it('Should validate with more than 24 bytes of calldata', async function () {
+      const longCallData = ethers.concat([
+        MOCK_FUNCTION_SELECTOR,
+        ethers.zeroPadValue(strategy.address, 20),
+        '0x1234567890', // additional data
+      ]);
+
+      const userOp = { ...mockUserOp, callData: longCallData };
+      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
+
+      const result = await decentPaymaster
+        .connect(entryPointSigner)
+        .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0);
+
+      expect(result[1]).to.equal(0n);
+      expect(result[0]).to.equal('0x');
+    });
+
+    it('Should validate with non-contract address as target', async function () {
+      const randomAddress = ethers.Wallet.createRandom().address;
+      const callData = ethers.concat([
+        MOCK_FUNCTION_SELECTOR,
+        ethers.zeroPadValue(randomAddress, 20),
+      ]);
+
+      const userOp = { ...mockUserOp, callData: callData };
+
+      await decentPaymaster.whitelistFunctions(randomAddress, [MOCK_FUNCTION_SELECTOR], [true]);
+      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
+
+      const result = await decentPaymaster
+        .connect(entryPointSigner)
+        .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0);
+
+      expect(result[1]).to.equal(0n);
+      expect(result[0]).to.equal('0x');
+    });
+
+    it('Should revert with malformed calldata', async function () {
+      const malformedCallData = '0x1234'; // Less than 4 bytes for selector
+      const userOp = { ...mockUserOp, callData: malformedCallData };
+
+      await expect(
+        decentPaymaster
+          .connect(await ethers.getImpersonatedSigner(await entryPoint.getAddress()))
+          .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0),
+      ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidCallDataLength');
+    });
+  });
+
+  describe('Deposit handling', function () {
+    it('Should accept deposits through deposit function', async function () {
+      const depositAmount = ethers.parseEther('1');
+
+      await expect(decentPaymaster.deposit({ value: depositAmount })).to.changeEtherBalance(
+        entryPoint,
+        depositAmount,
+      );
+    });
+
+    it('Should reject direct ETH transfers', async function () {
+      const depositAmount = ethers.parseEther('1');
+
+      await expect(
+        owner.sendTransaction({
+          to: await decentPaymaster.getAddress(),
+          value: depositAmount,
+        }),
+      ).to.be.reverted;
+    });
+
+    it('Should handle zero value deposits', async function () {
+      const depositAmount = 0n;
+
+      await expect(decentPaymaster.deposit({ value: depositAmount })).to.changeEtherBalance(
+        entryPoint,
+        depositAmount,
+      );
+    });
+
+    it('Should handle large value deposits', async function () {
+      const depositAmount = ethers.parseEther('1000');
+
+      await expect(decentPaymaster.deposit({ value: depositAmount })).to.changeEtherBalance(
+        entryPoint,
+        depositAmount,
+      );
+    });
+
+    it('Should handle multiple deposits', async function () {
+      const deposit1 = ethers.parseEther('1');
+      const deposit2 = ethers.parseEther('2');
+      const deposit3 = ethers.parseEther('3');
+
+      await decentPaymaster.deposit({ value: deposit1 });
+      await decentPaymaster.deposit({ value: deposit2 });
+      await decentPaymaster.deposit({ value: deposit3 });
+
+      const totalDeposit = deposit1 + deposit2 + deposit3;
+      const balance = await entryPoint.balanceOf(await decentPaymaster.getAddress());
+      expect(balance).to.equal(totalDeposit);
+    });
+  });
+
+  describe('ERC165', function () {
+    // Interface IDs
+    let iPaymasterInterfaceId: string;
+    let iDecentPaymasterInterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async function () {
+      // Calculate IPaymaster interface ID
+      const IPaymasterInterface = IPaymaster__factory.createInterface();
+      iPaymasterInterfaceId = calculateInterfaceId(IPaymasterInterface);
+
+      // Calculate IDecentPaymaster interface ID
+      const IDecentPaymasterInterface = IDecentPaymasterV1__factory.createInterface();
+      iDecentPaymasterInterfaceId = calculateInterfaceId(IDecentPaymasterInterface);
+
+      // Calculate IVersion interface ID
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      // Calculate IERC165 interface ID
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await decentPaymaster.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IPaymaster interface', async function () {
+      const supported = await decentPaymaster.supportsInterface(iPaymasterInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IDecentPaymaster interface', async function () {
+      const supported = await decentPaymaster.supportsInterface(iDecentPaymasterInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await decentPaymaster.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await decentPaymaster.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
+    });
+  });
+
+  describe('Version', () => {
+    it('should return the correct version number', async () => {
+      expect(await decentPaymaster.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('UUPS Upgradeability', function () {
+    // Run UUPS upgradeability tests
+    runUUPSUpgradeabilityTests({
+      getContract: () => decentPaymaster,
+      createNewImplementation: async () => {
+        const newImplementation = await new DecentPaymasterV1__factory(owner).deploy();
+        return newImplementation;
+      },
+      owner: () => owner,
+      nonOwner: () => nonOwner,
+    });
+  });
+});

--- a/test/helpers/uupsUpgradeabilityTests.ts
+++ b/test/helpers/uupsUpgradeabilityTests.ts
@@ -1,0 +1,78 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { UUPSUpgradeable, UUPSUpgradeable__factory } from '../../typechain-types';
+
+/**
+ * Shared test utilities for testing the UUPS upgradeability functionality
+ * Used by all contracts that implement UUPSUpgradeable
+ */
+
+/**
+ * Parameters for running the UUPS Upgradeability tests
+ */
+interface UUPSUpgradeabilityTestParams {
+  /**
+   * Gets the current contract instance implementing UUPSUpgradeable
+   */
+  getContract: () => UUPSUpgradeable;
+
+  /**
+   * Creates a new implementation of the contract
+   */
+  createNewImplementation: () => Promise<UUPSUpgradeable>;
+
+  /**
+   * Owner account that should be allowed to upgrade
+   */
+  owner: () => SignerWithAddress;
+
+  /**
+   * Non-owner account that should not be allowed to upgrade
+   */
+  nonOwner: () => SignerWithAddress;
+
+  /**
+   * Error message to expect when a non-owner tries to upgrade
+   * Default is 'OwnableUnauthorizedAccount'
+   */
+  unauthorizedErrorMessage?: string;
+}
+
+/**
+ * Run all the UUPS upgradeability tests on the given contract
+ * @param params The test parameters
+ */
+export function runUUPSUpgradeabilityTests(params: UUPSUpgradeabilityTestParams): void {
+  it('should allow the owner to authorize an upgrade', async () => {
+    // Deploy a new implementation
+    const newImplementation = await params.createNewImplementation();
+    const newImplAddress = await newImplementation.getAddress();
+
+    // Get contract and connect owner
+    const contract = params.getContract();
+    const contractAddress = await contract.getAddress();
+    const upgradeableContract = UUPSUpgradeable__factory.connect(contractAddress, params.owner());
+
+    // Call with empty bytes for the second parameter
+    // We don't check for a specific event since some implementations might emit different events,
+    // but we do check that it doesn't revert
+    await expect(upgradeableContract.upgradeTo(newImplAddress)).to.not.be.reverted;
+  });
+
+  it('should not allow non-owners to authorize an upgrade', async () => {
+    // Deploy a new implementation
+    const newImplementation = await params.createNewImplementation();
+    const newImplAddress = await newImplementation.getAddress();
+
+    // Get contract and connect non-owner
+    const contract = params.getContract();
+    const contractAddress = await contract.getAddress();
+    const upgradeableContract = UUPSUpgradeable__factory.connect(
+      contractAddress,
+      params.nonOwner(),
+    );
+
+    // Call upgradeToAndCall as a non-owner - should be reverted
+    await expect(upgradeableContract.upgradeTo(newImplAddress)).to.be.reverted;
+  });
+}


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/206

- Added `@account-abstraction/contracts` dependency (v0.7.0) and updated related dependencies
- Implemented UUPS upgradeability test utilities in `uupsUpgradeabilityTests.ts` for validating owner and non-owner upgrade authorization
- Created `MockEntryPoint` contract implementing `IEntryPoint` and `IERC165` interfaces for testing account abstraction features
- Developed paymaster contracts:
  - `BasePaymasterV1`: Abstract contract with core paymaster functionality and deposit management
  - `DecentPaymasterV1`: Concrete implementation with function approval system for strategy contracts
  - `IDecentPaymasterV1`: Interface defining function approval methods
- Added comprehensive tests for paymaster initialization, function approval, validation, deposit handling, and ERC165 support