### PR TITLE
feat!: integrate Light Account verification into DecentPaymaster

### DIFF
--- a/contracts/account-abstraction/BasePaymasterV1.sol
+++ b/contracts/account-abstraction/BasePaymasterV1.sol
@@ -22,7 +22,7 @@ abstract contract BasePaymasterV1 is IPaymaster, OwnableUpgradeable {
     uint256 internal constant PAYMASTER_DATA_OFFSET =
         UserOperationLib.PAYMASTER_DATA_OFFSET;
 
-    function __BasePaymaster_init(
+    function __BasePaymasterV1_init(
         address _owner,
         IEntryPoint _entryPoint
     ) internal onlyInitializing {

--- a/contracts/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/account-abstraction/DecentPaymasterV1.sol
@@ -1,13 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {BasePaymasterV1, IEntryPoint} from "./BasePaymasterV1.sol";
 import {IDecentPaymasterV1} from "../interfaces/account-abstraction/IDecentPaymasterV1.sol";
+import {BasePaymasterV1} from "./BasePaymasterV1.sol";
+import {SmartAccountVerificationV1} from "./SmartAccountVerificationV1.sol";
 import {Version} from "../Version.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract DecentPaymasterV1 is IDecentPaymasterV1, Version, BasePaymasterV1 {
+contract DecentPaymasterV1 is
+    IDecentPaymasterV1,
+    Version,
+    BasePaymasterV1,
+    SmartAccountVerificationV1
+{
     uint16 private constant VERSION = 1;
 
     // Mapping: contract address => function selector => is whitelisted
@@ -16,6 +23,7 @@ contract DecentPaymasterV1 is IDecentPaymasterV1, Version, BasePaymasterV1 {
     event FunctionWhitelisted(address contractAddress, bytes4 selector);
     event FunctionUnwhitelisted(address contractAddress, bytes4 selector);
 
+    error InvalidSmartAccount();
     error UnauthorizedFunction();
     error InvalidCallDataLength();
 
@@ -28,14 +36,16 @@ contract DecentPaymasterV1 is IDecentPaymasterV1, Version, BasePaymasterV1 {
      * to better work with ProxyFactory.
      *
      * @param data The data to initialize the contract with
-     * @dev The data is encoded as (address, address)
+     * @dev The data is encoded as (address, address, address)
      */
     function initialize(bytes calldata data) public initializer {
-        (address _owner, address _entryPoint) = abi.decode(
-            data,
-            (address, address)
-        );
-        __BasePaymaster_init(_owner, IEntryPoint(_entryPoint));
+        (
+            address _owner,
+            address _entryPoint,
+            address _lightAccountFactory
+        ) = abi.decode(data, (address, address, address));
+        __BasePaymasterV1_init(_owner, IEntryPoint(_entryPoint));
+        __SmartAccountVerificationV1_init(_lightAccountFactory);
     }
 
     /**
@@ -88,14 +98,26 @@ contract DecentPaymasterV1 is IDecentPaymasterV1, Version, BasePaymasterV1 {
         override
         returns (bytes memory context, uint256 validationData)
     {
-        bytes calldata callData = userOp.callData;
+        if (!verifySmartAccount(userOp.sender)) {
+            revert InvalidSmartAccount();
+        }
 
+        // If we're here, we've confirmed that the sender is an actual instance of a LightAccount,
+        // and so therefore its "execute" function behaves as expected.
+        //
+        // This prevents a potential exploit where a user crafts a malicious UserOp
+        // which targets a contract that is expected to be a LightAccount, but is not,
+        // and allows the implementation of that contract's "execute" function to perform
+        // any arbitrary logic (aka logic which does not execute the whitelisted function
+        // encoded in the UserOp).
+
+        bytes calldata callData = userOp.callData;
         // Verify we have at least 4 bytes for the selector
         if (callData.length < 4) {
             revert InvalidCallDataLength();
         }
 
-        // Extract and verify the LightSmartAccount's "execute" function selector
+        // Extract and verify the LightAccount's "execute" function selector
         // 0xb61d27f6 = bytes4(keccak256("execute(address,uint256,bytes)"))
         if (bytes4(callData) != 0xb61d27f6) {
             revert UnauthorizedFunction();

--- a/test/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/account-abstraction/DecentPaymasterV1.test.ts
@@ -14,6 +14,8 @@ import {
   MockGaslessTarget__factory,
   MockLightAccount,
   MockLightAccount__factory,
+  MockLightAccountFactory,
+  MockLightAccountFactory__factory,
 } from '../../typechain-types';
 import { getModuleProxyFactory } from '../GlobalSafeDeployments.test';
 import { calculateProxyAddress } from '../helpers';
@@ -36,9 +38,13 @@ async function deployDecentPaymasterProxy(
   implementation: DecentPaymasterV1,
   owner: SignerWithAddress,
   entryPoint: string,
+  lightAccountFactory: string,
 ): Promise<DecentPaymasterV1> {
   const initializeCalldata = implementation.interface.encodeFunctionData('initialize', [
-    ethers.AbiCoder.defaultAbiCoder().encode(['address', 'address'], [owner.address, entryPoint]),
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ['address', 'address', 'address'],
+      [owner.address, entryPoint, lightAccountFactory],
+    ),
   ]);
 
   const moduleProxyFactory = getModuleProxyFactory();
@@ -69,6 +75,8 @@ describe('DecentPaymasterV1', function () {
   let entryPoint: MockEntryPoint;
   let mockLightAccount: MockLightAccount;
   let mockTarget: MockGaslessTarget;
+  let mockLightAccountFactory: MockLightAccountFactory;
+  let mockLightAccountFactoryAddress: string;
 
   // signers
   let owner: SignerWithAddress;
@@ -91,6 +99,17 @@ describe('DecentPaymasterV1', function () {
     // Deploy MockGaslessTarget
     mockTarget = await new MockGaslessTarget__factory(owner).deploy();
 
+    // Deploy MockLightAccountFactory
+    mockLightAccountFactory = await new MockLightAccountFactory__factory(owner).deploy();
+    mockLightAccountFactoryAddress = mockLightAccountFactory.target.toString();
+
+    // Set up the mock light account factory to return our mock account
+    await mockLightAccountFactory.setAccountAddress(
+      await mockLightAccount.owner(),
+      0n,
+      await mockLightAccount.getAddress(),
+    );
+
     // Get the foo function selector
     FOO_SELECTOR = mockTarget.interface.getFunction('foo').selector;
 
@@ -102,6 +121,7 @@ describe('DecentPaymasterV1', function () {
       masterCopy,
       owner,
       await entryPoint.getAddress(),
+      mockLightAccountFactoryAddress,
     );
 
     // Create mock UserOperation with properly encoded calldata
@@ -138,12 +158,16 @@ describe('DecentPaymasterV1', function () {
       expect(await decentPaymaster.owner()).to.equal(owner.address);
     });
 
+    it('Should set the light account factory', async function () {
+      expect(await decentPaymaster.lightAccountFactory()).to.equal(mockLightAccountFactoryAddress);
+    });
+
     it('Should not allow reinitialization', async function () {
       await expect(
         decentPaymaster.initialize(
           ethers.AbiCoder.defaultAbiCoder().encode(
-            ['address', 'address'],
-            [owner.address, await entryPoint.getAddress()],
+            ['address', 'address', 'address'],
+            [owner.address, await entryPoint.getAddress(), mockLightAccountFactoryAddress],
           ),
         ),
       ).to.be.revertedWith('Initializable: contract is already initialized');
@@ -200,16 +224,9 @@ describe('DecentPaymasterV1', function () {
     beforeEach(async function () {
       // Whitelist the foo function on the mock target
       await decentPaymaster.whitelistFunction(await mockTarget.getAddress(), FOO_SELECTOR);
-
-      // Fund the impersonated signer
-      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
-      await owner.sendTransaction({
-        to: await entryPointSigner.getAddress(),
-        value: ethers.parseEther('1'),
-      });
     });
 
-    it('Should validate whitelisted function calls', async function () {
+    it('Should validate whitelisted function calls from valid light accounts', async function () {
       const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
       const result = await decentPaymaster
         .connect(entryPointSigner)


### PR DESCRIPTION
depends on https://github.com/decentdao/decent-contracts/pull/222

BREAKING CHANGES:
- DecentPaymaster initialization now requires Light Account factory address
- Added Light Account verification to UserOp validation
- Rejects transactions from non-Light Account senders

This commit enhances the security of DecentPaymaster by integrating Light Account
verification, ensuring that only legitimate Light Account instances can use the
paymaster's services. This prevents potential exploits where malicious contracts
could impersonate Light Accounts.

Security improvements:
- Validates sender is a genuine Light Account through factory verification
- Prevents exploitation through fake "execute" function implementations
- Adds explicit error handling for invalid Light Account attempts
- Ensures consistent and safe execution of whitelisted functions

Technical changes:
- DecentPaymasterV1 now inherits from SmartAccountVerificationV1
- Modified initialize() to accept Smart Account factory address
- Added verifySmartAccount() check in validatePaymasterUserOp
- Updated initialization data encoding from (address,address) to (address,address,address)
- Added new InvalidSmartAccount error
- Improved code documentation explaining security measures
- Updated test suite with Smart Account factory integration

Modified files:
- contracts/account-abstraction/DecentPaymasterV1.sol
- test/account-abstraction/DecentPaymasterV1.test.ts

This change significantly improves the security model of the paymaster by ensuring
that only genuine Light Accounts created through the official factory can utilize
its services, preventing potential abuse through malicious contract implementations.