### PR TITLE
Refactor: Integrate ERC4337VoterSupportV1 into LinearERC20VotingV1 strategy

### DIFF
--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -101,6 +101,7 @@ contract LinearERC20VotingV1 is
      * @param _requiredProposerWeight Minimum weight to create proposals
      * @param _quorumNumerator Numerator for quorum calculation
      * @param _basisNumerator Numerator for basis calculation
+     * @param _lightAccountFactory Address of the LightAccountFactory
      */
     function initialize(
         address _owner,
@@ -109,13 +110,15 @@ contract LinearERC20VotingV1 is
         uint32 _votingPeriod,
         uint256 _requiredProposerWeight,
         uint256 _quorumNumerator,
-        uint256 _basisNumerator
+        uint256 _basisNumerator,
+        address _lightAccountFactory
     ) public initializer {
         if (address(_governanceToken) == address(0))
             revert InvalidTokenAddress();
         governanceToken = IVotes(_governanceToken);
 
         BaseStrategyV1.initialize(_owner, _proposalInitializer);
+        __ERC4337VoterSupportV1_init(_lightAccountFactory);
 
         _updateQuorumNumerator(_quorumNumerator);
         _updateBasisNumerator(_basisNumerator);
@@ -376,8 +379,18 @@ contract LinearERC20VotingV1 is
     ) internal virtual {
         if (proposalVotes[_proposalId].votingEndTimestamp == 0)
             revert InvalidProposal();
-        if (block.timestamp > proposalVotes[_proposalId].votingEndTimestamp)
+        if (block.timestamp > proposalVotes[_proposalId].votingEndTimestamp) {
+            if (!_votingPeriodEnded[_proposalId]) {
+                _votingPeriodEnded[_proposalId] = true;
+                emit VotingPeriodEnded(
+                    _proposalId,
+                    proposalVotes[_proposalId].votingEndTimestamp,
+                    block.timestamp
+                );
+                return;
+            }
             revert VotingEnded();
+        }
         if (proposalVotes[_proposalId].hasVoted[_voter]) revert AlreadyVoted();
 
         proposalVotes[_proposalId].hasVoted[_voter] = true;

--- a/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.sol
@@ -42,7 +42,8 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
         uint256 _quorumNumerator,
         uint256 _basisNumerator,
         address _hatsContract,
-        uint256[] memory _initialWhitelistedHats
+        uint256[] memory _initialWhitelistedHats,
+        address _lightAccountFactory
     ) public initializer {
         // Initialize LinearERC20VotingV1
         LinearERC20VotingV1.initialize(
@@ -52,7 +53,8 @@ contract LinearERC20VotingWithHatsProposalCreationV1 is
             _votingPeriod,
             0, // requiredProposerWeight is zero because we only care about the hat check
             _quorumNumerator,
-            _basisNumerator
+            _basisNumerator,
+            _lightAccountFactory
         );
 
         // Initialize HatsProposalCreationWhitelistV1

--- a/test/deployables/strategies/LinearERC20VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingV1.test.ts
@@ -1,6 +1,7 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { mine, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
+import type { ContractTransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
@@ -28,6 +29,7 @@ describe('LinearERC20VotingV1', () => {
   let tokenHolder1: SignerWithAddress;
   let tokenHolder2: SignerWithAddress;
   let tokenHolder3: SignerWithAddress;
+  let lightAccountFactoryMock: SignerWithAddress;
 
   // Contracts
   let linearERC20VotingImplementation: LinearERC20VotingV1;
@@ -36,7 +38,7 @@ describe('LinearERC20VotingV1', () => {
   let mockOwnership: MockOwnership;
 
   // Constants
-  const VOTING_PERIOD = 100; // blocks
+  const VOTING_PERIOD = 100; // seconds
   const REQUIRED_PROPOSER_WEIGHT = 100; // 100 tokens to propose
   const QUORUM_NUMERATOR = 300000; // 30% of 1000000
   const BASIS_NUMERATOR = 500000; // 50% of 1000000
@@ -52,10 +54,11 @@ describe('LinearERC20VotingV1', () => {
     strategyOwner: SignerWithAddress,
     governanceToken: string,
     azoriusAddr: string,
+    lightAccountFactory: string,
   ): Promise<LinearERC20VotingV1> {
     // Create the initialization data
     const initializeCalldata = LinearERC20VotingV1__factory.createInterface().encodeFunctionData(
-      'initialize(address,address,address,uint32,uint256,uint256,uint256)',
+      'initialize(address,address,address,uint32,uint256,uint256,uint256,address)',
       [
         strategyOwner.address,
         governanceToken,
@@ -64,6 +67,7 @@ describe('LinearERC20VotingV1', () => {
         REQUIRED_PROPOSER_WEIGHT,
         QUORUM_NUMERATOR,
         BASIS_NUMERATOR,
+        lightAccountFactory,
       ],
     );
 
@@ -78,7 +82,7 @@ describe('LinearERC20VotingV1', () => {
   }
 
   beforeEach(async () => {
-    [deployer, owner, nonOwner, tokenHolder1, tokenHolder2, tokenHolder3] =
+    [deployer, owner, nonOwner, tokenHolder1, tokenHolder2, tokenHolder3, lightAccountFactoryMock] =
       await ethers.getSigners();
 
     // Use nonOwner address as a mock azorius address for testing
@@ -103,6 +107,7 @@ describe('LinearERC20VotingV1', () => {
       owner,
       await mockToken.getAddress(),
       proposalInitializer,
+      lightAccountFactoryMock.address,
     );
   });
 
@@ -115,12 +120,17 @@ describe('LinearERC20VotingV1', () => {
       expect(await linearERC20Voting.requiredProposerWeight()).to.equal(REQUIRED_PROPOSER_WEIGHT);
       expect(await linearERC20Voting.quorumNumerator()).to.equal(QUORUM_NUMERATOR);
       expect(await linearERC20Voting.basisNumerator()).to.equal(BASIS_NUMERATOR);
+      expect(await linearERC20Voting.lightAccountFactory()).to.equal(
+        lightAccountFactoryMock.address,
+      );
     });
 
     it('should not allow reinitialization', async () => {
       // Attempt to reinitialize - should revert
       await expect(
-        linearERC20Voting['initialize(address,address,address,uint32,uint256,uint256,uint256)'](
+        linearERC20Voting[
+          'initialize(address,address,address,uint32,uint256,uint256,uint256,address)'
+        ](
           owner.address,
           await mockToken.getAddress(),
           proposalInitializer,
@@ -128,14 +138,15 @@ describe('LinearERC20VotingV1', () => {
           REQUIRED_PROPOSER_WEIGHT,
           QUORUM_NUMERATOR,
           BASIS_NUMERATOR,
+          lightAccountFactoryMock.address,
         ),
-      ).to.be.reverted;
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidInitialization');
     });
 
     it('should revert when initializing with zero token address', async () => {
       // Create initialization data with zero address for token
       const initializeCalldata = LinearERC20VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address,address,uint32,uint256,uint256,uint256)',
+        'initialize(address,address,address,uint32,uint256,uint256,uint256,address)',
         [
           owner.address,
           ethers.ZeroAddress,
@@ -144,6 +155,7 @@ describe('LinearERC20VotingV1', () => {
           REQUIRED_PROPOSER_WEIGHT,
           QUORUM_NUMERATOR,
           BASIS_NUMERATOR,
+          lightAccountFactoryMock.address,
         ],
       );
 
@@ -154,6 +166,21 @@ describe('LinearERC20VotingV1', () => {
           initializeCalldata,
         ),
       ).to.be.reverted;
+    });
+
+    it('should emit ProposalInitialized event when initializing a proposal', async () => {
+      const proposalId = 200;
+      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
+
+      // Get current block timestmp to calculate expected end timestamp
+      const currentBlockTimestamp = await time.latest();
+
+      // +1 because the proposal will be in the next block, and that block's timestamp will be increased by one second
+      const expectedEndTimestamp = currentBlockTimestamp + 1 + VOTING_PERIOD;
+
+      await expect(linearERC20Voting.connect(nonOwner).initializeProposal(initializeData))
+        .to.emit(linearERC20Voting, 'ProposalInitialized')
+        .withArgs(proposalId, expectedEndTimestamp);
     });
   });
 
@@ -234,18 +261,18 @@ describe('LinearERC20VotingV1', () => {
   });
 
   describe('Proposal Functions', () => {
-    it('should allow only azorius to initialize proposal', async () => {
+    it('should allow only authorized account to initialize proposal', async () => {
       // Mock proposal ID
       const proposalId = 1;
       // Mock data for initializing a proposal
       const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
 
-      // Only Azorius can initialize proposals
+      // Only authorized account can initialize proposals
       await expect(
         linearERC20Voting.connect(owner).initializeProposal(initializeData),
       ).to.be.revertedWithCustomError(linearERC20Voting, 'ProposalInitializerUnauthorizedAccount');
 
-      // Test with Azorius signer
+      // Test with authorized account
       await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
 
       // Check that proposal was initialized correctly
@@ -319,13 +346,57 @@ describe('LinearERC20VotingV1', () => {
       ).to.be.revertedWithCustomError(linearERC20Voting, 'AlreadyVoted');
     });
 
-    it('should not allow voting after voting period ends', async () => {
-      // Mine blocks to advance past the voting period
-      await mine(VOTING_PERIOD + 1);
+    describe('voting period ended', () => {
+      let noVotesBefore: bigint;
+      let yesVotesBefore: bigint;
+      let abstainVotesBefore: bigint;
+      let initialVoteTx: ContractTransactionResponse;
+      let endTimestamp: bigint;
 
-      await expect(
-        linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
+      beforeEach(async () => {
+        // Get initial vote counts
+        [noVotesBefore, yesVotesBefore, abstainVotesBefore, , endTimestamp] =
+          await linearERC20Voting.getProposalVotes(proposalId);
+
+        // Mine blocks to advance past the voting period
+        await time.increaseTo(Number(endTimestamp) + 1);
+
+        // First vote to mark the period as ended
+        initialVoteTx = await linearERC20Voting
+          .connect(tokenHolder1)
+          .vote(proposalId, VoteType.YES);
+      });
+
+      it('should handle first vote after voting period ends correctly', async () => {
+        // Verify event emission
+        await expect(initialVoteTx).to.emit(linearERC20Voting, 'VotingPeriodEnded');
+
+        // Verify no votes were actually counted
+        const [noVotesAfter, yesVotesAfter, abstainVotesAfter, , ,] =
+          await linearERC20Voting.getProposalVotes(proposalId);
+        expect(noVotesAfter).to.equal(noVotesBefore, 'NO votes should not change');
+        expect(yesVotesAfter).to.equal(yesVotesBefore, 'YES votes should not change');
+        expect(abstainVotesAfter).to.equal(abstainVotesBefore, 'ABSTAIN votes should not change');
+
+        // Verify the voting period is marked as ended
+        void expect(await linearERC20Voting.votingPeriodEnded(proposalId)).to.be.true;
+      });
+
+      it('should revert on votes after voting period is marked as ended', async () => {
+        // Verify subsequent votes revert
+        await expect(
+          linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES),
+        ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
+
+        await expect(
+          linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.NO),
+        ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
+
+        // Verify even the same account that marked it as ended can't vote again
+        await expect(
+          linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.ABSTAIN),
+        ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
+      });
     });
 
     it('should revert on invalid vote type', async () => {
@@ -340,6 +411,7 @@ describe('LinearERC20VotingV1', () => {
 
   describe('isPassed Logic', () => {
     const proposalId = 1;
+    let proposalBeginTimestamp: number;
 
     beforeEach(async () => {
       // Delegate tokens to voters
@@ -350,6 +422,7 @@ describe('LinearERC20VotingV1', () => {
       // Initialize a proposal using the azorius mock account
       const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
       await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
+      proposalBeginTimestamp = await time.latest();
     });
 
     it('should pass when yes > no and meets quorum', async () => {
@@ -359,7 +432,7 @@ describe('LinearERC20VotingV1', () => {
       await linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.NO);
 
       // Mine blocks to end the voting period
-      await mine(VOTING_PERIOD + 1);
+      await time.increaseTo(proposalBeginTimestamp + VOTING_PERIOD + 1);
 
       // Proposal should pass
       void expect(await linearERC20Voting.isPassed(proposalId)).to.be.true;
@@ -382,8 +455,8 @@ describe('LinearERC20VotingV1', () => {
       // Update quorum to 40% to make this test fail
       await linearERC20Voting.connect(owner).updateQuorumNumerator(400000);
 
-      // Mine blocks to end the voting period
-      await mine(VOTING_PERIOD + 1);
+      // Mine timestamp to end the voting period
+      await time.increaseTo(proposalBeginTimestamp + VOTING_PERIOD + 1);
 
       // Proposal should fail due to insufficient quorum
       void expect(await linearERC20Voting.isPassed(proposalId)).to.be.false;
@@ -395,8 +468,8 @@ describe('LinearERC20VotingV1', () => {
       await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.NO);
       await linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.YES);
 
-      // Mine blocks to end the voting period
-      await mine(VOTING_PERIOD + 1);
+      // Mine timestamp to end the voting period
+      await time.increaseTo(proposalBeginTimestamp + VOTING_PERIOD + 1);
 
       // Proposal should fail due to insufficient basis (YES < NO)
       void expect(await linearERC20Voting.isPassed(proposalId)).to.be.false;
@@ -689,9 +762,18 @@ describe('LinearERC20VotingV1', () => {
       // Advance time to just after voting end
       await time.increaseTo(Number(endTimestamp) + 1);
 
+      // First vote attempt after period ends should mark it as ended and return
+      const tx = await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
+      await expect(tx).to.emit(linearERC20Voting, 'VotingPeriodEnded');
+
       // Try to vote after voting ended - should revert
       await expect(
         linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
+
+      // Subsequent vote attempts should revert
+      await expect(
+        linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.YES),
       ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
     });
 
@@ -753,14 +835,69 @@ describe('LinearERC20VotingV1', () => {
       // Should still be able to vote before end timestamp
       await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
 
-      // Advance to end timestamp with a single mine operation
-      // This avoids the "same timestamp" error by using mine with a timestamp parameter
-      await ethers.provider.send('evm_mine', [Number(endTimestamp)]);
+      // Advance to end timestamp
+      await time.increaseTo(Number(endTimestamp) + 1);
 
-      // Should no longer be able to vote at exactly the end timestamp
+      // First vote attempt after period ends should mark it as ended and return
+      const tx = await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
+      await expect(tx).to.emit(linearERC20Voting, 'VotingPeriodEnded');
+
+      // Subsequent vote attempts should revert
       await expect(
-        linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES),
+        linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.YES),
       ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
+    });
+
+    describe('voting period ended events', () => {
+      it('should emit VotingPeriodEnded event with correct parameters', async () => {
+        // Get the voting end timestamp
+        const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
+
+        // Mine timestamp to advance past the voting period
+        await time.increaseTo(Number(endTimestamp) + 1);
+
+        // First vote attempt after period ends should emit event with correct parameters
+        const currentTimestamp = await time.latest();
+        const tx = await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
+
+        await expect(tx)
+          .to.emit(linearERC20Voting, 'VotingPeriodEnded')
+          .withArgs(proposalId, endTimestamp, currentTimestamp + 1);
+      });
+
+      it('should only emit VotingPeriodEnded event once', async () => {
+        // Get the voting end timestamp
+        const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
+
+        // Mine timestamp to advance past the voting period
+        await time.increaseTo(Number(endTimestamp) + 1);
+
+        // First vote attempt should emit event
+        const tx1 = await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
+        await expect(tx1).to.emit(linearERC20Voting, 'VotingPeriodEnded');
+
+        // Subsequent vote attempts should revert
+        await expect(
+          linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.YES),
+        ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
+      });
+
+      it('should update votingPeriodEnded state after emitting event', async () => {
+        // Get the voting end timestamp
+        const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
+
+        // Mine timestamp to advance past the voting period
+        await time.increaseTo(Number(endTimestamp) + 1);
+
+        // votingPeriodEnded should initially be false
+        void expect(await linearERC20Voting.votingPeriodEnded(proposalId)).to.be.false;
+
+        // First vote attempt after period ends should update state
+        await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
+
+        // Should now be true
+        void expect(await linearERC20Voting.votingPeriodEnded(proposalId)).to.be.true;
+      });
     });
   });
 

--- a/test/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingWithHatsProposalCreationV1.test.ts
@@ -39,6 +39,7 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
   let tokenHolder1: SignerWithAddress;
   let hatWearer: SignerWithAddress;
   let nonHatWearer: SignerWithAddress;
+  let lightAccountFactoryMock: SignerWithAddress;
 
   // Contracts
   let linearERC20VotingWithHatsProposalCreationImplementation: LinearERC20VotingWithHatsProposalCreationV1;
@@ -63,10 +64,11 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
     azoriusAddr: string,
     hatsContract: MockHats,
     initialWhitelistedHats: bigint[],
+    lightAccountFactory: string,
   ): Promise<LinearERC20VotingWithHatsProposalCreationV1> {
     // Create the initialization data using the interface
     const initializeCalldata = implementation.interface.encodeFunctionData(
-      'initialize(address,address,address,uint32,uint256,uint256,address,uint256[])',
+      'initialize(address,address,address,uint32,uint256,uint256,address,uint256[],address)',
       [
         strategyOwner.address,
         await governanceToken.getAddress(),
@@ -76,6 +78,7 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
         BASIS_NUMERATOR,
         await hatsContract.getAddress(),
         initialWhitelistedHats,
+        lightAccountFactory,
       ],
     );
 
@@ -93,7 +96,8 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
   }
 
   beforeEach(async () => {
-    [deployer, owner, nonOwner, tokenHolder1, hatWearer, nonHatWearer] = await ethers.getSigners();
+    [deployer, owner, nonOwner, tokenHolder1, hatWearer, nonHatWearer, lightAccountFactoryMock] =
+      await ethers.getSigners();
 
     // Use nonOwner address as a mock azorius address for testing
     azoriusAddress = await nonOwner.getAddress();
@@ -117,6 +121,7 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
         azoriusAddress,
         mockHats,
         [proposerHatId1, proposerHatId2],
+        lightAccountFactoryMock.address,
       );
   });
 
@@ -147,13 +152,18 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
         expect(whitelistedHats.length).to.equal(2);
         expect(whitelistedHats[0]).to.equal(proposerHatId1);
         expect(whitelistedHats[1]).to.equal(proposerHatId2);
+
+        // Check LightAccountFactory address
+        expect(await linearERC20VotingWithHatsProposalCreation.lightAccountFactory()).to.equal(
+          lightAccountFactoryMock.address,
+        );
       });
 
       it('should not allow reinitialization', async () => {
         // Deploy a new implementation to initialize again with the same params
         const initializeCalldata =
           linearERC20VotingWithHatsProposalCreationImplementation.interface.encodeFunctionData(
-            'initialize(address,address,address,uint32,uint256,uint256,address,uint256[])',
+            'initialize(address,address,address,uint32,uint256,uint256,address,uint256[],address)',
             [
               owner.address,
               await mockToken.getAddress(),
@@ -163,6 +173,7 @@ describe('LinearERC20VotingWithHatsProposalCreationV1', () => {
               BASIS_NUMERATOR,
               await mockHats.getAddress(),
               [proposerHatId1, proposerHatId2],
+              lightAccountFactoryMock.address,
             ],
           );
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/250

Fixes [ENG-821](https://linear.app/decent-labs/issue/ENG-821/integrate-erc4337votersupportv1-into-linearerc20votingv1-strategies)

**Summary:**

This PR integrates the enhanced `ERC4337VoterSupportV1` (which now uses `SmartAccountValidationV1`) into the `LinearERC20VotingV1` and `LinearERC20VotingWithHatsProposalCreationV1` contracts. This ensures that these strategies correctly identify voters using LightAccounts and can track when a proposal's voting period has effectively ended for ERC-4337 purposes.

**Key Changes:**

1.  **`LinearERC20VotingV1.sol` Modifications:**
    *   **Initialization:**
        *   The `initialize` function now accepts a `_lightAccountFactory` address parameter.
        *   Calls `__ERC4337VoterSupportV1_init(_lightAccountFactory)` to set up the base contract.
    *   **Vote Logic (`_vote` function):**
        *   When `block.timestamp` exceeds `proposalVotes[_proposalId].votingEndTimestamp`:
            *   If `_votingPeriodEnded[_proposalId]` is `false` (meaning this is the first vote attempt after the period ended):
                *   Sets `_votingPeriodEnded[_proposalId]` to `true`.
                *   Emits the `VotingPeriodEnded` event with the `proposalId`, `votingEndTimestamp`, and current `block.timestamp`.
                *   The function then returns, effectively not counting the vote but marking the period as concluded for ERC-4337 observers.
            *   If `_votingPeriodEnded[_proposalId]` is already `true`, it reverts with `VotingEnded()`.
        *   This ensures the `VotingPeriodEnded` event is emitted at most once per proposal and only when a vote is attempted post-deadline.

2.  **`LinearERC20VotingWithHatsProposalCreationV1.sol` Modifications:**
    *   **Initialization:**
        *   The `initialize` function now accepts a `_lightAccountFactory` address parameter.
        *   This `_lightAccountFactory` address is passed down to the `LinearERC20VotingV1.initialize` call.

3.  **Test Suite `LinearERC20VotingV1.test.ts` Updates:**
    *   **Setup:**
        *   Now includes a `lightAccountFactoryMock` signer/address.
        *   The `deployLinearERC20VotingV1` helper and direct `initialize` calls now pass the `lightAccountFactoryMock.address`.
    *   **Initialization Tests:**
        *   Verify that the `lightAccountFactory` address is correctly set during initialization.
        *   Updated `initialize` function signature in reinitialization and zero-address token tests.
    *   **Voting Period End Logic:**
        *   The `VOTING_PERIOD` constant is now interpreted as seconds (consistent with `block.timestamp`).
        *   Tests for voting after the period ends are significantly enhanced:
            *   Use `time.increaseTo` for more precise timestamp control.
            *   Verify that the first vote attempt after `votingEndTimestamp` emits `VotingPeriodEnded` and does *not* count the vote.
            *   Verify that `votingPeriodEnded(proposalId)` returns `true` after this first attempt.
            *   Verify that subsequent vote attempts (by the same or different accounts) revert with `VotingEnded`.
    *   **Timestamp-Based Tests:**
        *   Adjusted `evm_mine` usage with explicit timestamps to `time.increaseTo` for better control and to align with timestamp-based voting periods.

4.  **Test Suite `LinearERC20VotingWithHatsProposalCreationV1.test.ts` Updates:**
    *   **Setup:**
        *   Added `lightAccountFactoryMock` signer/address.
        *   The `deployLinearERC20VotingWithHatsProposalCreationV1` helper and direct `initialize` calls now pass the `lightAccountFactoryMock.address`.
    *   **Initialization Tests:**
        *   Verify that the `lightAccountFactory` address is correctly set by checking the base `LinearERC20VotingV1`'s state (as it's passed down).
        *   Updated `initialize` function signature in reinitialization tests.

**Motivation:**

*   To fully enable ERC-4337 Account Abstraction support in the linear voting strategies by correctly initializing the `ERC4337VoterSupportV1` base.
*   To implement the on-chain mechanism for signaling when a proposal's voting period has ended, allowing ERC-4337 bundlers/paymasters to make informed decisions about processing gasless vote transactions.
*   To ensure that votes are not counted after the official `votingEndTimestamp`, while still providing a one-time mechanism to flag the period as concluded for off-chain systems.