### PR TITLE
refactor(strategy): Abstract time handling in BaseStrategyV1 with ClockMode

### DIFF
--- a/contracts/deployables/strategies/BaseStrategyV1.sol
+++ b/contracts/deployables/strategies/BaseStrategyV1.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.30;
 
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
-import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -68,12 +67,9 @@ abstract contract BaseStrategyV1 is
     function isProposer(address _address) external view virtual returns (bool);
 
     /** @inheritdoc IBaseStrategyV1*/
-    function getClockMode() external view virtual returns (ClockMode);
-
-    /** @inheritdoc IBaseStrategyV1*/
-    function getProposalVotingPeriodPoints(
+    function getVotingTimestamps(
         uint32 _proposalId
-    ) external view virtual returns (uint256 startPoint, uint256 endPoint);
+    ) external view virtual returns (uint48 startTime, uint48 endTime);
 
     /** @inheritdoc ERC165*/
     function supportsInterface(

--- a/contracts/deployables/strategies/BaseStrategyV1.sol
+++ b/contracts/deployables/strategies/BaseStrategyV1.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
+import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -67,10 +68,14 @@ abstract contract BaseStrategyV1 is
     function isProposer(address _address) external view virtual returns (bool);
 
     /** @inheritdoc IBaseStrategyV1*/
-    function votingEndTimestamp(
-        uint32 _proposalId
-    ) external view virtual returns (uint48);
+    function getClockMode() external view virtual returns (ClockMode);
 
+    /** @inheritdoc IBaseStrategyV1*/
+    function getProposalVotingPeriodPoints(
+        uint32 _proposalId
+    ) external view virtual returns (uint256 startPoint, uint256 endPoint);
+
+    /** @inheritdoc ERC165*/
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {

--- a/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {ClockMode} from "../ClockMode.sol";
-
 /**
  * The specification for a voting strategy in Azorius.
  *

--- a/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+import {ClockMode} from "../ClockMode.sol";
+
 /**
  * The specification for a voting strategy in Azorius.
  *
@@ -42,12 +44,20 @@ interface IBaseStrategyV1 {
     function isProposer(address _address) external view returns (bool);
 
     /**
-     * Returns the absolute timestamp that voting ends on a given Proposal.
-     *
-     * @param _proposalId proposalId to check
-     * @return uint48 timestamp when voting ends on the Proposal
+     * @notice Returns the clock mode used by this strategy instance.
+     * @dev This determines if time-related values are in blocks or timestamps.
+     * @return The ClockMode for the strategy.
      */
-    function votingEndTimestamp(
+    function getClockMode() external view returns (ClockMode);
+
+    /**
+     * @notice Returns the start and end points of a proposal's voting period.
+     * @dev Interpretation of the points depends on getClockMode().
+     * @param _proposalId The ID of the proposal.
+     * @return startPoint The start point of the voting period.
+     * @return endPoint The end point of the voting period.
+     */
+    function getProposalVotingPeriodPoints(
         uint32 _proposalId
-    ) external view returns (uint48);
+    ) external view returns (uint256 startPoint, uint256 endPoint);
 }

--- a/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
@@ -44,20 +44,12 @@ interface IBaseStrategyV1 {
     function isProposer(address _address) external view returns (bool);
 
     /**
-     * @notice Returns the clock mode used by this strategy instance.
-     * @dev This determines if time-related values are in blocks or timestamps.
-     * @return The ClockMode for the strategy.
-     */
-    function getClockMode() external view returns (ClockMode);
-
-    /**
-     * @notice Returns the start and end points of a proposal's voting period.
-     * @dev Interpretation of the points depends on getClockMode().
+     * @notice Returns the start and end timestamps of a proposal's voting period.
      * @param _proposalId The ID of the proposal.
-     * @return startPoint The start point of the voting period.
-     * @return endPoint The end point of the voting period.
+     * @return startTime The start timestamp of the voting period.
+     * @return endTime The end timestamp of the voting period.
      */
-    function getProposalVotingPeriodPoints(
+    function getVotingTimestamps(
         uint32 _proposalId
-    ) external view returns (uint256 startPoint, uint256 endPoint);
+    ) external view returns (uint48 startTime, uint48 endTime);
 }


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/258

Fixes [ENG-858](https://linear.app/decent-labs/issue/ENG-858/refactor-basestrategyv1-for-flexible-time-handling-via-clockmode-and)

This commit refactors `BaseStrategyV1` and its interface `IBaseStrategyV1` to introduce a more flexible and explicit way of handling time for voting periods. This is a foundational step towards unifying block-based and timestamp-based logic within voting strategies by leveraging the new `ClockMode` concept.

Key changes:
- Removed `votingEndTimestamp(uint32) returns (uint48)` from both the interface and the abstract contract.
- Added `getClockMode() external view virtual returns (ClockMode)` to `IBaseStrategyV1` and `BaseStrategyV1`. This function allows strategies to declare whether they operate on block numbers or timestamps.
- Added `getProposalVotingPeriodPoints(uint32 _proposalId) external view virtual returns (uint256 startPoint, uint256 endPoint)` to `IBaseStrategyV1` and `BaseStrategyV1`. This function replaces `votingEndTimestamp` and provides both the start and end points of a voting period, which are to be interpreted according to the strategy's declared `ClockMode`.

**Important Note:** This is an intermediate step in a larger refactoring effort. This commit modifies the `IBaseStrategyV1` interface. As a result, contracts that implement this interface (e.g., `LinearERC20VotingV1`, `LinearERC721VotingV1`, and their variants) will **fail to compile**. Consequently, the test suite will also not run successfully. These compilation errors and test failures are expected at this stage and will be addressed in subsequent commits as the implementing contracts are updated to conform to the new interface.