### PR TITLE
refactor(LinearERC20VotingV1): Implement ClockMode and update time handling

### DIFF
--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -10,7 +10,7 @@ import {SmartAccountValidationV1} from "../account-abstraction/SmartAccountValid
 abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
     /**
      * @dev Tracks whether a proposal's voting period has been marked as ended.
-     * This flag is set to true when the first vote attempt occurs after the voting end timestamp,
+     * This flag is set to true when the first vote attempt occurs after the voting end timepoint,
      * triggering a VotingPeriodEnded event. Used to allow an at-most-once vote to not revert
      * after the voting period has ended, and to give bundlers the ability to determine
      * if a proposal voting period has ended without using the banned NUMBER opcode.
@@ -19,8 +19,8 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
 
     event VotingPeriodEnded(
         uint32 indexed proposalId,
-        uint48 votingEndTimestamp,
-        uint48 currentTimestamp
+        uint256 votingEndPoint,
+        uint256 currentPoint
     );
 
     constructor() {
@@ -51,11 +51,11 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
 
     /**
      * @dev Tracks whether a proposal's voting period has been officially marked as ended.
-     * This flag is set to true when the first vote attempt occurs after the voting end timestamp,
+     * This flag is set to true when the first vote attempt occurs after the voting end timepoint,
      * triggering a VotingPeriodEnded event. Used to ensure the event is emitted exactly once
-     * per proposal, and only if a vote has been attempted after the voting end timestamp.
+     * per proposal, and only if a vote has been attempted after the voting end timepoint.
      * @param _proposalId The ID of the proposal to check.
-     * @return True if the voting period has ended and a vote has been attempted after the voting end timestamp, false otherwise.
+     * @return True if the voting period has ended and a vote has been attempted after the voting end timepoint, false otherwise.
      */
     function votingPeriodEnded(
         uint32 _proposalId

--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -10,7 +10,7 @@ import {SmartAccountValidationV1} from "../account-abstraction/SmartAccountValid
 abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
     /**
      * @dev Tracks whether a proposal's voting period has been marked as ended.
-     * This flag is set to true when the first vote attempt occurs after the voting end timepoint,
+     * This flag is set to true when the first vote attempt occurs after the voting end timestamp,
      * triggering a VotingPeriodEnded event. Used to allow an at-most-once vote to not revert
      * after the voting period has ended, and to give bundlers the ability to determine
      * if a proposal voting period has ended without using the banned NUMBER opcode.
@@ -19,8 +19,8 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
 
     event VotingPeriodEnded(
         uint32 indexed proposalId,
-        uint256 votingEndPoint,
-        uint256 currentPoint
+        uint48 votingEndTime,
+        uint48 currentTime
     );
 
     constructor() {
@@ -51,11 +51,11 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
 
     /**
      * @dev Tracks whether a proposal's voting period has been officially marked as ended.
-     * This flag is set to true when the first vote attempt occurs after the voting end timepoint,
+     * This flag is set to true when the first vote attempt occurs after the voting end timestamp,
      * triggering a VotingPeriodEnded event. Used to ensure the event is emitted exactly once
-     * per proposal, and only if a vote has been attempted after the voting end timepoint.
+     * per proposal, and only if a vote has been attempted after the voting end timestamp.
      * @param _proposalId The ID of the proposal to check.
-     * @return True if the voting period has ended and a vote has been attempted after the voting end timepoint, false otherwise.
+     * @return True if the voting period has ended and a vote has been attempted after the voting end timestamp, false otherwise.
      */
     function votingPeriodEnded(
         uint32 _proposalId

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -272,9 +272,8 @@ contract LinearERC20VotingV1 is
         uint32 _proposalId
     ) public view virtual override returns (bool) {
         ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
-        uint48 currentTime = uint48(block.timestamp);
 
-        return (currentTime > currentProposalVotes.votingEndTime && // voting period has ended
+        return (block.timestamp > currentProposalVotes.votingEndTime && // voting period has ended
             meetsQuorum(
                 getProposalVotingSupply(_proposalId),
                 currentProposalVotes.yesVotes,
@@ -338,7 +337,7 @@ contract LinearERC20VotingV1 is
 
     function getVotingTimestamps(
         uint32 _proposalId
-    ) public view virtual override returns (uint48 startTime, uint48 endTime) {
+    ) public view virtual override returns (uint48, uint48) {
         return (
             proposalVotes[_proposalId].votingStartTime,
             proposalVotes[_proposalId].votingEndTime

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -46,8 +46,9 @@ contract LinearERC20VotingV1 is
      * Defines the current state of votes on a particular Proposal.
      */
     struct ProposalVotes {
-        uint256 votingStartPoint; // timepoint that voting starts
-        uint256 votingEndPoint; // timepoint that voting ends
+        uint48 votingStartTime; // timestamp that voting starts
+        uint256 votingStartBlock; // block that voting starts
+        uint48 votingEndTime; // timestamp that voting ends
         uint256 noVotes; // current number of NO votes for the Proposal
         uint256 yesVotes; // current number of YES votes for the Proposal
         uint256 abstainVotes; // current number of ABSTAIN votes for the Proposal
@@ -56,7 +57,7 @@ contract LinearERC20VotingV1 is
 
     IVotes public governanceToken;
 
-    /** Time (seconds or blocks) that a new Proposal can be voted on. */
+    /** Time that a new Proposal can be voted on. */
     uint32 public votingPeriod;
 
     /** Voting weight required to be able to submit Proposals. */
@@ -77,11 +78,11 @@ contract LinearERC20VotingV1 is
     /** `proposalId` to `ProposalVotes`, the voting state of a Proposal. */
     mapping(uint256 => ProposalVotes) internal proposalVotes;
 
-    ClockMode private _clockMode;
+    ClockMode public governanceClockMode;
 
     event VotingPeriodUpdated(uint32 votingPeriod);
     event RequiredProposerWeightUpdated(uint256 requiredProposerWeight);
-    event ProposalInitialized(uint32 proposalId, uint256 votingEndPoint);
+    event ProposalInitialized(uint32 proposalId, uint48 votingEndTime);
     event Voted(
         address voter,
         uint32 proposalId,
@@ -120,7 +121,7 @@ contract LinearERC20VotingV1 is
         if (address(_governanceToken) == address(0))
             revert InvalidTokenAddress();
         governanceToken = IVotes(_governanceToken);
-        _clockMode = ClockModeLib.getClockMode(_governanceToken);
+        governanceClockMode = ClockModeLib.getClockMode(_governanceToken);
 
         BaseStrategyV1.initialize(_owner, _proposalInitializer);
         __ERC4337VoterSupportV1_init(_lightAccountFactory);
@@ -208,8 +209,8 @@ contract LinearERC20VotingV1 is
      * @return noVotes current count of "NO" votes
      * @return yesVotes current count of "YES" votes
      * @return abstainVotes current count of "ABSTAIN" votes
-     * @return startPoint timepoint voting starts
-     * @return endPoint timepoint voting ends
+     * @return startTime timestamp voting starts
+     * @return endTime timestamp voting ends
      * @return votingSupply the total voting supply at the time of proposal creation
      */
     function getProposalVotes(
@@ -222,8 +223,8 @@ contract LinearERC20VotingV1 is
             uint256 noVotes,
             uint256 yesVotes,
             uint256 abstainVotes,
-            uint256 startPoint,
-            uint256 endPoint,
+            uint48 startTime,
+            uint48 endTime,
             uint256 votingSupply
         )
     {
@@ -231,8 +232,8 @@ contract LinearERC20VotingV1 is
         noVotes = currentProposalVotes.noVotes;
         yesVotes = currentProposalVotes.yesVotes;
         abstainVotes = currentProposalVotes.abstainVotes;
-        startPoint = currentProposalVotes.votingStartPoint;
-        endPoint = currentProposalVotes.votingEndPoint;
+        startTime = currentProposalVotes.votingStartTime;
+        endTime = currentProposalVotes.votingEndTime;
         votingSupply = getProposalVotingSupply(_proposalId);
     }
 
@@ -242,13 +243,14 @@ contract LinearERC20VotingV1 is
     ) public virtual override onlyProposalInitializer {
         uint32 proposalId = abi.decode(_data, (uint32));
 
-        uint256 startPoint = ClockModeLib.getCurrentPoint(_clockMode);
-        uint256 endPoint = startPoint + votingPeriod;
+        uint48 startTime = uint48(block.timestamp);
+        uint48 endTime = startTime + votingPeriod;
 
-        proposalVotes[proposalId].votingStartPoint = startPoint;
-        proposalVotes[proposalId].votingEndPoint = endPoint;
+        proposalVotes[proposalId].votingStartTime = startTime;
+        proposalVotes[proposalId].votingStartBlock = block.number;
+        proposalVotes[proposalId].votingEndTime = endTime;
 
-        emit ProposalInitialized(proposalId, endPoint);
+        emit ProposalInitialized(proposalId, endTime);
     }
 
     /**
@@ -270,9 +272,9 @@ contract LinearERC20VotingV1 is
         uint32 _proposalId
     ) public view virtual override returns (bool) {
         ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
-        uint256 currentPoint = ClockModeLib.getCurrentPoint(_clockMode);
+        uint48 currentTime = uint48(block.timestamp);
 
-        return (currentPoint > currentProposalVotes.votingEndPoint && // voting period has ended
+        return (currentTime > currentProposalVotes.votingEndTime && // voting period has ended
             meetsQuorum(
                 getProposalVotingSupply(_proposalId),
                 currentProposalVotes.yesVotes,
@@ -297,7 +299,9 @@ contract LinearERC20VotingV1 is
     ) public view virtual returns (uint256) {
         return
             governanceToken.getPastTotalSupply(
-                proposalVotes[_proposalId].votingStartPoint
+                governanceClockMode == ClockMode.Timestamp
+                    ? proposalVotes[_proposalId].votingStartTime
+                    : proposalVotes[_proposalId].votingStartBlock
             );
     }
 
@@ -315,7 +319,9 @@ contract LinearERC20VotingV1 is
         return
             governanceToken.getPastVotes(
                 _voter,
-                proposalVotes[_proposalId].votingStartPoint
+                governanceClockMode == ClockMode.Timestamp
+                    ? proposalVotes[_proposalId].votingStartTime
+                    : proposalVotes[_proposalId].votingStartBlock
             );
     }
 
@@ -323,24 +329,19 @@ contract LinearERC20VotingV1 is
     function isProposer(
         address _address
     ) public view virtual override returns (bool) {
-        uint256 lastPoint = ClockModeLib.getCurrentPoint(_clockMode) - 1;
+        uint256 lastPoint = ClockModeLib.getCurrentPoint(governanceClockMode) -
+            1;
         return
             governanceToken.getPastVotes(_address, lastPoint) >=
             requiredProposerWeight;
     }
 
-    // getClockMode implementation
-    function getClockMode() public view virtual override returns (ClockMode) {
-        return _clockMode;
-    }
-
-    // Function renamed to match IBaseStrategyV1
-    function getProposalVotingPeriodPoints(
+    function getVotingTimestamps(
         uint32 _proposalId
-    ) public view virtual override returns (uint256, uint256) {
+    ) public view virtual override returns (uint48 startTime, uint48 endTime) {
         return (
-            proposalVotes[_proposalId].votingStartPoint,
-            proposalVotes[_proposalId].votingEndPoint
+            proposalVotes[_proposalId].votingStartTime,
+            proposalVotes[_proposalId].votingEndTime
         );
     }
 
@@ -395,18 +396,15 @@ contract LinearERC20VotingV1 is
         uint8 _voteType,
         uint256 _weight
     ) internal virtual {
-        if (proposalVotes[_proposalId].votingEndPoint == 0)
+        if (proposalVotes[_proposalId].votingEndTime == 0)
             revert InvalidProposal();
-        if (
-            ClockModeLib.getCurrentPoint(_clockMode) >
-            proposalVotes[_proposalId].votingEndPoint
-        ) {
+        if (block.timestamp > proposalVotes[_proposalId].votingEndTime) {
             if (!_votingPeriodEnded[_proposalId]) {
                 _votingPeriodEnded[_proposalId] = true;
                 emit VotingPeriodEnded(
                     _proposalId,
-                    proposalVotes[_proposalId].votingEndPoint,
-                    ClockModeLib.getCurrentPoint(_clockMode)
+                    proposalVotes[_proposalId].votingEndTime,
+                    uint48(block.timestamp)
                 );
                 return;
             }

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -4,9 +4,11 @@ pragma solidity ^0.8.30;
 import {Version} from "../Version.sol";
 import {BaseStrategyV1} from "./BaseStrategyV1.sol";
 import {ERC4337VoterSupportV1} from "./ERC4337VoterSupportV1.sol";
-import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+import {ClockModeLib} from "../../libs/ClockModeLib.sol";
 import {IBaseQuorumPercentV1} from "../../interfaces/decent/deployables/IBaseQuorumPercentV1.sol";
+import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
 import {IBaseVotingBasisPercentV1} from "../../interfaces/decent/deployables/IBaseVotingBasisPercentV1.sol";
+import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -44,8 +46,8 @@ contract LinearERC20VotingV1 is
      * Defines the current state of votes on a particular Proposal.
      */
     struct ProposalVotes {
-        uint48 votingStartTimestamp; // time that voting starts at
-        uint48 votingEndTimestamp; // time that voting ends
+        uint256 votingStartPoint; // timepoint that voting starts
+        uint256 votingEndPoint; // timepoint that voting ends
         uint256 noVotes; // current number of NO votes for the Proposal
         uint256 yesVotes; // current number of YES votes for the Proposal
         uint256 abstainVotes; // current number of ABSTAIN votes for the Proposal
@@ -54,7 +56,7 @@ contract LinearERC20VotingV1 is
 
     IVotes public governanceToken;
 
-    /** Time that a new Proposal can be voted on. */
+    /** Time (seconds or blocks) that a new Proposal can be voted on. */
     uint32 public votingPeriod;
 
     /** Voting weight required to be able to submit Proposals. */
@@ -75,9 +77,11 @@ contract LinearERC20VotingV1 is
     /** `proposalId` to `ProposalVotes`, the voting state of a Proposal. */
     mapping(uint256 => ProposalVotes) internal proposalVotes;
 
+    ClockMode private _clockMode;
+
     event VotingPeriodUpdated(uint32 votingPeriod);
     event RequiredProposerWeightUpdated(uint256 requiredProposerWeight);
-    event ProposalInitialized(uint32 proposalId, uint48 votingEndTimestamp);
+    event ProposalInitialized(uint32 proposalId, uint256 votingEndPoint);
     event Voted(
         address voter,
         uint32 proposalId,
@@ -116,6 +120,7 @@ contract LinearERC20VotingV1 is
         if (address(_governanceToken) == address(0))
             revert InvalidTokenAddress();
         governanceToken = IVotes(_governanceToken);
+        _clockMode = ClockModeLib.getClockMode(_governanceToken);
 
         BaseStrategyV1.initialize(_owner, _proposalInitializer);
         __ERC4337VoterSupportV1_init(_lightAccountFactory);
@@ -203,8 +208,9 @@ contract LinearERC20VotingV1 is
      * @return noVotes current count of "NO" votes
      * @return yesVotes current count of "YES" votes
      * @return abstainVotes current count of "ABSTAIN" votes
-     * @return startTimestamp timestamp voting starts
-     * @return endTimestamp timestamp voting ends
+     * @return startPoint timepoint voting starts
+     * @return endPoint timepoint voting ends
+     * @return votingSupply the total voting supply at the time of proposal creation
      */
     function getProposalVotes(
         uint32 _proposalId
@@ -216,16 +222,17 @@ contract LinearERC20VotingV1 is
             uint256 noVotes,
             uint256 yesVotes,
             uint256 abstainVotes,
-            uint48 startTimestamp,
-            uint48 endTimestamp,
+            uint256 startPoint,
+            uint256 endPoint,
             uint256 votingSupply
         )
     {
-        noVotes = proposalVotes[_proposalId].noVotes;
-        yesVotes = proposalVotes[_proposalId].yesVotes;
-        abstainVotes = proposalVotes[_proposalId].abstainVotes;
-        startTimestamp = proposalVotes[_proposalId].votingStartTimestamp;
-        endTimestamp = proposalVotes[_proposalId].votingEndTimestamp;
+        ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
+        noVotes = currentProposalVotes.noVotes;
+        yesVotes = currentProposalVotes.yesVotes;
+        abstainVotes = currentProposalVotes.abstainVotes;
+        startPoint = currentProposalVotes.votingStartPoint;
+        endPoint = currentProposalVotes.votingEndPoint;
         votingSupply = getProposalVotingSupply(_proposalId);
     }
 
@@ -234,14 +241,14 @@ contract LinearERC20VotingV1 is
         bytes memory _data
     ) public virtual override onlyProposalInitializer {
         uint32 proposalId = abi.decode(_data, (uint32));
-        uint48 _votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
 
-        proposalVotes[proposalId].votingEndTimestamp = _votingEndTimestamp;
-        proposalVotes[proposalId].votingStartTimestamp = uint48(
-            block.timestamp
-        );
+        uint256 startPoint = ClockModeLib.getCurrentPoint(_clockMode);
+        uint256 endPoint = startPoint + votingPeriod;
 
-        emit ProposalInitialized(proposalId, _votingEndTimestamp);
+        proposalVotes[proposalId].votingStartPoint = startPoint;
+        proposalVotes[proposalId].votingEndPoint = endPoint;
+
+        emit ProposalInitialized(proposalId, endPoint);
     }
 
     /**
@@ -262,16 +269,18 @@ contract LinearERC20VotingV1 is
     function isPassed(
         uint32 _proposalId
     ) public view virtual override returns (bool) {
-        return (block.timestamp >
-            proposalVotes[_proposalId].votingEndTimestamp && // voting period has ended
+        ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
+        uint256 currentPoint = ClockModeLib.getCurrentPoint(_clockMode);
+
+        return (currentPoint > currentProposalVotes.votingEndPoint && // voting period has ended
             meetsQuorum(
                 getProposalVotingSupply(_proposalId),
-                proposalVotes[_proposalId].yesVotes,
-                proposalVotes[_proposalId].abstainVotes
+                currentProposalVotes.yesVotes,
+                currentProposalVotes.abstainVotes
             ) && // yes + abstain votes meets the quorum
             meetsBasis(
-                proposalVotes[_proposalId].yesVotes,
-                proposalVotes[_proposalId].noVotes
+                currentProposalVotes.yesVotes,
+                currentProposalVotes.noVotes
             )); // yes votes meets the basis
     }
 
@@ -288,7 +297,7 @@ contract LinearERC20VotingV1 is
     ) public view virtual returns (uint256) {
         return
             governanceToken.getPastTotalSupply(
-                proposalVotes[_proposalId].votingStartTimestamp
+                proposalVotes[_proposalId].votingStartPoint
             );
     }
 
@@ -306,7 +315,7 @@ contract LinearERC20VotingV1 is
         return
             governanceToken.getPastVotes(
                 _voter,
-                proposalVotes[_proposalId].votingStartTimestamp
+                proposalVotes[_proposalId].votingStartPoint
             );
     }
 
@@ -314,24 +323,24 @@ contract LinearERC20VotingV1 is
     function isProposer(
         address _address
     ) public view virtual override returns (bool) {
+        uint256 lastPoint = ClockModeLib.getCurrentPoint(_clockMode) - 1;
         return
-            governanceToken.getPastVotes(_address, block.timestamp - 1) >=
+            governanceToken.getPastVotes(_address, lastPoint) >=
             requiredProposerWeight;
     }
 
-    /** @inheritdoc BaseStrategyV1*/
-    function votingEndTimestamp(
-        uint32 _proposalId
-    ) public view virtual override returns (uint48) {
-        return proposalVotes[_proposalId].votingEndTimestamp;
+    // getClockMode implementation
+    function getClockMode() public view virtual override returns (ClockMode) {
+        return _clockMode;
     }
 
-    function getProposalPeriod(
+    // Function renamed to match IBaseStrategyV1
+    function getProposalVotingPeriodPoints(
         uint32 _proposalId
-    ) public view virtual returns (uint48, uint48) {
+    ) public view virtual override returns (uint256, uint256) {
         return (
-            proposalVotes[_proposalId].votingStartTimestamp,
-            proposalVotes[_proposalId].votingEndTimestamp
+            proposalVotes[_proposalId].votingStartPoint,
+            proposalVotes[_proposalId].votingEndPoint
         );
     }
 
@@ -386,15 +395,18 @@ contract LinearERC20VotingV1 is
         uint8 _voteType,
         uint256 _weight
     ) internal virtual {
-        if (proposalVotes[_proposalId].votingEndTimestamp == 0)
+        if (proposalVotes[_proposalId].votingEndPoint == 0)
             revert InvalidProposal();
-        if (block.timestamp > proposalVotes[_proposalId].votingEndTimestamp) {
+        if (
+            ClockModeLib.getCurrentPoint(_clockMode) >
+            proposalVotes[_proposalId].votingEndPoint
+        ) {
             if (!_votingPeriodEnded[_proposalId]) {
                 _votingPeriodEnded[_proposalId] = true;
                 emit VotingPeriodEnded(
                     _proposalId,
-                    proposalVotes[_proposalId].votingEndTimestamp,
-                    uint48(block.timestamp)
+                    proposalVotes[_proposalId].votingEndPoint,
+                    ClockModeLib.getCurrentPoint(_clockMode)
                 );
                 return;
             }


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/260

Fixes [ENG-860](https://linear.app/decent-labs/issue/ENG-860/refactor-linearerc20votingv1-and-erc4337votersupportv1-for-clockmode)

This commit refactors `LinearERC20VotingV1` and `ERC4337VoterSupportV1` to fully integrate the `ClockMode` system, making the strategy adaptable to both timestamp-based and block-number-based governance tokens.

Key changes in `LinearERC20VotingV1`:
- Imports `ClockModeLib` and `ClockMode`.
- The contract now determines its `_clockMode` in the `initialize` function by calling `ClockModeLib.getClockMode()` on the `governanceToken`.
- `ProposalVotes` struct now uses `votingStartPoint` and `votingEndPoint` (both `uint256`) instead of `uint48` timestamps.
- The `votingPeriod` is now understood as either seconds or blocks, depending on `_clockMode`.
- All internal logic for proposal initialization (`initializeProposal`), checking if a proposal has passed (`isPassed`), retrieving vote counts (`getVotes`, `getProposalVotingSupply`), and checking proposer status (`isProposer`) now uses `ClockModeLib.getCurrentPoint(_clockMode)` and the stored `votingStartPoint` and `votingEndPoint`.
- The `ProposalInitialized` event now emits `votingEndPoint` (uint256).
- Implements the new `IBaseStrategyV1` interface:
    - Adds `getClockMode()` which returns the determined `_clockMode`.
    - Replaces `votingEndTimestamp()` and the old `getProposalPeriod()` with `getProposalVotingPeriodPoints()`, returning the `votingStartPoint` and `votingEndPoint`.
- The `_vote` internal function now uses `ClockModeLib.getCurrentPoint(_clockMode)` and `votingEndPoint` for checking if the voting period has ended and for emitting the `VotingPeriodEnded` event.

Changes in `ERC4337VoterSupportV1`:
- The `VotingPeriodEnded` event parameters `votingEndTimestamp` and `currentTimestamp` are renamed to `votingEndPoint` and `currentPoint` (both `uint256`) to reflect their flexible nature (timestamp or block number).
- NatSpec comments updated to use "timepoint" instead of "timestamp".

**Important Note:** This commit makes `LinearERC20VotingV1` compliant with the new `IBaseStrategyV1` interface. However, other strategy contracts (like `LinearERC721VotingV1` and any "WithHats" variants) and their associated tests are still pending updates. Therefore, **compilation errors and test failures are still expected** across the broader project. These will be addressed in subsequent commits.