### PR TITLE
refactor: simplify voting test suites by removing redundant Light Account tests

### DIFF
--- a/test/LinearERC20VotingV1.test.ts
+++ b/test/LinearERC20VotingV1.test.ts
@@ -9,8 +9,6 @@ import {
   LinearERC20VotingV1__factory,
   MockERC20Votes,
   MockERC20Votes__factory,
-  MockLightAccount,
-  MockLightAccount__factory,
 } from '../typechain-types';
 import { getModuleProxyFactory } from './GlobalSafeDeployments.test';
 import { calculateProxyAddress } from './helpers';
@@ -30,7 +28,6 @@ describe('LinearERC20VotingV1', () => {
   let linearERC20VotingImplementation: LinearERC20VotingV1;
   let linearERC20Voting: LinearERC20VotingV1;
   let mockToken: MockERC20Votes;
-  let mockLightAccount: MockLightAccount;
 
   // Constants
   const VOTING_PERIOD = 100; // blocks
@@ -97,9 +94,6 @@ describe('LinearERC20VotingV1', () => {
 
     // Deploy MockERC20Votes token
     mockToken = await new MockERC20Votes__factory(deployer).deploy();
-
-    // Deploy MockLightAccount contract
-    mockLightAccount = await new MockLightAccount__factory(deployer).deploy(tokenHolder1.address);
 
     // Mint tokens to token holders
     await mockToken.mint(tokenHolder1.address, 1000);
@@ -526,42 +520,6 @@ describe('LinearERC20VotingV1', () => {
       await mockToken.mint(tokenHolder1.address, 2000);
       const votingSupplyAfterMint = await linearERC20Voting.getProposalVotingSupply(proposalId);
       expect(votingSupplyAfterMint).to.equal(3000);
-    });
-  });
-
-  describe('Smart Account Support', () => {
-    const proposalId = 2;
-
-    beforeEach(async () => {
-      // Setup with tokens for the test
-      await mockToken.mint(await mockLightAccount.getAddress(), 1000);
-
-      // Delegate tokens to the mock contract
-      await mockToken.connect(deployer).delegate(await mockLightAccount.getAddress());
-
-      // Initialize the proposal
-      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
-    });
-
-    it('should correctly identify voter when using smart account', async () => {
-      // The MockLightAccount contract has owner() set to tokenHolder1.address in the beforeEach
-
-      // We need to test that ERC4337VoterSupport correctly resolves the owner of the contract
-      // But we can't directly call from the contract's address, so we need to verify indirectly
-
-      // Vote from tokenHolder1 (which is the owner of mockOwnership)
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-
-      // Check votes were attributed correctly
-      const [, yesVotes, , , ,] = await linearERC20Voting.getProposalVotes(proposalId);
-      expect(yesVotes).to.equal(1000);
-
-      // Check that tokenHolder1 is marked as having voted
-      void expect(await linearERC20Voting.hasVoted(proposalId, tokenHolder1.address)).to.be.true;
-
-      // The test for ERC4337VoterSupport is more limited without advanced mocking
-      // But we can verify that the _voter function works by setting up additional tests in ERC4337VoterSupportV1.test.ts
     });
   });
 

--- a/test/LinearERC721VotingV1.test.ts
+++ b/test/LinearERC721VotingV1.test.ts
@@ -9,7 +9,6 @@ import {
   LinearERC721VotingV1__factory,
   MockERC721,
   MockERC721__factory,
-  MockLightAccount__factory,
 } from '../typechain-types';
 import { getModuleProxyFactory } from './GlobalSafeDeployments.test';
 import { calculateProxyAddress } from './helpers';
@@ -971,8 +970,8 @@ describe('LinearERC721VotingV1', () => {
 
     it('should revert when trying to initialize with an invalid ERC721 token', async () => {
       // We need to deploy a contract that doesn't implement the ERC721 interface
-      // For this test, we can use the MockOwnership contract which doesn't support the ERC721 interface
-      const mockNonERC721 = await new MockLightAccount__factory(deployer).deploy(deployer.address);
+      // For this test, we can use the LinearERC721VotingV1 contract itself, which doesn't support the ERC721 interface
+      const mockNonERC721 = await new LinearERC721VotingV1__factory(deployer).deploy();
 
       const tokenAddresses = [await mockNonERC721.getAddress()];
       const tokenWeights = [TOKEN1_WEIGHT];
@@ -1031,28 +1030,6 @@ describe('LinearERC721VotingV1', () => {
       await expect(linearERC721Voting.connect(nonOwner).initializeProposal(initializeData))
         .to.emit(linearERC721Voting, 'ProposalInitialized')
         .withArgs(proposalId, expectedEndBlock);
-    });
-  });
-
-  describe('Smart Account Support', () => {
-    it('should recognize that contracts integrate with ERC4337VoterSupport', async () => {
-      // This is a simplified test to verify the ERC4337VoterSupport integration exists
-      // In a real scenario, we'd test the full smart contract account voting flow
-
-      // Since properly testing this requires complex test infrastructure to impersonate contracts,
-      // we'll simply verify that the _voter function is inherited from ERC4337VoterSupportV1
-
-      // Deploy a mock contract with ownership
-      const mockLightAccount = await new MockLightAccount__factory(deployer).deploy(
-        tokenHolder1.address,
-      );
-
-      // Verify the owner is set correctly
-      expect(await mockLightAccount.owner()).to.equal(tokenHolder1.address);
-
-      // We're verifying that the contract inherits ERC4337VoterSupportV1
-      // This is mostly a conceptual test - in production this would allow contract wallets
-      // to vote as their owners
     });
   });
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/223

This commit streamlines the test suites for LinearERC20VotingV1 and LinearERC721VotingV1 by removing duplicate Light Account testing logic, which is now covered in dedicated ERC4337VoterSupportV1 tests.

Changes:
- Removed Smart Account Support test sections from both voting test files
- Removed unused MockLightAccount imports and contract instances
- Simplified invalid ERC721 token test to use LinearERC721VotingV1 as mock
- Removed redundant Light Account setup code and related test fixtures

Rationale:
- Light Account verification is now thoroughly tested in ERC4337VoterSupportV1.test.ts
- Removes duplicate test coverage that was less comprehensive
- Improves test maintainability by centralizing account abstraction testing
- Reduces test complexity by removing unnecessary contract deployments

Modified files:
- test/LinearERC20VotingV1.test.ts
- test/LinearERC721VotingV1.test.ts

This change follows the principle of keeping test responsibilities focused and avoiding duplicate test coverage across different test suites.