### PR TITLE
refactor(AzoriusV1): Adapt to ClockMode and new strategy time functions

### DIFF
--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.30;
 import {Version} from "../Version.sol";
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
 import {IAzoriusV1, Enum} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
+import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
+import {ClockModeLib} from "../../libs/ClockModeLib.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
@@ -387,10 +389,14 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         if (_proposal.strategy == address(0)) revert InvalidProposal();
 
         IBaseStrategyV1 _strategy = IBaseStrategyV1(_proposal.strategy);
+        ClockMode clockMode = _strategy.getClockMode();
+        uint256 currentPoint = ClockModeLib.getCurrentPoint(clockMode);
 
-        uint48 votingEndTimestamp = _strategy.votingEndTimestamp(_proposalId);
+        (, uint256 votingEndPoint) = _strategy.getProposalVotingPeriodPoints(
+            _proposalId
+        );
 
-        if (block.timestamp <= votingEndTimestamp) {
+        if (currentPoint <= votingEndPoint) {
             return ProposalState.ACTIVE;
         } else if (!_strategy.isPassed(_proposalId)) {
             return ProposalState.FAILED;
@@ -399,13 +405,11 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
             // this allows for the potential for on-chain voting for
             // "off-chain" executed decisions
             return ProposalState.EXECUTED;
-        } else if (
-            block.timestamp <= votingEndTimestamp + _proposal.timelockPeriod
-        ) {
+        } else if (currentPoint <= votingEndPoint + _proposal.timelockPeriod) {
             return ProposalState.TIMELOCKED;
         } else if (
-            block.timestamp <=
-            votingEndTimestamp +
+            currentPoint <=
+            votingEndPoint +
                 _proposal.timelockPeriod +
                 _proposal.executionPeriod
         ) {

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.30;
 import {Version} from "../Version.sol";
 import {IBaseStrategyV1} from "../../interfaces/decent/deployables/IBaseStrategyV1.sol";
 import {IAzoriusV1, Enum} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
-import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
-import {ClockModeLib} from "../../libs/ClockModeLib.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
@@ -389,14 +387,10 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         if (_proposal.strategy == address(0)) revert InvalidProposal();
 
         IBaseStrategyV1 _strategy = IBaseStrategyV1(_proposal.strategy);
-        ClockMode clockMode = _strategy.getClockMode();
-        uint256 currentPoint = ClockModeLib.getCurrentPoint(clockMode);
+        (, uint256 endTime) = _strategy.getVotingTimestamps(_proposalId);
 
-        (, uint256 votingEndPoint) = _strategy.getProposalVotingPeriodPoints(
-            _proposalId
-        );
-
-        if (currentPoint <= votingEndPoint) {
+        uint256 currentTimestamp = block.timestamp;
+        if (currentTimestamp <= endTime) {
             return ProposalState.ACTIVE;
         } else if (!_strategy.isPassed(_proposalId)) {
             return ProposalState.FAILED;
@@ -405,13 +399,11 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
             // this allows for the potential for on-chain voting for
             // "off-chain" executed decisions
             return ProposalState.EXECUTED;
-        } else if (currentPoint <= votingEndPoint + _proposal.timelockPeriod) {
+        } else if (currentTimestamp <= endTime + _proposal.timelockPeriod) {
             return ProposalState.TIMELOCKED;
         } else if (
-            currentPoint <=
-            votingEndPoint +
-                _proposal.timelockPeriod +
-                _proposal.executionPeriod
+            currentTimestamp <=
+            endTime + _proposal.timelockPeriod + _proposal.executionPeriod
         ) {
             return ProposalState.EXECUTABLE;
         } else {

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -387,10 +387,11 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         if (_proposal.strategy == address(0)) revert InvalidProposal();
 
         IBaseStrategyV1 _strategy = IBaseStrategyV1(_proposal.strategy);
-        (, uint256 endTime) = _strategy.getVotingTimestamps(_proposalId);
+        (, uint256 votingEndTimestamp) = _strategy.getVotingTimestamps(
+            _proposalId
+        );
 
-        uint256 currentTimestamp = block.timestamp;
-        if (currentTimestamp <= endTime) {
+        if (block.timestamp <= votingEndTimestamp) {
             return ProposalState.ACTIVE;
         } else if (!_strategy.isPassed(_proposalId)) {
             return ProposalState.FAILED;
@@ -399,11 +400,15 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
             // this allows for the potential for on-chain voting for
             // "off-chain" executed decisions
             return ProposalState.EXECUTED;
-        } else if (currentTimestamp <= endTime + _proposal.timelockPeriod) {
+        } else if (
+            block.timestamp <= votingEndTimestamp + _proposal.timelockPeriod
+        ) {
             return ProposalState.TIMELOCKED;
         } else if (
-            currentTimestamp <=
-            endTime + _proposal.timelockPeriod + _proposal.executionPeriod
+            block.timestamp <=
+            votingEndTimestamp +
+                _proposal.timelockPeriod +
+                _proposal.executionPeriod
         ) {
             return ProposalState.EXECUTABLE;
         } else {


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/259

Fixes [ENG-859](https://linear.app/decent-labs/issue/ENG-859/update-azoriusv1-to-use-clockmode-and-new-strategy-time-functions)

This commit updates `AzoriusV1` to align with the refactored `IBaseStrategyV1` interface, enabling it to correctly interpret time-based conditions (like proposal state) for strategies that may use either block numbers or timestamps.

Key changes:
- Imported `ClockMode` and `ClockModeLib`.
- In `getProposalState`:
    - Retrieves the `ClockMode` from the proposal's strategy using `_strategy.getClockMode()`.
    - Uses `ClockModeLib.getCurrentPoint(clockMode)` to determine the current reference point (block number or timestamp).
    - Calls `_strategy.getProposalVotingPeriodPoints(_proposalId)` to get the voting period's start and end points.
    - The logic for determining proposal states (`ACTIVE`, `TIMELOCKED`, `EXECUTABLE`) now compares `currentPoint` against `votingEndPoint` and the proposal's `timelockPeriod` and `executionPeriod`.

**Important Note:** This commit depends on the interface changes in `IBaseStrategyV1`. Concrete strategy contracts that have not yet been updated to implement the new `getClockMode()` and `getProposalVotingPeriodPoints()` functions will still cause **compilation failures**. Consequently, the test suite will also not run successfully. These issues are expected at this stage and will be resolved as the strategies are updated in subsequent commits.