### PR TITLE
Feature: Implement Smart Account and UserOp Validation Logic

### DIFF
--- a/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
+++ b/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {ILightAccount} from "../../interfaces/light-account/ILightAccount.sol";
+import {ILightAccountFactory} from "../../interfaces/light-account/ILightAccountFactory.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+abstract contract SmartAccountValidationV1 is Initializable {
+    ILightAccountFactory public lightAccountFactory;
+
+    error InvalidSmartAccount();
+    error InvalidUserOpCallDataLength();
+    error InvalidCallData();
+    error InvalidInnerCallDataLength();
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function __SmartAccountValidationV1_init(
+        address _lightAccountFactory
+    ) internal initializer {
+        lightAccountFactory = ILightAccountFactory(_lightAccountFactory);
+    }
+
+    function validateSmartAccount(
+        address smartAccount
+    ) internal view virtual returns (bool, address) {
+        // First check if the address has code (is a contract)
+        uint256 size;
+        assembly {
+            size := extcodesize(smartAccount)
+        }
+
+        // If it's an EOA (no code), it's not a `LightAccount`
+        if (size == 0) {
+            return (false, address(0));
+        }
+
+        try ILightAccount(smartAccount).owner() returns (
+            address lightAccountOwner
+        ) {
+            // Regenerate the expected light account address
+            address lightAccountAddress = lightAccountFactory.getAddress(
+                lightAccountOwner,
+                0 // we assume that Decent App is only creating one account per user
+            );
+
+            // If the given `smartAccount` address is the same as the derived
+            // `lightAccountAddress`, then we know that the `smartAccount`
+            // was created by the `LightAccountFactory` and therefore can be trusted.
+            return (lightAccountAddress == smartAccount, lightAccountOwner);
+        } catch {
+            // `smartAccount` does not implement `owner()`
+            // so it's definitely not a `LightAccount`
+            return (false, address(0));
+        }
+    }
+
+    function validateUserOp(
+        PackedUserOperation calldata userOp
+    ) internal view virtual returns (address, address, bytes4) {
+        (bool isValid, address lightAccountOwner) = validateSmartAccount(
+            userOp.sender
+        );
+        if (!isValid) {
+            revert InvalidSmartAccount();
+        }
+
+        // If we're here, we've confirmed that the sender is an actual instance of a LightAccount,
+        // and so therefore its "execute" function behaves as expected.
+        //
+        // This prevents a potential exploit where a user crafts a malicious UserOp
+        // which targets a contract that is expected to be a LightAccount, but is not,
+        // and allows the implementation of that contract's "execute" function to perform
+        // any arbitrary logic (aka logic which does not execute the whitelisted function
+        // encoded in the UserOp).
+
+        // Validate that we have at least 4 bytes for the selector
+        if (userOp.callData.length < 4) {
+            revert InvalidUserOpCallDataLength();
+        }
+
+        // Extract and validate the LightAccount's "execute" function selector
+        // 0xb61d27f6 = bytes4(keccak256("execute(address,uint256,bytes)"))
+        if (bytes4(userOp.callData) != 0xb61d27f6) {
+            revert InvalidCallData();
+        }
+
+        // Decode the "execute" function parameters
+        (address target, , bytes memory innerCallData) = abi.decode(
+            userOp.callData[4:],
+            (address, uint256, bytes)
+        );
+
+        // Extract the actual function selector from the innerCallData
+        if (innerCallData.length < 4) {
+            revert InvalidInnerCallDataLength();
+        }
+
+        return (lightAccountOwner, target, bytes4(innerCallData));
+    }
+}

--- a/contracts/interfaces/light-account/ILightAccount.sol
+++ b/contracts/interfaces/light-account/ILightAccount.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+interface ILightAccount {
+    function owner() external view returns (address);
+
+    function execute(
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) external;
+}

--- a/contracts/interfaces/light-account/ILightAccountFactory.sol
+++ b/contracts/interfaces/light-account/ILightAccountFactory.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+interface ILightAccountFactory {
+    /// @notice Calculate the counterfactual address of this account as it would be returned by `createAccount`.
+    /// @param owner The owner of the account to be created.
+    /// @param salt A salt, which can be changed to create multiple accounts with the same owner.
+    /// @return The address of the account that would be created with `createAccount`.
+    function getAddress(
+        address owner,
+        uint256 salt
+    ) external view returns (address);
+}

--- a/contracts/mocks/MockGaslessTarget.sol
+++ b/contracts/mocks/MockGaslessTarget.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+contract MockGaslessTarget {
+    // First function to whitelist
+    function foo(
+        uint32 someNumber,
+        uint8 someFlag
+    ) external pure returns (bool) {
+        // Just a dummy implementation
+        return someNumber > 0 && someFlag > 0;
+    }
+
+    // Second function to whitelist
+    function bar(
+        address someAddress,
+        uint256 someAmount
+    ) external pure returns (uint256) {
+        // Just a dummy implementation
+        return someAddress != address(0) ? someAmount : 0;
+    }
+}

--- a/contracts/mocks/MockInvalidLightAccount.sol
+++ b/contracts/mocks/MockInvalidLightAccount.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+// This contract does not implement the ILightAccount interface
+// Specifically, it does not have the owner() function
+contract MockInvalidLightAccount {
+    function execute(
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) external {
+        // Empty implementation - we only need this for generating calldata
+    }
+}

--- a/contracts/mocks/MockLightAccount.sol
+++ b/contracts/mocks/MockLightAccount.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {ILightAccount} from "../interfaces/light-account/ILightAccount.sol";
+
+contract MockLightAccount is ILightAccount {
+    address private _owner;
+
+    constructor(address initialOwner) {
+        _owner = initialOwner;
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+
+    function setOwner(address newOwner) external {
+        _owner = newOwner;
+    }
+
+    function execute(
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) external {
+        // Empty implementation - we only need this for generating calldata
+    }
+}

--- a/contracts/mocks/MockLightAccountFactory.sol
+++ b/contracts/mocks/MockLightAccountFactory.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import {ILightAccountFactory} from "../interfaces/light-account/ILightAccountFactory.sol";
+
+contract MockLightAccountFactory is ILightAccountFactory {
+    mapping(address => mapping(uint256 => address)) private _accountAddresses;
+
+    function setAccountAddress(
+        address owner,
+        uint256 salt,
+        address account
+    ) external {
+        _accountAddresses[owner][salt] = account;
+    }
+
+    function getAddress(
+        address owner,
+        uint256 salt
+    ) external view override returns (address) {
+        return _accountAddresses[owner][salt];
+    }
+}

--- a/contracts/mocks/concretes/deployables/account-abstraction/ConcreteSmartAccountValidation.sol
+++ b/contracts/mocks/concretes/deployables/account-abstraction/ConcreteSmartAccountValidation.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import {SmartAccountValidationV1} from "../../../../deployables/account-abstraction/SmartAccountValidationV1.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
+
+contract ConcreteSmartAccountValidation is SmartAccountValidationV1 {
+    function initialize(address _lightAccountFactory) public initializer {
+        __SmartAccountValidationV1_init(_lightAccountFactory);
+    }
+
+    function validateSmartAccountPublic(
+        address smartAccount
+    ) public view returns (bool, address) {
+        return validateSmartAccount(smartAccount);
+    }
+
+    function validateUserOpPublic(
+        PackedUserOperation calldata userOp
+    ) public view returns (address, address, bytes4) {
+        return validateUserOp(userOp);
+    }
+}

--- a/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
+++ b/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
@@ -1,0 +1,265 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteSmartAccountValidation,
+  ConcreteSmartAccountValidation__factory,
+  ERC1967Proxy__factory,
+  MockGaslessTarget,
+  MockGaslessTarget__factory,
+  MockInvalidLightAccount,
+  MockInvalidLightAccount__factory,
+  MockLightAccount,
+  MockLightAccount__factory,
+  MockLightAccountFactory,
+  MockLightAccountFactory__factory,
+} from '../../../typechain-types';
+
+interface PackedUserOperation {
+  sender: string;
+  nonce: bigint;
+  initCode: string;
+  callData: string;
+  accountGasLimits: string;
+  preVerificationGas: bigint;
+  gasFees: string;
+  paymasterAndData: string;
+  signature: string;
+}
+
+async function deploySmartAccountValidation(
+  deployer: SignerWithAddress,
+  implementation: ConcreteSmartAccountValidation,
+  mockLightAccountFactoryAddress: string,
+) {
+  // Create full initialization data with function selector
+  const fullInitData =
+    ConcreteSmartAccountValidation__factory.createInterface().getFunction('initialize').selector +
+    ethers.AbiCoder.defaultAbiCoder()
+      .encode(['address'], [mockLightAccountFactoryAddress])
+      .slice(2);
+
+  // Deploy the proxy with the implementation
+  const proxy = await new ERC1967Proxy__factory(deployer).deploy(implementation, fullInitData);
+
+  return ConcreteSmartAccountValidation__factory.connect(await proxy.getAddress(), deployer);
+}
+
+describe('SmartAccountValidationV1', function () {
+  // contracts
+  let concreteSmartAccountValidation: ConcreteSmartAccountValidation;
+  let mockLightAccount: MockLightAccount;
+  let mockInvalidLightAccount: MockInvalidLightAccount;
+  let mockLightAccountFactory: MockLightAccountFactory;
+
+  // signers
+  let deployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+
+  beforeEach(async function () {
+    // Get signers
+    [deployer, owner] = await ethers.getSigners();
+
+    // Deploy MockLightAccount
+    mockLightAccount = await new MockLightAccount__factory(deployer).deploy(owner.address);
+
+    // Deploy MockInvalidLightAccount
+    mockInvalidLightAccount = await new MockInvalidLightAccount__factory(deployer).deploy();
+
+    // Deploy MockLightAccountFactory
+    mockLightAccountFactory = await new MockLightAccountFactory__factory(deployer).deploy();
+
+    // Deploy ConcreteSmartAccountValidation
+    const concreteValidationImplementation = await new ConcreteSmartAccountValidation__factory(
+      deployer,
+    ).deploy();
+
+    concreteSmartAccountValidation = await deploySmartAccountValidation(
+      deployer,
+      concreteValidationImplementation,
+      mockLightAccountFactory.target.toString(),
+    );
+  });
+
+  describe('validateSmartAccount', function () {
+    describe('valid smart accounts', function () {
+      it('should validate valid smart accounts', async function () {
+        // set up the mock factory contract to return the correct address to `validateSmartAccount`
+        await mockLightAccountFactory.setAccountAddress(
+          await mockLightAccount.owner(),
+          0n,
+          await mockLightAccount.getAddress(),
+        );
+
+        const [isValid, lightAccountOwner] =
+          await concreteSmartAccountValidation.validateSmartAccountPublic(
+            await mockLightAccount.getAddress(),
+          );
+        void expect(isValid).to.be.true;
+        expect(lightAccountOwner).to.equal(await mockLightAccount.owner());
+      });
+    });
+
+    describe('invalid light accounts', function () {
+      describe('non-contracts', function () {
+        it('should return false for non-contract addresses', async function () {
+          const randomAddress = ethers.Wallet.createRandom().address;
+
+          // Should return false since the address won't have the owner() function
+          const [isValid, lightAccountOwner] =
+            await concreteSmartAccountValidation.validateSmartAccountPublic(randomAddress);
+          void expect(isValid).to.be.false;
+          expect(lightAccountOwner).to.equal(ethers.ZeroAddress);
+        });
+      });
+
+      describe('contracts', function () {
+        it('should return false for invalid light accounts that do implement the ILightAccount interface (owner())', async function () {
+          // not calling "setAccountAddress", so the LightAccountFactory will always
+          // return the zero address when calling `getAddress` for a given owner and salt
+          // (which is implemented in the SmartAccountValidation validateSmartAccount function).
+          const [isValid, lightAccountOwner] =
+            await concreteSmartAccountValidation.validateSmartAccountPublic(
+              await mockLightAccount.getAddress(),
+            );
+          void expect(isValid).to.be.false;
+          expect(lightAccountOwner).to.equal(await mockLightAccount.owner());
+        });
+
+        it('should return false for invalid light accounts that do not implement the ILightAccount interface (owner())', async function () {
+          // Hits the "catch" block in the `validateSmartAccount` function
+          const [isValid, lightAccountOwner] =
+            await concreteSmartAccountValidation.validateSmartAccountPublic(
+              await mockInvalidLightAccount.getAddress(),
+            );
+          void expect(isValid).to.be.false;
+          expect(lightAccountOwner).to.equal(ethers.ZeroAddress);
+        });
+      });
+    });
+  });
+
+  describe('validateUserOp', function () {
+    let mockUserOp: PackedUserOperation;
+    let mockTarget: MockGaslessTarget;
+    let FOO_SELECTOR: string;
+
+    beforeEach(async function () {
+      // Deploy MockGaslessTarget
+      mockTarget = await new MockGaslessTarget__factory(deployer).deploy();
+
+      // Get the foo function selector
+      FOO_SELECTOR = mockTarget.interface.getFunction('foo').selector;
+
+      // Create mock UserOperation with properly encoded calldata
+      const innerCalldata = mockTarget.interface.encodeFunctionData('foo', [
+        123, // uint32 someNumber
+        1, // uint8 someFlag
+      ]);
+
+      const executeCalldata = mockLightAccount.interface.encodeFunctionData('execute', [
+        await mockTarget.getAddress(),
+        0n, // value
+        innerCalldata,
+      ]);
+
+      mockUserOp = {
+        sender: await mockLightAccount.getAddress(),
+        nonce: 0n,
+        initCode: '0x',
+        callData: executeCalldata,
+        accountGasLimits: ethers.ZeroHash,
+        preVerificationGas: 0n,
+        gasFees: ethers.ZeroHash,
+        paymasterAndData: '0x',
+        signature: '0x',
+      };
+    });
+
+    it('should validate valid calldata from valid light accounts', async function () {
+      // Set up the mock factory contract to return the correct address
+      await mockLightAccountFactory.setAccountAddress(
+        await mockLightAccount.owner(),
+        0n,
+        await mockLightAccount.getAddress(),
+      );
+
+      const [lightAccountOwner, target, selector] =
+        await concreteSmartAccountValidation.validateUserOpPublic(mockUserOp);
+      expect(lightAccountOwner).to.equal(await mockLightAccount.owner());
+      expect(target).to.equal(await mockTarget.getAddress());
+      expect(selector).to.equal(FOO_SELECTOR);
+    });
+
+    it('should revert with InvalidSmartAccount when sender is not a valid light account', async function () {
+      // Not setting up the mock factory to return the correct address
+      // This will make validateSmartAccount return false, triggering InvalidSmartAccount
+
+      await expect(
+        concreteSmartAccountValidation.validateUserOpPublic(mockUserOp),
+      ).to.be.revertedWithCustomError(concreteSmartAccountValidation, 'InvalidSmartAccount');
+    });
+
+    it('should revert on invalid calldata length', async function () {
+      // Set up the mock factory contract to return the correct address
+      await mockLightAccountFactory.setAccountAddress(
+        await mockLightAccount.owner(),
+        0n,
+        await mockLightAccount.getAddress(),
+      );
+
+      const invalidCallData = '0x1234'; // Too short
+      const invalidUserOp = { ...mockUserOp, callData: invalidCallData };
+
+      await expect(
+        concreteSmartAccountValidation.validateUserOpPublic(invalidUserOp),
+      ).to.be.revertedWithCustomError(
+        concreteSmartAccountValidation,
+        'InvalidUserOpCallDataLength',
+      );
+    });
+
+    it('should revert on unauthorized function calls', async function () {
+      // Set up the mock factory contract to return the correct address
+      await mockLightAccountFactory.setAccountAddress(
+        await mockLightAccount.owner(),
+        0n,
+        await mockLightAccount.getAddress(),
+      );
+
+      const unauthorizedCallData = ethers.concat([
+        '0x99999999',
+        ethers.zeroPadValue(await mockTarget.getAddress(), 20),
+        '0x',
+      ]);
+
+      const unauthorizedUserOp = { ...mockUserOp, callData: unauthorizedCallData };
+
+      await expect(
+        concreteSmartAccountValidation.validateUserOpPublic(unauthorizedUserOp),
+      ).to.be.revertedWithCustomError(concreteSmartAccountValidation, 'InvalidCallData');
+    });
+
+    it('should revert with InvalidInnerCallDataLength when inner calldata is too short', async function () {
+      // Set up the mock factory contract to return the correct address
+      await mockLightAccountFactory.setAccountAddress(
+        await mockLightAccount.owner(),
+        0n,
+        await mockLightAccount.getAddress(),
+      );
+
+      // Create execute calldata with too short inner calldata
+      const executeCalldata = mockLightAccount.interface.encodeFunctionData('execute', [
+        await mockTarget.getAddress(),
+        0n, // value
+        '0x12', // inner calldata less than 4 bytes
+      ]);
+
+      const userOp = { ...mockUserOp, callData: executeCalldata };
+
+      await expect(
+        concreteSmartAccountValidation.validateUserOpPublic(userOp),
+      ).to.be.revertedWithCustomError(concreteSmartAccountValidation, 'InvalidInnerCallDataLength');
+    });
+  });
+});

--- a/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
+++ b/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
@@ -82,8 +82,8 @@ describe('SmartAccountValidationV1', function () {
   });
 
   describe('validateSmartAccount', function () {
-    describe('valid smart accounts', function () {
-      it('should validate valid smart accounts', async function () {
+    describe('When the smart account is valid', function () {
+      it('should return true and the owner address', async function () {
         // set up the mock factory contract to return the correct address to `validateSmartAccount`
         await mockLightAccountFactory.setAccountAddress(
           await mockLightAccount.owner(),
@@ -100,9 +100,9 @@ describe('SmartAccountValidationV1', function () {
       });
     });
 
-    describe('invalid light accounts', function () {
-      describe('non-contracts', function () {
-        it('should return false for non-contract addresses', async function () {
+    describe('When the smart account is invalid', function () {
+      describe('When the address is not a contract', function () {
+        it('should return false and the zero address', async function () {
           const randomAddress = ethers.Wallet.createRandom().address;
 
           // Should return false since the address won't have the owner() function
@@ -113,8 +113,8 @@ describe('SmartAccountValidationV1', function () {
         });
       });
 
-      describe('contracts', function () {
-        it('should return false for invalid light accounts that do implement the ILightAccount interface (owner())', async function () {
+      describe('When the address is a contract', function () {
+        it('should return false when factory check fails', async function () {
           // not calling "setAccountAddress", so the LightAccountFactory will always
           // return the zero address when calling `getAddress` for a given owner and salt
           // (which is implemented in the SmartAccountValidation validateSmartAccount function).
@@ -126,7 +126,7 @@ describe('SmartAccountValidationV1', function () {
           expect(lightAccountOwner).to.equal(await mockLightAccount.owner());
         });
 
-        it('should return false for invalid light accounts that do not implement the ILightAccount interface (owner())', async function () {
+        it('should return false when owner() call reverts', async function () {
           // Hits the "catch" block in the `validateSmartAccount` function
           const [isValid, lightAccountOwner] =
             await concreteSmartAccountValidation.validateSmartAccountPublic(
@@ -176,7 +176,7 @@ describe('SmartAccountValidationV1', function () {
       };
     });
 
-    it('should validate valid calldata from valid light accounts', async function () {
+    it('should return owner, target, and selector for valid UserOps', async function () {
       // Set up the mock factory contract to return the correct address
       await mockLightAccountFactory.setAccountAddress(
         await mockLightAccount.owner(),
@@ -191,7 +191,7 @@ describe('SmartAccountValidationV1', function () {
       expect(selector).to.equal(FOO_SELECTOR);
     });
 
-    it('should revert with InvalidSmartAccount when sender is not a valid light account', async function () {
+    it('should revert when the sender is not a valid smart account', async function () {
       // Not setting up the mock factory to return the correct address
       // This will make validateSmartAccount return false, triggering InvalidSmartAccount
 
@@ -200,7 +200,7 @@ describe('SmartAccountValidationV1', function () {
       ).to.be.revertedWithCustomError(concreteSmartAccountValidation, 'InvalidSmartAccount');
     });
 
-    it('should revert on invalid calldata length', async function () {
+    it('should revert when calldata length is invalid', async function () {
       // Set up the mock factory contract to return the correct address
       await mockLightAccountFactory.setAccountAddress(
         await mockLightAccount.owner(),
@@ -219,7 +219,7 @@ describe('SmartAccountValidationV1', function () {
       );
     });
 
-    it('should revert on unauthorized function calls', async function () {
+    it('should revert when the calldata function selector is not authorized', async function () {
       // Set up the mock factory contract to return the correct address
       await mockLightAccountFactory.setAccountAddress(
         await mockLightAccount.owner(),
@@ -240,7 +240,7 @@ describe('SmartAccountValidationV1', function () {
       ).to.be.revertedWithCustomError(concreteSmartAccountValidation, 'InvalidCallData');
     });
 
-    it('should revert with InvalidInnerCallDataLength when inner calldata is too short', async function () {
+    it('should revert when inner calldata length is invalid', async function () {
       // Set up the mock factory contract to return the correct address
       await mockLightAccountFactory.setAccountAddress(
         await mockLightAccount.owner(),


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/244

Fixes [ENG-815](https://linear.app/decent-labs/issue/ENG-815/implement-base-smart-account-and-useroperation-validation-contract)

**Summary:**

This PR introduces the `SmartAccountValidationV1` abstract contract, designed to provide robust validation mechanisms for smart accounts (specifically LightAccounts) and their associated UserOperations within an ERC-4337 account abstraction context. It also includes necessary interfaces, mock contracts for thorough testing, and a comprehensive test suite.

**Changes:**

*   **New Abstract Contract `SmartAccountValidationV1.sol`:**
    *   Added `contracts/deployables/account-abstraction/SmartAccountValidationV1.sol`.
    *   This contract provides core logic to:
        *   `validateSmartAccount`: Verify if a given address is a genuine `LightAccount` created by a known `LightAccountFactory`. It checks for contract existence and the ability to call `owner()` on the `LightAccount`, then cross-references the address with the factory.
        *   `validateUserOp`: Validate a `PackedUserOperation`. It first validates the `userOp.sender` using `validateSmartAccount`. Then, it ensures the `userOp.callData` correctly targets the `execute(address,uint256,bytes)` function of the `LightAccount` and extracts the underlying target address and function selector.
    *   Includes custom errors for various invalid states (e.g., `InvalidSmartAccount`, `InvalidUserOpCallDataLength`).
    *   Designed to be initializable, taking a `LightAccountFactory` address.
*   **New Interfaces for Light Accounts:**
    *   `contracts/interfaces/light-account/ILightAccount.sol`: Defines the interface for a `LightAccount`, requiring `owner()` and `execute(...)` functions.
    *   `contracts/interfaces/light-account/ILightAccountFactory.sol`: Defines the interface for a `LightAccountFactory`, requiring a `getAddress(owner, salt)` function.
*   **New Mock Contracts for Testing:**
    *   `contracts/mocks/MockLightAccount.sol`: A mock implementation of `ILightAccount`.
    *   `contracts/mocks/MockInvalidLightAccount.sol`: A mock contract that does *not* correctly implement `ILightAccount` (missing `owner()`), for testing negative paths.
    *   `contracts/mocks/MockLightAccountFactory.sol`: A mock implementation of `ILightAccountFactory` that allows setting expected account addresses for given owners and salts.
    *   `contracts/mocks/MockGaslessTarget.sol`: A simple target contract with dummy functions (`foo`, `bar`) for use in `UserOperation` calldata.
    *   `contracts/mocks/concretes/deployables/account-abstraction/ConcreteSmartAccountValidation.sol`: A concrete implementation of `SmartAccountValidationV1` used to expose internal validation functions for direct testing.
*   **New Test Suite `SmartAccountValidationV1.test.ts`:**
    *   Added `test/deployables/account-abstraction/SmartAccountValidationV1.test.ts`.
    *   Provides extensive test coverage for `SmartAccountValidationV1` via its concrete counterpart:
        *   Validation of legitimate smart accounts.
        *   Rejection of EOAs and contracts not conforming to the `ILightAccount` interface or not created by the expected factory.
        *   Successful validation of well-formed `UserOperation` objects.
        *   Rejection of `UserOperation` objects with invalid senders.
        *   Rejection of `UserOperation` objects with malformed `callData` (too short, incorrect `execute` selector).
        *   Rejection of `UserOperation` objects with malformed inner `callData` (too short).

**Motivation:**

*   To establish a secure and reliable way to verify that a `UserOperation` is initiated by a valid smart contract account (LightAccount) that was deployed through a trusted factory.
*   To ensure that the `callData` within a `UserOperation` is structured as expected, targeting the `execute` function of the LightAccount, thereby preventing malicious or malformed calls from being processed by paymasters or bundlers relying on this validation logic.
*   To provide a reusable and extensible base for smart account validation in systems leveraging ERC-4337.