### PR TITLE
feat(governance): Introduce ClockModeLib for standardized time handling

### DIFF
--- a/contracts/interfaces/decent/ClockMode.sol
+++ b/contracts/interfaces/decent/ClockMode.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+/**
+ * @title ClockMode
+ * @dev Enum to distinguish between timestamp-based and block number-based time.
+ */
+enum ClockMode {
+    Timestamp,
+    BlockNumber
+}

--- a/contracts/libs/ClockModeLib.sol
+++ b/contracts/libs/ClockModeLib.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {ClockMode} from "../interfaces/decent/ClockMode.sol";
+import {IERC6372} from "@openzeppelin/contracts/interfaces/IERC6372.sol";
+
+/**
+ * @title ClockModeLib
+ * @dev Library for handling operations related to ClockMode.
+ */
+library ClockModeLib {
+    bytes32 internal constant CLOCK_MODE_TIMESTAMP_BYTES32 =
+        keccak256("mode=timestamp");
+
+    /**
+     * @dev Gets the clock mode of a token.
+     * Attempts to call CLOCK_MODE() on the token. If it reverts or returns an unexpected value,
+     * defaults to BlockNumber.
+     * @param _token The token address.
+     * @return The detected ClockMode.
+     */
+    function getClockMode(address _token) internal view returns (ClockMode) {
+        try IERC6372(_token).CLOCK_MODE() returns (string memory mode) {
+            if (keccak256(bytes(mode)) == CLOCK_MODE_TIMESTAMP_BYTES32) {
+                return ClockMode.Timestamp;
+            }
+            return ClockMode.BlockNumber;
+        } catch {
+            return ClockMode.BlockNumber;
+        }
+    }
+
+    /**
+     * @dev Gets the current time point (block number or timestamp) based on the ClockMode.
+     * @param _mode The ClockMode to use.
+     * @return The current time point.
+     */
+    function getCurrentPoint(ClockMode _mode) internal view returns (uint256) {
+        if (_mode == ClockMode.Timestamp) {
+            return block.timestamp;
+        } else {
+            return block.number;
+        }
+    }
+}

--- a/contracts/mocks/ClockModeLibTester.sol
+++ b/contracts/mocks/ClockModeLibTester.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {ClockModeLib} from "../libs/ClockModeLib.sol";
+import {ClockMode} from "../interfaces/decent/ClockMode.sol";
+
+contract ClockModeLibTester {
+    function getClockModeFromLib(
+        address token
+    ) external view returns (ClockMode) {
+        return ClockModeLib.getClockMode(token);
+    }
+
+    function getCurrentPointFromLib(
+        ClockMode mode
+    ) external view returns (uint256) {
+        return ClockModeLib.getCurrentPoint(mode);
+    }
+}

--- a/contracts/mocks/MockBlockNumberToken.sol
+++ b/contracts/mocks/MockBlockNumberToken.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IERC6372} from "@openzeppelin/contracts/interfaces/IERC6372.sol";
+
+contract MockBlockNumberToken is IERC6372 {
+    function CLOCK_MODE() external pure returns (string memory) {
+        return "mode=blocknumber&from=default"; // Or any string not "mode=timestamp"
+    }
+
+    function clock() external view returns (uint48) {
+        return uint48(block.number);
+    }
+}

--- a/contracts/mocks/MockNonIERC6372Token.sol
+++ b/contracts/mocks/MockNonIERC6372Token.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+contract MockNonIERC6372Token {
+    // This contract deliberately does not implement IERC6372.
+    // It can have other functions, but not CLOCK_MODE() or clock() from that interface.
+    function someOtherFunction() external pure returns (bool) {
+        return true;
+    }
+}

--- a/contracts/mocks/MockRevertingToken.sol
+++ b/contracts/mocks/MockRevertingToken.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IERC6372} from "@openzeppelin/contracts/interfaces/IERC6372.sol";
+
+contract MockRevertingToken is IERC6372 {
+    function CLOCK_MODE() external pure returns (string memory) {
+        revert("CLOCK_MODE_REVERT");
+    }
+
+    function clock() external pure returns (uint48) {
+        revert("CLOCK_REVERT");
+    }
+}

--- a/contracts/mocks/MockTimestampToken.sol
+++ b/contracts/mocks/MockTimestampToken.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IERC6372} from "@openzeppelin/contracts/interfaces/IERC6372.sol";
+
+contract MockTimestampToken is IERC6372 {
+    function CLOCK_MODE() external pure returns (string memory) {
+        return "mode=timestamp";
+    }
+
+    function clock() external view returns (uint48) {
+        return uint48(block.timestamp);
+    }
+}

--- a/test/libs/ClockModeLib.test.ts
+++ b/test/libs/ClockModeLib.test.ts
@@ -1,0 +1,107 @@
+import { loadFixture, mine, time } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ClockModeLibTester,
+  ClockModeLibTester__factory,
+  MockBlockNumberToken,
+  MockBlockNumberToken__factory,
+  MockNonIERC6372Token,
+  MockNonIERC6372Token__factory,
+  MockRevertingToken,
+  MockRevertingToken__factory,
+  MockTimestampToken,
+  MockTimestampToken__factory,
+} from '../../typechain-types';
+
+// Define ClockMode enum to match Solidity for convenience
+enum ClockMode {
+  Timestamp,
+  BlockNumber,
+}
+
+describe('ClockModeLib', () => {
+  async function deployFixtures() {
+    const [deployer] = await ethers.getSigners();
+
+    const timestampToken: MockTimestampToken = await new MockTimestampToken__factory(
+      deployer,
+    ).deploy();
+
+    const blockNumberToken: MockBlockNumberToken = await new MockBlockNumberToken__factory(
+      deployer,
+    ).deploy();
+
+    const revertingToken: MockRevertingToken = await new MockRevertingToken__factory(
+      deployer,
+    ).deploy();
+
+    const nonIERC6372Token: MockNonIERC6372Token = await new MockNonIERC6372Token__factory(
+      deployer,
+    ).deploy();
+
+    const clockModeLibTester: ClockModeLibTester = await new ClockModeLibTester__factory(
+      deployer,
+    ).deploy();
+
+    return {
+      timestampToken,
+      blockNumberToken,
+      revertingToken,
+      nonIERC6372Token,
+      clockModeLibTester,
+      deployer,
+    };
+  }
+
+  describe('getClockMode(address)', () => {
+    it('should return Timestamp for a token returning "mode=timestamp"', async () => {
+      const { clockModeLibTester, timestampToken } = await loadFixture(deployFixtures);
+      expect(
+        await clockModeLibTester.getClockModeFromLib(await timestampToken.getAddress()),
+      ).to.equal(ClockMode.Timestamp);
+    });
+
+    it('should return BlockNumber for a token returning a different mode string', async () => {
+      const { clockModeLibTester, blockNumberToken } = await loadFixture(deployFixtures);
+      expect(
+        await clockModeLibTester.getClockModeFromLib(await blockNumberToken.getAddress()),
+      ).to.equal(ClockMode.BlockNumber);
+    });
+
+    it('should return BlockNumber if CLOCK_MODE() reverts', async () => {
+      const { clockModeLibTester, revertingToken } = await loadFixture(deployFixtures);
+      expect(
+        await clockModeLibTester.getClockModeFromLib(await revertingToken.getAddress()),
+      ).to.equal(ClockMode.BlockNumber);
+    });
+
+    it('should return BlockNumber for a token not implementing IERC6372 (call reverts)', async () => {
+      const { clockModeLibTester, nonIERC6372Token } = await loadFixture(deployFixtures);
+      expect(
+        await clockModeLibTester.getClockModeFromLib(await nonIERC6372Token.getAddress()),
+      ).to.equal(ClockMode.BlockNumber);
+    });
+  });
+
+  describe('getCurrentPoint(ClockMode)', () => {
+    it('should return block.timestamp for Timestamp mode', async () => {
+      const { clockModeLibTester } = await loadFixture(deployFixtures);
+      // Advance time a bit to ensure it's not 0
+      await time.increase(60);
+      const currentBlockTimestamp = await time.latest();
+      const point = await clockModeLibTester.getCurrentPointFromLib(ClockMode.Timestamp);
+      expect(point).to.equal(currentBlockTimestamp);
+    });
+
+    it('should return block.number for BlockNumber mode', async () => {
+      const { clockModeLibTester } = await loadFixture(deployFixtures);
+      // Mine a few blocks to ensure it's not 0 or 1
+      await mine(5);
+      const currentBlockNumber = await time.latestBlock();
+      expect(await clockModeLibTester.getCurrentPointFromLib(ClockMode.BlockNumber)).to.equal(
+        currentBlockNumber,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/257

Fixes [ENG-855](https://linear.app/decent-labs/issue/ENG-855/implement-clockmodelib-for-standardized-time-point-resolution)

This commit introduces a `ClockMode` enum and `ClockModeLib` to standardize how the system determines whether to use `block.timestamp` or `block.number` for time-sensitive operations, particularly when interacting with tokens that may implement ERC6372.

The `ClockModeLib` provides:
- `getClockMode(address token)`: Detects the clock mode of a given token. It defaults to `BlockNumber` if the token does not implement `CLOCK_MODE()` as per ERC6372, if `CLOCK_MODE()` reverts, or if it returns a non-standard string.
- `getCurrentPoint(ClockMode mode)`: Returns either `block.timestamp` or `block.number` based on the specified `ClockMode`.

Includes:
- `ClockMode.sol`: Enum for `Timestamp` and `BlockNumber` modes.
- `ClockModeLib.sol`: Library with detection and utility functions.
- Mock contracts (`MockTimestampToken`, `MockBlockNumberToken`, `MockRevertingToken`, `MockNonIERC6372Token`) for thorough testing.
- `ClockModeLibTester.sol`: A contract to facilitate testing the library.
- Comprehensive Hardhat tests for `ClockModeLib`.