### PR TITLE
feat!: add Light Account verification to voting strategies

### DIFF
--- a/contracts/azorius/strategies/LinearERC20VotingV1.sol
+++ b/contracts/azorius/strategies/LinearERC20VotingV1.sol
@@ -28,6 +28,52 @@ contract LinearERC20VotingV1 is
     }
 
     /**
+     * Sets up the contract with its initial parameters.
+     *
+     * @param initializeParams encoded initialization parameters: `address _owner`,
+     * `address _governanceToken`, `address _azoriusModule`, `uint32 _votingPeriod`,
+     * `uint256 _quorumNumerator`, `uint256 _basisNumerator`, `address _lightAccountFactory`
+     */
+    function setUp(bytes memory initializeParams) public virtual override {
+        (
+            address _owner,
+            IVotes _governanceToken,
+            address _azoriusModule,
+            uint32 _votingPeriod,
+            uint256 _requiredProposerWeight,
+            uint256 _quorumNumerator,
+            uint256 _basisNumerator,
+            address _lightAccountFactory
+        ) = abi.decode(
+                initializeParams,
+                (
+                    address,
+                    IVotes,
+                    address,
+                    uint32,
+                    uint256,
+                    uint256,
+                    uint256,
+                    address
+                )
+            );
+
+        LinearERC20VotingExtensible.setUp(
+            abi.encode(
+                _owner,
+                _governanceToken,
+                _azoriusModule,
+                _votingPeriod,
+                _requiredProposerWeight,
+                _quorumNumerator,
+                _basisNumerator
+            )
+        );
+
+        __ERC4337VoterSupportV1_init(_lightAccountFactory);
+    }
+
+    /**
      * Casts votes for a Proposal, equal to the caller's token delegation.
      *
      * @param _proposalId id of the Proposal to vote on

--- a/contracts/azorius/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
+++ b/contracts/azorius/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
@@ -11,8 +11,8 @@ import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1
  * restricted to users wearing whitelisted Hats.
  */
 contract LinearERC20VotingWithHatsProposalCreationV1 is
-    HatsProposalCreationWhitelistV1,
-    LinearERC20VotingV1
+    LinearERC20VotingV1,
+    HatsProposalCreationWhitelistV1
 {
     uint16 private constant VERSION = 1;
 
@@ -29,14 +29,11 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
      * @param initializeParams encoded initialization parameters: `address _owner`,
      * `address _governanceToken`, `address _azoriusModule`, `uint32 _votingPeriod`,
      * `uint256 _quorumNumerator`, `uint256 _basisNumerator`, `address _hatsContract`,
-     * `uint256[] _initialWhitelistedHats`
+     * `uint256[] _initialWhitelistedHats`, `address _lightAccountFactory`
      */
     function setUp(
         bytes memory initializeParams
-    )
-        public
-        override(HatsProposalCreationWhitelistV1, LinearERC20VotingExtensible)
-    {
+    ) public override(LinearERC20VotingV1, HatsProposalCreationWhitelistV1) {
         (
             address _owner,
             address _governanceToken,
@@ -45,7 +42,8 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
             uint256 _quorumNumerator,
             uint256 _basisNumerator,
             address _hatsContract,
-            uint256[] memory _initialWhitelistedHats
+            uint256[] memory _initialWhitelistedHats,
+            address _lightAccountFactory
         ) = abi.decode(
                 initializeParams,
                 (
@@ -56,11 +54,12 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
                     uint256,
                     uint256,
                     address,
-                    uint256[]
+                    uint256[],
+                    address
                 )
             );
 
-        LinearERC20VotingExtensible.setUp(
+        LinearERC20VotingV1.setUp(
             abi.encode(
                 _owner,
                 _governanceToken,
@@ -68,7 +67,8 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
                 _votingPeriod,
                 0, // requiredProposerWeight is zero because we only care about the hat check
                 _quorumNumerator,
-                _basisNumerator
+                _basisNumerator,
+                _lightAccountFactory
             )
         );
 

--- a/contracts/azorius/strategies/LinearERC721VotingV1.sol
+++ b/contracts/azorius/strategies/LinearERC721VotingV1.sol
@@ -34,6 +34,56 @@ contract LinearERC721VotingV1 is
     }
 
     /**
+     * Sets up the contract with its initial parameters.
+     *
+     * @param initializeParams encoded initialization parameters: `address _owner`,
+     * `address[] memory _tokens`, `uint256[] memory _weights`, `address _azoriusModule`,
+     * `uint32 _votingPeriod`, `uint256 _quorumThreshold`, `uint256 _basisNumerator`,
+     * `address _lightAccountFactory`
+     */
+    function setUp(bytes memory initializeParams) public virtual override {
+        (
+            address _owner,
+            address[] memory _tokens,
+            uint256[] memory _weights,
+            address _azoriusModule,
+            uint32 _votingPeriod,
+            uint256 _quorumThreshold,
+            uint256 _proposerThreshold,
+            uint256 _basisNumerator,
+            address _lightAccountFactory
+        ) = abi.decode(
+                initializeParams,
+                (
+                    address,
+                    address[],
+                    uint256[],
+                    address,
+                    uint32,
+                    uint256,
+                    uint256,
+                    uint256,
+                    address
+                )
+            );
+
+        LinearERC721VotingExtensible.setUp(
+            abi.encode(
+                _owner,
+                _tokens,
+                _weights,
+                _azoriusModule,
+                _votingPeriod,
+                _quorumThreshold,
+                _proposerThreshold,
+                _basisNumerator
+            )
+        );
+
+        __ERC4337VoterSupportV1_init(_lightAccountFactory);
+    }
+
+    /**
      * Submits a vote on an existing Proposal.
      *
      * @param _proposalId id of the Proposal to vote on

--- a/contracts/azorius/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/azorius/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -11,8 +11,8 @@ import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1
  * restricted to users wearing whitelisted Hats.
  */
 contract LinearERC721VotingWithHatsProposalCreationV1 is
-    HatsProposalCreationWhitelistV1,
-    LinearERC721VotingV1
+    LinearERC721VotingV1,
+    HatsProposalCreationWhitelistV1
 {
     uint16 private constant VERSION = 1;
 
@@ -29,14 +29,11 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
      * @param initializeParams encoded initialization parameters: `address _owner`,
      * `address[] memory _tokens`, `uint256[] memory _weights`, `address _azoriusModule`,
      * `uint32 _votingPeriod`, `uint256 _quorumThreshold`, `uint256 _basisNumerator`,
-     * `address _hatsContract`, `uint256[] _initialWhitelistedHats`
+     * `address _hatsContract`, `uint256[] _initialWhitelistedHats`, `address _lightAccountFactory`
      */
     function setUp(
         bytes memory initializeParams
-    )
-        public
-        override(HatsProposalCreationWhitelistV1, LinearERC721VotingExtensible)
-    {
+    ) public override(LinearERC721VotingV1, HatsProposalCreationWhitelistV1) {
         (
             address _owner,
             address[] memory _tokens,
@@ -46,7 +43,8 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
             uint256 _quorumThreshold,
             uint256 _basisNumerator,
             address _hatsContract,
-            uint256[] memory _initialWhitelistedHats
+            uint256[] memory _initialWhitelistedHats,
+            address _lightAccountFactory
         ) = abi.decode(
                 initializeParams,
                 (
@@ -58,11 +56,12 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
                     uint256,
                     uint256,
                     address,
-                    uint256[]
+                    uint256[],
+                    address
                 )
             );
 
-        LinearERC721VotingExtensible.setUp(
+        LinearERC721VotingV1.setUp(
             abi.encode(
                 _owner,
                 _tokens,
@@ -71,7 +70,8 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
                 _votingPeriod,
                 _quorumThreshold,
                 0, // _proposerThreshold is zero because we only care about the hat check
-                _basisNumerator
+                _basisNumerator,
+                _lightAccountFactory
             )
         );
 

--- a/test/LinearERC20VotingV1.test.ts
+++ b/test/LinearERC20VotingV1.test.ts
@@ -23,6 +23,7 @@ describe('LinearERC20VotingV1', () => {
   let tokenHolder1: SignerWithAddress;
   let tokenHolder2: SignerWithAddress;
   let tokenHolder3: SignerWithAddress;
+  let lightAccountFactory: SignerWithAddress;
 
   // Contracts
   let linearERC20VotingImplementation: LinearERC20VotingV1;
@@ -52,7 +53,7 @@ describe('LinearERC20VotingV1', () => {
       'setUp',
       [
         ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'address', 'address', 'uint32', 'uint256', 'uint256', 'uint256'],
+          ['address', 'address', 'address', 'uint32', 'uint256', 'uint256', 'uint256', 'address'],
           [
             strategyOwner.address,
             governanceToken,
@@ -61,6 +62,7 @@ describe('LinearERC20VotingV1', () => {
             REQUIRED_PROPOSER_WEIGHT,
             QUORUM_NUMERATOR,
             BASIS_NUMERATOR,
+            lightAccountFactory.address,
           ],
         ),
       ],
@@ -86,7 +88,7 @@ describe('LinearERC20VotingV1', () => {
   }
 
   beforeEach(async () => {
-    [deployer, owner, nonOwner, tokenHolder1, tokenHolder2, tokenHolder3] =
+    [deployer, owner, nonOwner, tokenHolder1, tokenHolder2, tokenHolder3, lightAccountFactory] =
       await ethers.getSigners();
 
     // Use nonOwner address as a mock azorius address for testing
@@ -120,6 +122,7 @@ describe('LinearERC20VotingV1', () => {
       expect(await linearERC20Voting.requiredProposerWeight()).to.equal(REQUIRED_PROPOSER_WEIGHT);
       expect(await linearERC20Voting.quorumNumerator()).to.equal(QUORUM_NUMERATOR);
       expect(await linearERC20Voting.basisNumerator()).to.equal(BASIS_NUMERATOR);
+      expect(await linearERC20Voting.lightAccountFactory()).to.equal(lightAccountFactory.address);
     });
 
     it('should not allow reinitialization', async () => {
@@ -128,7 +131,7 @@ describe('LinearERC20VotingV1', () => {
         'setUp',
         [
           ethers.AbiCoder.defaultAbiCoder().encode(
-            ['address', 'address', 'address', 'uint32', 'uint256', 'uint256', 'uint256'],
+            ['address', 'address', 'address', 'uint32', 'uint256', 'uint256', 'uint256', 'address'],
             [
               owner.address,
               await mockToken.getAddress(),
@@ -137,6 +140,7 @@ describe('LinearERC20VotingV1', () => {
               REQUIRED_PROPOSER_WEIGHT,
               QUORUM_NUMERATOR,
               BASIS_NUMERATOR,
+              lightAccountFactory.address,
             ],
           ),
         ],
@@ -151,7 +155,7 @@ describe('LinearERC20VotingV1', () => {
         'setUp',
         [
           ethers.AbiCoder.defaultAbiCoder().encode(
-            ['address', 'address', 'address', 'uint32', 'uint256', 'uint256', 'uint256'],
+            ['address', 'address', 'address', 'uint32', 'uint256', 'uint256', 'uint256', 'address'],
             [
               owner.address,
               ethers.ZeroAddress,
@@ -160,6 +164,7 @@ describe('LinearERC20VotingV1', () => {
               REQUIRED_PROPOSER_WEIGHT,
               QUORUM_NUMERATOR,
               BASIS_NUMERATOR,
+              lightAccountFactory.address,
             ],
           ),
         ],

--- a/test/LinearERC20VotingWithHatsProposalCreationV1.test.ts
+++ b/test/LinearERC20VotingWithHatsProposalCreationV1.test.ts
@@ -26,6 +26,7 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
   let tokenHolder1: SignerWithAddress;
   let hatWearer: SignerWithAddress;
   let nonHatWearer: SignerWithAddress;
+  let lightAccountFactory: SignerWithAddress;
 
   // Contracts
   let linearERC20VotingWithHatsProposalCreationImplementation: LinearERC20VotingWithHatsProposalCreationV1;
@@ -66,6 +67,7 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
               'uint256',
               'address',
               'uint256[]',
+              'address',
             ],
             [
               strategyOwner.address,
@@ -76,6 +78,7 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
               BASIS_NUMERATOR,
               await hatsContract.getAddress(),
               initialWhitelistedHats,
+              lightAccountFactory.address,
             ],
           ),
         ],
@@ -107,7 +110,8 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
   }
 
   beforeEach(async () => {
-    [deployer, owner, nonOwner, tokenHolder1, hatWearer, nonHatWearer] = await ethers.getSigners();
+    [deployer, owner, nonOwner, tokenHolder1, hatWearer, nonHatWearer, lightAccountFactory] =
+      await ethers.getSigners();
 
     // Use nonOwner address as a mock azorius address for testing
     azoriusAddress = await nonOwner.getAddress();
@@ -161,6 +165,11 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
         expect(whitelistedHats.length).to.equal(2);
         expect(whitelistedHats[0]).to.equal(proposerHatId1);
         expect(whitelistedHats[1]).to.equal(proposerHatId2);
+
+        // Check LightAccountFactory address
+        expect(await linearERC20VotingWithHatsProposalCreation.lightAccountFactory()).to.equal(
+          lightAccountFactory.address,
+        );
       });
 
       it('should not allow reinitialization', async () => {
@@ -179,6 +188,7 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
                   'uint256',
                   'address',
                   'uint256[]',
+                  'address',
                 ],
                 [
                   owner.address,
@@ -189,6 +199,7 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
                   BASIS_NUMERATOR,
                   await mockHats.getAddress(),
                   [proposerHatId1, proposerHatId2],
+                  lightAccountFactory.address,
                 ],
               ),
             ],

--- a/test/LinearERC721VotingV1.test.ts
+++ b/test/LinearERC721VotingV1.test.ts
@@ -23,6 +23,7 @@ describe('LinearERC721VotingV1', () => {
   let tokenHolder1: SignerWithAddress;
   let tokenHolder2: SignerWithAddress;
   let tokenHolder3: SignerWithAddress;
+  let lightAccountFactory: SignerWithAddress;
 
   // Contracts
   let linearERC721VotingImplementation: LinearERC721VotingV1;
@@ -72,6 +73,7 @@ describe('LinearERC721VotingV1', () => {
             'uint256',
             'uint256',
             'uint256',
+            'address',
           ],
           [
             strategyOwner.address,
@@ -82,6 +84,7 @@ describe('LinearERC721VotingV1', () => {
             QUORUM_THRESHOLD,
             PROPOSER_THRESHOLD,
             BASIS_NUMERATOR,
+            lightAccountFactory.address,
           ],
         ),
       ],
@@ -122,7 +125,7 @@ describe('LinearERC721VotingV1', () => {
   }
 
   beforeEach(async () => {
-    [deployer, owner, nonOwner, tokenHolder1, tokenHolder2, tokenHolder3] =
+    [deployer, owner, nonOwner, tokenHolder1, tokenHolder2, tokenHolder3, lightAccountFactory] =
       await ethers.getSigners();
 
     // Use nonOwner address as a mock azorius address for testing
@@ -170,6 +173,7 @@ describe('LinearERC721VotingV1', () => {
       expect(await linearERC721Voting.quorumThreshold()).to.equal(QUORUM_THRESHOLD);
       expect(await linearERC721Voting.proposerThreshold()).to.equal(PROPOSER_THRESHOLD);
       expect(await linearERC721Voting.basisNumerator()).to.equal(BASIS_NUMERATOR);
+      expect(await linearERC721Voting.lightAccountFactory()).to.equal(lightAccountFactory.address);
     });
 
     it('should not allow reinitialization', async () => {
@@ -189,6 +193,7 @@ describe('LinearERC721VotingV1', () => {
               'uint256',
               'uint256',
               'uint256',
+              'address',
             ],
             [
               owner.address,
@@ -199,6 +204,7 @@ describe('LinearERC721VotingV1', () => {
               QUORUM_THRESHOLD,
               PROPOSER_THRESHOLD,
               BASIS_NUMERATOR,
+              lightAccountFactory.address,
             ],
           ),
         ],
@@ -226,6 +232,7 @@ describe('LinearERC721VotingV1', () => {
               'uint256',
               'uint256',
               'uint256',
+              'address',
             ],
             [
               owner.address,
@@ -236,6 +243,7 @@ describe('LinearERC721VotingV1', () => {
               QUORUM_THRESHOLD,
               PROPOSER_THRESHOLD,
               BASIS_NUMERATOR,
+              lightAccountFactory.address,
             ],
           ),
         ],
@@ -271,6 +279,7 @@ describe('LinearERC721VotingV1', () => {
               'uint256',
               'uint256',
               'uint256',
+              'address',
             ],
             [
               owner.address,
@@ -281,6 +290,7 @@ describe('LinearERC721VotingV1', () => {
               QUORUM_THRESHOLD,
               PROPOSER_THRESHOLD,
               BASIS_NUMERATOR,
+              lightAccountFactory.address,
             ],
           ),
         ],
@@ -316,6 +326,7 @@ describe('LinearERC721VotingV1', () => {
               'uint256',
               'uint256',
               'uint256',
+              'address',
             ],
             [
               owner.address,
@@ -326,6 +337,7 @@ describe('LinearERC721VotingV1', () => {
               QUORUM_THRESHOLD,
               PROPOSER_THRESHOLD,
               BASIS_NUMERATOR,
+              lightAccountFactory.address,
             ],
           ),
         ],
@@ -990,6 +1002,7 @@ describe('LinearERC721VotingV1', () => {
               'uint256',
               'uint256',
               'uint256',
+              'address',
             ],
             [
               owner.address,
@@ -1000,6 +1013,7 @@ describe('LinearERC721VotingV1', () => {
               QUORUM_THRESHOLD,
               PROPOSER_THRESHOLD,
               BASIS_NUMERATOR,
+              lightAccountFactory.address,
             ],
           ),
         ],

--- a/test/LinearERC721VotingWithHatsProposalCreationV1.test.ts
+++ b/test/LinearERC721VotingWithHatsProposalCreationV1.test.ts
@@ -27,6 +27,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
   let tokenHolder1: SignerWithAddress;
   let hatWearer: SignerWithAddress;
   let nonHatWearer: SignerWithAddress;
+  let lightAccountFactory: SignerWithAddress;
 
   // Contracts
   let linearERC721VotingWithHatsProposalCreationImplementation: LinearERC721VotingWithHatsProposalCreationV1;
@@ -67,6 +68,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
           'uint256',
           'address',
           'uint256[]',
+          'address',
         ],
         [
           strategyOwner.address,
@@ -78,6 +80,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
           BASIS_NUMERATOR,
           await hatsContract.getAddress(),
           initialWhitelistedHats,
+          lightAccountFactory.address,
         ],
       ),
     ]);
@@ -107,7 +110,8 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
   }
 
   beforeEach(async () => {
-    [deployer, owner, nonOwner, tokenHolder1, hatWearer, nonHatWearer] = await ethers.getSigners();
+    [deployer, owner, nonOwner, tokenHolder1, hatWearer, nonHatWearer, lightAccountFactory] =
+      await ethers.getSigners();
 
     // Use nonOwner address as a mock azorius address for testing
     azoriusAddress = await nonOwner.getAddress();
@@ -176,6 +180,11 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
         expect(whitelistedHats.length).to.equal(2);
         expect(whitelistedHats[0]).to.equal(proposerHatId1);
         expect(whitelistedHats[1]).to.equal(proposerHatId2);
+
+        // Check LightAccountFactory address
+        expect(await linearERC721VotingWithHatsProposalCreation.lightAccountFactory()).to.equal(
+          lightAccountFactory.address,
+        );
       });
 
       it('should not allow reinitialization', async () => {
@@ -198,6 +207,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
                   'uint256',
                   'address',
                   'uint256[]',
+                  'address',
                 ],
                 [
                   owner.address,
@@ -209,6 +219,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
                   BASIS_NUMERATOR,
                   await mockHats.getAddress(),
                   [proposerHatId1, proposerHatId2],
+                  lightAccountFactory.address,
                 ],
               ),
             ],


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/224

BREAKING CHANGES:
- All voting strategy initializations now require lightAccountFactory parameter
- Changed inheritance order in Hats voting strategies for proper initialization
- Modified setUp function signatures across all voting contracts

This commit integrates Light Account verification into all voting strategies by adding the LightAccountFactory initialization parameter. This ensures consistent and secure handling of account abstraction across the voting system.

Technical changes:
- Added setUp implementation in LinearERC20VotingV1 and LinearERC721VotingV1
- Added lightAccountFactory parameter to all strategy initialization methods
- Fixed inheritance order in Hats-based voting strategies to ensure proper initialization
- Updated all test files to include lightAccountFactory in initialization parameters
- Added verification of lightAccountFactory address in tests

Modified files:
- contracts/azorius/strategies/LinearERC20VotingV1.sol
- contracts/azorius/strategies/LinearERC721VotingV1.sol
- contracts/azorius/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
- contracts/azorius/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
- test/LinearERC20VotingV1.test.ts
- test/LinearERC721VotingV1.test.ts
- test/LinearERC20VotingWithHatsProposalCreationV1.test.ts
- test/LinearERC721VotingWithHatsProposalCreationV1.test.ts

This change completes the integration of Light Account verification across the voting system, ensuring that all voting strategies properly handle account abstraction while maintaining security and consistency.