### PR TITLE
feat: add LightAccount verification system

### DIFF
--- a/contracts/account-abstraction/SmartAccountVerificationV1.sol
+++ b/contracts/account-abstraction/SmartAccountVerificationV1.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import {ILightAccount} from "../interfaces/ILightAccount.sol";
+import {ILightAccountFactory} from "../interfaces/ILightAccountFactory.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+abstract contract SmartAccountVerificationV1 is Initializable {
+    ILightAccountFactory public lightAccountFactory;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function __SmartAccountVerificationV1_init(
+        address _lightAccountFactory
+    ) internal {
+        lightAccountFactory = ILightAccountFactory(_lightAccountFactory);
+    }
+
+    function verifySmartAccount(
+        address smartAccount
+    ) internal view virtual returns (bool) {
+        // First check if the address has code (is a contract)
+        uint256 size;
+        assembly {
+            size := extcodesize(smartAccount)
+        }
+
+        // If it's an EOA (no code), it's not a `LightAccount`
+        if (size == 0) {
+            return false;
+        }
+
+        try ILightAccount(smartAccount).owner() returns (
+            address lightAccountOwner
+        ) {
+            // Regenerate the expected light account address
+            address lightAccountAddress = lightAccountFactory.getAddress(
+                lightAccountOwner,
+                0 // we assume that Decent App is only creating one account per user
+            );
+
+            // If the given `smartAccount` address is the same as the derived
+            // `lightAccountAddress`, then we know that the `smartAccount`
+            // was created by the `LightAccountFactory` and therefore can be trusted.
+            return lightAccountAddress == smartAccount;
+        } catch {
+            // `smartAccount` does not implement `owner()`
+            // so it's definitely not a `LightAccount`
+            return false;
+        }
+    }
+}

--- a/contracts/interfaces/ILightAccountFactory.sol
+++ b/contracts/interfaces/ILightAccountFactory.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+interface ILightAccountFactory {
+    /// @notice Calculate the counterfactual address of this account as it would be returned by `createAccount`.
+    /// @param owner The owner of the account to be created.
+    /// @param salt A salt, which can be changed to create multiple accounts with the same owner.
+    /// @return The address of the account that would be created with `createAccount`.
+    function getAddress(
+        address owner,
+        uint256 salt
+    ) external view returns (address);
+}

--- a/contracts/mocks/ConcreteSmartAccountVerification.sol
+++ b/contracts/mocks/ConcreteSmartAccountVerification.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import {SmartAccountVerificationV1} from "../account-abstraction/SmartAccountVerificationV1.sol";
+
+contract ConcreteSmartAccountVerification is SmartAccountVerificationV1 {
+    function initialize(address _lightAccountFactory) public initializer {
+        __SmartAccountVerificationV1_init(_lightAccountFactory);
+    }
+
+    function verifySmartAccountPublic(
+        address smartAccount
+    ) public view returns (bool) {
+        return verifySmartAccount(smartAccount);
+    }
+}

--- a/contracts/mocks/MockInvalidLightAccount.sol
+++ b/contracts/mocks/MockInvalidLightAccount.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+// This contract does not implement the ILightAccount interface
+// Specifically, it does not have the owner() function
+contract MockInvalidLightAccount {
+    function execute(
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) external {
+        // Empty implementation - we only need this for generating calldata
+    }
+}

--- a/contracts/mocks/MockLightAccountFactory.sol
+++ b/contracts/mocks/MockLightAccountFactory.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import {ILightAccountFactory} from "../interfaces/ILightAccountFactory.sol";
+
+contract MockLightAccountFactory is ILightAccountFactory {
+    mapping(address => mapping(uint256 => address)) private _accountAddresses;
+
+    function setAccountAddress(
+        address owner,
+        uint256 salt,
+        address account
+    ) external {
+        _accountAddresses[owner][salt] = account;
+    }
+
+    function getAddress(
+        address owner,
+        uint256 salt
+    ) external view override returns (address) {
+        return _accountAddresses[owner][salt];
+    }
+}

--- a/test/account-abstraction/SmartAccountVerificationV1.test.ts
+++ b/test/account-abstraction/SmartAccountVerificationV1.test.ts
@@ -1,0 +1,135 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteSmartAccountVerification,
+  ConcreteSmartAccountVerification__factory,
+  MockInvalidLightAccount,
+  MockInvalidLightAccount__factory,
+  MockLightAccount,
+  MockLightAccount__factory,
+  MockLightAccountFactory,
+  MockLightAccountFactory__factory,
+} from '../../typechain-types';
+import { getModuleProxyFactory } from '../GlobalSafeDeployments.test';
+import { calculateProxyAddress } from '../helpers';
+
+async function deploySmartAccountVerification(
+  deployer: SignerWithAddress,
+  implementation: ConcreteSmartAccountVerification,
+  mockLightAccountFactoryAddress: string,
+) {
+  const initializeCalldata =
+    ConcreteSmartAccountVerification__factory.createInterface().encodeFunctionData('initialize', [
+      mockLightAccountFactoryAddress,
+    ]);
+
+  const moduleProxyFactory = getModuleProxyFactory();
+  const salt = ethers.keccak256(ethers.randomBytes(32));
+
+  await moduleProxyFactory.deployModule(
+    await implementation.getAddress(),
+    initializeCalldata,
+    salt,
+  );
+
+  const predictedSmartAccountVerificationAddress = await calculateProxyAddress(
+    moduleProxyFactory,
+    await implementation.getAddress(),
+    initializeCalldata,
+    salt,
+  );
+
+  return ConcreteSmartAccountVerification__factory.connect(
+    predictedSmartAccountVerificationAddress,
+    deployer,
+  );
+}
+
+describe('LightAccountVerificationV1', function () {
+  // contracts
+  let concreteVerification: ConcreteSmartAccountVerification;
+  let mockLightAccount: MockLightAccount;
+  let mockInvalidLightAccount: MockInvalidLightAccount;
+  let mockLightAccountFactory: MockLightAccountFactory;
+
+  // signers
+  let deployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+
+  beforeEach(async function () {
+    // Get signers
+    [deployer, owner] = await ethers.getSigners();
+
+    // Deploy MockLightAccount
+    mockLightAccount = await new MockLightAccount__factory(deployer).deploy(owner.address);
+
+    // Deploy MockInvalidLightAccount
+    mockInvalidLightAccount = await new MockInvalidLightAccount__factory(deployer).deploy();
+
+    // Deploy MockLightAccountFactory
+    mockLightAccountFactory = await new MockLightAccountFactory__factory(deployer).deploy();
+
+    // Deploy MockLightAccountVerification
+    const concreteVerificationImplementation = await new ConcreteSmartAccountVerification__factory(
+      deployer,
+    ).deploy();
+
+    concreteVerification = await deploySmartAccountVerification(
+      deployer,
+      concreteVerificationImplementation,
+      mockLightAccountFactory.target.toString(),
+    );
+  });
+
+  describe('verifySmartAccount', function () {
+    describe('valid smart accounts', function () {
+      it('should verify valid smart accounts', async function () {
+        // set up the mock factory contract to return the correct address to `verifySmartAccount`
+        await mockLightAccountFactory.setAccountAddress(
+          await mockLightAccount.owner(),
+          0n,
+          await mockLightAccount.getAddress(),
+        );
+
+        void expect(
+          await concreteVerification.verifySmartAccountPublic(await mockLightAccount.getAddress()),
+        ).to.be.true;
+      });
+    });
+
+    describe('invalid light accounts', function () {
+      describe('non-contracts', function () {
+        it('should return false for non-contract addresses', async function () {
+          const randomAddress = ethers.Wallet.createRandom().address;
+
+          // Should return false since the address won't have the owner() function
+          void expect(await concreteVerification.verifySmartAccountPublic(randomAddress)).to.be
+            .false;
+        });
+      });
+
+      describe('contracts', function () {
+        it('should return false for invalid light accounts that do implement the ILightAccount interface (owner())', async function () {
+          // not calling "setAccountAddress", so the LightAccountFactory will always
+          // return the zero address when calling `getAddress` for a given owner and salt
+          // (which is implemented in the LightAccountVerification verifySmartAccount function).
+          void expect(
+            await concreteVerification.verifySmartAccountPublic(
+              await mockLightAccount.getAddress(),
+            ),
+          ).to.be.false;
+        });
+
+        it('should return false for invalid light accounts that do not implement the ILightAccount interface (owner())', async function () {
+          // Hits the "catch" block in the `verifySmartAccount` function
+          void expect(
+            await concreteVerification.verifySmartAccountPublic(
+              await mockInvalidLightAccount.getAddress(),
+            ),
+          ).to.be.false;
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/220

feat: add LightAccount verification system

Add a new verification system for Light Accounts that ensures accounts are created through the official factory contract. This system provides a secure way to validate Light Account authenticity in other contracts.

Key components:
- New abstract `SmartAccountVerificationV1` contract with core verification logic
- `ILightAccountFactory` interface defining the factory contract's required methods
- Comprehensive test suite with mock contracts for testing various scenarios

Technical details:
- Verification checks both contract existence and proper factory deployment
- Uses try/catch pattern to safely handle non-compliant contracts
- Assumes single account per user (salt=0) for Decent App compatibility
- Implements OpenZeppelin's Initializable pattern for proxy support

The verification process:
1. Checks if target is a contract (has code)
2. Verifies implementation of owner() function
3. Validates account address matches factory-derived address
4. Handles all edge cases (EOAs, invalid contracts, wrong factory)

New files:
- contracts/account-abstraction/SmartAccountVerificationV1.sol
- contracts/interfaces/ILightAccountFactory.sol
- contracts/mocks/ConcreteSmartAccountVerification.sol
- contracts/mocks/MockInvalidLightAccount.sol
- contracts/mocks/MockLightAccountFactory.sol
- test/account-abstraction/SmartAccountVerificationV1.test.ts