### PR TITLE
Refactor: Enhance HatsProposalCreationWhitelistV1 and Integrations

### DIFF
--- a/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
+++ b/contracts/deployables/strategies/HatsProposalCreationWhitelistV1.sol
@@ -29,39 +29,30 @@ abstract contract HatsProposalCreationWhitelistV1 is
      * @param _initialWhitelistedHats Array of initial whitelisted Hat IDs
      */
     function initialize(
+        address _owner,
         address _hatsContract,
         uint256[] memory _initialWhitelistedHats
     ) public virtual initializer {
-        if (_hatsContract == address(0)) revert InvalidHatsContract();
+        __Ownable_init(_owner);
+
+        if (_hatsContract == address(0)) revert MissingHatsContract();
         hatsContract = IHats(_hatsContract);
 
         if (_initialWhitelistedHats.length == 0) revert NoHatsWhitelisted();
         for (uint256 i = 0; i < _initialWhitelistedHats.length; i++) {
-            _whitelistHat(_initialWhitelistedHats[i]);
+            whitelistHat(_initialWhitelistedHats[i]);
         }
     }
 
-    /**
-     * @dev Function that authorizes an upgrade to a new implementation.
-     * @param newImplementation The address of the new implementation
-     */
     function _authorizeUpgrade(
         address newImplementation
     ) internal virtual override onlyOwner {}
 
     /**
-     * Adds a Hat to the whitelist for proposal creation.
-     * @param _hatId The ID of the Hat to whitelist
-     */
-    function whitelistHat(uint256 _hatId) external onlyOwner {
-        _whitelistHat(_hatId);
-    }
-
-    /**
      * Internal function to add a Hat to the whitelist.
      * @param _hatId The ID of the Hat to whitelist
      */
-    function _whitelistHat(uint256 _hatId) internal {
+    function whitelistHat(uint256 _hatId) public onlyOwner {
         for (uint256 i = 0; i < whitelistedHatIds.length; i++) {
             if (whitelistedHatIds[i] == _hatId) revert HatAlreadyWhitelisted();
         }
@@ -73,7 +64,7 @@ abstract contract HatsProposalCreationWhitelistV1 is
      * Removes a Hat from the whitelist for proposal creation.
      * @param _hatId The ID of the Hat to remove from the whitelist
      */
-    function removeHatFromWhitelist(uint256 _hatId) external onlyOwner {
+    function unwhitelistHat(uint256 _hatId) external onlyOwner {
         bool found = false;
         for (uint256 i = 0; i < whitelistedHatIds.length; i++) {
             if (whitelistedHatIds[i] == _hatId) {
@@ -87,18 +78,17 @@ abstract contract HatsProposalCreationWhitelistV1 is
         }
         if (!found) revert HatNotWhitelisted();
 
-        emit HatRemovedFromWhitelist(_hatId);
+        emit HatUnwhitelisted(_hatId);
     }
 
     /**
-     * @dev Checks if an address is authorized to create proposals.
-     * @param _address The address to check for proposal creation authorization.
+     * @dev Checks if an address is wearing any of the whitelisted Hats.
+     * @param _address The address to check for wearing whitelisted Hats.
      * @return bool Returns true if the address is wearing any of the whitelisted Hats, false otherwise.
-     * @notice This function overrides the isProposer function from the parent contract.
-     * It iterates through all whitelisted Hat IDs and checks if the given address
-     * is wearing any of them using the Hats Protocol.
      */
-    function isProposer(address _address) public view virtual returns (bool) {
+    function isWearingWhitelistedHat(
+        address _address
+    ) public view virtual returns (bool) {
         for (uint256 i = 0; i < whitelistedHatIds.length; i++) {
             if (hatsContract.isWearerOfHat(_address, whitelistedHatIds[i])) {
                 return true;

--- a/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {Version} from "../Version.sol";
 import {LinearERC20VotingV1} from "./LinearERC20VotingV1.sol";
 import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1.sol";
-import {BaseStrategyV1} from "./BaseStrategyV1.sol";
 
 /**
  * An [Azorius](./Azorius.md) [BaseStrategy](./BaseStrategy.md) implementation that
@@ -59,6 +57,7 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
 
         // Initialize HatsProposalCreationWhitelistV1
         HatsProposalCreationWhitelistV1.initialize(
+            _owner,
             _hatsContract,
             _initialWhitelistedHats
         );
@@ -77,17 +76,10 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
         onlyOwner
     {}
 
-    /** @inheritdoc HatsProposalCreationWhitelistV1*/
     function isProposer(
         address _address
-    )
-        public
-        view
-        virtual
-        override(HatsProposalCreationWhitelistV1, LinearERC20VotingV1)
-        returns (bool)
-    {
-        return HatsProposalCreationWhitelistV1.isProposer(_address);
+    ) public view virtual override returns (bool) {
+        return isWearingWhitelistedHat(_address);
     }
 
     /**

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {Version} from "../Version.sol";
 import {LinearERC721VotingV1} from "./LinearERC721VotingV1.sol";
 import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1.sol";
-import {BaseStrategyV1} from "./BaseStrategyV1.sol";
 
 /**
  * An [Azorius](./Azorius.md) [BaseStrategy](./BaseStrategy.md) implementation that
@@ -62,6 +60,7 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
 
         // Initialize HatsProposalCreationWhitelistV1
         HatsProposalCreationWhitelistV1.initialize(
+            _owner,
             _hatsContract,
             _initialWhitelistedHats
         );
@@ -80,17 +79,10 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
         onlyOwner
     {}
 
-    /** @inheritdoc HatsProposalCreationWhitelistV1*/
     function isProposer(
         address _address
-    )
-        public
-        view
-        virtual
-        override(HatsProposalCreationWhitelistV1, LinearERC721VotingV1)
-        returns (bool)
-    {
-        return HatsProposalCreationWhitelistV1.isProposer(_address);
+    ) public view virtual override returns (bool) {
+        return isWearingWhitelistedHat(_address);
     }
 
     /**

--- a/contracts/interfaces/decent/deployables/IHatsProposalCreationWhitelistV1.sol
+++ b/contracts/interfaces/decent/deployables/IHatsProposalCreationWhitelistV1.sol
@@ -17,12 +17,12 @@ interface IHatsProposalCreationWhitelistV1 {
     /**
      * @dev Emitted when a Hat is removed from the whitelist.
      */
-    event HatRemovedFromWhitelist(uint256 hatId);
+    event HatUnwhitelisted(uint256 hatId);
 
     /**
-     * @dev Error thrown when the Hats contract address is invalid.
+     * @dev Error thrown when the Hats contract address is missing.
      */
-    error InvalidHatsContract();
+    error MissingHatsContract();
 
     /**
      * @dev Error thrown when no Hats are whitelisted.
@@ -55,14 +55,16 @@ interface IHatsProposalCreationWhitelistV1 {
      * @dev Removes a Hat from the whitelist for proposal creation.
      * @param _hatId The ID of the Hat to remove from the whitelist
      */
-    function removeHatFromWhitelist(uint256 _hatId) external;
+    function unwhitelistHat(uint256 _hatId) external;
 
     /**
-     * @dev Checks if an address is authorized to create proposals.
-     * @param _address The address to check for proposal creation authorization.
+     * @dev Checks if an address is wearing any of the whitelisted Hats.
+     * @param _address The address to check for wearing whitelisted Hats.
      * @return Returns true if the address is wearing any of the whitelisted Hats, false otherwise.
      */
-    function isProposer(address _address) external view returns (bool);
+    function isWearingWhitelistedHat(
+        address _address
+    ) external view returns (bool);
 
     /**
      * @dev Returns the IDs of all whitelisted Hats.

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteHatsProposalCreationWhitelistV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteHatsProposalCreationWhitelistV1.sol
@@ -15,10 +15,11 @@ contract ConcreteHatsProposalCreationWhitelistV1 is
      * @param _initialWhitelistedHats Array of initial whitelisted Hat IDs
      */
     function initialize(
+        address _owner,
         address _hatsContract,
         uint256[] memory _initialWhitelistedHats
     ) public override initializer {
-        __Ownable_init(msg.sender);
-        super.initialize(_hatsContract, _initialWhitelistedHats);
+        __Ownable_init(_owner);
+        super.initialize(_owner, _hatsContract, _initialWhitelistedHats);
     }
 }

--- a/test/deployables/strategies/HatsProposalCreationWhitelistV1.test.ts
+++ b/test/deployables/strategies/HatsProposalCreationWhitelistV1.test.ts
@@ -41,7 +41,7 @@ describe('HatsProposalCreationWhitelistV1', () => {
     const initializeCalldata =
       ConcreteHatsProposalCreationWhitelistV1__factory.createInterface().encodeFunctionData(
         'initialize',
-        [hatsContract, initialWhitelistedHats],
+        [ownerSigner.address, hatsContract, initialWhitelistedHats],
       );
 
     // Deploy the proxy with owner as the deployer so msg.sender becomes the owner
@@ -110,7 +110,7 @@ describe('HatsProposalCreationWhitelistV1', () => {
       const initData =
         ConcreteHatsProposalCreationWhitelistV1__factory.createInterface().encodeFunctionData(
           'initialize',
-          [await mockHats.getAddress(), emptyWhitelistedHats],
+          [owner.address, await mockHats.getAddress(), emptyWhitelistedHats],
         );
 
       // Attempt to deploy the proxy - should revert
@@ -129,13 +129,13 @@ describe('HatsProposalCreationWhitelistV1', () => {
       const initData =
         ConcreteHatsProposalCreationWhitelistV1__factory.createInterface().encodeFunctionData(
           'initialize',
-          [ethers.ZeroAddress, [proposerHatId1]],
+          [owner.address, ethers.ZeroAddress, [proposerHatId1]],
         );
 
       // Attempt to deploy the proxy - should revert
       await expect(
         new ERC1967Proxy__factory(owner).deploy(await mockImplementation.getAddress(), initData),
-      ).to.be.revertedWithCustomError(mockImplementation, 'InvalidHatsContract');
+      ).to.be.revertedWithCustomError(mockImplementation, 'MissingHatsContract');
     });
   });
 
@@ -175,30 +175,26 @@ describe('HatsProposalCreationWhitelistV1', () => {
     });
   });
 
-  describe('removeHatFromWhitelist', () => {
+  describe('unwhitelistHat', () => {
     it('should allow owner to remove a hat from the whitelist', async () => {
-      await concreteHatsProposalCreationWhitelist
-        .connect(owner)
-        .removeHatFromWhitelist(proposerHatId1);
+      await concreteHatsProposalCreationWhitelist.connect(owner).unwhitelistHat(proposerHatId1);
 
       const whitelistedHats = await concreteHatsProposalCreationWhitelist.getWhitelistedHatIds();
       expect(whitelistedHats.length).to.equal(1);
       expect(whitelistedHats[0]).to.equal(proposerHatId2);
     });
 
-    it('should emit HatRemovedFromWhitelist event when a hat is removed', async () => {
+    it('should emit HatUnwhitelisted event when a hat is removed', async () => {
       await expect(
-        concreteHatsProposalCreationWhitelist.connect(owner).removeHatFromWhitelist(proposerHatId1),
+        concreteHatsProposalCreationWhitelist.connect(owner).unwhitelistHat(proposerHatId1),
       )
-        .to.emit(concreteHatsProposalCreationWhitelist, 'HatRemovedFromWhitelist')
+        .to.emit(concreteHatsProposalCreationWhitelist, 'HatUnwhitelisted')
         .withArgs(proposerHatId1);
     });
 
     it('should not allow non-owner to remove a hat from the whitelist', async () => {
       await expect(
-        concreteHatsProposalCreationWhitelist
-          .connect(nonOwner)
-          .removeHatFromWhitelist(proposerHatId1),
+        concreteHatsProposalCreationWhitelist.connect(nonOwner).unwhitelistHat(proposerHatId1),
       ).to.be.revertedWithCustomError(
         concreteHatsProposalCreationWhitelist,
         'OwnableUnauthorizedAccount',
@@ -207,14 +203,12 @@ describe('HatsProposalCreationWhitelistV1', () => {
 
     it('should not allow removing a hat that is not whitelisted', async () => {
       await expect(
-        concreteHatsProposalCreationWhitelist
-          .connect(owner)
-          .removeHatFromWhitelist(nonProposerHatId),
+        concreteHatsProposalCreationWhitelist.connect(owner).unwhitelistHat(nonProposerHatId),
       ).to.be.revertedWithCustomError(concreteHatsProposalCreationWhitelist, 'HatNotWhitelisted');
     });
   });
 
-  describe('isProposer override', () => {
+  describe('isWearingWhitelistedHat override', () => {
     runHatsProposerTests({
       getMockHats: () => mockHats,
       getContract: () => concreteHatsProposalCreationWhitelist,
@@ -244,9 +238,7 @@ describe('HatsProposalCreationWhitelistV1', () => {
     });
 
     it('should return updated list after removing a hat', async () => {
-      await concreteHatsProposalCreationWhitelist
-        .connect(owner)
-        .removeHatFromWhitelist(proposerHatId1);
+      await concreteHatsProposalCreationWhitelist.connect(owner).unwhitelistHat(proposerHatId1);
 
       const whitelistedHats = await concreteHatsProposalCreationWhitelist.getWhitelistedHatIds();
       expect(whitelistedHats.length).to.equal(1);
@@ -278,8 +270,7 @@ describe('HatsProposalCreationWhitelistV1', () => {
 
   describe('UUPS Upgradeability', function () {
     runUUPSUpgradeabilityTests({
-      getContract: () =>
-        concreteHatsProposalCreationWhitelist as unknown as import('../../../typechain-types').UUPSUpgradeable,
+      getContract: () => concreteHatsProposalCreationWhitelist,
       createNewImplementation: async () => {
         const newImplementation = await new ConcreteHatsProposalCreationWhitelistV1__factory(
           owner,

--- a/test/helpers/hatsProposerTests.ts
+++ b/test/helpers/hatsProposerTests.ts
@@ -11,7 +11,7 @@ import { MockHats } from '../../typechain-types';
  * Interface for any contract that implements the isProposer and whitelistHat methods
  */
 interface HatsProposerTester {
-  isProposer(address: string): Promise<boolean>;
+  isWearingWhitelistedHat(address: string): Promise<boolean>;
   whitelistHat(hatId: bigint): Promise<any>;
   connect(signer: SignerWithAddress): HatsProposerTester;
 }
@@ -48,7 +48,9 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
 
   it('should return true for an address wearing a whitelisted hat', async () => {
     // hatWearer has proposerHatId, which is whitelisted
-    const isHatWearerProposer = await params.getContract().isProposer(params.hatWearer().address);
+    const isHatWearerProposer = await params
+      .getContract()
+      .isWearingWhitelistedHat(params.hatWearer().address);
     void expect(isHatWearerProposer).to.be.true;
   });
 
@@ -56,7 +58,7 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
     // nonHatWearer has nonProposerHatId, which is not whitelisted
     const isNonHatWearerProposer = await params
       .getContract()
-      .isProposer(params.nonHatWearer().address);
+      .isWearingWhitelistedHat(params.nonHatWearer().address);
     void expect(isNonHatWearerProposer).to.be.false;
   });
 
@@ -64,7 +66,7 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
     // tokenHolder has no hats at all, but has tokens/NFTs
     const isTokenHolderProposer = await params
       .getContract()
-      .isProposer(params.tokenHolder().address);
+      .isWearingWhitelistedHat(params.tokenHolder().address);
     void expect(isTokenHolderProposer).to.be.false;
   });
 
@@ -72,7 +74,7 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
     // First verify nonHatWearer is not a proposer initially
     const isNonHatWearerProposerBefore = await params
       .getContract()
-      .isProposer(params.nonHatWearer().address);
+      .isWearingWhitelistedHat(params.nonHatWearer().address);
     void expect(isNonHatWearerProposerBefore).to.be.false;
 
     // Adding nonProposerHatId to the whitelist
@@ -81,7 +83,7 @@ export function runHatsProposerTests(params: HatsProposerTestParams): void {
     // Now nonHatWearer should be a proposer
     const isNonHatWearerProposerAfterWhitelist = await params
       .getContract()
-      .isProposer(params.nonHatWearer().address);
+      .isWearingWhitelistedHat(params.nonHatWearer().address);
     void expect(isNonHatWearerProposerAfterWhitelist).to.be.true;
   });
 }


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/245

Fixes [ENG-816](https://linear.app/decent-labs/issue/ENG-816/refactor-standardize-and-improve-hatsproposalcreationwhitelistv1)

**Summary:**

This PR refactors the `HatsProposalCreationWhitelistV1` contract and its related components for improved clarity, consistency, and Ownable pattern adherence. The changes include renaming functions and events, adjusting initialization, and updating all consuming contracts, interfaces, and tests accordingly.

**Key Changes:**

1.  **`HatsProposalCreationWhitelistV1.sol` Refinements:**
    *   **Initialization:** The `initialize` function now explicitly takes an `_owner` parameter and calls `__Ownable_init(_owner)` for proper ownership setup.
    *   **Error Renaming:** The error `InvalidHatsContract` has been renamed to `MissingHatsContract` for better semantic meaning.
    *   **Function Renaming & Visibility:**
        *   The internal `_whitelistHat` function has been made `public onlyOwner` and renamed to `whitelistHat`. The previous external `whitelistHat` function was removed to avoid redundancy.
        *   `removeHatFromWhitelist` has been renamed to `unwhitelistHat` for conciseness.
        *   The core proposer-checking function `isProposer` has been renamed to `isWearingWhitelistedHat` to more accurately describe its behavior (checking if an address wears any of the whitelisted hats).
    *   **Event Renaming:** The event `HatRemovedFromWhitelist` is now `HatUnwhitelisted`.
    *   Natspec comments have been updated throughout the contract to reflect these changes.

2.  **Updates to Consuming Strategy Contracts:**
    *   **`LinearERC20VotingWithHatsProposalCreationV1.sol`**
    *   **`LinearERC721VotingWithHatsProposalCreationV1.sol`**
        *   The `initialize` function in `HatsProposalCreationWhitelistV1` is now called with the `_owner` parameter.
        *   Unused imports (`Version`, `BaseStrategyV1`) have been removed.
        *   The overridden `isProposer` function now calls the renamed `isWearingWhitelistedHat` from the parent.

3.  **Interface `IHatsProposalCreationWhitelistV1.sol` Alignment:**
    *   All function names, event names, and error names have been updated to match the changes in the concrete `HatsProposalCreationWhitelistV1` contract.

4.  **Mock Contract `ConcreteHatsProposalCreationWhitelistV1.sol` Update:**
    *   The `initialize` function has been updated to accept and pass the `_owner` parameter to the parent's `initialize` and `__Ownable_init`.

5.  **Test Suite `HatsProposalCreationWhitelistV1.test.ts` Modifications:**
    *   Initialization calls in tests now correctly pass the `owner` address.
    *   Assertions for error names (`MissingHatsContract`) have been updated.
    *   All test logic and event checks now use the new function names (`whitelistHat`, `unwhitelistHat`, `isWearingWhitelistedHat`) and event name (`HatUnwhitelisted`).
    *   Type casting for UUPS upgradeability tests has been adjusted.

6.  **Helper Function `hatsProposerTests.ts` Adjustments:**
    *   The `HatsProposerTester` interface and its usage within the shared test logic have been updated to use `isWearingWhitelistedHat` instead of `isProposer`.

**Motivation:**

*   To improve the clarity and expressiveness of the `HatsProposalCreationWhitelistV1` contract's API.
*   To ensure correct and explicit ownership initialization following OpenZeppelin's `Ownable` pattern.
*   To maintain consistency across the contract, its interface, consuming contracts, and test suites.
*   To remove potential redundancies (e.g., separate internal and external `whitelistHat` functions).