### PR TITLE
Refactor: Integrate SmartAccountValidation into ERC4337VoterSupportV1

### DIFF
--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -1,37 +1,65 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.28;
 
-import {IOwnershipV1} from "../../interfaces/decent/deployables/IOwnershipV1.sol";
+import {SmartAccountValidationV1} from "../account-abstraction/SmartAccountValidationV1.sol";
 
 /**
  * Functionality to support ERC4337 (Account Abstraction) by properly identifying the voter
  * when a contract account is used to interact with the voting system.
  */
-abstract contract ERC4337VoterSupportV1 {
+abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
+    /**
+     * @dev Tracks whether a proposal's voting period has been marked as ended.
+     * This flag is set to true when the first vote attempt occurs after the voting end timestamp,
+     * triggering a VotingPeriodEnded event. Used to allow an at-most-once vote to not revert
+     * after the voting period has ended, and to give bundlers the ability to determine
+     * if a proposal voting period has ended without using the banned NUMBER opcode.
+     */
+    mapping(uint32 => bool) internal _votingPeriodEnded;
+
+    event VotingPeriodEnded(
+        uint32 indexed proposalId,
+        uint256 votingEndTimestamp,
+        uint256 currentTimestamp
+    );
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function __ERC4337VoterSupportV1_init(
+        address _lightAccountFactory
+    ) internal {
+        __SmartAccountValidationV1_init(_lightAccountFactory);
+    }
+
     /**
      * Returns the address of the voter which owns the voting weight
      * @param _msgSender address of the sender. It can be the wallet address, or the smart account address with EOA as owner
      * @return address of the voter
      */
-    function _voter(
-        address _msgSender
-    ) internal view virtual returns (address) {
-        // First check if the address has code (is a contract)
-        uint256 size;
-        assembly {
-            size := extcodesize(_msgSender)
-        }
-
-        // If it's an EOA (no code), return the address directly
-        if (size == 0) {
+    function voter(address _msgSender) public view virtual returns (address) {
+        (bool isValid, address lightAccountOwner) = validateSmartAccount(
+            _msgSender
+        );
+        if (!isValid) {
             return _msgSender;
         }
 
-        // If it's a contract, try to get its owner
-        try IOwnershipV1(_msgSender).owner() returns (address _value) {
-            return _value;
-        } catch {
-            return _msgSender;
-        }
+        return lightAccountOwner;
+    }
+
+    /**
+     * @dev Tracks whether a proposal's voting period has been officially marked as ended.
+     * This flag is set to true when the first vote attempt occurs after the voting end timestamp,
+     * triggering a VotingPeriodEnded event. Used to ensure the event is emitted exactly once
+     * per proposal, and only if a vote has been attempted after the voting end timestamp.
+     * @param _proposalId The ID of the proposal to check.
+     * @return True if the voting period has ended and a vote has been attempted after the voting end timestamp, false otherwise.
+     */
+    function votingPeriodEnded(
+        uint32 _proposalId
+    ) external view virtual returns (bool) {
+        return _votingPeriodEnded[_proposalId];
     }
 }

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -184,7 +184,7 @@ contract LinearERC20VotingV1 is
      * @param _voteType Proposal support as defined in VoteType (NO, YES, ABSTAIN)
      */
     function vote(uint32 _proposalId, uint8 _voteType) external virtual {
-        address voter = _voter(msg.sender);
+        address voter = voter(msg.sender);
         _vote(
             _proposalId,
             voter,

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -285,7 +285,7 @@ contract LinearERC721VotingV1 is
         if (_tokenAddresses.length != _tokenIds.length) revert InvalidParams();
         _vote(
             _proposalId,
-            _voter(msg.sender),
+            voter(msg.sender),
             _voteType,
             _tokenAddresses,
             _tokenIds

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteERC4337VoterSupportV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteERC4337VoterSupportV1.sol
@@ -2,15 +2,20 @@
 pragma solidity ^0.8.28;
 
 import {ERC4337VoterSupportV1} from "../../../../deployables/strategies/ERC4337VoterSupportV1.sol";
+import {ILightAccountFactory} from "../../../../interfaces/light-account/ILightAccountFactory.sol";
 
 /**
  * A concrete implementation of ERC4337VoterSupportV1 for testing purposes.
  */
 contract ConcreteERC4337VoterSupportV1 is ERC4337VoterSupportV1 {
+    function initialize(address _lightAccountFactory) public initializer {
+        __ERC4337VoterSupportV1_init(_lightAccountFactory);
+    }
+
     /**
-     * A public function that exposes the _voter function for testing.
+     * A public function that allows setting the _votingPeriodEnded mapping for testing.
      */
-    function voter(address msgSender) public view returns (address) {
-        return _voter(msgSender);
+    function setVotingPeriodEnded(uint32 proposalId, bool ended) public {
+        _votingPeriodEnded[proposalId] = ended;
     }
 }

--- a/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
+++ b/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
@@ -4,9 +4,31 @@ import { ethers } from 'hardhat';
 import {
   ConcreteERC4337VoterSupportV1,
   ConcreteERC4337VoterSupportV1__factory,
-  MockOwnership,
-  MockOwnership__factory,
+  ERC1967Proxy__factory,
+  MockLightAccount,
+  MockLightAccount__factory,
+  MockLightAccountFactory,
+  MockLightAccountFactory__factory,
 } from '../../../typechain-types';
+
+async function deployConcreteERC4337VoterSupport(
+  deployer: SignerWithAddress,
+  implementation: ConcreteERC4337VoterSupportV1,
+  lightAccountFactory: MockLightAccountFactory,
+) {
+  const initializeCalldata =
+    ConcreteERC4337VoterSupportV1__factory.createInterface().encodeFunctionData('initialize', [
+      lightAccountFactory.target,
+    ]);
+
+  // Deploy the proxy with owner as the deployer so msg.sender becomes the owner
+  const proxy = await new ERC1967Proxy__factory(deployer).deploy(
+    await implementation.getAddress(),
+    initializeCalldata,
+  );
+
+  return ConcreteERC4337VoterSupportV1__factory.connect(await proxy.getAddress(), deployer);
+}
 
 describe('ERC4337VoterSupportV1', () => {
   // Signers
@@ -16,53 +38,122 @@ describe('ERC4337VoterSupportV1', () => {
 
   // Contracts
   let concreteERC4337VoterSupport: ConcreteERC4337VoterSupportV1;
-  let mockOwnership: MockOwnership;
+  let mockLightAccount: MockLightAccount;
+  let mockLightAccountFactory: MockLightAccountFactory;
 
   beforeEach(async () => {
     [deployer, owner, user] = await ethers.getSigners();
 
-    // Deploy the ERC4337VoterSupport concrete
-    concreteERC4337VoterSupport = await new ConcreteERC4337VoterSupportV1__factory(
-      deployer,
-    ).deploy();
-
     // Deploy a mock ownership contract with the owner address
-    mockOwnership = await new MockOwnership__factory(deployer).deploy(owner.address);
+    mockLightAccount = await new MockLightAccount__factory(deployer).deploy(owner.address);
+
+    // Deploy MockLightAccountFactory
+    mockLightAccountFactory = await new MockLightAccountFactory__factory(deployer).deploy();
+
+    // Deploy an implementation instance of the ConcreteERC4337VoterSupportV1
+    const implementation = await new ConcreteERC4337VoterSupportV1__factory(deployer).deploy();
+
+    // Deploy an instance of the ERC4337VoterSupport concrete implementation
+    concreteERC4337VoterSupport = await deployConcreteERC4337VoterSupport(
+      deployer,
+      implementation,
+      mockLightAccountFactory,
+    );
+
+    // Set up the mock light account factory to return our mock account
+    await mockLightAccountFactory.setAccountAddress(
+      await mockLightAccount.owner(),
+      0n,
+      await mockLightAccount.getAddress(),
+    );
   });
 
   describe('voter', () => {
-    describe('when the msgSender is a smart account', () => {
-      it('should return the owner of the smart account', async () => {
+    describe('light accounts', function () {
+      it('should return the owner of the light account', async () => {
         // Test with our mock ownership contract
-        const voter = await concreteERC4337VoterSupport.voter(await mockOwnership.getAddress());
+        const voter = await concreteERC4337VoterSupport.voter(await mockLightAccount.getAddress());
         expect(voter).to.equal(owner.address);
       });
-
-      it('should return address(0) when smart account owner is zero address', async () => {
-        // Set the owner to the zero address
-        await mockOwnership.setOwner(ethers.ZeroAddress);
-
-        const voter = await concreteERC4337VoterSupport.voter(await mockOwnership.getAddress());
-        expect(voter).to.equal(ethers.ZeroAddress);
-      });
     });
 
-    describe('when the msgSender is an EOA', () => {
-      it('should return the msgSender', async () => {
-        // For EOAs, the voter function should just return the address itself
-        const eoaAddress = user.address;
-        const voter = await concreteERC4337VoterSupport.voter(eoaAddress);
-        expect(voter).to.equal(eoaAddress);
+    describe('non-light accounts', function () {
+      describe('when the msgSender is an EOA', () => {
+        it('should return the msgSender', async () => {
+          // For EOAs, the voter function should just return the address itself
+          const eoaAddress = user.address;
+          const voter = await concreteERC4337VoterSupport.voter(eoaAddress);
+          expect(voter).to.equal(eoaAddress);
+        });
+      });
+
+      describe('when the msgSender is a contract that does not implement IOwnership', () => {
+        it('should return the contract address', async () => {
+          // Use the ConcreteRC4337VoterSupport contract itself as a contract that doesn't implement IOwnership
+          const contractAddress = await concreteERC4337VoterSupport.getAddress();
+          const voter = await concreteERC4337VoterSupport.voter(contractAddress);
+          expect(voter).to.equal(contractAddress);
+        });
       });
     });
+  });
 
-    describe('when the msgSender is a contract that does not implement IOwnership', () => {
-      it('should return the contract address', async () => {
-        // Use the ConcreteRC4337VoterSupport contract itself as a contract that doesn't implement IOwnership
-        const contractAddress = await concreteERC4337VoterSupport.getAddress();
-        const voter = await concreteERC4337VoterSupport.voter(contractAddress);
-        expect(voter).to.equal(contractAddress);
-      });
+  describe('voting period ended', () => {
+    it('should initially return false for any proposal', async () => {
+      const proposalId = 1;
+      const result = await concreteERC4337VoterSupport.votingPeriodEnded(proposalId);
+      void expect(result).to.be.false;
+    });
+
+    it('should be able to set and get voting period ended status', async () => {
+      const proposalId = 1;
+
+      // Initially false
+      let result = await concreteERC4337VoterSupport.votingPeriodEnded(proposalId);
+      void expect(result).to.be.false;
+
+      // Set to true
+      await concreteERC4337VoterSupport.setVotingPeriodEnded(proposalId, true);
+      result = await concreteERC4337VoterSupport.votingPeriodEnded(proposalId);
+      void expect(result).to.be.true;
+
+      // Set back to false
+      await concreteERC4337VoterSupport.setVotingPeriodEnded(proposalId, false);
+      result = await concreteERC4337VoterSupport.votingPeriodEnded(proposalId);
+      void expect(result).to.be.false;
+    });
+
+    it('should maintain separate states for different proposal IDs', async () => {
+      const proposalId1 = 1;
+      const proposalId2 = 2;
+
+      // Set first proposal to ended
+      await concreteERC4337VoterSupport.setVotingPeriodEnded(proposalId1, true);
+
+      // First proposal should be ended
+      const result1 = await concreteERC4337VoterSupport.votingPeriodEnded(proposalId1);
+      void expect(result1).to.be.true;
+
+      // Second proposal should still be false
+      const result2 = await concreteERC4337VoterSupport.votingPeriodEnded(proposalId2);
+      void expect(result2).to.be.false;
+    });
+
+    it('should be accessible by any address', async () => {
+      const proposalId = 1;
+
+      await concreteERC4337VoterSupport.setVotingPeriodEnded(proposalId, true);
+
+      // Test access from different accounts
+      const userResult = await concreteERC4337VoterSupport
+        .connect(user)
+        .votingPeriodEnded(proposalId);
+      void expect(userResult).to.be.true;
+
+      const ownerResult = await concreteERC4337VoterSupport
+        .connect(owner)
+        .votingPeriodEnded(proposalId);
+      void expect(ownerResult).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/247

Fixes [ENG-820](https://linear.app/decent-labs/issue/ENG-820/refactor-erc4337votersupportv1-to-use-smartaccountvalidationv1-and-add)

**Summary:**

This PR refactors `ERC4337VoterSupportV1` to leverage the recently introduced `SmartAccountValidationV1` for determining the true voter when an interaction comes from a smart contract account (specifically a LightAccount). It also introduces a mechanism to track and query if a proposal's voting period has ended, primarily for ERC-4337 bundler and paymaster use cases.

**Key Changes:**

1.  **`ERC4337VoterSupportV1.sol` Enhancements:**
    *   **Inheritance:** Now inherits from `SmartAccountValidationV1`.
    *   **Initialization:**
        *   Added a default constructor `_disableInitializers()`.
        *   Introduced `__ERC4337VoterSupportV1_init(address _lightAccountFactory)` to initialize the `SmartAccountValidationV1` base.
    *   **`voter(address _msgSender)` Function (Previously `_voter`):**
        *   Now `public` visibility.
        *   Calls `validateSmartAccount(_msgSender)` from the `SmartAccountValidationV1` base.
        *   If `_msgSender` is a valid LightAccount, it returns the `lightAccountOwner`.
        *   Otherwise (EOA or non-LightAccount contract), it returns `_msgSender` directly.
    *   **Voting Period Ended Tracking:**
        *   Added a `mapping(uint32 => bool) internal _votingPeriodEnded;` to store the ended status of proposal voting periods.
        *   Introduced a `VotingPeriodEnded` event.
        *   Added a `public view virtual` function `votingPeriodEnded(uint32 _proposalId)` to allow external queries of this status.
        *   *Note: The logic to set `_votingPeriodEnded` and emit the event is expected to be implemented in consuming strategy contracts when a vote is attempted after the period ends.*

2.  **Updates to Consuming Strategy Contracts:**
    *   **`LinearERC20VotingV1.sol`**
    *   **`LinearERC721VotingV1.sol`**
        *   Now call the public `voter(msg.sender)` function (previously `_voter(msg.sender)`).
        *   These contracts will need to be updated to call `__ERC4337VoterSupportV1_init` during their own initialization if they inherit this functionality directly or indirectly. (This part of the integration might be in a subsequent PR based on the diff).

3.  **Mock Contract `ConcreteERC4337VoterSupportV1.sol` Modifications:**
    *   Added an `initialize(address _lightAccountFactory)` function to properly initialize the base contract for testing.
    *   The public `voter` function was already present for testing `_voter`.
    *   Added a public `setVotingPeriodEnded(uint32 proposalId, bool ended)` function to allow direct manipulation of the `_votingPeriodEnded` mapping during tests.

4.  **Test Suite `ERC4337VoterSupportV1.test.ts` Refinements:**
    *   Updated to use `MockLightAccount` and `MockLightAccountFactory` for testing scenarios involving LightAccount voters.
    *   Includes a `deployConcreteERC4337VoterSupport` helper for proxy deployment and initialization.
    *   Tests for the `voter` function now cover:
        *   Valid LightAccounts returning their owner.
        *   EOAs returning themselves.
        *   Non-LightAccount contracts returning their own address.
    *   Added new tests for the `votingPeriodEnded` functionality:
        *   Initial state (should be `false`).
        *   Setting and getting the status.
        *   Ensuring separate states for different proposal IDs.
        *   Accessibility from any address.

**Motivation:**

*   To standardize and improve the reliability of identifying the underlying EOA owner when a vote comes from a LightAccount, by using the robust `SmartAccountValidationV1`.
*   To provide a clear, on-chain mechanism for ERC-4337 bundlers and paymasters to determine if a proposal's voting period has concluded, which can be crucial for deciding whether to process or sponsor a `UserOperation` containing a vote.
*   To remove the previous ad-hoc EOA/contract check and `IOwnershipV1` try-catch logic, simplifying the voter identification process.