### PR TITLE
refactor: rename isProposer to isWearingWhitelistedHat for clarity

### DIFF
--- a/contracts/azorius/strategies/HatsProposalCreationWhitelistV1.sol
+++ b/contracts/azorius/strategies/HatsProposalCreationWhitelistV1.sol
@@ -81,14 +81,13 @@ abstract contract HatsProposalCreationWhitelistV1 is
     }
 
     /**
-     * @dev Checks if an address is authorized to create proposals.
-     * @param _address The address to check for proposal creation authorization.
+     * @dev Checks if an address is wearing any of the whitelisted Hats.
+     * @param _address The address to check for wearing whitelisted Hats.
      * @return bool Returns true if the address is wearing any of the whitelisted Hats, false otherwise.
-     * @notice This function overrides the isProposer function from the parent contract.
-     * It iterates through all whitelisted Hat IDs and checks if the given address
-     * is wearing any of them using the Hats Protocol.
      */
-    function isProposer(address _address) public view virtual returns (bool) {
+    function isWearingWhitelistedHat(
+        address _address
+    ) public view virtual returns (bool) {
         for (uint256 i = 0; i < whitelistedHatIds.length; i++) {
             if (hatsContract.isWearerOfHat(_address, whitelistedHatIds[i])) {
                 return true;

--- a/contracts/azorius/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
+++ b/contracts/azorius/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
@@ -77,17 +77,10 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
         );
     }
 
-    /** @inheritdoc HatsProposalCreationWhitelistV1*/
     function isProposer(
         address _address
-    )
-        public
-        view
-        virtual
-        override(HatsProposalCreationWhitelistV1, LinearERC20VotingExtensible)
-        returns (bool)
-    {
-        return HatsProposalCreationWhitelistV1.isProposer(_address);
+    ) public view virtual override returns (bool) {
+        return isWearingWhitelistedHat(_address);
     }
 
     function getVersion() public view virtual override returns (uint16) {

--- a/contracts/azorius/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/azorius/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -80,17 +80,10 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
         );
     }
 
-    /** @inheritdoc HatsProposalCreationWhitelistV1*/
     function isProposer(
         address _address
-    )
-        public
-        view
-        virtual
-        override(HatsProposalCreationWhitelistV1, LinearERC721VotingExtensible)
-        returns (bool)
-    {
-        return HatsProposalCreationWhitelistV1.isProposer(_address);
+    ) public view virtual override returns (bool) {
+        return isWearingWhitelistedHat(_address);
     }
 
     /**

--- a/contracts/interfaces/IHatsProposalCreationWhitelistV1.sol
+++ b/contracts/interfaces/IHatsProposalCreationWhitelistV1.sol
@@ -58,11 +58,13 @@ interface IHatsProposalCreationWhitelistV1 {
     function unwhitelistHat(uint256 _hatId) external;
 
     /**
-     * @dev Checks if an address is authorized to create proposals.
-     * @param _address The address to check for proposal creation authorization.
+     * @dev Checks if an address is wearing any of the whitelisted Hats.
+     * @param _address The address to check for wearing whitelisted Hats.
      * @return Returns true if the address is wearing any of the whitelisted Hats, false otherwise.
      */
-    function isProposer(address _address) external view returns (bool);
+    function isWearingWhitelistedHat(
+        address _address
+    ) external view returns (bool);
 
     /**
      * @dev Returns the IDs of all whitelisted Hats.

--- a/test/HatsProposalCreationWhitelistV1.test.ts
+++ b/test/HatsProposalCreationWhitelistV1.test.ts
@@ -239,7 +239,7 @@ describe('HatsProposalCreationWhitelistV1', () => {
     });
   });
 
-  describe('isProposer override', () => {
+  describe('isWearingWhitelistedHat override', () => {
     runHatsProposerTests({
       getMockHats: () => mockHats,
       getContract: () => concreteHatsProposalCreationWhitelist,

--- a/test/helpers/hatsProposerTests.ts
+++ b/test/helpers/hatsProposerTests.ts
@@ -11,7 +11,7 @@ import { MockHats2 } from '../../typechain-types';
  * Interface for any contract that implements the isProposer and whitelistHat methods
  */
 interface HatsProposerTester {
-  isProposer(address: string): Promise<boolean>;
+  isWearingWhitelistedHat(address: string): Promise<boolean>;
   whitelistHat(hatId: bigint): Promise<any>;
   connect(signer: SignerWithAddress): HatsProposerTester;
 }
@@ -48,7 +48,9 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
 
   it('should return true for an address wearing a whitelisted hat', async () => {
     // hatWearer has proposerHatId, which is whitelisted
-    const isHatWearerProposer = await params.getContract().isProposer(params.hatWearer().address);
+    const isHatWearerProposer = await params
+      .getContract()
+      .isWearingWhitelistedHat(params.hatWearer().address);
     void expect(isHatWearerProposer).to.be.true;
   });
 
@@ -56,7 +58,7 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
     // nonHatWearer has nonProposerHatId, which is not whitelisted
     const isNonHatWearerProposer = await params
       .getContract()
-      .isProposer(params.nonHatWearer().address);
+      .isWearingWhitelistedHat(params.nonHatWearer().address);
     void expect(isNonHatWearerProposer).to.be.false;
   });
 
@@ -64,7 +66,7 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
     // tokenHolder has no hats at all, but has tokens/NFTs
     const isTokenHolderProposer = await params
       .getContract()
-      .isProposer(params.tokenHolder().address);
+      .isWearingWhitelistedHat(params.tokenHolder().address);
     void expect(isTokenHolderProposer).to.be.false;
   });
 
@@ -72,7 +74,7 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
     // First verify nonHatWearer is not a proposer initially
     const isNonHatWearerProposerBefore = await params
       .getContract()
-      .isProposer(params.nonHatWearer().address);
+      .isWearingWhitelistedHat(params.nonHatWearer().address);
     void expect(isNonHatWearerProposerBefore).to.be.false;
 
     // Adding nonProposerHatId to the whitelist
@@ -81,7 +83,7 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
     // Now nonHatWearer should be a proposer
     const isNonHatWearerProposerAfterWhitelist = await params
       .getContract()
-      .isProposer(params.nonHatWearer().address);
+      .isWearingWhitelistedHat(params.nonHatWearer().address);
     void expect(isNonHatWearerProposerAfterWhitelist).to.be.true;
   });
 }


### PR DESCRIPTION
Changes:
- Updated the function name from isProposer to isWearingWhitelistedHat in HatsProposalCreationWhitelistV1 and its implementations.
- Adjusted related comments and documentation to reflect the new function purpose.
- Modified test cases to use the new function name.

This refactor enhances code readability by providing a more descriptive function name that accurately represents its functionality.