### PR TITLE
Add ERC4337 voter support and ownership interface contracts

### DIFF
--- a/contracts/azorius/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/azorius/strategies/ERC4337VoterSupportV1.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import {IOwnershipV1} from "../../interfaces/IOwnershipV1.sol";
+
+/**
+ * Functionality to support ERC4337 (Account Abstraction) by properly identifying the voter
+ * when a contract account is used to interact with the voting system.
+ */
+abstract contract ERC4337VoterSupportV1 {
+    /**
+     * Returns the address of the voter which owns the voting weight
+     * @param _msgSender address of the sender. It can be the wallet address, or the smart account address with EOA as owner
+     * @return address of the voter
+     */
+    function _voter(
+        address _msgSender
+    ) internal view virtual returns (address) {
+        // First check if the address has code (is a contract)
+        uint256 size;
+        assembly {
+            size := extcodesize(_msgSender)
+        }
+
+        // If it's an EOA (no code), return the address directly
+        if (size == 0) {
+            return _msgSender;
+        }
+
+        // If it's a contract, try to get its owner
+        try IOwnershipV1(_msgSender).owner() returns (address _value) {
+            return _value;
+        } catch {
+            return _msgSender;
+        }
+    }
+}

--- a/contracts/interfaces/IOwnershipV1.sol
+++ b/contracts/interfaces/IOwnershipV1.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+/**
+ * Interface to get the owner of a smart account
+ */
+interface IOwnershipV1 {
+    /**
+     * @notice Returns the owner address of this contract
+     * @dev This can return either an EOA address for regular voters, or a smart contract address like a DAO Safe
+     * @return The address of the owner
+     */
+    function owner() external view returns (address);
+}

--- a/contracts/mocks/ConcreteERC4337VoterSupportV1.sol
+++ b/contracts/mocks/ConcreteERC4337VoterSupportV1.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {ERC4337VoterSupportV1} from "../azorius/strategies/ERC4337VoterSupportV1.sol";
+
+/**
+ * A concrete implementation of ERC4337VoterSupportV1 for testing purposes.
+ */
+contract ConcreteERC4337VoterSupportV1 is ERC4337VoterSupportV1 {
+    /**
+     * A public function that exposes the _voter function for testing.
+     */
+    function voter(address msgSender) public view returns (address) {
+        return _voter(msgSender);
+    }
+}

--- a/contracts/mocks/MockOwnership.sol
+++ b/contracts/mocks/MockOwnership.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {IOwnershipV1} from "../interfaces/IOwnershipV1.sol";
+
+/**
+ * A mock contract implementing IOwnershipV1 for testing purposes.
+ */
+contract MockOwnership is IOwnershipV1 {
+    address private _owner;
+
+    constructor(address initialOwner) {
+        _owner = initialOwner;
+    }
+
+    /**
+     * Returns the owner of this contract.
+     */
+    function owner() external view override returns (address) {
+        return _owner;
+    }
+
+    /**
+     * Updates the owner address for testing.
+     */
+    function setOwner(address newOwner) external {
+        _owner = newOwner;
+    }
+}

--- a/test/ERC4337VoterSupportV1.test.ts
+++ b/test/ERC4337VoterSupportV1.test.ts
@@ -1,0 +1,68 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteERC4337VoterSupportV1,
+  ConcreteERC4337VoterSupportV1__factory,
+  MockOwnership,
+  MockOwnership__factory,
+} from '../typechain-types';
+
+describe('ERC4337VoterSupportV1', () => {
+  // Signers
+  let deployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  // Contracts
+  let concreteERC4337VoterSupport: ConcreteERC4337VoterSupportV1;
+  let mockOwnership: MockOwnership;
+
+  beforeEach(async () => {
+    [deployer, owner, user] = await ethers.getSigners();
+
+    // Deploy the ERC4337VoterSupport concrete
+    concreteERC4337VoterSupport = await new ConcreteERC4337VoterSupportV1__factory(
+      deployer,
+    ).deploy();
+
+    // Deploy a mock ownership contract with the owner address
+    mockOwnership = await new MockOwnership__factory(deployer).deploy(owner.address);
+  });
+
+  describe('voter', () => {
+    describe('when the msgSender is a smart account', () => {
+      it('should return the owner of the smart account', async () => {
+        // Test with our mock ownership contract
+        const voter = await concreteERC4337VoterSupport.voter(await mockOwnership.getAddress());
+        expect(voter).to.equal(owner.address);
+      });
+
+      it('should return address(0) when smart account owner is zero address', async () => {
+        // Set the owner to the zero address
+        await mockOwnership.setOwner(ethers.ZeroAddress);
+
+        const voter = await concreteERC4337VoterSupport.voter(await mockOwnership.getAddress());
+        expect(voter).to.equal(ethers.ZeroAddress);
+      });
+    });
+
+    describe('when the msgSender is an EOA', () => {
+      it('should return the msgSender', async () => {
+        // For EOAs, the voter function should just return the address itself
+        const eoaAddress = user.address;
+        const voter = await concreteERC4337VoterSupport.voter(eoaAddress);
+        expect(voter).to.equal(eoaAddress);
+      });
+    });
+
+    describe('when the msgSender is a contract that does not implement IOwnership', () => {
+      it('should return the contract address', async () => {
+        // Use the ConcreteRC4337VoterSupport contract itself as a contract that doesn't implement IOwnership
+        const contractAddress = await concreteERC4337VoterSupport.getAddress();
+        const voter = await concreteERC4337VoterSupport.voter(contractAddress);
+        expect(voter).to.equal(contractAddress);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Introduced `ERC4337VoterSupportV1` for identifying voters in account abstraction scenarios.
- Created `IOwnershipV1` interface to retrieve the owner of smart accounts.
- Developed `ConcreteERC4337VoterSupportV1` for testing the voter identification functionality.
- Added `MockOwnership` contract to simulate ownership for testing purposes.
- Implemented comprehensive tests for the voter identification logic across different scenarios.