### PR TITLE
refactor!: rename SmartAccountVerification to SmartAccountValidation

### DIFF
--- a/contracts/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/account-abstraction/DecentPaymasterV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import {IDecentPaymasterV1} from "../interfaces/account-abstraction/IDecentPaymasterV1.sol";
 import {BasePaymasterV1} from "./BasePaymasterV1.sol";
-import {SmartAccountVerificationV1} from "./SmartAccountVerificationV1.sol";
+import {SmartAccountValidationV1} from "./SmartAccountValidationV1.sol";
 import {Version} from "../Version.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
@@ -13,7 +13,7 @@ contract DecentPaymasterV1 is
     IDecentPaymasterV1,
     Version,
     BasePaymasterV1,
-    SmartAccountVerificationV1
+    SmartAccountValidationV1
 {
     uint16 private constant VERSION = 1;
 
@@ -43,7 +43,7 @@ contract DecentPaymasterV1 is
             address _lightAccountFactory
         ) = abi.decode(data, (address, address, address));
         __BasePaymasterV1_init(_owner, IEntryPoint(_entryPoint));
-        __SmartAccountVerificationV1_init(_lightAccountFactory);
+        __SmartAccountValidationV1_init(_lightAccountFactory);
     }
 
     /**
@@ -96,9 +96,9 @@ contract DecentPaymasterV1 is
         override
         returns (bytes memory context, uint256 validationData)
     {
-        (address target, bytes4 selector) = verifyUserOp(userOp);
+        (address target, bytes4 selector) = validateUserOp(userOp);
 
-        // Verify the function is whitelistd for this target
+        // Validate the function is whitelistd for this target
         if (!isFunctionWhitelisted(target, selector)) {
             revert NotWhitelistedFunction(target, selector);
         }

--- a/contracts/account-abstraction/SmartAccountValidationV1.sol
+++ b/contracts/account-abstraction/SmartAccountValidationV1.sol
@@ -6,7 +6,7 @@ import {ILightAccountFactory} from "../interfaces/ILightAccountFactory.sol";
 import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-abstract contract SmartAccountVerificationV1 is Initializable {
+abstract contract SmartAccountValidationV1 is Initializable {
     ILightAccountFactory public lightAccountFactory;
 
     error InvalidSmartAccount();
@@ -18,13 +18,13 @@ abstract contract SmartAccountVerificationV1 is Initializable {
         _disableInitializers();
     }
 
-    function __SmartAccountVerificationV1_init(
+    function __SmartAccountValidationV1_init(
         address _lightAccountFactory
     ) internal {
         lightAccountFactory = ILightAccountFactory(_lightAccountFactory);
     }
 
-    function verifySmartAccount(
+    function validateSmartAccount(
         address smartAccount
     ) internal view virtual returns (bool) {
         // First check if the address has code (is a contract)
@@ -58,10 +58,10 @@ abstract contract SmartAccountVerificationV1 is Initializable {
         }
     }
 
-    function verifyUserOp(
+    function validateUserOp(
         PackedUserOperation calldata userOp
     ) internal view virtual returns (address, bytes4) {
-        if (!verifySmartAccount(userOp.sender)) {
+        if (!validateSmartAccount(userOp.sender)) {
             revert InvalidSmartAccount();
         }
 
@@ -74,12 +74,12 @@ abstract contract SmartAccountVerificationV1 is Initializable {
         // any arbitrary logic (aka logic which does not execute the whitelisted function
         // encoded in the UserOp).
 
-        // Verify we have at least 4 bytes for the selector
+        // Validate that we have at least 4 bytes for the selector
         if (userOp.callData.length < 4) {
             revert InvalidUserOpCallDataLength();
         }
 
-        // Extract and verify the LightAccount's "execute" function selector
+        // Extract and validate the LightAccount's "execute" function selector
         // 0xb61d27f6 = bytes4(keccak256("execute(address,uint256,bytes)"))
         if (bytes4(userOp.callData) != 0xb61d27f6) {
             revert InvalidCallData();

--- a/contracts/azorius/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/azorius/strategies/ERC4337VoterSupportV1.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.19;
 
 import {ILightAccount} from "../../interfaces/ILightAccount.sol";
-import {SmartAccountVerificationV1} from "../../account-abstraction/SmartAccountVerificationV1.sol";
+import {SmartAccountValidationV1} from "../../account-abstraction/SmartAccountValidationV1.sol";
 
 /**
  * Functionality to support ERC4337 (Account Abstraction) by properly identifying the voter
  * when a contract account is used to interact with the voting system.
  */
-abstract contract ERC4337VoterSupportV1 is SmartAccountVerificationV1 {
+abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
     constructor() {
         _disableInitializers();
     }
@@ -16,7 +16,7 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountVerificationV1 {
     function __ERC4337VoterSupportV1_init(
         address _lightAccountFactory
     ) internal {
-        __SmartAccountVerificationV1_init(_lightAccountFactory);
+        __SmartAccountValidationV1_init(_lightAccountFactory);
     }
 
     /**
@@ -27,11 +27,11 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountVerificationV1 {
     function _voter(
         address _msgSender
     ) internal view virtual returns (address) {
-        if (!verifySmartAccount(_msgSender)) {
+        if (!validateSmartAccount(_msgSender)) {
             return _msgSender;
         }
 
-        // This call is safe, because `verifySmartAccount` ensures that the address implements
+        // This call is safe, because `validateSmartAccount` ensures that the address implements
         // the `ILightAccount` interface, and so calling `owner()` will not revert.
         return ILightAccount(_msgSender).owner();
     }

--- a/contracts/mocks/ConcreteSmartAccountValidation.sol
+++ b/contracts/mocks/ConcreteSmartAccountValidation.sol
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.19;
 
-import {SmartAccountVerificationV1} from "../account-abstraction/SmartAccountVerificationV1.sol";
+import {SmartAccountValidationV1} from "../account-abstraction/SmartAccountValidationV1.sol";
 import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 
-contract ConcreteSmartAccountVerification is SmartAccountVerificationV1 {
+contract ConcreteSmartAccountValidation is SmartAccountValidationV1 {
     function initialize(address _lightAccountFactory) public initializer {
-        __SmartAccountVerificationV1_init(_lightAccountFactory);
+        __SmartAccountValidationV1_init(_lightAccountFactory);
     }
 
-    function verifySmartAccountPublic(
+    function validateSmartAccountPublic(
         address smartAccount
     ) public view returns (bool) {
-        return verifySmartAccount(smartAccount);
+        return validateSmartAccount(smartAccount);
     }
 
-    function verifyUserOpPublic(
+    function validateUserOpPublic(
         PackedUserOperation calldata userOp
     ) public view returns (address, bytes4) {
-        return verifyUserOp(userOp);
+        return validateUserOp(userOp);
     }
 }

--- a/test/account-abstraction/SmartAccountValidationV1.test.ts
+++ b/test/account-abstraction/SmartAccountValidationV1.test.ts
@@ -2,8 +2,8 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  ConcreteSmartAccountVerification,
-  ConcreteSmartAccountVerification__factory,
+  ConcreteSmartAccountValidation,
+  ConcreteSmartAccountValidation__factory,
   MockGaslessTarget,
   MockGaslessTarget__factory,
   MockInvalidLightAccount,
@@ -28,13 +28,13 @@ interface PackedUserOperation {
   signature: string;
 }
 
-async function deploySmartAccountVerification(
+async function deploySmartAccountValidation(
   deployer: SignerWithAddress,
-  implementation: ConcreteSmartAccountVerification,
+  implementation: ConcreteSmartAccountValidation,
   mockLightAccountFactoryAddress: string,
 ) {
   const initializeCalldata =
-    ConcreteSmartAccountVerification__factory.createInterface().encodeFunctionData('initialize', [
+    ConcreteSmartAccountValidation__factory.createInterface().encodeFunctionData('initialize', [
       mockLightAccountFactoryAddress,
     ]);
 
@@ -47,22 +47,22 @@ async function deploySmartAccountVerification(
     salt,
   );
 
-  const predictedSmartAccountVerificationAddress = await calculateProxyAddress(
+  const predictedSmartAccountValidationAddress = await calculateProxyAddress(
     moduleProxyFactory,
     await implementation.getAddress(),
     initializeCalldata,
     salt,
   );
 
-  return ConcreteSmartAccountVerification__factory.connect(
-    predictedSmartAccountVerificationAddress,
+  return ConcreteSmartAccountValidation__factory.connect(
+    predictedSmartAccountValidationAddress,
     deployer,
   );
 }
 
-describe('LightAccountVerificationV1', function () {
+describe('SmartAccountValidationV1', function () {
   // contracts
-  let concreteVerification: ConcreteSmartAccountVerification;
+  let concreteSmartAccountValidation: ConcreteSmartAccountValidation;
   let mockLightAccount: MockLightAccount;
   let mockInvalidLightAccount: MockInvalidLightAccount;
   let mockLightAccountFactory: MockLightAccountFactory;
@@ -84,22 +84,22 @@ describe('LightAccountVerificationV1', function () {
     // Deploy MockLightAccountFactory
     mockLightAccountFactory = await new MockLightAccountFactory__factory(deployer).deploy();
 
-    // Deploy MockLightAccountVerification
-    const concreteVerificationImplementation = await new ConcreteSmartAccountVerification__factory(
+    // Deploy ConcreteSmartAccountValidation
+    const concreteValidationImplementation = await new ConcreteSmartAccountValidation__factory(
       deployer,
     ).deploy();
 
-    concreteVerification = await deploySmartAccountVerification(
+    concreteSmartAccountValidation = await deploySmartAccountValidation(
       deployer,
-      concreteVerificationImplementation,
+      concreteValidationImplementation,
       mockLightAccountFactory.target.toString(),
     );
   });
 
-  describe('verifySmartAccount', function () {
+  describe('validateSmartAccount', function () {
     describe('valid smart accounts', function () {
-      it('should verify valid smart accounts', async function () {
-        // set up the mock factory contract to return the correct address to `verifySmartAccount`
+      it('should validate valid smart accounts', async function () {
+        // set up the mock factory contract to return the correct address to `validateSmartAccount`
         await mockLightAccountFactory.setAccountAddress(
           await mockLightAccount.owner(),
           0n,
@@ -107,7 +107,9 @@ describe('LightAccountVerificationV1', function () {
         );
 
         void expect(
-          await concreteVerification.verifySmartAccountPublic(await mockLightAccount.getAddress()),
+          await concreteSmartAccountValidation.validateSmartAccountPublic(
+            await mockLightAccount.getAddress(),
+          ),
         ).to.be.true;
       });
     });
@@ -118,8 +120,9 @@ describe('LightAccountVerificationV1', function () {
           const randomAddress = ethers.Wallet.createRandom().address;
 
           // Should return false since the address won't have the owner() function
-          void expect(await concreteVerification.verifySmartAccountPublic(randomAddress)).to.be
-            .false;
+          void expect(
+            await concreteSmartAccountValidation.validateSmartAccountPublic(randomAddress),
+          ).to.be.false;
         });
       });
 
@@ -127,18 +130,18 @@ describe('LightAccountVerificationV1', function () {
         it('should return false for invalid light accounts that do implement the ILightAccount interface (owner())', async function () {
           // not calling "setAccountAddress", so the LightAccountFactory will always
           // return the zero address when calling `getAddress` for a given owner and salt
-          // (which is implemented in the LightAccountVerification verifySmartAccount function).
+          // (which is implemented in the SmartAccountValidation validateSmartAccount function).
           void expect(
-            await concreteVerification.verifySmartAccountPublic(
+            await concreteSmartAccountValidation.validateSmartAccountPublic(
               await mockLightAccount.getAddress(),
             ),
           ).to.be.false;
         });
 
         it('should return false for invalid light accounts that do not implement the ILightAccount interface (owner())', async function () {
-          // Hits the "catch" block in the `verifySmartAccount` function
+          // Hits the "catch" block in the `validateSmartAccount` function
           void expect(
-            await concreteVerification.verifySmartAccountPublic(
+            await concreteSmartAccountValidation.validateSmartAccountPublic(
               await mockInvalidLightAccount.getAddress(),
             ),
           ).to.be.false;
@@ -147,7 +150,7 @@ describe('LightAccountVerificationV1', function () {
     });
   });
 
-  describe('verifySmartAccountAndCallData', function () {
+  describe('validateUserOp', function () {
     let mockUserOp: PackedUserOperation;
     let mockTarget: MockGaslessTarget;
     let FOO_SELECTOR: string;
@@ -192,18 +195,19 @@ describe('LightAccountVerificationV1', function () {
         await mockLightAccount.getAddress(),
       );
 
-      const [target, selector] = await concreteVerification.verifyUserOpPublic(mockUserOp);
+      const [target, selector] =
+        await concreteSmartAccountValidation.validateUserOpPublic(mockUserOp);
       expect(target).to.equal(await mockTarget.getAddress());
       expect(selector).to.equal(FOO_SELECTOR);
     });
 
     it('should revert with InvalidSmartAccount when sender is not a valid light account', async function () {
       // Not setting up the mock factory to return the correct address
-      // This will make verifySmartAccount return false, triggering InvalidSmartAccount
+      // This will make validateSmartAccount return false, triggering InvalidSmartAccount
 
       await expect(
-        concreteVerification.verifyUserOpPublic(mockUserOp),
-      ).to.be.revertedWithCustomError(concreteVerification, 'InvalidSmartAccount');
+        concreteSmartAccountValidation.validateUserOpPublic(mockUserOp),
+      ).to.be.revertedWithCustomError(concreteSmartAccountValidation, 'InvalidSmartAccount');
     });
 
     it('should revert on invalid calldata length', async function () {
@@ -218,8 +222,11 @@ describe('LightAccountVerificationV1', function () {
       const invalidUserOp = { ...mockUserOp, callData: invalidCallData };
 
       await expect(
-        concreteVerification.verifyUserOpPublic(invalidUserOp),
-      ).to.be.revertedWithCustomError(concreteVerification, 'InvalidUserOpCallDataLength');
+        concreteSmartAccountValidation.validateUserOpPublic(invalidUserOp),
+      ).to.be.revertedWithCustomError(
+        concreteSmartAccountValidation,
+        'InvalidUserOpCallDataLength',
+      );
     });
 
     it('should revert on unauthorized function calls', async function () {
@@ -239,8 +246,8 @@ describe('LightAccountVerificationV1', function () {
       const unauthorizedUserOp = { ...mockUserOp, callData: unauthorizedCallData };
 
       await expect(
-        concreteVerification.verifyUserOpPublic(unauthorizedUserOp),
-      ).to.be.revertedWithCustomError(concreteVerification, 'InvalidCallData');
+        concreteSmartAccountValidation.validateUserOpPublic(unauthorizedUserOp),
+      ).to.be.revertedWithCustomError(concreteSmartAccountValidation, 'InvalidCallData');
     });
 
     it('should revert with InvalidInnerCallDataLength when inner calldata is too short', async function () {
@@ -260,10 +267,9 @@ describe('LightAccountVerificationV1', function () {
 
       const userOp = { ...mockUserOp, callData: executeCalldata };
 
-      await expect(concreteVerification.verifyUserOpPublic(userOp)).to.be.revertedWithCustomError(
-        concreteVerification,
-        'InvalidInnerCallDataLength',
-      );
+      await expect(
+        concreteSmartAccountValidation.validateUserOpPublic(userOp),
+      ).to.be.revertedWithCustomError(concreteSmartAccountValidation, 'InvalidInnerCallDataLength');
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/226

BREAKING CHANGES:
- Renamed SmartAccountVerificationV1.sol to SmartAccountValidationV1.sol
- Updated all verify* function names to validate*
- Updated all contract references and imports to use new naming

This commit improves naming consistency by changing "verification" to "validation" throughout the smart account validation system. This better aligns with standard terminology in the account abstraction ecosystem, where "validation" is the commonly used term for checking UserOperation validity.

Changes:
- Renamed main contract from SmartAccountVerificationV1 to SmartAccountValidationV1
- Renamed verifySmartAccount to validateSmartAccount
- Renamed verifyUserOp to validateUserOp
- Updated initialization function name to __SmartAccountValidationV1_init
- Updated all imports and inheritance declarations
- Removed old test files and mock contracts with "verification" naming
- Updated comments to use "validate" terminology consistently

Modified files:
- contracts/account-abstraction/DecentPaymasterV1.sol
- contracts/azorius/strategies/ERC4337VoterSupportV1.sol Renamed files:
- SmartAccountVerificationV1.sol → SmartAccountValidationV1.sol Removed files:
- contracts/mocks/ConcreteSmartAccountVerification.sol
- test/account-abstraction/SmartAccountVerificationV1.test.ts

This rename provides better clarity and consistency with industry terminology while maintaining all existing functionality.