### PR TITLE
refactor!: extract UserOp verification logic into SmartAccountVerificationV1

### DIFF
--- a/contracts/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/account-abstraction/DecentPaymasterV1.sol
@@ -23,9 +23,7 @@ contract DecentPaymasterV1 is
     event FunctionWhitelisted(address contractAddress, bytes4 selector);
     event FunctionUnwhitelisted(address contractAddress, bytes4 selector);
 
-    error InvalidSmartAccount();
-    error UnauthorizedFunction();
-    error InvalidCallDataLength();
+    error NotWhitelistedFunction(address target, bytes4 selector);
 
     constructor() {
         _disableInitializers();
@@ -98,46 +96,11 @@ contract DecentPaymasterV1 is
         override
         returns (bytes memory context, uint256 validationData)
     {
-        if (!verifySmartAccount(userOp.sender)) {
-            revert InvalidSmartAccount();
-        }
-
-        // If we're here, we've confirmed that the sender is an actual instance of a LightAccount,
-        // and so therefore its "execute" function behaves as expected.
-        //
-        // This prevents a potential exploit where a user crafts a malicious UserOp
-        // which targets a contract that is expected to be a LightAccount, but is not,
-        // and allows the implementation of that contract's "execute" function to perform
-        // any arbitrary logic (aka logic which does not execute the whitelisted function
-        // encoded in the UserOp).
-
-        bytes calldata callData = userOp.callData;
-        // Verify we have at least 4 bytes for the selector
-        if (callData.length < 4) {
-            revert InvalidCallDataLength();
-        }
-
-        // Extract and verify the LightAccount's "execute" function selector
-        // 0xb61d27f6 = bytes4(keccak256("execute(address,uint256,bytes)"))
-        if (bytes4(callData) != 0xb61d27f6) {
-            revert UnauthorizedFunction();
-        }
-
-        // Decode the "execute" function parameters
-        (address target, , bytes memory innerCallData) = abi.decode(
-            callData[4:],
-            (address, uint256, bytes)
-        );
-
-        // Extract the actual function selector from the innerCallData
-        if (innerCallData.length < 4) {
-            revert InvalidCallDataLength();
-        }
-        bytes4 selector = bytes4(innerCallData);
+        (address target, bytes4 selector) = verifyUserOp(userOp);
 
         // Verify the function is whitelistd for this target
         if (!isFunctionWhitelisted(target, selector)) {
-            revert UnauthorizedFunction();
+            revert NotWhitelistedFunction(target, selector);
         }
 
         return (abi.encode(), 0);

--- a/contracts/account-abstraction/SmartAccountVerificationV1.sol
+++ b/contracts/account-abstraction/SmartAccountVerificationV1.sol
@@ -3,10 +3,16 @@ pragma solidity ^0.8.19;
 
 import {ILightAccount} from "../interfaces/ILightAccount.sol";
 import {ILightAccountFactory} from "../interfaces/ILightAccountFactory.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 abstract contract SmartAccountVerificationV1 is Initializable {
     ILightAccountFactory public lightAccountFactory;
+
+    error InvalidSmartAccount();
+    error InvalidUserOpCallDataLength();
+    error InvalidCallData();
+    error InvalidInnerCallDataLength();
 
     constructor() {
         _disableInitializers();
@@ -50,5 +56,46 @@ abstract contract SmartAccountVerificationV1 is Initializable {
             // so it's definitely not a `LightAccount`
             return false;
         }
+    }
+
+    function verifyUserOp(
+        PackedUserOperation calldata userOp
+    ) internal view virtual returns (address, bytes4) {
+        if (!verifySmartAccount(userOp.sender)) {
+            revert InvalidSmartAccount();
+        }
+
+        // If we're here, we've confirmed that the sender is an actual instance of a LightAccount,
+        // and so therefore its "execute" function behaves as expected.
+        //
+        // This prevents a potential exploit where a user crafts a malicious UserOp
+        // which targets a contract that is expected to be a LightAccount, but is not,
+        // and allows the implementation of that contract's "execute" function to perform
+        // any arbitrary logic (aka logic which does not execute the whitelisted function
+        // encoded in the UserOp).
+
+        // Verify we have at least 4 bytes for the selector
+        if (userOp.callData.length < 4) {
+            revert InvalidUserOpCallDataLength();
+        }
+
+        // Extract and verify the LightAccount's "execute" function selector
+        // 0xb61d27f6 = bytes4(keccak256("execute(address,uint256,bytes)"))
+        if (bytes4(userOp.callData) != 0xb61d27f6) {
+            revert InvalidCallData();
+        }
+
+        // Decode the "execute" function parameters
+        (address target, , bytes memory innerCallData) = abi.decode(
+            userOp.callData[4:],
+            (address, uint256, bytes)
+        );
+
+        // Extract the actual function selector from the innerCallData
+        if (innerCallData.length < 4) {
+            revert InvalidInnerCallDataLength();
+        }
+
+        return (target, bytes4(innerCallData));
     }
 }

--- a/contracts/mocks/ConcreteSmartAccountVerification.sol
+++ b/contracts/mocks/ConcreteSmartAccountVerification.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.19;
 
 import {SmartAccountVerificationV1} from "../account-abstraction/SmartAccountVerificationV1.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 
 contract ConcreteSmartAccountVerification is SmartAccountVerificationV1 {
     function initialize(address _lightAccountFactory) public initializer {
@@ -12,5 +13,11 @@ contract ConcreteSmartAccountVerification is SmartAccountVerificationV1 {
         address smartAccount
     ) public view returns (bool) {
         return verifySmartAccount(smartAccount);
+    }
+
+    function verifyUserOpPublic(
+        PackedUserOperation calldata userOp
+    ) public view returns (address, bytes4) {
+        return verifyUserOp(userOp);
     }
 }

--- a/test/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/account-abstraction/DecentPaymasterV1.test.ts
@@ -226,7 +226,7 @@ describe('DecentPaymasterV1', function () {
       await decentPaymaster.whitelistFunction(await mockTarget.getAddress(), FOO_SELECTOR);
     });
 
-    it('Should validate whitelisted function calls from valid light accounts', async function () {
+    it('Should validate whitelisted function calls', async function () {
       const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
       const result = await decentPaymaster
         .connect(entryPointSigner)
@@ -236,38 +236,14 @@ describe('DecentPaymasterV1', function () {
       expect(result[0]).to.equal('0x'); // context
     });
 
-    it('Should revert on unauthorized function calls', async function () {
-      const unauthorizedCallData = ethers.concat([
-        '0x99999999',
-        ethers.zeroPadValue(await mockTarget.getAddress(), 20),
-        '0x',
-      ]);
+    it('Should revert on non-whitelisted function calls', async function () {
+      // Create a new function selector that isn't whitelisted
+      const nonWhitelistedSelector = '0x99999999';
 
-      const unauthorizedUserOp = { ...mockUserOp, callData: unauthorizedCallData };
-
-      await expect(
-        decentPaymaster
-          .connect(await ethers.getImpersonatedSigner(await entryPoint.getAddress()))
-          .validatePaymasterUserOp.staticCall(unauthorizedUserOp, ethers.ZeroHash, 0),
-      ).to.be.revertedWithCustomError(decentPaymaster, 'UnauthorizedFunction');
-    });
-
-    it('Should revert on invalid calldata length', async function () {
-      const invalidCallData = '0x1234'; // Too short
-      const invalidUserOp = { ...mockUserOp, callData: invalidCallData };
-
-      await expect(
-        decentPaymaster
-          .connect(await ethers.getImpersonatedSigner(await entryPoint.getAddress()))
-          .validatePaymasterUserOp.staticCall(invalidUserOp, ethers.ZeroHash, 0),
-      ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidCallDataLength');
-    });
-
-    it('Should validate with exactly 24 bytes of calldata', async function () {
-      // Create minimal inner calldata with no parameters
-      const innerCalldata = mockTarget.interface.encodeFunctionData('foo', [
-        0, // uint32 someNumber = 0
-        0, // uint8 someFlag = 0
+      // Create inner calldata with non-whitelisted selector
+      const innerCalldata = ethers.concat([
+        nonWhitelistedSelector,
+        ethers.AbiCoder.defaultAbiCoder().encode(['uint32', 'uint8'], [123, 1]),
       ]);
 
       // Create the execute calldata
@@ -278,80 +254,12 @@ describe('DecentPaymasterV1', function () {
       ]);
 
       const userOp = { ...mockUserOp, callData: executeCalldata };
-      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
-
-      const result = await decentPaymaster
-        .connect(entryPointSigner)
-        .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0);
-
-      expect(result[1]).to.equal(0n);
-      expect(result[0]).to.equal('0x');
-    });
-
-    it('Should validate with more than 24 bytes of calldata', async function () {
-      // Create inner calldata with large numbers to make it longer
-      const innerCalldata = mockTarget.interface.encodeFunctionData('foo', [
-        0xffffffff, // uint32 someNumber = max value
-        0xff, // uint8 someFlag = max value
-      ]);
-
-      // Create the execute calldata
-      const executeCalldata = mockLightAccount.interface.encodeFunctionData('execute', [
-        await mockTarget.getAddress(),
-        0n, // value
-        innerCalldata,
-      ]);
-
-      const userOp = { ...mockUserOp, callData: executeCalldata };
-      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
-
-      const result = await decentPaymaster
-        .connect(entryPointSigner)
-        .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0);
-
-      expect(result[1]).to.equal(0n);
-      expect(result[0]).to.equal('0x');
-    });
-
-    it('Should validate with non-contract address as target', async function () {
-      const randomAddress = ethers.Wallet.createRandom().address;
-
-      // First whitelist the function for the random address
-      await decentPaymaster.whitelistFunction(randomAddress, FOO_SELECTOR);
-
-      // Create inner calldata
-      const innerCalldata = mockTarget.interface.encodeFunctionData('foo', [
-        123, // uint32 someNumber
-        1, // uint8 someFlag
-      ]);
-
-      // Create the execute calldata but use the random address as target
-      const executeCalldata = mockLightAccount.interface.encodeFunctionData('execute', [
-        randomAddress,
-        0n, // value
-        innerCalldata,
-      ]);
-
-      const userOp = { ...mockUserOp, callData: executeCalldata };
-      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
-
-      const result = await decentPaymaster
-        .connect(entryPointSigner)
-        .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0);
-
-      expect(result[1]).to.equal(0n);
-      expect(result[0]).to.equal('0x');
-    });
-
-    it('Should revert with malformed calldata', async function () {
-      const malformedCallData = '0x1234'; // Less than 4 bytes for selector
-      const userOp = { ...mockUserOp, callData: malformedCallData };
 
       await expect(
         decentPaymaster
           .connect(await ethers.getImpersonatedSigner(await entryPoint.getAddress()))
           .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0),
-      ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidCallDataLength');
+      ).to.be.revertedWithCustomError(decentPaymaster, 'NotWhitelistedFunction');
     });
   });
 

--- a/test/account-abstraction/SmartAccountVerificationV1.test.ts
+++ b/test/account-abstraction/SmartAccountVerificationV1.test.ts
@@ -4,6 +4,8 @@ import { ethers } from 'hardhat';
 import {
   ConcreteSmartAccountVerification,
   ConcreteSmartAccountVerification__factory,
+  MockGaslessTarget,
+  MockGaslessTarget__factory,
   MockInvalidLightAccount,
   MockInvalidLightAccount__factory,
   MockLightAccount,
@@ -13,6 +15,18 @@ import {
 } from '../../typechain-types';
 import { getModuleProxyFactory } from '../GlobalSafeDeployments.test';
 import { calculateProxyAddress } from '../helpers';
+
+interface PackedUserOperation {
+  sender: string;
+  nonce: bigint;
+  initCode: string;
+  callData: string;
+  accountGasLimits: string;
+  preVerificationGas: bigint;
+  gasFees: string;
+  paymasterAndData: string;
+  signature: string;
+}
 
 async function deploySmartAccountVerification(
   deployer: SignerWithAddress,
@@ -130,6 +144,126 @@ describe('LightAccountVerificationV1', function () {
           ).to.be.false;
         });
       });
+    });
+  });
+
+  describe('verifySmartAccountAndCallData', function () {
+    let mockUserOp: PackedUserOperation;
+    let mockTarget: MockGaslessTarget;
+    let FOO_SELECTOR: string;
+
+    beforeEach(async function () {
+      // Deploy MockGaslessTarget
+      mockTarget = await new MockGaslessTarget__factory(deployer).deploy();
+
+      // Get the foo function selector
+      FOO_SELECTOR = mockTarget.interface.getFunction('foo').selector;
+
+      // Create mock UserOperation with properly encoded calldata
+      const innerCalldata = mockTarget.interface.encodeFunctionData('foo', [
+        123, // uint32 someNumber
+        1, // uint8 someFlag
+      ]);
+
+      const executeCalldata = mockLightAccount.interface.encodeFunctionData('execute', [
+        await mockTarget.getAddress(),
+        0n, // value
+        innerCalldata,
+      ]);
+
+      mockUserOp = {
+        sender: await mockLightAccount.getAddress(),
+        nonce: 0n,
+        initCode: '0x',
+        callData: executeCalldata,
+        accountGasLimits: ethers.ZeroHash,
+        preVerificationGas: 0n,
+        gasFees: ethers.ZeroHash,
+        paymasterAndData: '0x',
+        signature: '0x',
+      };
+    });
+
+    it('should validate valid calldata from valid light accounts', async function () {
+      // Set up the mock factory contract to return the correct address
+      await mockLightAccountFactory.setAccountAddress(
+        await mockLightAccount.owner(),
+        0n,
+        await mockLightAccount.getAddress(),
+      );
+
+      const [target, selector] = await concreteVerification.verifyUserOpPublic(mockUserOp);
+      expect(target).to.equal(await mockTarget.getAddress());
+      expect(selector).to.equal(FOO_SELECTOR);
+    });
+
+    it('should revert with InvalidSmartAccount when sender is not a valid light account', async function () {
+      // Not setting up the mock factory to return the correct address
+      // This will make verifySmartAccount return false, triggering InvalidSmartAccount
+
+      await expect(
+        concreteVerification.verifyUserOpPublic(mockUserOp),
+      ).to.be.revertedWithCustomError(concreteVerification, 'InvalidSmartAccount');
+    });
+
+    it('should revert on invalid calldata length', async function () {
+      // Set up the mock factory contract to return the correct address
+      await mockLightAccountFactory.setAccountAddress(
+        await mockLightAccount.owner(),
+        0n,
+        await mockLightAccount.getAddress(),
+      );
+
+      const invalidCallData = '0x1234'; // Too short
+      const invalidUserOp = { ...mockUserOp, callData: invalidCallData };
+
+      await expect(
+        concreteVerification.verifyUserOpPublic(invalidUserOp),
+      ).to.be.revertedWithCustomError(concreteVerification, 'InvalidUserOpCallDataLength');
+    });
+
+    it('should revert on unauthorized function calls', async function () {
+      // Set up the mock factory contract to return the correct address
+      await mockLightAccountFactory.setAccountAddress(
+        await mockLightAccount.owner(),
+        0n,
+        await mockLightAccount.getAddress(),
+      );
+
+      const unauthorizedCallData = ethers.concat([
+        '0x99999999',
+        ethers.zeroPadValue(await mockTarget.getAddress(), 20),
+        '0x',
+      ]);
+
+      const unauthorizedUserOp = { ...mockUserOp, callData: unauthorizedCallData };
+
+      await expect(
+        concreteVerification.verifyUserOpPublic(unauthorizedUserOp),
+      ).to.be.revertedWithCustomError(concreteVerification, 'InvalidCallData');
+    });
+
+    it('should revert with InvalidInnerCallDataLength when inner calldata is too short', async function () {
+      // Set up the mock factory contract to return the correct address
+      await mockLightAccountFactory.setAccountAddress(
+        await mockLightAccount.owner(),
+        0n,
+        await mockLightAccount.getAddress(),
+      );
+
+      // Create execute calldata with too short inner calldata
+      const executeCalldata = mockLightAccount.interface.encodeFunctionData('execute', [
+        await mockTarget.getAddress(),
+        0n, // value
+        '0x12', // inner calldata less than 4 bytes
+      ]);
+
+      const userOp = { ...mockUserOp, callData: executeCalldata };
+
+      await expect(concreteVerification.verifyUserOpPublic(userOp)).to.be.revertedWithCustomError(
+        concreteVerification,
+        'InvalidInnerCallDataLength',
+      );
     });
   });
 });


### PR DESCRIPTION
BREAKING CHANGES:
- Moved UserOp validation logic from DecentPaymasterV1 to SmartAccountVerificationV1
- Consolidated error handling with more specific error messages
- Changed UnauthorizedFunction error to NotWhitelistedFunction with additional context

This commit improves code organization and reusability by extracting the UserOperation verification logic into the base SmartAccountVerificationV1 contract. This allows other contracts to reuse the same validation logic while maintaining consistent security checks.

Technical changes:
- Added verifyUserOp() function to SmartAccountVerificationV1
- Simplified DecentPaymasterV1 by leveraging the new verification function
- Added specific error types for different validation failures:
  * InvalidSmartAccount
  * InvalidUserOpCallDataLength
  * InvalidCallData
  * InvalidInnerCallDataLength
  * NotWhitelistedFunction (includes target and selector)
- Added comprehensive test suite for UserOp verification
- Updated existing tests to reflect new error handling

Security improvements:
- Centralized validation logic reduces risk of implementation inconsistencies
- More detailed error messages aid in debugging and monitoring
- Maintained all existing security checks while improving code organization

Modified files:
- contracts/account-abstraction/DecentPaymasterV1.sol
- contracts/account-abstraction/SmartAccountVerificationV1.sol
- contracts/mocks/ConcreteSmartAccountVerification.sol
- test/account-abstraction/DecentPaymasterV1.test.ts
- test/account-abstraction/SmartAccountVerificationV1.test.ts