### PR TITLE
refactor(MultisigFreezeGuardV1): Transition to time-based periods

### DIFF
--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -20,10 +20,10 @@ contract MultisigFreezeGuardV1 is
 {
     uint16 private constant VERSION = 1;
 
-    /** Timelock period (in blocks). */
+    /** Timelock period (in seconds). */
     uint32 public timelockPeriod;
 
-    /** Execution period (in blocks). */
+    /** Execution period (in seconds). */
     uint32 public executionPeriod;
 
     /**
@@ -35,8 +35,8 @@ contract MultisigFreezeGuardV1 is
     /** Reference to the Safe that can be frozen. */
     ISafe public childGnosisSafe;
 
-    /** Mapping of signatures hash to the block during which it was timelocked. */
-    mapping(bytes32 => uint32) internal transactionTimelockedBlock;
+    /** Mapping of signatures hash to the timestamp during which it was timelocked. */
+    mapping(bytes32 => uint48) internal transactionTimelocked;
 
     event MultisigFreezeGuardSetup(
         address creator,
@@ -116,7 +116,7 @@ contract MultisigFreezeGuardV1 is
     ) external {
         bytes32 signaturesHash = keccak256(signatures);
 
-        if (transactionTimelockedBlock[signaturesHash] != 0)
+        if (transactionTimelocked[signaturesHash] != 0)
             revert AlreadyTimelocked();
 
         bytes memory transactionHashData = childGnosisSafe
@@ -142,7 +142,7 @@ contract MultisigFreezeGuardV1 is
             signatures
         );
 
-        transactionTimelockedBlock[signaturesHash] = uint32(block.number);
+        transactionTimelocked[signaturesHash] = uint48(block.timestamp);
 
         emit TransactionTimelocked(msg.sender, transactionHash, signatures);
     }
@@ -176,17 +176,16 @@ contract MultisigFreezeGuardV1 is
     ) external view override(BaseFreezeGuardV1) {
         bytes32 signaturesHash = keccak256(signatures);
 
-        if (transactionTimelockedBlock[signaturesHash] == 0)
-            revert NotTimelocked();
+        if (transactionTimelocked[signaturesHash] == 0) revert NotTimelocked();
 
         if (
-            block.number <
-            transactionTimelockedBlock[signaturesHash] + timelockPeriod
+            block.timestamp <
+            transactionTimelocked[signaturesHash] + timelockPeriod
         ) revert Timelocked();
 
         if (
-            block.number >
-            transactionTimelockedBlock[signaturesHash] +
+            block.timestamp >
+            transactionTimelocked[signaturesHash] +
                 timelockPeriod +
                 executionPeriod
         ) revert Expired();
@@ -206,10 +205,10 @@ contract MultisigFreezeGuardV1 is
     }
 
     /** @inheritdoc IMultisigFreezeGuardV1*/
-    function getTransactionTimelockedBlock(
+    function getTransactionTimelocked(
         bytes32 _signaturesHash
-    ) public view returns (uint32) {
-        return transactionTimelockedBlock[_signaturesHash];
+    ) public view returns (uint48) {
+        return transactionTimelocked[_signaturesHash];
     }
 
     /** Internal implementation of `updateTimelockPeriod` */

--- a/contracts/interfaces/decent/deployables/IMultisigFreezeGuardV1.sol
+++ b/contracts/interfaces/decent/deployables/IMultisigFreezeGuardV1.sol
@@ -82,7 +82,7 @@ interface IMultisigFreezeGuardV1 {
      * @param _signaturesHash hash of the transaction signatures
      * @return uint32 block number in which the transaction began its timelock period
      */
-    function getTransactionTimelockedBlock(
+    function getTransactionTimelocked(
         bytes32 _signaturesHash
-    ) external view returns (uint32);
+    ) external view returns (uint48);
 }

--- a/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -233,9 +233,9 @@ describe('MultisigFreezeGuardV1', () => {
         .withArgs(owner.address, ethers.isHexString, mockSignatures);
 
       // Check that the transaction is now timelocked
-      const timelockedBlock =
-        await multisigFreezeGuard.getTransactionTimelockedBlock(mockSignaturesHash);
-      expect(timelockedBlock).to.not.equal(0);
+      const timelockedTimestamp =
+        await multisigFreezeGuard.getTransactionTimelocked(mockSignaturesHash);
+      expect(timelockedTimestamp).to.not.equal(0);
     });
 
     it('should not allow timelocking the same signatures twice', async () => {
@@ -366,8 +366,7 @@ describe('MultisigFreezeGuardV1', () => {
     });
 
     it('should revert if timelock has expired', async () => {
-      // Mine blocks to make timelock expire
-      await mine(TIMELOCK_PERIOD + EXECUTION_PERIOD + 1);
+      await time.increase(TIMELOCK_PERIOD + EXECUTION_PERIOD + 1);
 
       await expect(
         multisigFreezeGuard.checkTransaction(
@@ -387,8 +386,7 @@ describe('MultisigFreezeGuardV1', () => {
     });
 
     it('should revert if DAO is frozen', async () => {
-      // Mine blocks to pass the timelock period
-      await mine(TIMELOCK_PERIOD + 1);
+      await time.increase(TIMELOCK_PERIOD + 1);
 
       // Set DAO to frozen
       await mockFreezeVoting.setIsFrozen(true);
@@ -411,8 +409,7 @@ describe('MultisigFreezeGuardV1', () => {
     });
 
     it('should allow transaction if properly timelocked and DAO not frozen', async () => {
-      // Mine blocks to pass the timelock period but not expire
-      await mine(TIMELOCK_PERIOD + 1);
+      await time.increase(TIMELOCK_PERIOD + 1);
 
       // Set DAO to not frozen
       await mockFreezeVoting.setIsFrozen(false);
@@ -444,15 +441,13 @@ describe('MultisigFreezeGuardV1', () => {
     });
   });
 
-  describe('getTransactionTimelockedBlock', () => {
+  describe('getTransactionTimelocked', () => {
     it('should return 0 for unknown signatures', async () => {
       const unknownSignatures = ethers.keccak256('0x9999');
-      expect(await multisigFreezeGuard.getTransactionTimelockedBlock(unknownSignatures)).to.equal(
-        0,
-      );
+      expect(await multisigFreezeGuard.getTransactionTimelocked(unknownSignatures)).to.equal(0);
     });
 
-    it('should return correct block number for timelocked signatures', async () => {
+    it('should return correct timestamp for timelocked signatures', async () => {
       // Configure mock Safe for valid signature validation
       await mockSafe.setValidSignature(mockSignaturesHash, true);
 
@@ -471,12 +466,12 @@ describe('MultisigFreezeGuardV1', () => {
         0,
       );
 
-      // Get the current block number
-      const blockNumber = await ethers.provider.getBlockNumber();
+      // Get the current timestamp
+      const timestamp = await time.latest();
 
-      // Check that the returned block number matches
-      expect(await multisigFreezeGuard.getTransactionTimelockedBlock(mockSignaturesHash)).to.equal(
-        blockNumber,
+      // Check that the returned timestamp matches
+      expect(await multisigFreezeGuard.getTransactionTimelocked(mockSignaturesHash)).to.equal(
+        timestamp,
       );
     });
   });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/255

Fixes [ENG-848](https://linear.app/decent-labs/issue/ENG-848/refactor-multisigfreezeguardv1-to-use-time-based-periods-seconds)

Converts `MultisigFreezeGuardV1` from using block numbers to using timestamps for `timelockPeriod` and `executionPeriod`.

Key changes include:
- `timelockPeriod` and `executionPeriod` now represent seconds instead of blocks.
- Internal state `transactionTimelockedBlock` is renamed to `transactionTimelocked` and now stores `block.timestamp` (as `uint48`) instead of `block.number`.
- The getter function `getTransactionTimelockedBlock` is renamed to `getTransactionTimelocked` and returns a `uint48` timestamp.
- All internal logic and comparisons are updated to use `block.timestamp`.
- Tests are refactored to use Hardhat Network Helpers' `time` functions (e.g., `time.increase`, `time.latest`) for advancing time, replacing block-based mining.
- Comments and event descriptions are updated to reflect the change from blocks to seconds.

This change ensures that the freeze guard's timing mechanisms are more consistent and predictable, regardless of fluctuations in block production speed.