### PR TITLE
refactor: Standardize votingEndTimestamp to uint48

### DIFF
--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -23,7 +23,7 @@ interface ILinearERC721VotingV1 {
 
     function votingEndTimestamp(
         uint32 proposalId
-    ) external view returns (uint32);
+    ) external view returns (uint48);
 
     function getTokenWeight(
         address tokenAddress

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -388,7 +388,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
 
         IBaseStrategyV1 _strategy = IBaseStrategyV1(_proposal.strategy);
 
-        uint256 votingEndTimestamp = _strategy.votingEndTimestamp(_proposalId);
+        uint48 votingEndTimestamp = _strategy.votingEndTimestamp(_proposalId);
 
         if (block.timestamp <= votingEndTimestamp) {
             return ProposalState.ACTIVE;

--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -19,8 +19,8 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
 
     event VotingPeriodEnded(
         uint32 indexed proposalId,
-        uint256 votingEndTimestamp,
-        uint256 currentTimestamp
+        uint48 votingEndTimestamp,
+        uint48 currentTimestamp
     );
 
     constructor() {

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -394,7 +394,7 @@ contract LinearERC20VotingV1 is
                 emit VotingPeriodEnded(
                     _proposalId,
                     proposalVotes[_proposalId].votingEndTimestamp,
-                    block.timestamp
+                    uint48(block.timestamp)
                 );
                 return;
             }

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -509,7 +509,7 @@ contract LinearERC721VotingV1 is
                 emit VotingPeriodEnded(
                     _proposalId,
                     proposal.votingEndTimestamp,
-                    block.timestamp
+                    uint48(block.timestamp)
                 );
                 return;
             }

--- a/contracts/mocks/MockLinearERC721VotingV1.sol
+++ b/contracts/mocks/MockLinearERC721VotingV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 contract MockLinearERC721VotingV1 {
     // Mapping: proposalId => endTimestamp
-    mapping(uint32 => uint32) public votingEndTimestamp;
+    mapping(uint32 => uint48) public votingEndTimestamp;
     // Mapping: proposalId => votingPeriodEnded
     mapping(uint32 => bool) public votingPeriodEnded;
     // Mapping: proposalId => tokenAddress => tokenId => hasVoted
@@ -23,7 +23,7 @@ contract MockLinearERC721VotingV1 {
 
     function setVotingEndTimestamp(
         uint32 proposalId,
-        uint32 endTimestamp
+        uint48 endTimestamp
     ) external {
         votingEndTimestamp[proposalId] = endTimestamp;
     }


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/253

Fixes [ENG-847](https://linear.app/decent-labs/issue/ENG-847/standardize-votingendtimestamp-to-uint48-for-future-proofing-and-gas)

Updates the `votingEndTimestamp` type to `uint48` across relevant contracts, including voting strategies, validators, Azorius, and mocks.

This change provides a significantly larger range for timestamps compared to `uint32` (preventing issues around the year 2106) while optimizing gas usage compared to `uint256`. The `currentTimestamp` in the `VotingPeriodEnded` event is also updated to `uint48` for consistency.