### PR TITLE
refactor(FreezeVoting): Transition freeze voting to time-based periods

### DIFF
--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -29,13 +29,13 @@ abstract contract BaseFreezeVotingV1 is
     IBaseFreezeVotingV1,
     ERC165
 {
-    /** Block number the freeze proposal was created at. */
-    uint32 public freezeProposalCreatedBlock;
+    /** Timestamp the freeze proposal was created at. */
+    uint48 public freezeProposalCreated;
 
-    /** Number of blocks a freeze proposal has to succeed. */
+    /** Number of seconds a freeze proposal has to succeed. */
     uint32 public freezeProposalPeriod;
 
-    /** Number of blocks a freeze lasts, from time of freeze proposal creation. */
+    /** Number of seconds a freeze lasts, from time of freeze proposal creation. */
     uint32 public freezePeriod;
 
     /** Number of freeze votes required to activate a freeze. */
@@ -45,10 +45,10 @@ abstract contract BaseFreezeVotingV1 is
     uint256 public freezeProposalVoteCount;
 
     /**
-     * Mapping of address to the block the freeze vote was started to
+     * Mapping of address to the timestamp the freeze vote was started to
      * whether the address has voted yet on the freeze proposal.
      */
-    mapping(address => mapping(uint256 => bool)) public userHasFreezeVoted;
+    mapping(address => mapping(uint48 => bool)) public userHasFreezeVoted;
 
     event FreezeVoteCast(address indexed voter, uint256 votesCast);
     event FreezeProposalCreated(address indexed creator);
@@ -86,14 +86,14 @@ abstract contract BaseFreezeVotingV1 is
     function isFrozen() external view returns (bool) {
         return
             freezeProposalVoteCount >= freezeVotesThreshold &&
-            block.number < freezeProposalCreatedBlock + freezePeriod;
+            block.timestamp < freezeProposalCreated + freezePeriod;
     }
 
     /**
      * Unfreezes the DAO, only callable by the owner (parentDAO).
      */
     function unfreeze() external onlyOwner {
-        freezeProposalCreatedBlock = 0;
+        freezeProposalCreated = 0;
         freezeProposalVoteCount = 0;
     }
 

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -32,8 +32,8 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
      *
      * @param _owner The owner of the contract
      * @param _freezeVotesThreshold The number of votes required to activate a freeze
-     * @param _freezeProposalPeriod The number of blocks a freeze proposal has to succeed
-     * @param _freezePeriod The number of blocks a freeze lasts
+     * @param _freezeProposalPeriod The number of seconds a freeze proposal has to succeed
+     * @param _freezePeriod The number of seconds a freeze lasts
      * @param _votesERC20 The ERC20 voting token contract address
      */
     function initialize(
@@ -65,14 +65,14 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
     function castFreezeVote() external override {
         uint256 userVotes;
 
-        if (block.number > freezeProposalCreatedBlock + freezeProposalPeriod) {
+        if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
             // create a new freeze proposal and set total votes to msg.sender's vote count
 
-            freezeProposalCreatedBlock = uint32(block.number);
+            freezeProposalCreated = uint48(block.timestamp);
 
             userVotes = votesERC20.getPastVotes(
                 msg.sender,
-                freezeProposalCreatedBlock - 1
+                freezeProposalCreated - 1
             );
 
             if (userVotes == 0) revert NoVotes();
@@ -83,12 +83,12 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
         } else {
             // there is an existing freeze proposal, count user's votes toward it
 
-            if (userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock])
+            if (userHasFreezeVoted[msg.sender][freezeProposalCreated])
                 revert AlreadyVoted();
 
             userVotes = votesERC20.getPastVotes(
                 msg.sender,
-                freezeProposalCreatedBlock - 1
+                freezeProposalCreated - 1
             );
 
             if (userVotes == 0) revert NoVotes();
@@ -96,7 +96,7 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
             freezeProposalVoteCount += userVotes;
         }
 
-        userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock] = true;
+        userHasFreezeVoted[msg.sender][freezeProposalCreated] = true;
 
         emit FreezeVoteCast(msg.sender, userVotes);
     }

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -41,8 +41,8 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
      *
      * @param _owner The owner of the contract
      * @param _freezeVotesThreshold The number of votes required to activate a freeze
-     * @param _freezeProposalPeriod The number of blocks a freeze proposal has to succeed
-     * @param _freezePeriod The number of blocks a freeze lasts
+     * @param _freezeProposalPeriod The number of seconds a freeze proposal has to succeed
+     * @param _freezePeriod The number of seconds a freeze lasts
      * @param _strategy The address of the voting strategy
      */
     function initialize(
@@ -81,9 +81,9 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
     ) external {
         if (_tokenAddresses.length != _tokenIds.length) revert UnequalArrays();
 
-        if (block.number > freezeProposalCreatedBlock + freezeProposalPeriod) {
+        if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
             // create a new freeze proposal
-            freezeProposalCreatedBlock = uint32(block.number);
+            freezeProposalCreated = uint48(block.timestamp);
             freezeProposalVoteCount = 0;
             emit FreezeProposalCreated(msg.sender);
         }
@@ -113,15 +113,12 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
 
             if (_voter != IERC721(tokenAddress).ownerOf(tokenId)) continue;
 
-            if (
-                idHasFreezeVoted[freezeProposalCreatedBlock][tokenAddress][
-                    tokenId
-                ]
-            ) continue;
+            if (idHasFreezeVoted[freezeProposalCreated][tokenAddress][tokenId])
+                continue;
 
             votes += strategy.getTokenWeight(tokenAddress);
 
-            idHasFreezeVoted[freezeProposalCreatedBlock][tokenAddress][
+            idHasFreezeVoted[freezeProposalCreated][tokenAddress][
                 tokenId
             ] = true;
         }

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -30,8 +30,8 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
      *
      * @param _owner The owner of the contract
      * @param _freezeVotesThreshold The number of votes required to activate a freeze
-     * @param _freezeProposalPeriod The number of blocks a freeze proposal has to succeed
-     * @param _freezePeriod The number of blocks a freeze lasts
+     * @param _freezeProposalPeriod The number of seconds a freeze proposal has to succeed
+     * @param _freezePeriod The number of seconds a freeze lasts
      * @param _parentSafe The address of the parent Safe contract
      */
     function initialize(
@@ -63,10 +63,10 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
     function castFreezeVote() external override {
         if (!parentSafe.isOwner(msg.sender)) revert NotOwner();
 
-        if (block.number > freezeProposalCreatedBlock + freezeProposalPeriod) {
+        if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
             // create a new freeze proposal and count the caller's vote
 
-            freezeProposalCreatedBlock = uint32(block.number);
+            freezeProposalCreated = uint48(block.timestamp);
 
             freezeProposalVoteCount = 1;
 
@@ -74,13 +74,13 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
         } else {
             // there is an existing freeze proposal, count the caller's vote
 
-            if (userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock])
+            if (userHasFreezeVoted[msg.sender][freezeProposalCreated])
                 revert AlreadyVoted();
 
             freezeProposalVoteCount++;
         }
 
-        userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock] = true;
+        userHasFreezeVoted[msg.sender][freezeProposalCreated] = true;
 
         emit FreezeVoteCast(msg.sender, 1);
     }

--- a/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
@@ -39,20 +39,20 @@ interface IBaseFreezeVotingV1 {
 
     /**
      * Updates the freeze proposal period for future freeze votes. This is the length of time
-     * (in blocks) that a freeze vote is conducted for.
+     * (in seconds) that a freeze vote is conducted for.
      *
-     * @param _freezeProposalPeriod number of blocks a freeze proposal has to succeed
+     * @param _freezeProposalPeriod number of seconds a freeze proposal has to succeed
      */
     function updateFreezeProposalPeriod(uint32 _freezeProposalPeriod) external;
 
     /**
-     * Updates the freeze period. This is the length of time (in blocks) the subDAO is actually
+     * Updates the freeze period. This is the length of time (in seconds) the subDAO is actually
      * frozen for if a freeze vote passes.
      *
      * This period can be overridden by a call to `unfreeze()`, which would require a passed Proposal
      * from the parentDAO.
      *
-     * @param _freezePeriod number of blocks a freeze lasts, from time of freeze proposal creation
+     * @param _freezePeriod number of seconds a freeze lasts, from time of freeze proposal creation
      */
     function updateFreezePeriod(uint32 _freezePeriod) external;
 

--- a/contracts/mocks/concretes/deployables/freeze-voting/ConcreteBaseFreezeVotingV1.sol
+++ b/contracts/mocks/concretes/deployables/freeze-voting/ConcreteBaseFreezeVotingV1.sol
@@ -35,21 +35,21 @@ contract ConcreteBaseFreezeVotingV1 is BaseFreezeVotingV1 {
      */
     function castFreezeVote() external override {
         // If no freeze proposal exists yet, create one
-        if (freezeProposalCreatedBlock == 0) {
-            freezeProposalCreatedBlock = uint32(block.number);
+        if (freezeProposalCreated == 0) {
+            freezeProposalCreated = uint48(block.timestamp);
             freezeProposalVoteCount = 0; // Initialize to zero
             emit FreezeProposalCreated(msg.sender);
         }
 
         // Check if proposal period has expired
         require(
-            block.number <= freezeProposalCreatedBlock + freezeProposalPeriod,
+            block.timestamp <= freezeProposalCreated + freezeProposalPeriod,
             "Freeze proposal period expired"
         );
 
         // Check if the user has already voted on this proposal
         require(
-            !userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock],
+            !userHasFreezeVoted[msg.sender][freezeProposalCreated],
             "Already voted"
         );
 
@@ -57,7 +57,7 @@ contract ConcreteBaseFreezeVotingV1 is BaseFreezeVotingV1 {
         uint256 _mockVotePower = 1;
 
         // Record the vote
-        userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock] = true;
+        userHasFreezeVoted[msg.sender][freezeProposalCreated] = true;
         freezeProposalVoteCount += _mockVotePower;
 
         emit FreezeVoteCast(msg.sender, _mockVotePower);

--- a/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -114,7 +114,7 @@ describe('BaseFreezeVotingV1', () => {
   describe('Freeze Voting Process', () => {
     it('should create a freeze proposal on first vote', async () => {
       // Initial state
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(0);
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(0);
 
       // First vote creates the proposal
@@ -125,8 +125,8 @@ describe('BaseFreezeVotingV1', () => {
         .withArgs(voter1.address, 1);
 
       // Check state after first vote
-      const currentBlock = await ethers.provider.getBlockNumber();
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(currentBlock);
+      const currentTimestamp = await time.latest();
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(currentTimestamp);
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(1);
     });
 
@@ -162,8 +162,8 @@ describe('BaseFreezeVotingV1', () => {
       // First vote to create proposal
       await freezeVoting.connect(voter1).castFreezeVote();
 
-      // Mine blocks to pass the freeze proposal period
-      await mine(FREEZE_PROPOSAL_PERIOD + 1);
+      // Increase time to pass the freeze proposal period
+      await time.increase(FREEZE_PROPOSAL_PERIOD + 1);
 
       // New vote should be rejected
       await expect(freezeVoting.connect(voter2).castFreezeVote()).to.be.revertedWith(
@@ -205,8 +205,8 @@ describe('BaseFreezeVotingV1', () => {
       // Should be frozen initially
       void expect(await freezeVoting.isFrozen()).to.be.true;
 
-      // Mine blocks to pass the freeze period
-      await mine(FREEZE_PERIOD + 1);
+      // Increase time to pass the freeze period
+      await time.increase(FREEZE_PERIOD + 1);
 
       // Should no longer be frozen
       void expect(await freezeVoting.isFrozen()).to.be.false;
@@ -228,7 +228,7 @@ describe('BaseFreezeVotingV1', () => {
       void expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Check that state was reset
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(0);
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(0);
     });
 
@@ -347,15 +347,16 @@ describe('BaseFreezeVotingV1', () => {
   describe('User Has Voted Tracking', () => {
     it('should correctly track if a user has voted on a proposal', async () => {
       // Initial state - user has not voted
-      const createdBlock = await freezeVoting.freezeProposalCreatedBlock();
-      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, createdBlock)).to.be.false;
+      const createdTimestamp = await freezeVoting.freezeProposalCreated();
+      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, createdTimestamp)).to.be
+        .false;
 
       // User votes
       await freezeVoting.connect(voter1).castFreezeVote();
 
       // Updated state - user has voted
-      const newCreatedBlock = await freezeVoting.freezeProposalCreatedBlock();
-      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, newCreatedBlock)).to.be
+      const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
+      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, newCreatedTimestamp)).to.be
         .true;
     });
 
@@ -363,26 +364,27 @@ describe('BaseFreezeVotingV1', () => {
       // User votes
       await freezeVoting.connect(voter1).castFreezeVote();
 
-      // Get the created block number
-      const createdBlock = await freezeVoting.freezeProposalCreatedBlock();
+      // Get the created timestamp
+      const createdTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Check that user has voted
-      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, createdBlock)).to.be.true;
+      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, createdTimestamp)).to.be
+        .true;
 
       // Owner unfreezes
       await freezeVoting.connect(owner).unfreeze();
 
-      // The createdBlock is now 0, so the voting status should be reset
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(0);
+      // The created timestamp is now 0, so the voting status should be reset
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
 
       // User should be able to vote again on a new proposal
       await freezeVoting.connect(voter1).castFreezeVote();
 
-      // Get the new created block number
-      const newCreatedBlock = await freezeVoting.freezeProposalCreatedBlock();
+      // Get the new created timestamp
+      const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Check that user has voted on the new proposal
-      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, newCreatedBlock)).to.be
+      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, newCreatedTimestamp)).to.be
         .true;
     });
   });

--- a/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { mine, time } from '@nomicfoundation/hardhat-network-helpers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -150,9 +150,9 @@ describe('ERC20FreezeVotingV1', () => {
     });
 
     it('should create a freeze proposal when first user votes', async () => {
-      // Set up mock past votes for the block
-      const voteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter1.address, voteBlock, VOTER1_TOKENS);
+      // Set up mock past votes for the timestamp
+      const voteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter1.address, voteTimestamp, VOTER1_TOKENS);
 
       // Cast the first vote
       await expect(freezeVoting.connect(voter1).castFreezeVote())
@@ -162,16 +162,16 @@ describe('ERC20FreezeVotingV1', () => {
         .withArgs(voter1.address, VOTER1_TOKENS);
 
       // Check state after vote
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.be.gt(0); // Just check that a block was recorded
+      expect(await freezeVoting.freezeProposalCreated()).to.be.gt(0); // Just check that a timestamp was recorded
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(VOTER1_TOKENS);
     });
 
     it('should accumulate votes correctly based on token balances', async () => {
       // Set up mock past votes for voters
-      const voteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter1.address, voteBlock, VOTER1_TOKENS);
-      await votesToken.setPastVotes(voter2.address, voteBlock, VOTER2_TOKENS);
-      await votesToken.setPastVotes(voter3.address, voteBlock, VOTER3_TOKENS);
+      const voteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter1.address, voteTimestamp, VOTER1_TOKENS);
+      await votesToken.setPastVotes(voter2.address, voteTimestamp, VOTER2_TOKENS);
+      await votesToken.setPastVotes(voter3.address, voteTimestamp, VOTER3_TOKENS);
 
       // First vote
       await freezeVoting.connect(voter1).castFreezeVote();
@@ -189,9 +189,9 @@ describe('ERC20FreezeVotingV1', () => {
     });
 
     it('should prevent duplicate votes from the same user', async () => {
-      // Set up mock past votes for the vote block
-      const voteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter1.address, voteBlock, VOTER1_TOKENS);
+      // Set up mock past votes for the vote timestamp
+      const voteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter1.address, voteTimestamp, VOTER1_TOKENS);
 
       // First vote
       await freezeVoting.connect(voter1).castFreezeVote();
@@ -205,19 +205,19 @@ describe('ERC20FreezeVotingV1', () => {
 
     it('should reject votes after proposal period expiry', async () => {
       // Set up mock past votes for voters
-      const voteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter1.address, voteBlock, VOTER1_TOKENS);
-      await votesToken.setPastVotes(voter2.address, voteBlock, VOTER2_TOKENS);
+      const voteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter1.address, voteTimestamp, VOTER1_TOKENS);
+      await votesToken.setPastVotes(voter2.address, voteTimestamp, VOTER2_TOKENS);
 
       // First vote to create proposal
       await freezeVoting.connect(voter1).castFreezeVote();
 
-      // Mine blocks to pass the freeze proposal period
-      await mine(FREEZE_PROPOSAL_PERIOD + 1);
+      // Increase time to pass the freeze proposal period
+      await time.increase(FREEZE_PROPOSAL_PERIOD + 1);
 
       // Second vote should create a new proposal, not add to the expired one
-      const voteBlock2 = await time.latestBlock();
-      await votesToken.setPastVotes(voter2.address, voteBlock2, VOTER2_TOKENS);
+      const voteTimestamp2 = await time.latest();
+      await votesToken.setPastVotes(voter2.address, voteTimestamp2, VOTER2_TOKENS);
 
       await expect(freezeVoting.connect(voter2).castFreezeVote())
         .to.emit(freezeVoting, 'FreezeProposalCreated')
@@ -231,10 +231,10 @@ describe('ERC20FreezeVotingV1', () => {
   describe('Freeze State', () => {
     beforeEach(async () => {
       // Set up mock past votes for all voters
-      const voteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter1.address, voteBlock, VOTER1_TOKENS);
-      await votesToken.setPastVotes(voter2.address, voteBlock, VOTER2_TOKENS);
-      await votesToken.setPastVotes(voter3.address, voteBlock, VOTER3_TOKENS);
+      const voteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter1.address, voteTimestamp, VOTER1_TOKENS);
+      await votesToken.setPastVotes(voter2.address, voteTimestamp, VOTER2_TOKENS);
+      await votesToken.setPastVotes(voter3.address, voteTimestamp, VOTER3_TOKENS);
     });
 
     it('should not be frozen initially', async () => {
@@ -269,8 +269,8 @@ describe('ERC20FreezeVotingV1', () => {
       // Should be frozen initially
       void expect(await freezeVoting.isFrozen()).to.be.true;
 
-      // Mine blocks to pass the freeze period
-      await mine(FREEZE_PERIOD + 1);
+      // Increase time to pass the freeze period
+      await time.increase(FREEZE_PERIOD + 1);
 
       // Should no longer be frozen
       void expect(await freezeVoting.isFrozen()).to.be.false;
@@ -292,7 +292,7 @@ describe('ERC20FreezeVotingV1', () => {
       void expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Check that state was reset
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(0);
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(0);
     });
 
@@ -328,9 +328,9 @@ describe('ERC20FreezeVotingV1', () => {
       void expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Set up mock past votes for new proposal
-      const newVoteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter1.address, newVoteBlock, VOTER1_TOKENS);
-      await votesToken.setPastVotes(voter2.address, newVoteBlock, VOTER2_TOKENS);
+      const newVoteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter1.address, newVoteTimestamp, VOTER1_TOKENS);
+      await votesToken.setPastVotes(voter2.address, newVoteTimestamp, VOTER2_TOKENS);
 
       // Start a new proposal with not enough votes
       await freezeVoting.connect(voter1).castFreezeVote();
@@ -340,8 +340,8 @@ describe('ERC20FreezeVotingV1', () => {
       void expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Set up mock past votes for voter3
-      const finalVoteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter3.address, finalVoteBlock, VOTER3_TOKENS);
+      const finalVoteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter3.address, finalVoteTimestamp, VOTER3_TOKENS);
 
       // Add the third vote to reach threshold
       await freezeVoting.connect(voter3).castFreezeVote();
@@ -402,10 +402,10 @@ describe('ERC20FreezeVotingV1', () => {
 
     it('should affect freeze status when threshold is updated', async () => {
       // Set up mock past votes for all voters
-      const voteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter1.address, voteBlock, VOTER1_TOKENS);
-      await votesToken.setPastVotes(voter2.address, voteBlock, VOTER2_TOKENS);
-      await votesToken.setPastVotes(voter3.address, voteBlock, VOTER3_TOKENS);
+      const voteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter1.address, voteTimestamp, VOTER1_TOKENS);
+      await votesToken.setPastVotes(voter2.address, voteTimestamp, VOTER2_TOKENS);
+      await votesToken.setPastVotes(voter3.address, voteTimestamp, VOTER3_TOKENS);
 
       // Cast votes to meet the threshold of 300
       await freezeVoting.connect(voter1).castFreezeVote();
@@ -426,21 +426,22 @@ describe('ERC20FreezeVotingV1', () => {
   describe('User Has Voted Tracking', () => {
     beforeEach(async () => {
       // Set up mock past votes for voter1
-      const voteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter1.address, voteBlock, VOTER1_TOKENS);
+      const voteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter1.address, voteTimestamp, VOTER1_TOKENS);
     });
 
     it('should correctly track if a user has voted on a proposal', async () => {
       // Initial state - user has not voted
-      const createdBlock = await freezeVoting.freezeProposalCreatedBlock();
-      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, createdBlock)).to.be.false;
+      const createdTimestamp = await freezeVoting.freezeProposalCreated();
+      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, createdTimestamp)).to.be
+        .false;
 
       // User votes
       await freezeVoting.connect(voter1).castFreezeVote();
 
       // Updated state - user has voted
-      const newCreatedBlock = await freezeVoting.freezeProposalCreatedBlock();
-      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, newCreatedBlock)).to.be
+      const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
+      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, newCreatedTimestamp)).to.be
         .true;
     });
 
@@ -448,30 +449,31 @@ describe('ERC20FreezeVotingV1', () => {
       // User votes
       await freezeVoting.connect(voter1).castFreezeVote();
 
-      // Get the created block number
-      const createdBlock = await freezeVoting.freezeProposalCreatedBlock();
+      // Get the created timestamp
+      const createdTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Check that user has voted
-      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, createdBlock)).to.be.true;
+      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, createdTimestamp)).to.be
+        .true;
 
       // Owner unfreezes
       await freezeVoting.connect(owner).unfreeze();
 
-      // The createdBlock is now 0, so the voting status should be reset
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(0);
+      // The created timestamp is now 0, so the voting status should be reset
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
 
-      // Set up mock past votes for the new block
-      const newVoteBlock = await time.latestBlock();
-      await votesToken.setPastVotes(voter1.address, newVoteBlock, VOTER1_TOKENS);
+      // Set up mock past votes for the new timestamp
+      const newVoteTimestamp = await time.latest();
+      await votesToken.setPastVotes(voter1.address, newVoteTimestamp, VOTER1_TOKENS);
 
       // User should be able to vote again on a new proposal
       await freezeVoting.connect(voter1).castFreezeVote();
 
-      // Get the new created block number
-      const newCreatedBlock = await freezeVoting.freezeProposalCreatedBlock();
+      // Get the new created timestamp
+      const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Check that user has voted on the new proposal
-      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, newCreatedBlock)).to.be
+      void expect(await freezeVoting.userHasFreezeVoted(voter1.address, newCreatedTimestamp)).to.be
         .true;
     });
   });

--- a/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -216,7 +216,7 @@ describe('ERC721FreezeVotingV1', () => {
         .withArgs(voter1.address, TOKEN1_WEIGHT);
 
       // Check state after vote
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.be.gt(0); // Just check that a block was recorded
+      expect(await freezeVoting.freezeProposalCreated()).to.be.gt(0); // Just check that a timestamp was recorded
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(TOKEN1_WEIGHT);
     });
 
@@ -307,10 +307,10 @@ describe('ERC721FreezeVotingV1', () => {
       await freezeVoting
         .connect(voter1)
         ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
-      const firstProposalBlock = await freezeVoting.freezeProposalCreatedBlock();
+      const firstProposalTimestamp = await freezeVoting.freezeProposalCreated();
 
-      // Mine blocks to pass the freeze proposal period
-      await mine(FREEZE_PROPOSAL_PERIOD + 1);
+      // Increase time to pass the freeze proposal period
+      await time.increase(FREEZE_PROPOSAL_PERIOD + 1);
 
       // Second vote should create a new proposal
       await expect(
@@ -321,9 +321,9 @@ describe('ERC721FreezeVotingV1', () => {
         .to.emit(freezeVoting, 'FreezeProposalCreated')
         .withArgs(voter2.address);
 
-      // New proposal should have a different block number
-      const secondProposalBlock = await freezeVoting.freezeProposalCreatedBlock();
-      expect(secondProposalBlock).to.not.equal(firstProposalBlock);
+      // New proposal should have a different timestamp
+      const secondProposalTimestamp = await freezeVoting.freezeProposalCreated();
+      expect(secondProposalTimestamp).to.not.equal(firstProposalTimestamp);
 
       // Vote count should be just voter2's vote
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(TOKEN2_WEIGHT);
@@ -367,8 +367,8 @@ describe('ERC721FreezeVotingV1', () => {
       // Should be frozen initially
       void expect(await freezeVoting.isFrozen()).to.be.true;
 
-      // Mine blocks to pass the freeze period
-      await mine(FREEZE_PERIOD + 1);
+      // Increase time to pass the freeze period
+      await time.increase(FREEZE_PERIOD + 1);
 
       // Should no longer be frozen
       void expect(await freezeVoting.isFrozen()).to.be.false;
@@ -390,7 +390,7 @@ describe('ERC721FreezeVotingV1', () => {
       void expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Check that state was reset
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(0);
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(0);
     });
 
@@ -511,12 +511,12 @@ describe('ERC721FreezeVotingV1', () => {
 
   describe('Token Has Voted Tracking', () => {
     it('should correctly track if a token has been used to vote', async () => {
-      const createdBlock = 0; // Initial state
+      const createdTimestamp = 0; // Initial state
 
       // Initial state - token has not been used to vote
       void expect(
         await freezeVoting.idHasFreezeVoted(
-          createdBlock,
+          createdTimestamp,
           voter1TokenAddresses[0],
           voter1TokenIds[0],
         ),
@@ -527,13 +527,13 @@ describe('ERC721FreezeVotingV1', () => {
         .connect(voter1)
         ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
 
-      // Get the proposal created block
-      const newCreatedBlock = await freezeVoting.freezeProposalCreatedBlock();
+      // Get the proposal created timestamp
+      const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Updated state - token has been used to vote
       void expect(
         await freezeVoting.idHasFreezeVoted(
-          newCreatedBlock,
+          newCreatedTimestamp,
           voter1TokenAddresses[0],
           voter1TokenIds[0],
         ),
@@ -546,13 +546,13 @@ describe('ERC721FreezeVotingV1', () => {
         .connect(voter1)
         ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
 
-      // Get the created block number
-      const createdBlock = await freezeVoting.freezeProposalCreatedBlock();
+      // Get the created timestamp
+      const createdTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Check that token has been used to vote
       void expect(
         await freezeVoting.idHasFreezeVoted(
-          createdBlock,
+          createdTimestamp,
           voter1TokenAddresses[0],
           voter1TokenIds[0],
         ),
@@ -561,19 +561,19 @@ describe('ERC721FreezeVotingV1', () => {
       // Owner unfreezes
       await freezeVoting.connect(owner).unfreeze();
 
-      // The createdBlock is now 0, so the voting status is implicitly reset
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(0);
+      // The created timestamp is now 0, so the voting status is implicitly reset
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
 
       // User should be able to vote again with the same token
       await freezeVoting
         .connect(voter1)
         ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
-      const newCreatedBlock = await freezeVoting.freezeProposalCreatedBlock();
+      const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // The token should be marked as voted for the new proposal
       void expect(
         await freezeVoting.idHasFreezeVoted(
-          newCreatedBlock,
+          newCreatedTimestamp,
           voter1TokenAddresses[0],
           voter1TokenIds[0],
         ),

--- a/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -147,7 +147,7 @@ describe('MultisigFreezeVotingV1', () => {
         .withArgs(safeOwner1.address, 1);
 
       // Check state after vote
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.be.gt(0); // Just check that a block was recorded
+      expect(await freezeVoting.freezeProposalCreated()).to.be.gt(0); // Just check that a timestamp was recorded
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(1);
     });
 
@@ -187,10 +187,10 @@ describe('MultisigFreezeVotingV1', () => {
 
       // First proposal
       await freezeVoting.connect(safeOwner1).castFreezeVote();
-      const firstProposalBlock = await freezeVoting.freezeProposalCreatedBlock();
+      const firstProposalTimestamp = await freezeVoting.freezeProposalCreated();
 
-      // Mine blocks to pass the freeze proposal period
-      await mine(FREEZE_PROPOSAL_PERIOD + 1);
+      // Increase time to pass the freeze proposal period
+      await time.increase(FREEZE_PROPOSAL_PERIOD + 1);
 
       // Change Safe owner for second vote
       await mockSafe.setOwner(safeOwner2.address);
@@ -200,9 +200,9 @@ describe('MultisigFreezeVotingV1', () => {
         .to.emit(freezeVoting, 'FreezeProposalCreated')
         .withArgs(safeOwner2.address);
 
-      // New proposal should have a different block number
-      const secondProposalBlock = await freezeVoting.freezeProposalCreatedBlock();
-      expect(secondProposalBlock).to.not.equal(firstProposalBlock);
+      // New proposal should have a different timestamp
+      const secondProposalTimestamp = await freezeVoting.freezeProposalCreated();
+      expect(secondProposalTimestamp).to.not.equal(firstProposalTimestamp);
 
       // Vote count should be reset to 1
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(1);
@@ -258,8 +258,8 @@ describe('MultisigFreezeVotingV1', () => {
       // Should be frozen initially
       void expect(await freezeVoting.isFrozen()).to.be.true;
 
-      // Mine blocks to pass the freeze period
-      await mine(FREEZE_PERIOD + 1);
+      // Increase time to pass the freeze period
+      await time.increase(FREEZE_PERIOD + 1);
 
       // Should no longer be frozen
       void expect(await freezeVoting.isFrozen()).to.be.false;
@@ -288,7 +288,7 @@ describe('MultisigFreezeVotingV1', () => {
       void expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Check that state was reset
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(0);
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(0);
     });
 
@@ -434,19 +434,19 @@ describe('MultisigFreezeVotingV1', () => {
       await mockSafe.setOwner(safeOwner1.address);
 
       // Initial state - user has not voted
-      const createdBlock = await freezeVoting.freezeProposalCreatedBlock();
-      void expect(await freezeVoting.userHasFreezeVoted(safeOwner1.address, createdBlock)).to.be
+      const createdTimestamp = await freezeVoting.freezeProposalCreated();
+      void expect(await freezeVoting.userHasFreezeVoted(safeOwner1.address, createdTimestamp)).to.be
         .false;
 
       // User votes
       await freezeVoting.connect(safeOwner1).castFreezeVote();
 
-      // Get the new created block number
-      const newCreatedBlock = await freezeVoting.freezeProposalCreatedBlock();
+      // Get the new created timestamp
+      const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Updated state - user has voted
-      void expect(await freezeVoting.userHasFreezeVoted(safeOwner1.address, newCreatedBlock)).to.be
-        .true;
+      void expect(await freezeVoting.userHasFreezeVoted(safeOwner1.address, newCreatedTimestamp)).to
+        .be.true;
     });
 
     it('should reset user voting status when unfreeze is called', async () => {
@@ -456,26 +456,26 @@ describe('MultisigFreezeVotingV1', () => {
       // User votes
       await freezeVoting.connect(safeOwner1).castFreezeVote();
 
-      // Get the created block number
-      const createdBlock = await freezeVoting.freezeProposalCreatedBlock();
+      // Get the created timestamp
+      const createdTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Check that user has voted
-      void expect(await freezeVoting.userHasFreezeVoted(safeOwner1.address, createdBlock)).to.be
+      void expect(await freezeVoting.userHasFreezeVoted(safeOwner1.address, createdTimestamp)).to.be
         .true;
 
       // Owner unfreezes
       await freezeVoting.connect(owner).unfreeze();
 
-      // The createdBlock is now 0, so the voting status is reset
-      expect(await freezeVoting.freezeProposalCreatedBlock()).to.equal(0);
+      // The created timestamp is now 0, so the voting status is reset
+      expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
 
       // User should be able to vote again
       await freezeVoting.connect(safeOwner1).castFreezeVote();
-      const newCreatedBlock = await freezeVoting.freezeProposalCreatedBlock();
+      const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // User has voted on the new proposal
-      void expect(await freezeVoting.userHasFreezeVoted(safeOwner1.address, newCreatedBlock)).to.be
-        .true;
+      void expect(await freezeVoting.userHasFreezeVoted(safeOwner1.address, newCreatedTimestamp)).to
+        .be.true;
     });
   });
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/256

Fixes [ENG-849](https://linear.app/decent-labs/issue/ENG-849/refactor-all-freeze-voting-contracts-to-use-time-based-periods-seconds)

Converts `BaseFreezeVotingV1` and its concrete implementations (`ERC20FreezeVotingV1`, `ERC721FreezeVotingV1`, `MultisigFreezeVotingV1`) from using block numbers to using timestamps for freeze proposal and duration periods.

Key changes include:
- `freezeProposalCreatedBlock` (uint32) is renamed to `freezeProposalCreated` and now stores `block.timestamp` (as `uint48`).
- `freezeProposalPeriod` and `freezePeriod` now represent durations in seconds, and their descriptions are updated accordingly.
- The `userHasFreezeVoted` mapping in `BaseFreezeVotingV1` now uses the `freezeProposalCreated` timestamp as its second key.
- The `idHasFreezeVoted` mapping in `ERC721FreezeVotingV1` also now uses the `freezeProposalCreated` timestamp as its first key.
- All internal logic, including checking for proposal expiry and freeze duration in `isFrozen()`, now uses `block.timestamp`.
- Tests for all affected freeze voting contracts and the base contract are updated to use Hardhat Network Helpers' `time` functions (e.g., `time.increase`, `time.latest`) instead of `mine`.
- Interface descriptions and mock implementations are updated to reflect the change from blocks to seconds/timestamps.

This refactoring ensures that the timing of freeze proposals and the duration of freezes are determined by actual time, making the system more consistent and less dependent on block production rates.