### PR TITLE
feat: add IMintableV1 interface and integrate with VotesERC20LockableV1

### DIFF
--- a/contracts/VotesERC20LockableV1.sol
+++ b/contracts/VotesERC20LockableV1.sol
@@ -2,14 +2,12 @@
 pragma solidity ^0.8.19;
 
 import {ILockableV1} from "./interfaces/ILockableV1.sol";
+import {IMintableV1} from "./interfaces/IMintableV1.sol";
 import {VotesERC20} from "./VotesERC20.sol";
 import {Version} from "./Version.sol";
 import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 
-/**
- * An implementation of the Open Zeppelin `IVotes` voting token standard.
- */
-contract VotesERC20LockableV1 is ILockableV1, VotesERC20, Version {
+contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20, Version {
     uint16 private constant VERSION = 1;
 
     bool public locked;
@@ -98,6 +96,7 @@ contract VotesERC20LockableV1 is ILockableV1, VotesERC20, Version {
     ) public view virtual override(ERC165Storage, Version) returns (bool) {
         return
             interfaceId == type(ILockableV1).interfaceId ||
+            interfaceId == type(IMintableV1).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/interfaces/IMintableV1.sol
+++ b/contracts/interfaces/IMintableV1.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+interface IMintableV1 {
+    function mint(address to, uint256 amount) external;
+}

--- a/test/VotesERC20Lockable.test.ts
+++ b/test/VotesERC20Lockable.test.ts
@@ -6,6 +6,7 @@ import {
   IERC165__factory,
   IERC20Upgradeable__factory,
   ILockableV1__factory,
+  IMintableV1__factory,
   IVersion__factory,
   VotesERC20LockableV1,
   VotesERC20LockableV1__factory,
@@ -734,6 +735,7 @@ describe('VotesERC20Lockable', () => {
     let iVersionInterfaceId: string;
     let iERC165InterfaceId: string;
     let iLockableV1InterfaceId: string;
+    let iMintableV1InterfaceId: string;
     let iERC20UpgradeableInterfaceId: string;
 
     beforeEach(async function () {
@@ -758,6 +760,9 @@ describe('VotesERC20Lockable', () => {
       const ILockableV1Interface = ILockableV1__factory.createInterface();
       iLockableV1InterfaceId = calculateInterfaceId(ILockableV1Interface);
 
+      const IMintableV1Interface = IMintableV1__factory.createInterface();
+      iMintableV1InterfaceId = calculateInterfaceId(IMintableV1Interface);
+
       const IERC20UpgradeableInterface = IERC20Upgradeable__factory.createInterface();
       iERC20UpgradeableInterfaceId = calculateInterfaceId(IERC20UpgradeableInterface);
     });
@@ -774,6 +779,11 @@ describe('VotesERC20Lockable', () => {
 
     it('Should support ILockableV1 interface', async function () {
       const supported = await proxy.supportsInterface(iLockableV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IMintableV1 interface', async function () {
+      const supported = await proxy.supportsInterface(iMintableV1InterfaceId);
       void expect(supported).to.be.true;
     });
 


### PR DESCRIPTION
This commit introduces the IMintableV1 interface, allowing the minting of tokens. The VotesERC20LockableV1 contract is updated to implement this interface, enhancing its functionality. Additionally, tests are updated to verify support for the new minting interface.