### PR TITLE
refactor: fix reinitialization tests for voting contracts

### DIFF
--- a/test/LinearERC20VotingV1.test.ts
+++ b/test/LinearERC20VotingV1.test.ts
@@ -127,9 +127,8 @@ describe('LinearERC20VotingV1', () => {
 
     it('should not allow reinitialization', async () => {
       // Attempt to reinitialize - should revert
-      const initializeCalldata = LinearERC20VotingV1__factory.createInterface().encodeFunctionData(
-        'setUp',
-        [
+      await expect(
+        linearERC20Voting.setUp(
           ethers.AbiCoder.defaultAbiCoder().encode(
             ['address', 'address', 'address', 'uint32', 'uint256', 'uint256', 'uint256', 'address'],
             [
@@ -143,10 +142,8 @@ describe('LinearERC20VotingV1', () => {
               lightAccountFactory.address,
             ],
           ),
-        ],
-      );
-
-      await expect(linearERC20Voting.setUp(initializeCalldata)).to.be.reverted;
+        ),
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
 
     it('should revert when initializing with zero token address', async () => {

--- a/test/LinearERC20VotingWithHatsProposalCreationV1.test.ts
+++ b/test/LinearERC20VotingWithHatsProposalCreationV1.test.ts
@@ -174,44 +174,34 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
 
       it('should not allow reinitialization', async () => {
         // Deploy a new implementation to initialize again with the same params
-        const initializeCalldata =
-          linearERC20VotingWithHatsProposalCreationImplementation.interface.encodeFunctionData(
-            'setUp',
-            [
-              ethers.AbiCoder.defaultAbiCoder().encode(
-                [
-                  'address',
-                  'address',
-                  'address',
-                  'uint32',
-                  'uint256',
-                  'uint256',
-                  'address',
-                  'uint256[]',
-                  'address',
-                ],
-                [
-                  owner.address,
-                  await mockToken.getAddress(),
-                  azoriusAddress,
-                  VOTING_PERIOD,
-                  QUORUM_NUMERATOR,
-                  BASIS_NUMERATOR,
-                  await mockHats.getAddress(),
-                  [proposerHatId1, proposerHatId2],
-                  lightAccountFactory.address,
-                ],
-              ),
-            ],
-          );
-
-        // Try to initialize directly through the proxy - should revert
         await expect(
-          owner.sendTransaction({
-            to: await linearERC20VotingWithHatsProposalCreation.getAddress(),
-            data: initializeCalldata,
-          }),
-        ).to.be.reverted;
+          linearERC20VotingWithHatsProposalCreation.setUp(
+            ethers.AbiCoder.defaultAbiCoder().encode(
+              [
+                'address',
+                'address',
+                'address',
+                'uint32',
+                'uint256',
+                'uint256',
+                'address',
+                'uint256[]',
+                'address',
+              ],
+              [
+                owner.address,
+                await mockToken.getAddress(),
+                azoriusAddress,
+                VOTING_PERIOD,
+                QUORUM_NUMERATOR,
+                BASIS_NUMERATOR,
+                await mockHats.getAddress(),
+                [proposerHatId1, proposerHatId2],
+                lightAccountFactory.address,
+              ],
+            ),
+          ),
+        ).to.be.revertedWith('Initializable: contract is already initialized');
       });
     });
 

--- a/test/LinearERC721VotingV1.test.ts
+++ b/test/LinearERC721VotingV1.test.ts
@@ -180,9 +180,9 @@ describe('LinearERC721VotingV1', () => {
       const tokenAddresses = [await mockNFT1.getAddress(), await mockNFT2.getAddress()];
       const tokenWeights = [TOKEN1_WEIGHT, TOKEN2_WEIGHT];
 
-      const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'setUp',
-        [
+      // Try to call initialize again - should revert
+      await expect(
+        linearERC721Voting.setUp(
           ethers.AbiCoder.defaultAbiCoder().encode(
             [
               'address',
@@ -207,11 +207,8 @@ describe('LinearERC721VotingV1', () => {
               lightAccountFactory.address,
             ],
           ),
-        ],
-      );
-
-      // Try to call initialize again - should revert
-      await expect(linearERC721Voting.setUp(initializeCalldata)).to.be.reverted;
+        ),
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
 
     it('should revert when initializing with mismatched token arrays', async () => {

--- a/test/LinearERC721VotingWithHatsProposalCreationV1.test.ts
+++ b/test/LinearERC721VotingWithHatsProposalCreationV1.test.ts
@@ -191,47 +191,37 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
         const nftAddresses = [await mockNFT1.getAddress(), await mockNFT2.getAddress()];
         const nftWeights = [1, 2];
 
-        // Create initialization data for a second attempt
-        const initializeCalldata =
-          linearERC721VotingWithHatsProposalCreationImplementation.interface.encodeFunctionData(
-            'setUp',
-            [
-              ethers.AbiCoder.defaultAbiCoder().encode(
-                [
-                  'address',
-                  'address[]',
-                  'uint256[]',
-                  'address',
-                  'uint32',
-                  'uint256',
-                  'uint256',
-                  'address',
-                  'uint256[]',
-                  'address',
-                ],
-                [
-                  owner.address,
-                  nftAddresses,
-                  nftWeights,
-                  azoriusAddress,
-                  VOTING_PERIOD,
-                  QUORUM_THRESHOLD,
-                  BASIS_NUMERATOR,
-                  await mockHats.getAddress(),
-                  [proposerHatId1, proposerHatId2],
-                  lightAccountFactory.address,
-                ],
-              ),
-            ],
-          );
-
         // Try to initialize directly through the proxy - should revert
         await expect(
-          owner.sendTransaction({
-            to: await linearERC721VotingWithHatsProposalCreation.getAddress(),
-            data: initializeCalldata,
-          }),
-        ).to.be.reverted;
+          linearERC721VotingWithHatsProposalCreation.setUp(
+            ethers.AbiCoder.defaultAbiCoder().encode(
+              [
+                'address',
+                'address[]',
+                'uint256[]',
+                'address',
+                'uint32',
+                'uint256',
+                'uint256',
+                'address',
+                'uint256[]',
+                'address',
+              ],
+              [
+                owner.address,
+                nftAddresses,
+                nftWeights,
+                azoriusAddress,
+                VOTING_PERIOD,
+                QUORUM_THRESHOLD,
+                BASIS_NUMERATOR,
+                await mockHats.getAddress(),
+                [proposerHatId1, proposerHatId2],
+                lightAccountFactory.address,
+              ],
+            ),
+          ),
+        ).to.be.revertedWith('Initializable: contract is already initialized');
       });
     });
 


### PR DESCRIPTION
Changes:
- Updated reinitialization tests in LinearERC20VotingV1, LinearERC20VotingWithHatsProposalCreationV1, LinearERC721VotingV1, and LinearERC721VotingWithHatsProposalCreationV1 to directly call the setUp function instead of encoding calldata.
- Enhanced error messages to specify that the contract is already initialized.

This refactor improves test clarity and ensures consistent error handling across all voting contracts.