### PR TITLE
Refactor: Introduce Validator-Based System for DecentPaymasterV1

### DIFF
--- a/contracts/deployables/account-abstraction/BasePaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/BasePaymasterV1.sol
@@ -1,11 +1,13 @@
-// SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.8.28;
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.23;
 
-import {IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
-import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
-import {UserOperationLib, PackedUserOperation} from "@account-abstraction/contracts/core/UserOperationLib.sol";
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+/* solhint-disable reason-string */
+
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@account-abstraction/contracts/interfaces/IPaymaster.sol";
+import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import "@account-abstraction/contracts/core/UserOperationLib.sol";
 
 /**
  * Helper class for creating a paymaster.
@@ -22,7 +24,11 @@ abstract contract BasePaymasterV1 is IPaymaster, OwnableUpgradeable {
     uint256 internal constant PAYMASTER_DATA_OFFSET =
         UserOperationLib.PAYMASTER_DATA_OFFSET;
 
-    function __BasePaymaster_init(
+    constructor() {
+        _disableInitializers();
+    }
+
+    function __BasePaymasterV1_init(
         address _owner,
         IEntryPoint _entryPoint
     ) internal onlyInitializing {

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {BasePaymasterV1, IEntryPoint} from "./BasePaymasterV1.sol";
 import {IDecentPaymasterV1} from "../../interfaces/decent/deployables/IDecentPaymasterV1.sol";
+import {IFunctionValidator} from "../../interfaces/decent/deployables/IFunctionValidator.sol";
+import {BasePaymasterV1} from "./BasePaymasterV1.sol";
+import {SmartAccountValidationV1} from "./SmartAccountValidationV1.sol";
 import {Version} from "../Version.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
@@ -12,19 +15,24 @@ contract DecentPaymasterV1 is
     IDecentPaymasterV1,
     Version,
     BasePaymasterV1,
+    SmartAccountValidationV1,
     UUPSUpgradeable
 {
     uint16 private constant VERSION = 1;
 
-    // Mapping: strategy address => function selector => is approved
-    mapping(address => mapping(bytes4 => bool)) private _approvedFunctions;
+    // Mapping: contract address => function selector => validator contract
+    mapping(address => mapping(bytes4 => address)) private _functionValidators;
 
-    event FunctionApproved(address strategy, bytes4 selector, bool approved);
+    event FunctionValidatorSet(
+        address target,
+        bytes4 selector,
+        address validator
+    );
+    event FunctionValidatorRemoved(address target, bytes4 selector);
 
-    error UnauthorizedStrategy();
-    error InvalidCallDataLength();
-    error ZeroAddressStrategy();
-    error InvalidArrayLength();
+    error NoValidatorSet(address target, bytes4 selector);
+    error ValidationFailed(address target, bytes4 selector);
+    error InvalidValidator();
 
     constructor() {
         _disableInitializers();
@@ -39,10 +47,11 @@ contract DecentPaymasterV1 is
      */
     function initialize(
         address _owner,
-        address _entryPoint
+        address _entryPoint,
+        address _lightAccountFactory
     ) public initializer {
-        __BasePaymaster_init(_owner, IEntryPoint(_entryPoint));
-        __UUPSUpgradeable_init();
+        __BasePaymasterV1_init(_owner, IEntryPoint(_entryPoint));
+        __SmartAccountValidationV1_init(_lightAccountFactory);
     }
 
     /**
@@ -58,35 +67,55 @@ contract DecentPaymasterV1 is
     }
 
     /**
-     * Add or remove approved functions for a strategy contract
-     * @param contractAddress The contract address that will be whitelisted
-     * @param selectors Array of function selectors to approve/disapprove
-     * @param approved Whether to approve or remove approval for the selectors
+     * Set validator for a specific function
+     * @param target The target contract address
+     * @param selector Function selector to validate
+     * @param validator Address of the validator contract
      */
-    function whitelistFunctions(
-        address contractAddress,
-        bytes4[] calldata selectors,
-        bool[] calldata approved
+    function setFunctionValidator(
+        address target,
+        bytes4 selector,
+        address validator
     ) external onlyOwner {
-        if (contractAddress == address(0)) revert ZeroAddressStrategy();
-        if (selectors.length != approved.length) revert InvalidArrayLength();
-        for (uint256 i = 0; i < selectors.length; i++) {
-            _approvedFunctions[contractAddress][selectors[i]] = approved[i];
-            emit FunctionApproved(contractAddress, selectors[i], approved[i]);
+        if (validator == address(0)) revert InvalidValidator();
+
+        // Verify the validator implements IFunctionValidator interface
+        if (
+            !IFunctionValidator(validator).supportsInterface(
+                type(IFunctionValidator).interfaceId
+            )
+        ) {
+            revert InvalidValidator();
         }
+
+        _functionValidators[target][selector] = validator;
+        emit FunctionValidatorSet(target, selector, validator);
     }
 
     /**
-     * Check if a function is approved for a strategy
-     * @param contractAddress The contract address
-     * @param selector The function selector to check
-     * @return bool Whether the function is approved
+     * Remove validator for a specific function
+     * @param target The target contract address
+     * @param selector Function selector to remove validation for
      */
-    function isFunctionWhitelisted(
-        address contractAddress,
+    function removeFunctionValidator(
+        address target,
         bytes4 selector
-    ) public view returns (bool) {
-        return _approvedFunctions[contractAddress][selector];
+    ) external onlyOwner {
+        _functionValidators[target][selector] = address(0);
+        emit FunctionValidatorRemoved(target, selector);
+    }
+
+    /*
+     * Get a function's validator
+     * @param target The contract address
+     * @param selector The function selector to check
+     * @return address The validator address, or zero if no validator is set
+     */
+    function getFunctionValidator(
+        address target,
+        bytes4 selector
+    ) public view returns (address) {
+        return _functionValidators[target][selector];
     }
 
     /// @inheritdoc BasePaymasterV1
@@ -100,23 +129,34 @@ contract DecentPaymasterV1 is
         override
         returns (bytes memory context, uint256 validationData)
     {
-        bytes calldata callData = userOp.callData;
+        (
+            address lightAccountOwner,
+            address target,
+            bytes4 selector
+        ) = validateUserOp(userOp);
 
-        // Require minimum length for selector and target address
-        if (callData.length < 24) {
-            revert InvalidCallDataLength();
+        // Check if function has a validator
+        address validator = _functionValidators[target][selector];
+        if (validator == address(0)) {
+            revert NoValidatorSet(target, selector);
         }
 
-        // Extract function selector and target address
-        bytes4 selector = bytes4(callData[:4]);
-        address target;
-        assembly {
-            target := shr(96, calldataload(add(callData.offset, 4)))
-        }
+        // Extract the inner calldata from the UserOp
+        (, , bytes memory innerCallData) = abi.decode(
+            userOp.callData[4:],
+            (address, uint256, bytes)
+        );
 
-        // Verify the function is approved for this strategy
-        if (!isFunctionWhitelisted(target, selector)) {
-            revert UnauthorizedStrategy();
+        // Validate the operation will succeed
+        bool isValid = IFunctionValidator(validator).validateOperation(
+            userOp.sender,
+            lightAccountOwner,
+            target,
+            innerCallData
+        );
+
+        if (!isValid) {
+            revert ValidationFailed(target, selector);
         }
 
         return (abi.encode(), 0);

--- a/contracts/interfaces/decent/deployables/IDecentPaymasterV1.sol
+++ b/contracts/interfaces/decent/deployables/IDecentPaymasterV1.sol
@@ -2,14 +2,19 @@
 pragma solidity ^0.8.28;
 
 interface IDecentPaymasterV1 {
-    function whitelistFunctions(
+    function setFunctionValidator(
         address contractAddress,
-        bytes4[] calldata selectors,
-        bool[] calldata approved
+        bytes4 selector,
+        address validator
     ) external;
 
-    function isFunctionWhitelisted(
+    function removeFunctionValidator(
         address contractAddress,
         bytes4 selector
-    ) external view returns (bool);
+    ) external;
+
+    function getFunctionValidator(
+        address contractAddress,
+        bytes4 selector
+    ) external view returns (address);
 }

--- a/contracts/interfaces/decent/deployables/IFunctionValidator.sol
+++ b/contracts/interfaces/decent/deployables/IFunctionValidator.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+interface IFunctionValidator {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+
+    function validateOperation(
+        address userOpSender,
+        address lightAccountOwner,
+        address target,
+        bytes calldata callData
+    ) external view returns (bool isValid);
+}

--- a/contracts/mocks/MockValidator.sol
+++ b/contracts/mocks/MockValidator.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.28;
+
+import {IFunctionValidator} from "../interfaces/decent/deployables/IFunctionValidator.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+contract MockValidator is IFunctionValidator, ERC165 {
+    bool private shouldValidate;
+
+    function setShouldValidate(bool _shouldValidate) external {
+        shouldValidate = _shouldValidate;
+    }
+
+    function validateOperation(
+        address, // sender
+        address, // lightAccountOwner
+        address, // targetContract
+        bytes calldata // callData
+    ) external view returns (bool) {
+        // Return the configured validation result
+        return shouldValidate;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165, IFunctionValidator) returns (bool) {
+        return
+            interfaceId == type(IFunctionValidator).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -11,6 +11,14 @@ import {
   IVersion__factory,
   MockEntryPoint,
   MockEntryPoint__factory,
+  MockGaslessTarget,
+  MockGaslessTarget__factory,
+  MockLightAccount,
+  MockLightAccount__factory,
+  MockLightAccountFactory,
+  MockLightAccountFactory__factory,
+  MockValidator,
+  MockValidator__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
@@ -33,11 +41,12 @@ async function deployDecentPaymasterProxy(
   implementation: string,
   owner: SignerWithAddress,
   entryPoint: string,
+  lightAccountFactory: string,
 ): Promise<DecentPaymasterV1> {
   // Encode initialization parameters
   const initializeParams = ethers.AbiCoder.defaultAbiCoder().encode(
-    ['address', 'address'],
-    [owner.address, entryPoint],
+    ['address', 'address', 'address'],
+    [owner.address, entryPoint, lightAccountFactory],
   );
 
   // Create full initialization data with function selector
@@ -55,52 +64,81 @@ async function deployDecentPaymasterProxy(
 describe('DecentPaymasterV1', function () {
   // contracts
   let decentPaymaster: DecentPaymasterV1;
-  let masterCopy: string;
+  let masterCopy: DecentPaymasterV1;
   let entryPoint: MockEntryPoint;
+  let mockLightAccount: MockLightAccount;
+  let mockTarget: MockGaslessTarget;
+  let mockLightAccountFactory: MockLightAccountFactory;
+  let mockValidator: MockValidator;
+  let mockLightAccountFactoryAddress: string;
 
   // signers
   let owner: SignerWithAddress;
-  let proxyDeployer: SignerWithAddress;
-  let strategy: SignerWithAddress;
   let nonOwner: SignerWithAddress;
 
   // test data
   let mockUserOp: PackedUserOperation;
-  const MOCK_FUNCTION_SELECTOR = '0x12345678';
-  const MOCK_FUNCTION_SELECTOR_2 = '0x87654321';
-  const MOCK_FUNCTION_SELECTOR_3 = '0x11223344';
-  const MOCK_INVALID_SELECTOR = '0x99999999';
+  let FOO_SELECTOR: string;
 
   beforeEach(async function () {
     // Get signers
-    [proxyDeployer, owner, strategy, nonOwner] = await ethers.getSigners();
+    [owner, nonOwner] = await ethers.getSigners();
 
     // Deploy mock EntryPoint
     entryPoint = await new MockEntryPoint__factory(owner).deploy();
 
+    // Deploy MockLightAccount
+    mockLightAccount = await new MockLightAccount__factory(owner).deploy(owner.address);
+
+    // Deploy MockGaslessTarget
+    mockTarget = await new MockGaslessTarget__factory(owner).deploy();
+
+    // Deploy MockValidator
+    mockValidator = await new MockValidator__factory(owner).deploy();
+
+    // Deploy MockLightAccountFactory
+    mockLightAccountFactory = await new MockLightAccountFactory__factory(owner).deploy();
+    mockLightAccountFactoryAddress = mockLightAccountFactory.target.toString();
+
+    // Set up the mock light account factory to return our mock account
+    await mockLightAccountFactory.setAccountAddress(
+      await mockLightAccount.owner(),
+      0n,
+      await mockLightAccount.getAddress(),
+    );
+
+    // Get the foo function selector
+    FOO_SELECTOR = mockTarget.interface.getFunction('foo').selector;
+
     // Deploy DecentPaymaster implementation
-    masterCopy = await (await new DecentPaymasterV1__factory(owner).deploy()).getAddress();
+    masterCopy = await new DecentPaymasterV1__factory(owner).deploy();
 
     // Deploy DecentPaymaster proxy
     decentPaymaster = await deployDecentPaymasterProxy(
-      proxyDeployer,
-      masterCopy,
+      owner,
+      await masterCopy.getAddress(),
       owner,
       await entryPoint.getAddress(),
+      mockLightAccountFactoryAddress,
     );
 
-    // Create mock UserOperation
-    const mockCallData = ethers.concat([
-      MOCK_FUNCTION_SELECTOR,
-      strategy.address,
-      '0x', // empty data
+    // Create mock UserOperation with properly encoded calldata
+    const innerCalldata = mockTarget.interface.encodeFunctionData('foo', [
+      123, // uint32 someNumber
+      1, // uint8 someFlag
+    ]);
+
+    const executeCalldata = mockLightAccount.interface.encodeFunctionData('execute', [
+      await mockTarget.getAddress(),
+      0n, // value
+      innerCalldata,
     ]);
 
     mockUserOp = {
-      sender: ethers.ZeroAddress,
+      sender: await mockLightAccount.getAddress(),
       nonce: 0n,
       initCode: '0x',
-      callData: mockCallData,
+      callData: executeCalldata,
       accountGasLimits: ethers.ZeroHash,
       preVerificationGas: 0n,
       gasFees: ethers.ZeroHash,
@@ -118,116 +156,100 @@ describe('DecentPaymasterV1', function () {
       expect(await decentPaymaster.owner()).to.equal(owner.address);
     });
 
+    it('Should set the light account factory', async function () {
+      expect(await decentPaymaster.lightAccountFactory()).to.equal(mockLightAccountFactoryAddress);
+    });
+
     it('Should not allow reinitialization', async function () {
       await expect(
-        decentPaymaster.initialize(owner.address, await entryPoint.getAddress()),
+        decentPaymaster.initialize(
+          owner.address,
+          await entryPoint.getAddress(),
+          mockLightAccountFactoryAddress,
+        ),
       ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidInitialization');
     });
 
     it('Should have a version', async function () {
       const version = await decentPaymaster.getVersion();
-      void expect(version).to.equal(1);
+      expect(version).to.equal(1);
     });
   });
 
-  describe('Function Approval', function () {
-    it('Should allow owner to approve functions', async function () {
-      const selectors = [MOCK_FUNCTION_SELECTOR];
-      const approved = [true];
+  describe('Validator Management', function () {
+    it('Should allow owner to set validator for target', async function () {
+      await expect(
+        decentPaymaster.setFunctionValidator(
+          await mockTarget.getAddress(),
+          FOO_SELECTOR,
+          await mockValidator.getAddress(),
+        ),
+      )
+        .to.emit(decentPaymaster, 'FunctionValidatorSet')
+        .withArgs(await mockTarget.getAddress(), FOO_SELECTOR, await mockValidator.getAddress());
 
-      await expect(decentPaymaster.whitelistFunctions(strategy.address, selectors, approved))
-        .to.emit(decentPaymaster, 'FunctionApproved')
-        .withArgs(strategy.address, MOCK_FUNCTION_SELECTOR, true);
-
-      const isApproved = await decentPaymaster.isFunctionWhitelisted(
-        strategy.address,
-        MOCK_FUNCTION_SELECTOR,
-      );
-      void expect(isApproved).to.be.true;
+      void expect(
+        await decentPaymaster.getFunctionValidator(await mockTarget.getAddress(), FOO_SELECTOR),
+      ).to.be.equal(await mockValidator.getAddress());
     });
 
-    it('Should allow owner to revoke function approval', async function () {
-      const selectors = [MOCK_FUNCTION_SELECTOR];
-      const approved = [true];
-
-      await decentPaymaster.whitelistFunctions(strategy.address, selectors, approved);
-
-      await decentPaymaster.whitelistFunctions(strategy.address, selectors, [false]);
-      const isApproved = await decentPaymaster.isFunctionWhitelisted(
-        strategy.address,
-        MOCK_FUNCTION_SELECTOR,
+    it('Should allow owner to remove validator for target', async function () {
+      await decentPaymaster.setFunctionValidator(
+        await mockTarget.getAddress(),
+        FOO_SELECTOR,
+        await mockValidator.getAddress(),
       );
-      void expect(isApproved).to.be.false;
-    });
-
-    it('Should revert when non-owner tries to set approval', async function () {
-      const selectors = [MOCK_FUNCTION_SELECTOR];
-      const approved = [true];
+      void expect(
+        await decentPaymaster.getFunctionValidator(await mockTarget.getAddress(), FOO_SELECTOR),
+      ).to.be.equal(await mockValidator.getAddress());
 
       await expect(
-        decentPaymaster.connect(nonOwner).whitelistFunctions(strategy.address, selectors, approved),
+        decentPaymaster.removeFunctionValidator(await mockTarget.getAddress(), FOO_SELECTOR),
+      )
+        .to.emit(decentPaymaster, 'FunctionValidatorRemoved')
+        .withArgs(await mockTarget.getAddress(), FOO_SELECTOR);
+
+      void expect(
+        await decentPaymaster.getFunctionValidator(await mockTarget.getAddress(), FOO_SELECTOR),
+      ).to.be.equal(ethers.ZeroAddress);
+    });
+
+    it('Should revert when non-owner tries to set validator', async function () {
+      await expect(
+        decentPaymaster
+          .connect(nonOwner)
+          .setFunctionValidator(
+            await mockTarget.getAddress(),
+            FOO_SELECTOR,
+            await mockValidator.getAddress(),
+          ),
       ).to.be.revertedWithCustomError(decentPaymaster, 'OwnableUnauthorizedAccount');
     });
 
-    it('Should revert when arrays have different lengths', async function () {
-      const selectors = [MOCK_FUNCTION_SELECTOR];
-      const approved: boolean[] = [];
-
+    it('Should revert when setting invalid validator address', async function () {
       await expect(
-        decentPaymaster.whitelistFunctions(strategy.address, selectors, approved),
-      ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidArrayLength');
-    });
-
-    it('Should approve multiple functions in a single call', async function () {
-      const selectors = [
-        MOCK_FUNCTION_SELECTOR,
-        MOCK_FUNCTION_SELECTOR_2,
-        MOCK_FUNCTION_SELECTOR_3,
-      ];
-      const approved = [true, true, true];
-
-      await decentPaymaster.whitelistFunctions(strategy.address, selectors, approved);
-
-      for (const selector of selectors) {
-        const isApproved = await decentPaymaster.isFunctionWhitelisted(strategy.address, selector);
-        void expect(isApproved).to.be.true;
-      }
-    });
-
-    it('Should handle empty arrays', async function () {
-      const selectors: string[] = [];
-      const approved: boolean[] = [];
-
-      await decentPaymaster.whitelistFunctions(strategy.address, selectors, approved);
-      // Should not revert and should not modify any state
-    });
-
-    it('Should revert when using zero address as strategy', async function () {
-      const selectors = [MOCK_FUNCTION_SELECTOR];
-      const approved = [true];
-
-      await expect(
-        decentPaymaster.whitelistFunctions(ethers.ZeroAddress, selectors, approved),
-      ).to.be.revertedWithCustomError(decentPaymaster, 'ZeroAddressStrategy');
+        decentPaymaster.setFunctionValidator(
+          await mockTarget.getAddress(),
+          FOO_SELECTOR,
+          ethers.ZeroAddress,
+        ),
+      ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidValidator');
     });
   });
 
   describe('Validation', function () {
     beforeEach(async function () {
-      // Approve the function for the strategy
-      const selectors = [MOCK_FUNCTION_SELECTOR];
-      const approved = [true];
-      await decentPaymaster.whitelistFunctions(strategy.address, selectors, approved);
-
-      // Fund the impersonated signer
-      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
-      await owner.sendTransaction({
-        to: await entryPointSigner.getAddress(),
-        value: ethers.parseEther('1'),
-      });
+      // Set up validator for mock target and FOO_SELECTOR
+      await decentPaymaster.setFunctionValidator(
+        await mockTarget.getAddress(),
+        FOO_SELECTOR,
+        await mockValidator.getAddress(),
+      );
+      // Configure validator to return true
+      await mockValidator.setShouldValidate(true);
     });
 
-    it('Should validate approved function calls', async function () {
+    it('Should validate when validator approves', async function () {
       const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
       const result = await decentPaymaster
         .connect(entryPointSigner)
@@ -237,97 +259,54 @@ describe('DecentPaymasterV1', function () {
       expect(result[0]).to.equal('0x'); // context
     });
 
-    it('Should revert on unauthorized function calls', async function () {
-      const unauthorizedCallData = ethers.concat([
-        MOCK_INVALID_SELECTOR,
-        ethers.zeroPadValue(strategy.address, 20),
-        '0x',
-      ]);
-
-      const unauthorizedUserOp = { ...mockUserOp, callData: unauthorizedCallData };
+    it('Should revert when validator disapproves', async function () {
+      // Configure validator to return false
+      await mockValidator.setShouldValidate(false);
 
       await expect(
         decentPaymaster
           .connect(await ethers.getImpersonatedSigner(await entryPoint.getAddress()))
-          .validatePaymasterUserOp.staticCall(unauthorizedUserOp, ethers.ZeroHash, 0),
-      ).to.be.revertedWithCustomError(decentPaymaster, 'UnauthorizedStrategy');
+          .validatePaymasterUserOp.staticCall(mockUserOp, ethers.ZeroHash, 0),
+      ).to.be.revertedWithCustomError(decentPaymaster, 'ValidationFailed');
     });
 
-    it('Should revert on invalid calldata length', async function () {
-      const invalidCallData = '0x1234'; // Too short
-      const invalidUserOp = { ...mockUserOp, callData: invalidCallData };
+    it('Should revert when no validator is set', async function () {
+      // Remove validator
+      await decentPaymaster.removeFunctionValidator(await mockTarget.getAddress(), FOO_SELECTOR);
 
       await expect(
         decentPaymaster
           .connect(await ethers.getImpersonatedSigner(await entryPoint.getAddress()))
-          .validatePaymasterUserOp.staticCall(invalidUserOp, ethers.ZeroHash, 0),
-      ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidCallDataLength');
+          .validatePaymasterUserOp.staticCall(mockUserOp, ethers.ZeroHash, 0),
+      ).to.be.revertedWithCustomError(decentPaymaster, 'NoValidatorSet');
     });
 
-    it('Should validate with exactly 24 bytes of calldata', async function () {
-      const exactCallData = ethers.concat([
-        MOCK_FUNCTION_SELECTOR,
-        ethers.zeroPadValue(strategy.address, 20),
+    it('Should revert for non-whitelisted function selectors', async function () {
+      // Create a new function selector that isn't whitelisted
+      const nonWhitelistedSelector = mockTarget.interface.getFunction('bar').selector;
+
+      // Create inner calldata with non-whitelisted selector
+      const innerCalldata = mockTarget.interface.encodeFunctionData('bar', [
+        owner.address, // address someAddress
+        ethers.parseEther('1'), // uint256 someAmount
       ]);
 
-      const userOp = { ...mockUserOp, callData: exactCallData };
-      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
-
-      const result = await decentPaymaster
-        .connect(entryPointSigner)
-        .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0);
-
-      expect(result[1]).to.equal(0n);
-      expect(result[0]).to.equal('0x');
-    });
-
-    it('Should validate with more than 24 bytes of calldata', async function () {
-      const longCallData = ethers.concat([
-        MOCK_FUNCTION_SELECTOR,
-        ethers.zeroPadValue(strategy.address, 20),
-        '0x1234567890', // additional data
+      // Create the execute calldata
+      const executeCalldata = mockLightAccount.interface.encodeFunctionData('execute', [
+        await mockTarget.getAddress(),
+        0n, // value
+        innerCalldata,
       ]);
 
-      const userOp = { ...mockUserOp, callData: longCallData };
-      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
-
-      const result = await decentPaymaster
-        .connect(entryPointSigner)
-        .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0);
-
-      expect(result[1]).to.equal(0n);
-      expect(result[0]).to.equal('0x');
-    });
-
-    it('Should validate with non-contract address as target', async function () {
-      const randomAddress = ethers.Wallet.createRandom().address;
-      const callData = ethers.concat([
-        MOCK_FUNCTION_SELECTOR,
-        ethers.zeroPadValue(randomAddress, 20),
-      ]);
-
-      const userOp = { ...mockUserOp, callData: callData };
-
-      await decentPaymaster.whitelistFunctions(randomAddress, [MOCK_FUNCTION_SELECTOR], [true]);
-      const entryPointSigner = await ethers.getImpersonatedSigner(await entryPoint.getAddress());
-
-      const result = await decentPaymaster
-        .connect(entryPointSigner)
-        .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0);
-
-      expect(result[1]).to.equal(0n);
-      expect(result[0]).to.equal('0x');
-    });
-
-    it('Should revert with malformed calldata', async function () {
-      const malformedCallData = '0x1234'; // Less than 4 bytes for selector
-      const userOp = { ...mockUserOp, callData: malformedCallData };
+      const userOp = { ...mockUserOp, callData: executeCalldata };
 
       await expect(
         decentPaymaster
           .connect(await ethers.getImpersonatedSigner(await entryPoint.getAddress()))
           .validatePaymasterUserOp.staticCall(userOp, ethers.ZeroHash, 0),
-      ).to.be.revertedWithCustomError(decentPaymaster, 'InvalidCallDataLength');
+      )
+        .to.be.revertedWithCustomError(decentPaymaster, 'NoValidatorSet')
+        .withArgs(await mockTarget.getAddress(), nonWhitelistedSelector);
     });
   });
 
@@ -444,17 +423,6 @@ describe('DecentPaymasterV1', function () {
   });
 
   describe('UUPS Upgradeability', function () {
-    // beforeEach(async function () {
-    //   // Deploy proxy
-    //   decentPaymaster = await deployDecentPaymasterProxy(
-    //     proxyDeployer,
-    //     masterCopy,
-    //     owner,
-    //     await entryPoint.getAddress(),
-    //   );
-    // });
-
-    // Run UUPS upgradeability tests
     runUUPSUpgradeabilityTests({
       getContract: () => decentPaymaster,
       createNewImplementation: async () => {


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/246

Fixes [ENG-817](https://linear.app/decent-labs/issue/ENG-817/refactor-implement-validator-based-system-for-decentpaymasterv1)

**Summary:**

This PR overhauls the `DecentPaymasterV1` to replace its function whitelisting mechanism with a more extensible validator-based system. Instead of directly whitelisting target contracts and function selectors, the paymaster now allows registering dedicated validator contracts for specific functions. This change enhances flexibility and enables more complex validation logic for sponsored UserOperations.

The `BasePaymasterV1` also sees minor updates to its initialization and licensing.

**Key Changes:**

1.  **`DecentPaymasterV1.sol` Overhaul:**
    *   **Inheritance:** Now inherits from `SmartAccountValidationV1` to leverage its UserOperation sender validation.
    *   **Validator System:**
        *   Replaced `_approvedFunctions` mapping with `_functionValidators (address target => mapping(bytes4 selector => address validator))`.
        *   Introduced `setFunctionValidator` to associate a validator contract with a target contract's function.
        *   Added `removeFunctionValidator` to clear a validator.
        *   `getFunctionValidator` now retrieves the registered validator for a function.
    *   **Events & Errors:**
        *   Replaced `FunctionApproved` event with `FunctionValidatorSet` and `FunctionValidatorRemoved`.
        *   Updated error messages to reflect the new system (e.g., `NoValidatorSet`, `ValidationFailed`, `InvalidValidator`).
    *   **Initialization:** The `initialize` function now accepts a `_lightAccountFactory` address and initializes `SmartAccountValidationV1`.
    *   **Validation Logic (`_validatePaymasterUserOp`):**
        1.  Calls `validateUserOp` (from `SmartAccountValidationV1`) to authenticate the UserOperation's sender and extract the target contract and function selector.
        2.  Retrieves the registered `validator` for the target and selector.
        3.  If no validator is found, reverts with `NoValidatorSet`.
        4.  Decodes the inner `callData` from the UserOperation.
        5.  Delegates the final validation to `IFunctionValidator(validator).validateOperation(...)`, passing relevant UserOperation details.
        6.  Reverts with `ValidationFailed` if the validator returns `false`.

2.  **`BasePaymasterV1.sol` Updates:**
    *   SPDX license identifier changed to `GPL-3.0`.
    *   Solidity pragma version updated.
    *   `__BasePaymaster_init` renamed to `__BasePaymasterV1_init`.
    *   Added a default constructor to disable direct initializers.

3.  **New Interface `IFunctionValidator.sol`:**
    *   Defines a standard interface for validator contracts, requiring `supportsInterface(bytes4)` and `validateOperation(address userOpSender, address lightAccountOwner, address target, bytes calldata callData) returns (bool isValid)`.

4.  **Interface `IDecentPaymasterV1.sol` Update:**
    *   Modified to reflect the new validator management functions (`setFunctionValidator`, `removeFunctionValidator`, `getFunctionValidator`).

5.  **New `MockValidator.sol`:**
    *   Added a mock implementation of `IFunctionValidator` for testing purposes, allowing configurable validation outcomes.

6.  **Test Suite `DecentPaymasterV1.test.ts` Rewrite:**
    *   Completely revamped to test the new validator-based architecture.
    *   Includes setup for `MockLightAccount`, `MockGaslessTarget`, `MockLightAccountFactory`, and `MockValidator`.
    *   Proxy deployment and initialization tests updated for the new `_lightAccountFactory` parameter.
    *   "Function Approval" tests replaced with comprehensive "Validator Management" tests.
    *   "Validation" tests now cover scenarios with validators (approval, disapproval, no validator set), and use `MockLightAccount` for constructing `UserOperation.callData`.

**Motivation:**

*   To provide a more powerful and flexible mechanism for determining which UserOperations the `DecentPaymasterV1` should sponsor.
*   To allow for custom, fine-grained validation logic per target function, rather than a simple boolean whitelist.
*   To integrate `SmartAccountValidationV1` for robust sender authentication before applying paymaster-specific validation.
*   To improve the overall design and extensibility of the paymaster system.