### PR TITLE
Feature: Implement VotesERC20LockableV1 Contract

### DIFF
--- a/contracts/deployables/erc20/VotesERC20LockableV1.sol
+++ b/contracts/deployables/erc20/VotesERC20LockableV1.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {ILockableV1} from "../../interfaces/decent/deployables/ILockableV1.sol";
+import {IMintableV1} from "../../interfaces/decent/deployables/IMintableV1.sol";
+import {VotesERC20V1} from "./VotesERC20V1.sol";
+import {Version} from "../Version.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20V1 {
+    uint16 private constant VERSION = 1;
+
+    bool public locked;
+    mapping(address => bool) public whitelisted;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    modifier isTransferable(address from) {
+        if (
+            locked &&
+            // overrides while locked
+            !(from == owner() || // owner can always transfer
+                whitelisted[from] || // whitelisted addresses can always transfer
+                from == address(0)) // can always mint when locked
+        ) {
+            revert IsLocked();
+        }
+        _;
+    }
+
+    function initialize(
+        address _owner,
+        bool _locked,
+        string memory _name,
+        string memory _symbol,
+        address[] memory _allocationAddresses,
+        uint256[] memory _allocationAmounts
+    ) public virtual initializer {
+        super.initialize(
+            _name,
+            _symbol,
+            _allocationAddresses,
+            _allocationAmounts,
+            _owner
+        );
+        _transferOwnership(_owner);
+        locked = _locked;
+    }
+
+    /**
+     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
+     * Called by {upgradeTo} and {upgradeToAndCall}.
+     *
+     * Reverts if the sender is not the owner of the contract.
+     */
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal virtual override onlyOwner {
+        // Authorization is handled by the onlyOwner modifier
+    }
+
+    function lock(bool _locked) external onlyOwner {
+        if (_locked == locked) {
+            revert CannotSwitchLockState(_locked);
+        }
+        locked = _locked;
+        emit Locked(_locked);
+    }
+
+    function whitelist(address account, bool isWhitelisted) external onlyOwner {
+        bool currentlyWhitelisted = whitelisted[account];
+        whitelisted[account] = isWhitelisted;
+        if (currentlyWhitelisted != isWhitelisted) {
+            emit Whitelisted(account, isWhitelisted);
+        }
+    }
+
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    function _update(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual override isTransferable(from) {
+        super._update(from, to, amount);
+    }
+
+    function getVersion() public view virtual override returns (uint16) {
+        return VERSION;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(ILockableV1).interfaceId ||
+            interfaceId == type(IMintableV1).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/interfaces/decent/deployables/ILockableV1.sol
+++ b/contracts/interfaces/decent/deployables/ILockableV1.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+interface ILockableV1 {
+    event Locked(bool isLocked);
+    event Whitelisted(address indexed account, bool isWhitelisted);
+
+    error IsLocked();
+    error CannotSwitchLockState(bool newLockState);
+
+    function lock(bool _locked) external;
+
+    function locked() external view returns (bool);
+
+    function whitelist(address account, bool isWhitelisted) external;
+
+    function whitelisted(address account) external view returns (bool);
+}

--- a/contracts/interfaces/decent/deployables/IMintableV1.sol
+++ b/contracts/interfaces/decent/deployables/IMintableV1.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+interface IMintableV1 {
+    function mint(address to, uint256 amount) external;
+}

--- a/test/deployables/erc20/VotesERC20LockableV1.test.ts
+++ b/test/deployables/erc20/VotesERC20LockableV1.test.ts
@@ -61,7 +61,7 @@ describe('VotesERC20LockableV1', () => {
 
   describe('Initialization', () => {
     describe('Locked Behavior', () => {
-      it('should be be locked on deployment', async () => {
+      it('should be be locked on deployment when locked is true', async () => {
         const proxy = await deployVotesERC20Lockable(
           deployer,
           implementation,
@@ -75,7 +75,7 @@ describe('VotesERC20LockableV1', () => {
         expect(await proxy.locked()).to.equal(true);
       });
 
-      it('should be unlocked on deployment', async () => {
+      it('should be unlocked on deployment when locked is false', async () => {
         const proxy = await deployVotesERC20Lockable(
           deployer,
           implementation,

--- a/test/deployables/erc20/VotesERC20LockableV1.test.ts
+++ b/test/deployables/erc20/VotesERC20LockableV1.test.ts
@@ -1,0 +1,826 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import type { ContractTransactionResponse } from 'ethers';
+import { ethers } from 'hardhat';
+import {
+  ERC1967Proxy__factory,
+  IERC165__factory,
+  IERC20__factory,
+  ILockableV1__factory,
+  IMintableV1__factory,
+  IVersion__factory,
+  VotesERC20LockableV1,
+  VotesERC20LockableV1__factory,
+} from '../../../typechain-types';
+import { calculateInterfaceId } from '../../helpers/utils';
+import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
+
+async function deployVotesERC20Lockable(
+  deployer: SignerWithAddress,
+  implementation: VotesERC20LockableV1,
+  owner: SignerWithAddress,
+  locked: boolean,
+  name: string,
+  symbol: string,
+  allocationAddresses: string[],
+  allocationAmounts: bigint[],
+): Promise<VotesERC20LockableV1> {
+  const fullInitData =
+    VotesERC20LockableV1__factory.createInterface().getFunction(
+      'initialize(address,bool,string,string,address[],uint256[])',
+    ).selector +
+    ethers.AbiCoder.defaultAbiCoder()
+      .encode(
+        ['address', 'bool', 'string', 'string', 'address[]', 'uint256[]'],
+        [owner.address, locked, name, symbol, allocationAddresses, allocationAmounts],
+      )
+      .slice(2);
+
+  // Deploy the proxy with the implementation
+  const proxy = await new ERC1967Proxy__factory(deployer).deploy(implementation, fullInitData);
+
+  return VotesERC20LockableV1__factory.connect(await proxy.getAddress(), deployer);
+}
+
+describe('VotesERC20LockableV1', () => {
+  let implementation: VotesERC20LockableV1;
+  let deployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+  let nonOwner: SignerWithAddress;
+  let whitelistMember: SignerWithAddress;
+  let tokenHolder: SignerWithAddress;
+  let tokenRecipient: SignerWithAddress;
+  let spender: SignerWithAddress;
+
+  beforeEach(async () => {
+    [deployer, owner, nonOwner, whitelistMember, tokenHolder, tokenRecipient, spender] =
+      await ethers.getSigners();
+
+    implementation = await new VotesERC20LockableV1__factory(owner).deploy();
+  });
+
+  describe('Initialization', () => {
+    describe('Locked Behavior', () => {
+      it('should be be locked on deployment', async () => {
+        const proxy = await deployVotesERC20Lockable(
+          deployer,
+          implementation,
+          owner,
+          true,
+          'Test',
+          'TEST',
+          [],
+          [],
+        );
+        expect(await proxy.locked()).to.equal(true);
+      });
+
+      it('should be unlocked on deployment', async () => {
+        const proxy = await deployVotesERC20Lockable(
+          deployer,
+          implementation,
+          owner,
+          false,
+          'Test',
+          'TEST',
+          [],
+          [],
+        );
+        expect(await proxy.locked()).to.equal(false);
+      });
+    });
+
+    describe('Setup safety', () => {
+      let proxy: VotesERC20LockableV1;
+
+      beforeEach(async () => {
+        proxy = await deployVotesERC20Lockable(
+          deployer,
+          implementation,
+          owner,
+          false,
+          'Test',
+          'TEST',
+          [],
+          [],
+        );
+      });
+
+      it('should revert if initializer is called after deployment', async () => {
+        await expect(
+          proxy['initialize(address,bool,string,string,address[],uint256[])'](
+            owner.address,
+            false,
+            'Test',
+            'TEST',
+            [],
+            [],
+          ),
+        ).to.be.revertedWithCustomError(proxy, 'InvalidInitialization');
+      });
+    });
+  });
+
+  describe('Lock function', () => {
+    describe('When locked at deployment', () => {
+      const locked = true;
+      let proxy: VotesERC20LockableV1;
+
+      beforeEach(async () => {
+        proxy = await deployVotesERC20Lockable(
+          deployer,
+          implementation,
+          owner,
+          locked,
+          'Test',
+          'TEST',
+          [],
+          [],
+        );
+      });
+
+      describe('Unlocking by the owner should succeed', () => {
+        let unlockTx: ContractTransactionResponse;
+
+        beforeEach(async () => {
+          unlockTx = await proxy.connect(owner).lock(false);
+        });
+
+        it('should be unlocked', async () => {
+          expect(await proxy.locked()).to.equal(false);
+        });
+
+        it('should emit an event', async () => {
+          expect(unlockTx).to.emit(proxy, 'Locked').withArgs(false);
+        });
+      });
+
+      describe('Unlocking by a non-owner should fail', () => {
+        it('should revert', async () => {
+          await expect(proxy.connect(nonOwner).lock(false)).to.be.revertedWithCustomError(
+            proxy,
+            'OwnableUnauthorizedAccount',
+          );
+        });
+      });
+
+      describe('Trying to lock should fail', () => {
+        it('should revert', async () => {
+          await expect(proxy.connect(owner).lock(true)).to.be.revertedWithCustomError(
+            proxy,
+            'CannotSwitchLockState(bool true)',
+          );
+        });
+      });
+    });
+
+    describe('When unlocked at deployment', () => {
+      const locked = false;
+      let proxy: VotesERC20LockableV1;
+
+      beforeEach(async () => {
+        proxy = await deployVotesERC20Lockable(
+          deployer,
+          implementation,
+          owner,
+          locked,
+          'Test',
+          'TEST',
+          [],
+          [],
+        );
+      });
+
+      describe('Locking by the owner should succeed', () => {
+        let lockTx: ContractTransactionResponse;
+
+        beforeEach(async () => {
+          lockTx = await proxy.connect(owner).lock(true);
+        });
+
+        it('should be locked', async () => {
+          expect(await proxy.locked()).to.equal(true);
+        });
+
+        it('should emit an event', async () => {
+          expect(lockTx).to.emit(proxy, 'Locked').withArgs(true);
+        });
+      });
+
+      describe('Locking by a non-owner should fail', () => {
+        it('should revert', async () => {
+          await expect(proxy.connect(nonOwner).lock(true)).to.be.revertedWithCustomError(
+            proxy,
+            'OwnableUnauthorizedAccount',
+          );
+        });
+      });
+
+      describe('Trying to unlock should fail', () => {
+        it('should revert', async () => {
+          await expect(proxy.connect(owner).lock(false)).to.be.revertedWithCustomError(
+            proxy,
+            'CannotSwitchLockState(bool false)',
+          );
+        });
+      });
+    });
+  });
+
+  describe('Whitelist function', () => {
+    let proxy: VotesERC20LockableV1;
+
+    beforeEach(async () => {
+      proxy = await deployVotesERC20Lockable(
+        deployer,
+        implementation,
+        owner,
+        false,
+        'Test',
+        'TEST',
+        [],
+        [],
+      );
+    });
+
+    describe('Adding to whitelist', () => {
+      describe('When caller is owner', () => {
+        let addTx: ContractTransactionResponse;
+
+        beforeEach(async () => {
+          addTx = await proxy.connect(owner).whitelist(whitelistMember.address, true);
+        });
+
+        it('should add to whitelist', async () => {
+          expect(await proxy.whitelisted(whitelistMember.address)).to.equal(true);
+        });
+
+        it('should emit an event', async () => {
+          await expect(addTx).to.emit(proxy, 'Whitelisted').withArgs(whitelistMember.address, true);
+        });
+
+        describe('When adding the same address again', () => {
+          beforeEach(async () => {
+            addTx = await proxy.connect(owner).whitelist(whitelistMember.address, true);
+          });
+
+          it('should not emit an event', async () => {
+            await expect(addTx).to.not.emit(proxy, 'Whitelisted');
+          });
+        });
+      });
+
+      describe('When caller is not owner', () => {
+        it('should revert', async () => {
+          await expect(
+            proxy.connect(nonOwner).whitelist(whitelistMember.address, true),
+          ).to.be.revertedWithCustomError(proxy, 'OwnableUnauthorizedAccount');
+        });
+      });
+    });
+
+    describe('Removing from whitelist', () => {
+      beforeEach(async () => {
+        await proxy.connect(owner).whitelist(whitelistMember.address, true);
+      });
+
+      describe('When caller is owner', () => {
+        let removeTx: ContractTransactionResponse;
+
+        beforeEach(async () => {
+          removeTx = await proxy.connect(owner).whitelist(whitelistMember.address, false);
+        });
+
+        it('should remove from whitelist', async () => {
+          expect(await proxy.whitelisted(whitelistMember.address)).to.equal(false);
+        });
+
+        it('should emit an event', async () => {
+          expect(removeTx).to.emit(proxy, 'Whitelisted').withArgs(whitelistMember.address, false);
+        });
+
+        describe('When removing the same address again', () => {
+          beforeEach(async () => {
+            removeTx = await proxy.connect(owner).whitelist(whitelistMember.address, false);
+          });
+
+          it('should not emit an event', async () => {
+            await expect(removeTx).to.not.emit(proxy, 'Whitelisted');
+          });
+        });
+      });
+
+      describe('When caller is not owner', () => {
+        it('should revert', async () => {
+          await expect(
+            proxy.connect(nonOwner).whitelist(whitelistMember.address, false),
+          ).to.be.revertedWithCustomError(proxy, 'OwnableUnauthorizedAccount');
+        });
+      });
+    });
+  });
+
+  describe('Transferring Tokens', () => {
+    let tokenHolderAddresses: string[];
+    let tokenHolderAmounts: bigint[];
+
+    beforeEach(async () => {
+      tokenHolderAddresses = [tokenHolder.address, owner.address];
+      tokenHolderAmounts = [ethers.parseEther('100'), ethers.parseEther('100')];
+    });
+
+    describe('Transfer function', () => {
+      let proxy: VotesERC20LockableV1;
+
+      describe('when token is locked', () => {
+        const locked = true;
+
+        beforeEach(async () => {
+          proxy = await deployVotesERC20Lockable(
+            deployer,
+            implementation,
+            owner,
+            locked,
+            'Test',
+            'TEST',
+            tokenHolderAddresses,
+            tokenHolderAmounts,
+          );
+        });
+
+        describe('when caller is owner', () => {
+          beforeEach(async () => {
+            await proxy.connect(owner).transfer(tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(owner.address)).to.equal(ethers.parseEther('99'));
+          });
+        });
+
+        describe('when caller is whitelisted', () => {
+          beforeEach(async () => {
+            await proxy.connect(owner).whitelist(tokenHolder.address, true);
+            await proxy
+              .connect(tokenHolder)
+              .transfer(tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(tokenHolder.address)).to.equal(ethers.parseEther('99'));
+          });
+        });
+
+        describe('when caller is not owner or whitelisted', () => {
+          it('should revert', async () => {
+            await expect(
+              proxy.connect(tokenHolder).transfer(tokenRecipient.address, ethers.parseEther('1')),
+            ).to.be.revertedWithCustomError(proxy, 'IsLocked');
+          });
+        });
+      });
+
+      describe('when token is not locked', () => {
+        const locked = false;
+
+        beforeEach(async () => {
+          proxy = await deployVotesERC20Lockable(
+            deployer,
+            implementation,
+            owner,
+            locked,
+            'Test',
+            'TEST',
+            tokenHolderAddresses,
+            tokenHolderAmounts,
+          );
+        });
+
+        describe('when caller is owner', () => {
+          beforeEach(async () => {
+            await proxy.connect(owner).transfer(tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(owner.address)).to.equal(ethers.parseEther('99'));
+          });
+        });
+
+        describe('when caller is whitelisted', () => {
+          beforeEach(async () => {
+            await proxy.connect(owner).whitelist(tokenHolder.address, true);
+            await proxy
+              .connect(tokenHolder)
+              .transfer(tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(tokenHolder.address)).to.equal(ethers.parseEther('99'));
+          });
+        });
+
+        describe('when caller is not owner or whitelisted', () => {
+          beforeEach(async () => {
+            await proxy
+              .connect(tokenHolder)
+              .transfer(tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(tokenHolder.address)).to.equal(ethers.parseEther('99'));
+          });
+        });
+      });
+    });
+
+    describe('TransferFrom function', () => {
+      let proxy: VotesERC20LockableV1;
+
+      describe('when token is locked', () => {
+        const locked = true;
+
+        beforeEach(async () => {
+          proxy = await deployVotesERC20Lockable(
+            deployer,
+            implementation,
+            owner,
+            locked,
+            'Test',
+            'TEST',
+            tokenHolderAddresses,
+            tokenHolderAmounts,
+          );
+        });
+
+        describe('when token holder is owner', () => {
+          beforeEach(async () => {
+            await proxy.connect(owner).approve(spender.address, ethers.parseEther('10'));
+            await proxy
+              .connect(spender)
+              .transferFrom(owner.address, tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(owner.address)).to.equal(ethers.parseEther('99'));
+          });
+
+          it('should decrease allowance', async () => {
+            expect(await proxy.allowance(owner.address, spender.address)).to.equal(
+              ethers.parseEther('9'),
+            );
+          });
+        });
+
+        describe('when token holder is whitelisted', () => {
+          beforeEach(async () => {
+            await proxy.connect(owner).whitelist(tokenHolder.address, true);
+            await proxy.connect(tokenHolder).approve(spender.address, ethers.parseEther('10'));
+            await proxy
+              .connect(spender)
+              .transferFrom(tokenHolder.address, tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(tokenHolder.address)).to.equal(ethers.parseEther('99'));
+          });
+
+          it('should decrease allowance', async () => {
+            expect(await proxy.allowance(tokenHolder.address, spender.address)).to.equal(
+              ethers.parseEther('9'),
+            );
+          });
+        });
+
+        describe('when token holder is not owner or whitelisted', () => {
+          beforeEach(async () => {
+            await proxy.connect(tokenHolder).approve(spender.address, ethers.parseEther('10'));
+          });
+
+          it('should revert', async () => {
+            await expect(
+              proxy
+                .connect(spender)
+                .transferFrom(tokenHolder.address, tokenRecipient.address, ethers.parseEther('1')),
+            ).to.be.revertedWithCustomError(proxy, 'IsLocked');
+          });
+        });
+      });
+
+      describe('when token is not locked', () => {
+        const locked = false;
+
+        beforeEach(async () => {
+          proxy = await deployVotesERC20Lockable(
+            deployer,
+            implementation,
+            owner,
+            locked,
+            'Test',
+            'TEST',
+            tokenHolderAddresses,
+            tokenHolderAmounts,
+          );
+        });
+
+        describe('when token holder is owner', () => {
+          beforeEach(async () => {
+            await proxy.connect(owner).approve(spender.address, ethers.parseEther('10'));
+            await proxy
+              .connect(spender)
+              .transferFrom(owner.address, tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(owner.address)).to.equal(ethers.parseEther('99'));
+          });
+
+          it('should decrease allowance', async () => {
+            expect(await proxy.allowance(owner.address, spender.address)).to.equal(
+              ethers.parseEther('9'),
+            );
+          });
+        });
+
+        describe('when token holder is whitelisted', () => {
+          beforeEach(async () => {
+            await proxy.connect(owner).whitelist(tokenHolder.address, true);
+            await proxy.connect(tokenHolder).approve(spender.address, ethers.parseEther('10'));
+            await proxy
+              .connect(spender)
+              .transferFrom(tokenHolder.address, tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(tokenHolder.address)).to.equal(ethers.parseEther('99'));
+          });
+
+          it('should decrease allowance', async () => {
+            expect(await proxy.allowance(tokenHolder.address, spender.address)).to.equal(
+              ethers.parseEther('9'),
+            );
+          });
+        });
+
+        describe('when token holder is not owner or whitelisted', () => {
+          beforeEach(async () => {
+            await proxy.connect(tokenHolder).approve(spender.address, ethers.parseEther('10'));
+            await proxy
+              .connect(spender)
+              .transferFrom(tokenHolder.address, tokenRecipient.address, ethers.parseEther('1'));
+          });
+
+          it('should transfer tokens', async () => {
+            expect(await proxy.balanceOf(tokenRecipient.address)).to.equal(ethers.parseEther('1'));
+            expect(await proxy.balanceOf(tokenHolder.address)).to.equal(ethers.parseEther('99'));
+          });
+
+          it('should decrease allowance', async () => {
+            expect(await proxy.allowance(tokenHolder.address, spender.address)).to.equal(
+              ethers.parseEther('9'),
+            );
+          });
+        });
+
+        describe('when spender has insufficient allowance', () => {
+          beforeEach(async () => {
+            await proxy.connect(tokenHolder).approve(spender.address, ethers.parseEther('0.5'));
+          });
+
+          it('should revert', async () => {
+            await expect(
+              proxy
+                .connect(spender)
+                .transferFrom(tokenHolder.address, tokenRecipient.address, ethers.parseEther('1')),
+            ).to.be.revertedWithCustomError(proxy, 'ERC20InsufficientAllowance');
+          });
+        });
+      });
+    });
+  });
+
+  describe('Minting Tokens', () => {
+    let proxy: VotesERC20LockableV1;
+
+    describe('when token is locked', () => {
+      const locked = true;
+
+      beforeEach(async () => {
+        proxy = await deployVotesERC20Lockable(
+          deployer,
+          implementation,
+          owner,
+          locked,
+          'Test',
+          'TEST',
+          [],
+          [],
+        );
+      });
+
+      describe('when caller is owner', () => {
+        beforeEach(async () => {
+          await proxy.connect(owner).mint(owner.address, ethers.parseEther('1'));
+        });
+
+        it('should mint tokens', async () => {
+          expect(await proxy.balanceOf(owner.address)).to.equal(ethers.parseEther('1'));
+        });
+      });
+
+      describe('when caller is whitelisted', () => {
+        beforeEach(async () => {
+          await proxy.connect(owner).whitelist(tokenHolder.address, true);
+        });
+
+        it('should revert', async () => {
+          // revert shouldn't happen due to whitelist issues
+          expect(await proxy.whitelisted(tokenHolder.address)).to.equal(true);
+
+          await expect(
+            proxy.connect(tokenHolder).mint(tokenHolder.address, ethers.parseEther('1')),
+          ).to.be.revertedWithCustomError(proxy, 'OwnableUnauthorizedAccount');
+        });
+      });
+
+      describe('when caller is not owner or whitelisted', () => {
+        it('should revert', async () => {
+          await expect(
+            proxy.connect(tokenHolder).mint(tokenHolder.address, ethers.parseEther('1')),
+          ).to.be.revertedWithCustomError(proxy, 'OwnableUnauthorizedAccount');
+        });
+      });
+    });
+
+    describe('when token is not locked', () => {
+      const locked = false;
+
+      beforeEach(async () => {
+        proxy = await deployVotesERC20Lockable(
+          deployer,
+          implementation,
+          owner,
+          locked,
+          'Test',
+          'TEST',
+          [],
+          [],
+        );
+      });
+
+      describe('when caller is owner', () => {
+        beforeEach(async () => {
+          await proxy.connect(owner).mint(owner.address, ethers.parseEther('1'));
+        });
+
+        it('should mint tokens', async () => {
+          expect(await proxy.balanceOf(owner.address)).to.equal(ethers.parseEther('1'));
+        });
+      });
+
+      describe('when caller is whitelisted', () => {
+        beforeEach(async () => {
+          await proxy.connect(owner).whitelist(tokenHolder.address, true);
+        });
+
+        it('should revert', async () => {
+          // revert shouldn't happen due to whitelist issues
+          expect(await proxy.whitelisted(tokenHolder.address)).to.equal(true);
+
+          await expect(
+            proxy.connect(tokenHolder).mint(tokenHolder.address, ethers.parseEther('1')),
+          ).to.be.revertedWithCustomError(proxy, 'OwnableUnauthorizedAccount');
+        });
+      });
+
+      describe('when caller is not owner or whitelisted', () => {
+        it('should revert', async () => {
+          await expect(
+            proxy.connect(tokenHolder).mint(tokenHolder.address, ethers.parseEther('1')),
+          ).to.be.revertedWithCustomError(proxy, 'OwnableUnauthorizedAccount');
+        });
+      });
+    });
+  });
+
+  describe('Version', () => {
+    it('should return the correct version', async () => {
+      const proxy = await deployVotesERC20Lockable(
+        deployer,
+        implementation,
+        owner,
+        false,
+        'Test',
+        'TEST',
+        [],
+        [],
+      );
+      expect(await proxy.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', function () {
+    let proxy: VotesERC20LockableV1;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+    let iLockableV1InterfaceId: string;
+    let iMintableV1InterfaceId: string;
+    let iERC20InterfaceId: string;
+
+    beforeEach(async function () {
+      proxy = await deployVotesERC20Lockable(
+        deployer,
+        implementation,
+        owner,
+        false,
+        'Test',
+        'TEST',
+        [],
+        [],
+      );
+
+      // Dynamically calculate interface IDs
+      const IVersionInterface = IVersion__factory.createInterface();
+      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
+
+      const IERC165Interface = IERC165__factory.createInterface();
+      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
+
+      const ILockableV1Interface = ILockableV1__factory.createInterface();
+      iLockableV1InterfaceId = calculateInterfaceId(ILockableV1Interface);
+
+      const IMintableV1Interface = IMintableV1__factory.createInterface();
+      iMintableV1InterfaceId = calculateInterfaceId(IMintableV1Interface);
+
+      const IERC20Interface = IERC20__factory.createInterface();
+      iERC20InterfaceId = calculateInterfaceId(IERC20Interface);
+    });
+
+    it('Should support IERC165 interface', async function () {
+      const supported = await proxy.supportsInterface(iERC165InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IVersion interface', async function () {
+      const supported = await proxy.supportsInterface(iVersionInterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support ILockableV1 interface', async function () {
+      const supported = await proxy.supportsInterface(iLockableV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IMintableV1 interface', async function () {
+      const supported = await proxy.supportsInterface(iMintableV1InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should support IERC20 interface', async function () {
+      const supported = await proxy.supportsInterface(iERC20InterfaceId);
+      void expect(supported).to.be.true;
+    });
+
+    it('Should not support random interface', async function () {
+      const randomInterfaceId = '0x12345678';
+      const supported = await proxy.supportsInterface(randomInterfaceId);
+      void expect(supported).to.be.false;
+    });
+  });
+
+  describe('VotesERC20LockableV1 UUPS Upgradeability', function () {
+    let votesERC20Lockable: VotesERC20LockableV1;
+
+    beforeEach(async function () {
+      votesERC20Lockable = await deployVotesERC20Lockable(
+        deployer,
+        implementation,
+        owner,
+        false,
+        'Test Voting Token',
+        'TVT',
+        [],
+        [],
+      );
+    });
+
+    // Run UUPS upgradeability tests
+    runUUPSUpgradeabilityTests({
+      getContract: () => votesERC20Lockable,
+      createNewImplementation: async () => {
+        const newImplementation = await new VotesERC20LockableV1__factory(owner).deploy();
+        return newImplementation;
+      },
+      owner: () => owner,
+      nonOwner: () => nonOwner,
+    });
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/243

Fixes [ENG-812](https://linear.app/decent-labs/issue/ENG-812/implement-lockable-and-mintable-erc20-votes-token-voteserc20lockablev1)

**Summary:**

This PR introduces a new ERC20 token contract, `VotesERC20LockableV1`, which extends the functionality of `VotesERC20V1` to include lockable transfers and minting capabilities. It also includes the necessary interfaces and comprehensive tests for the new contract.

**Changes:**

*   **New Contract `VotesERC20LockableV1.sol`:**
    *   Added `contracts/deployables/erc20/VotesERC20LockableV1.sol`.
    *   This contract inherits from `VotesERC20V1` and implements `ILockableV1` and `IMintableV1`.
    *   It allows the owner to lock and unlock token transfers.
    *   Whitelisted addresses can transfer tokens even when the contract is locked.
    *   The owner can mint new tokens.
    *   Includes an `isTransferable` modifier to control token movements based on lock status and whitelist.
    *   Implements `ERC165` for interface detection and includes a `getVersion()` function.
*   **New Interface `ILockableV1.sol`:**
    *   Added `contracts/interfaces/decent/deployables/ILockableV1.sol`.
    *   Defines the interface for contracts that support locking of transfers and whitelisting addresses.
    *   Includes events `Locked` and `Whitelisted`, and errors `IsLocked` and `CannotSwitchLockState`.
*   **New Interface `IMintableV1.sol`:**
    *   Added `contracts/interfaces/decent/deployables/IMintableV1.sol`.
    *   Defines the interface for contracts that support minting new tokens.
*   **New Test Suite `VotesERC20LockableV1.test.ts`:**
    *   Added `test/deployables/erc20/VotesERC20LockableV1.test.ts`.
    *   Provides comprehensive test coverage for `VotesERC20LockableV1`, including:
        *   Initialization with locked and unlocked states.
        *   Locking and unlocking functionality by owner and non-owner.
        *   Whitelisting and removing addresses from the whitelist.
        *   Token transfers (`transfer` and `transferFrom`) under various lock and whitelist conditions.
        *   Token minting by the owner when locked and unlocked.
        *   Version checking.
        *   ERC165 interface support.
        *   UUPS upgradeability.

**Motivation:**

*   To provide a flexible ERC20 token that can have its transfers restricted by a central owner.
*   To allow specific addresses (e.g., exchanges, bridges) to bypass transfer restrictions via a whitelist.
*   To enable the owner to mint new tokens as needed.
*   To ensure the contract is robust, well-tested, and upgradeable.