### PR TITLE
Add HatsProposalCreationWhitelistV1 contract and associated interfaces

### DIFF
--- a/contracts/azorius/strategies/HatsProposalCreationWhitelistV1.sol
+++ b/contracts/azorius/strategies/HatsProposalCreationWhitelistV1.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import {IHatsProposalCreationWhitelistV1} from "../../interfaces/IHatsProposalCreationWhitelistV1.sol";
+import {IHats} from "../../interfaces/hats/IHats.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+abstract contract HatsProposalCreationWhitelistV1 is
+    IHatsProposalCreationWhitelistV1,
+    OwnableUpgradeable,
+    ERC165
+{
+    IHats public hatsContract;
+
+    /** Array to store whitelisted Hat IDs. */
+    uint256[] private whitelistedHatIds;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * Sets up the contract with its initial parameters.
+     *
+     * @param initializeParams encoded initialization parameters:
+     * `address _hatsContract`, `uint256[] _initialWhitelistedHats`
+     */
+    function setUp(bytes memory initializeParams) public virtual {
+        (address _hatsContract, uint256[] memory _initialWhitelistedHats) = abi
+            .decode(initializeParams, (address, uint256[]));
+
+        if (_hatsContract == address(0)) revert MissingHatsContract();
+        hatsContract = IHats(_hatsContract);
+
+        if (_initialWhitelistedHats.length == 0) revert NoHatsWhitelisted();
+        for (uint256 i = 0; i < _initialWhitelistedHats.length; i++) {
+            _whitelistHat(_initialWhitelistedHats[i]);
+        }
+    }
+
+    /**
+     * Adds a Hat to the whitelist for proposal creation.
+     * @param _hatId The ID of the Hat to whitelist
+     */
+    function whitelistHat(uint256 _hatId) external onlyOwner {
+        _whitelistHat(_hatId);
+    }
+
+    /**
+     * Internal function to add a Hat to the whitelist.
+     * @param _hatId The ID of the Hat to whitelist
+     */
+    function _whitelistHat(uint256 _hatId) internal {
+        for (uint256 i = 0; i < whitelistedHatIds.length; i++) {
+            if (whitelistedHatIds[i] == _hatId) revert HatAlreadyWhitelisted();
+        }
+        whitelistedHatIds.push(_hatId);
+        emit HatWhitelisted(_hatId);
+    }
+
+    /**
+     * Removes a Hat from the whitelist for proposal creation.
+     * @param _hatId The ID of the Hat to remove from the whitelist
+     */
+    function unwhitelistHat(uint256 _hatId) external onlyOwner {
+        bool found = false;
+        for (uint256 i = 0; i < whitelistedHatIds.length; i++) {
+            if (whitelistedHatIds[i] == _hatId) {
+                whitelistedHatIds[i] = whitelistedHatIds[
+                    whitelistedHatIds.length - 1
+                ];
+                whitelistedHatIds.pop();
+                found = true;
+                break;
+            }
+        }
+        if (!found) revert HatNotWhitelisted();
+
+        emit HatUnwhitelisted(_hatId);
+    }
+
+    /**
+     * @dev Checks if an address is authorized to create proposals.
+     * @param _address The address to check for proposal creation authorization.
+     * @return bool Returns true if the address is wearing any of the whitelisted Hats, false otherwise.
+     * @notice This function overrides the isProposer function from the parent contract.
+     * It iterates through all whitelisted Hat IDs and checks if the given address
+     * is wearing any of them using the Hats Protocol.
+     */
+    function isProposer(address _address) public view virtual returns (bool) {
+        for (uint256 i = 0; i < whitelistedHatIds.length; i++) {
+            if (hatsContract.isWearerOfHat(_address, whitelistedHatIds[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @dev Returns the IDs of all whitelisted Hats.
+     * @return uint256[] memory An array of whitelisted Hat IDs.
+     */
+    function getWhitelistedHatIds() public view returns (uint256[] memory) {
+        return whitelistedHatIds;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IHatsProposalCreationWhitelistV1).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/interfaces/IHatsProposalCreationWhitelistV1.sol
+++ b/contracts/interfaces/IHatsProposalCreationWhitelistV1.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import {IHats} from "./hats/IHats.sol";
+
+/**
+ * @title IHatsProposalCreationWhitelistV1
+ * @dev Interface for HatsProposalCreationWhitelistV1 contract that manages proposal creation permissions
+ * based on Hats Protocol.
+ */
+interface IHatsProposalCreationWhitelistV1 {
+    /**
+     * @dev Emitted when a Hat is added to the whitelist.
+     */
+    event HatWhitelisted(uint256 hatId);
+
+    /**
+     * @dev Emitted when a Hat is removed from the whitelist.
+     */
+    event HatUnwhitelisted(uint256 hatId);
+
+    /**
+     * @dev Error thrown when the Hats contract address is missing.
+     */
+    error MissingHatsContract();
+
+    /**
+     * @dev Error thrown when no Hats are whitelisted.
+     */
+    error NoHatsWhitelisted();
+
+    /**
+     * @dev Error thrown when attempting to whitelist a Hat that is already whitelisted.
+     */
+    error HatAlreadyWhitelisted();
+
+    /**
+     * @dev Error thrown when attempting to remove a Hat that is not whitelisted.
+     */
+    error HatNotWhitelisted();
+
+    /**
+     * @dev Returns the Hats contract.
+     * @return The Hats contract interface.
+     */
+    function hatsContract() external view returns (IHats);
+
+    /**
+     * @dev Adds a Hat to the whitelist for proposal creation.
+     * @param _hatId The ID of the Hat to whitelist
+     */
+    function whitelistHat(uint256 _hatId) external;
+
+    /**
+     * @dev Removes a Hat from the whitelist for proposal creation.
+     * @param _hatId The ID of the Hat to remove from the whitelist
+     */
+    function unwhitelistHat(uint256 _hatId) external;
+
+    /**
+     * @dev Checks if an address is authorized to create proposals.
+     * @param _address The address to check for proposal creation authorization.
+     * @return Returns true if the address is wearing any of the whitelisted Hats, false otherwise.
+     */
+    function isProposer(address _address) external view returns (bool);
+
+    /**
+     * @dev Returns the IDs of all whitelisted Hats.
+     * @return An array of whitelisted Hat IDs.
+     */
+    function getWhitelistedHatIds() external view returns (uint256[] memory);
+}

--- a/contracts/mocks/ConcreteHatsProposalCreationWhitelistV1.sol
+++ b/contracts/mocks/ConcreteHatsProposalCreationWhitelistV1.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import {HatsProposalCreationWhitelistV1} from "../azorius/strategies/HatsProposalCreationWhitelistV1.sol";
+
+contract ConcreteHatsProposalCreationWhitelistV1 is
+    HatsProposalCreationWhitelistV1
+{
+    function setUp(
+        address owner,
+        bytes memory initializeParams
+    ) public initializer {
+        __Ownable_init();
+        transferOwnership(owner);
+        super.setUp(initializeParams);
+    }
+}

--- a/contracts/mocks/MockHats2.sol
+++ b/contracts/mocks/MockHats2.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+/**
+ * @title MockHats
+ * @dev Ultra-minimal mock implementation that only provides exactly what's needed
+ * for testing HatsProposalCreationWhitelistV1.
+ *
+ * This mock is designed to be as simple as possible, focusing only on the
+ * isWearerOfHat functionality that the contract under test actually needs.
+ */
+contract MockHats2 {
+    // Simple storage for mock responses
+    mapping(address => mapping(uint256 => bool)) public isWearingHat;
+
+    /**
+     * @dev Set wearing status directly
+     * @param wearer The address to set status for
+     * @param hatId The hat ID
+     * @param isWearing Whether the address is wearing the hat
+     */
+    function setWearerStatus(
+        address wearer,
+        uint256 hatId,
+        bool isWearing
+    ) external {
+        isWearingHat[wearer][hatId] = isWearing;
+    }
+
+    /**
+     * @dev Check if an address is wearing a hat
+     * @param _wearer The address to check
+     * @param _hatId The hat ID to check
+     * @return bool Whether the address is wearing the hat
+     */
+    function isWearerOfHat(
+        address _wearer,
+        uint256 _hatId
+    ) external view returns (bool) {
+        return isWearingHat[_wearer][_hatId];
+    }
+}

--- a/test/HatsProposalCreationWhitelistV1.test.ts
+++ b/test/HatsProposalCreationWhitelistV1.test.ts
@@ -1,0 +1,307 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteHatsProposalCreationWhitelistV1,
+  ConcreteHatsProposalCreationWhitelistV1__factory,
+  IERC165__factory,
+  IHatsProposalCreationWhitelistV1__factory,
+  MockHats2,
+  MockHats2__factory,
+} from '../typechain-types';
+import { getModuleProxyFactory } from './GlobalSafeDeployments.test';
+import { calculateProxyAddress } from './helpers';
+import { runHatsProposerTests } from './helpers/hatsProposerTests';
+import { calculateInterfaceId } from './helpers/utils';
+
+describe('HatsProposalCreationWhitelistV1', () => {
+  // Signers
+  let deployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+  let nonOwner: SignerWithAddress;
+  let hatWearer: SignerWithAddress;
+  let nonHatWearer: SignerWithAddress;
+
+  // Contracts
+  let concreteHatsProposalCreationWhitelist: ConcreteHatsProposalCreationWhitelistV1;
+  let mockHats: MockHats2;
+
+  // Hat IDs - we can use any arbitrary values now
+  const proposerHatId1 = 1n;
+  const proposerHatId2 = 2n;
+  const nonProposerHatId = 3n;
+
+  async function deployHatsProposalCreationWhitelistProxy(
+    implementation: ConcreteHatsProposalCreationWhitelistV1,
+    ownerSigner: SignerWithAddress,
+    hatsContract: string,
+    initialWhitelistedHats: bigint[],
+  ): Promise<ConcreteHatsProposalCreationWhitelistV1> {
+    // Create the initialization data
+    const initializeCalldata =
+      ConcreteHatsProposalCreationWhitelistV1__factory.createInterface().encodeFunctionData(
+        'setUp(address,bytes)',
+        [
+          ownerSigner.address,
+          ethers.AbiCoder.defaultAbiCoder().encode(
+            ['address', 'uint256[]'],
+            [hatsContract, initialWhitelistedHats],
+          ),
+        ],
+      );
+
+    const moduleProxyFactory = getModuleProxyFactory();
+    const salt = ethers.keccak256(ethers.randomBytes(32));
+
+    // Deploy the proxy with owner as the deployer so msg.sender becomes the owner
+    await moduleProxyFactory.deployModule(
+      await implementation.getAddress(),
+      initializeCalldata,
+      salt,
+    );
+
+    const predictedAddress = await calculateProxyAddress(
+      moduleProxyFactory,
+      await implementation.getAddress(),
+      initializeCalldata,
+      salt,
+    );
+
+    // Connect the proxy to the contract owner
+    return ConcreteHatsProposalCreationWhitelistV1__factory.connect(predictedAddress, ownerSigner);
+  }
+
+  beforeEach(async () => {
+    [deployer, owner, nonOwner, hatWearer, nonHatWearer] = await ethers.getSigners();
+
+    // Deploy the ultra-minimal MockHats contract
+    mockHats = await new MockHats2__factory(deployer).deploy();
+
+    // Set up initial hat wearing status - this is all we need!
+    await mockHats.setWearerStatus(hatWearer.address, proposerHatId1, true);
+    await mockHats.setWearerStatus(nonHatWearer.address, nonProposerHatId, true);
+
+    // Deploy the ConcreteHatsProposalCreationWhitelist implementation
+    const masterCopy = await new ConcreteHatsProposalCreationWhitelistV1__factory(
+      deployer,
+    ).deploy();
+
+    // Deploy a proxy with initialization
+    concreteHatsProposalCreationWhitelist = await deployHatsProposalCreationWhitelistProxy(
+      masterCopy,
+      owner,
+      await mockHats.getAddress(),
+      [proposerHatId1, proposerHatId2],
+    );
+  });
+
+  describe('Initialization', () => {
+    it('should initialize with correct hats contract address', async () => {
+      expect(await concreteHatsProposalCreationWhitelist.hatsContract()).to.equal(
+        await mockHats.getAddress(),
+      );
+    });
+
+    it('should initialize with correct whitelisted hats', async () => {
+      const whitelistedHats = await concreteHatsProposalCreationWhitelist.getWhitelistedHatIds();
+      expect(whitelistedHats.length).to.equal(2);
+      expect(whitelistedHats[0]).to.equal(proposerHatId1);
+      expect(whitelistedHats[1]).to.equal(proposerHatId2);
+    });
+
+    it('should initialize with correct owner', async () => {
+      expect(await concreteHatsProposalCreationWhitelist.owner()).to.equal(owner.address);
+    });
+
+    it('should not allow initialization with no whitelisted hats', async () => {
+      // Deploy another implementation for this test
+      const mockImplementation = await new ConcreteHatsProposalCreationWhitelistV1__factory(
+        deployer,
+      ).deploy();
+
+      // Create initialization data with empty hats array
+      const emptyWhitelistedHats: bigint[] = [];
+      const initData =
+        ConcreteHatsProposalCreationWhitelistV1__factory.createInterface().encodeFunctionData(
+          'setUp(address,bytes)',
+          [
+            owner.address,
+            ethers.AbiCoder.defaultAbiCoder().encode(
+              ['address', 'uint256[]'],
+              [await mockHats.getAddress(), emptyWhitelistedHats],
+            ),
+          ],
+        );
+
+      const moduleProxyFactory = getModuleProxyFactory();
+      // Attempt to deploy the proxy - should revert
+      await expect(
+        moduleProxyFactory.deployModule(
+          await mockImplementation.getAddress(),
+          initData,
+          ethers.keccak256(ethers.randomBytes(32)),
+        ),
+      ).to.be.revertedWithCustomError(getModuleProxyFactory(), 'FailedInitialization');
+    });
+
+    it('should not allow initialization with invalid hats contract', async () => {
+      // Deploy another implementation for this test
+      const mockImplementation = await new ConcreteHatsProposalCreationWhitelistV1__factory(
+        deployer,
+      ).deploy();
+
+      // Create initialization data with zero address for hats contract
+      const initData =
+        ConcreteHatsProposalCreationWhitelistV1__factory.createInterface().encodeFunctionData(
+          'setUp(address,bytes)',
+          [
+            owner.address,
+            ethers.AbiCoder.defaultAbiCoder().encode(
+              ['address', 'uint256[]'],
+              [ethers.ZeroAddress, [proposerHatId1]],
+            ),
+          ],
+        );
+
+      const moduleProxyFactory = getModuleProxyFactory();
+
+      // Attempt to deploy the proxy - should revert
+      await expect(
+        moduleProxyFactory.deployModule(
+          await mockImplementation.getAddress(),
+          initData,
+          ethers.keccak256(ethers.randomBytes(32)),
+        ),
+      ).to.be.revertedWithCustomError(getModuleProxyFactory(), 'FailedInitialization');
+    });
+  });
+
+  describe('whitelistHat', () => {
+    it('should allow owner to whitelist a new hat', async () => {
+      await concreteHatsProposalCreationWhitelist.connect(owner).whitelistHat(nonProposerHatId);
+
+      const whitelistedHats = await concreteHatsProposalCreationWhitelist.getWhitelistedHatIds();
+      expect(whitelistedHats.length).to.equal(3);
+      expect(whitelistedHats[2]).to.equal(nonProposerHatId);
+    });
+
+    it('should emit HatWhitelisted event when a hat is whitelisted', async () => {
+      await expect(
+        concreteHatsProposalCreationWhitelist.connect(owner).whitelistHat(nonProposerHatId),
+      )
+        .to.emit(concreteHatsProposalCreationWhitelist, 'HatWhitelisted')
+        .withArgs(nonProposerHatId);
+    });
+
+    it('should not allow non-owner to whitelist a hat', async () => {
+      await expect(
+        concreteHatsProposalCreationWhitelist.connect(nonOwner).whitelistHat(nonProposerHatId),
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it('should not allow whitelisting an already whitelisted hat', async () => {
+      await expect(
+        concreteHatsProposalCreationWhitelist.connect(owner).whitelistHat(proposerHatId1),
+      ).to.be.revertedWithCustomError(
+        concreteHatsProposalCreationWhitelist,
+        'HatAlreadyWhitelisted',
+      );
+    });
+  });
+
+  describe('unwhitelistHat', () => {
+    it('should allow owner to remove a hat from the whitelist', async () => {
+      await concreteHatsProposalCreationWhitelist.connect(owner).unwhitelistHat(proposerHatId1);
+
+      const whitelistedHats = await concreteHatsProposalCreationWhitelist.getWhitelistedHatIds();
+      expect(whitelistedHats.length).to.equal(1);
+      expect(whitelistedHats[0]).to.equal(proposerHatId2);
+    });
+
+    it('should emit HatUnwhitelisted event when a hat is removed', async () => {
+      await expect(
+        concreteHatsProposalCreationWhitelist.connect(owner).unwhitelistHat(proposerHatId1),
+      )
+        .to.emit(concreteHatsProposalCreationWhitelist, 'HatUnwhitelisted')
+        .withArgs(proposerHatId1);
+    });
+
+    it('should not allow non-owner to remove a hat from the whitelist', async () => {
+      await expect(
+        concreteHatsProposalCreationWhitelist.connect(nonOwner).unwhitelistHat(proposerHatId1),
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it('should not allow removing a hat that is not whitelisted', async () => {
+      await expect(
+        concreteHatsProposalCreationWhitelist.connect(owner).unwhitelistHat(nonProposerHatId),
+      ).to.be.revertedWithCustomError(concreteHatsProposalCreationWhitelist, 'HatNotWhitelisted');
+    });
+  });
+
+  describe('isProposer override', () => {
+    runHatsProposerTests({
+      getMockHats: () => mockHats,
+      getContract: () => concreteHatsProposalCreationWhitelist,
+      hatWearer: () => hatWearer,
+      nonHatWearer: () => nonHatWearer,
+      tokenHolder: () => nonOwner, // Using nonOwner as tokenHolder since we don't have tokens in this test
+      owner: () => owner,
+      proposerHatId: proposerHatId1,
+      nonProposerHatId,
+    });
+  });
+
+  describe('getWhitelistedHatIds', () => {
+    it('should return the correct list of whitelisted hat IDs', async () => {
+      const whitelistedHats = await concreteHatsProposalCreationWhitelist.getWhitelistedHatIds();
+      expect(whitelistedHats.length).to.equal(2);
+      expect(whitelistedHats[0]).to.equal(proposerHatId1);
+      expect(whitelistedHats[1]).to.equal(proposerHatId2);
+    });
+
+    it('should return updated list after adding a hat', async () => {
+      await concreteHatsProposalCreationWhitelist.connect(owner).whitelistHat(nonProposerHatId);
+
+      const whitelistedHats = await concreteHatsProposalCreationWhitelist.getWhitelistedHatIds();
+      expect(whitelistedHats.length).to.equal(3);
+      expect(whitelistedHats[2]).to.equal(nonProposerHatId);
+    });
+
+    it('should return updated list after removing a hat', async () => {
+      await concreteHatsProposalCreationWhitelist.connect(owner).unwhitelistHat(proposerHatId1);
+
+      const whitelistedHats = await concreteHatsProposalCreationWhitelist.getWhitelistedHatIds();
+      expect(whitelistedHats.length).to.equal(1);
+      expect(whitelistedHats[0]).to.equal(proposerHatId2);
+    });
+  });
+
+  describe('ERC165', () => {
+    it('Should support IERC165 interface', async () => {
+      const interfaceId = calculateInterfaceId(IERC165__factory.createInterface());
+      void expect(await concreteHatsProposalCreationWhitelist.supportsInterface(interfaceId)).to.be
+        .true;
+    });
+
+    it('Should support IHatsProposalCreationWhitelistV1 interface', async () => {
+      const interfaceId = calculateInterfaceId(
+        IHatsProposalCreationWhitelistV1__factory.createInterface(),
+      );
+      void expect(await concreteHatsProposalCreationWhitelist.supportsInterface(interfaceId)).to.be
+        .true;
+    });
+
+    it('Should not support random interface', async () => {
+      // Random interface ID
+      void expect(await concreteHatsProposalCreationWhitelist.supportsInterface('0x12345678')).to.be
+        .false;
+    });
+
+    it('Should not support 0xffffffff interface', async () => {
+      // Random interface ID
+      void expect(await concreteHatsProposalCreationWhitelist.supportsInterface('0xffffffff')).to.be
+        .false;
+    });
+  });
+});

--- a/test/helpers/hatsProposerTests.ts
+++ b/test/helpers/hatsProposerTests.ts
@@ -1,0 +1,87 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { MockHats2 } from '../../typechain-types';
+
+/**
+ * Shared test utilities for testing the HatsProposalCreationWhitelistV1 isProposer functionality
+ * Used by both LinearERC20VotingWithHatsProposalCreationV1 and LinearERC721VotingWithHatsProposalCreationV1 tests
+ */
+
+/**
+ * Interface for any contract that implements the isProposer and whitelistHat methods
+ */
+interface HatsProposerTester {
+  isProposer(address: string): Promise<boolean>;
+  whitelistHat(hatId: bigint): Promise<any>;
+  connect(signer: SignerWithAddress): HatsProposerTester;
+}
+
+/**
+ * Parameters for running the isProposer tests
+ */
+interface HatsProposerTestParams {
+  getMockHats: () => MockHats2;
+  getContract: () => HatsProposerTester;
+  hatWearer: () => SignerWithAddress;
+  nonHatWearer: () => SignerWithAddress;
+  tokenHolder: () => SignerWithAddress;
+  owner: () => SignerWithAddress;
+  proposerHatId: bigint;
+  nonProposerHatId: bigint;
+}
+
+/**
+ * Run all the isProposer tests on the given contract
+ * @param describe The describe function from Mocha
+ * @param it The it function from Mocha
+ * @param params The test parameters
+ */
+export function runHatsProposerTests(params: HatsProposerTestParams): void {
+  beforeEach(async () => {
+    await params
+      .getMockHats()
+      .setWearerStatus(params.hatWearer().address, params.proposerHatId, true);
+    await params
+      .getMockHats()
+      .setWearerStatus(params.nonHatWearer().address, params.nonProposerHatId, true);
+  });
+
+  it('should return true for an address wearing a whitelisted hat', async () => {
+    // hatWearer has proposerHatId, which is whitelisted
+    const isHatWearerProposer = await params.getContract().isProposer(params.hatWearer().address);
+    void expect(isHatWearerProposer).to.be.true;
+  });
+
+  it('should return false for an address wearing a non-whitelisted hat', async () => {
+    // nonHatWearer has nonProposerHatId, which is not whitelisted
+    const isNonHatWearerProposer = await params
+      .getContract()
+      .isProposer(params.nonHatWearer().address);
+    void expect(isNonHatWearerProposer).to.be.false;
+  });
+
+  it('should return false for an address not wearing any hat even if they have tokens/NFTs', async () => {
+    // tokenHolder has no hats at all, but has tokens/NFTs
+    const isTokenHolderProposer = await params
+      .getContract()
+      .isProposer(params.tokenHolder().address);
+    void expect(isTokenHolderProposer).to.be.false;
+  });
+
+  it('should return true after adding a previously non-whitelisted hat to the whitelist', async () => {
+    // First verify nonHatWearer is not a proposer initially
+    const isNonHatWearerProposerBefore = await params
+      .getContract()
+      .isProposer(params.nonHatWearer().address);
+    void expect(isNonHatWearerProposerBefore).to.be.false;
+
+    // Adding nonProposerHatId to the whitelist
+    await params.getContract().connect(params.owner()).whitelistHat(params.nonProposerHatId);
+
+    // Now nonHatWearer should be a proposer
+    const isNonHatWearerProposerAfterWhitelist = await params
+      .getContract()
+      .isProposer(params.nonHatWearer().address);
+    void expect(isNonHatWearerProposerAfterWhitelist).to.be.true;
+  });
+}


### PR DESCRIPTION
depends on https://github.com/decentdao/decent-contracts/pull/210

- Introduced `HatsProposalCreationWhitelistV1` contract for managing proposal creation permissions based on whitelisted Hats.
- Created `IHatsProposalCreationWhitelistV1` interface defining the contract's functionality and events.
- Developed `ConcreteHatsProposalCreationWhitelistV1` mock contract for testing purposes.
- Added `MockHats2` contract to simulate the Hats protocol for testing.
- Implemented comprehensive tests for `HatsProposalCreationWhitelistV1`, covering initialization, whitelisting, unwhitelisting, and proposal authorization logic.