### PR TITLE
refactor(LinearERC721VotingV1): Implement ClockMode and update time handling

### DIFF
--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -352,25 +352,23 @@ contract LinearERC721VotingV1 is
         bytes memory _data
     ) public virtual override onlyProposalInitializer {
         uint32 proposalId = abi.decode(_data, (uint32));
-        uint48 startTime = uint48(block.timestamp);
-        uint48 endTime = startTime + votingPeriod;
+        uint48 votingEndTime = uint48(block.timestamp) + votingPeriod;
 
-        proposalVotes[proposalId].votingStartTime = startTime;
-        proposalVotes[proposalId].votingEndTime = endTime;
+        proposalVotes[proposalId].votingStartTime = uint48(block.timestamp);
+        proposalVotes[proposalId].votingEndTime = votingEndTime;
 
-        emit ProposalInitialized(proposalId, endTime);
+        emit ProposalInitialized(proposalId, votingEndTime);
     }
 
     /** @inheritdoc BaseStrategyV1*/
     function isPassed(
         uint32 _proposalId
     ) public view virtual override returns (bool) {
-        uint48 currentTime = uint48(block.timestamp);
         ProposalVotes storage currentProposal = proposalVotes[_proposalId];
-        return (currentTime > currentProposal.votingEndTime &&
+        return (block.timestamp > currentProposal.votingEndTime && // voting period has ended
             quorumThreshold <=
-            currentProposal.yesVotes + currentProposal.abstainVotes &&
-            meetsBasis(currentProposal.yesVotes, currentProposal.noVotes));
+            currentProposal.yesVotes + currentProposal.abstainVotes && // yes + abstain votes meets the quorum
+            meetsBasis(currentProposal.yesVotes, currentProposal.noVotes)); // yes votes meets the basis
     }
 
     /** @inheritdoc BaseStrategyV1*/
@@ -392,7 +390,7 @@ contract LinearERC721VotingV1 is
 
     function getVotingTimestamps(
         uint32 _proposalId
-    ) public view virtual override returns (uint48 startTime, uint48 endTime) {
+    ) public view virtual override returns (uint48, uint48) {
         return (
             proposalVotes[_proposalId].votingStartTime,
             proposalVotes[_proposalId].votingEndTime
@@ -502,15 +500,13 @@ contract LinearERC721VotingV1 is
 
         if (proposal.votingEndTime == 0) revert InvalidProposal();
 
-        uint48 currentTime = uint48(block.timestamp);
-
-        if (currentTime > proposal.votingEndTime) {
+        if (block.timestamp > proposal.votingEndTime) {
             if (!_votingPeriodEnded[_proposalId]) {
                 _votingPeriodEnded[_proposalId] = true;
                 emit VotingPeriodEnded(
                     _proposalId,
                     proposal.votingEndTime,
-                    currentTime
+                    uint48(block.timestamp)
                 );
                 return;
             }

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -2,11 +2,13 @@
 pragma solidity ^0.8.30;
 
 import {Version} from "../Version.sol";
-import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
 import {BaseStrategyV1} from "./BaseStrategyV1.sol";
 import {ERC4337VoterSupportV1} from "./ERC4337VoterSupportV1.sol";
-import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {ClockModeLib} from "../../libs/ClockModeLib.sol";
+import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
+import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
 import {IBaseVotingBasisPercentV1} from "../../interfaces/decent/deployables/IBaseVotingBasisPercentV1.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -50,8 +52,8 @@ contract LinearERC721VotingV1 is
      * Defines the current state of votes on a particular Proposal.
      */
     struct ProposalVotes {
-        uint48 votingStartTimestamp; // timestamp that voting starts at
-        uint48 votingEndTimestamp; // timestamp that voting ends
+        uint256 votingStartPoint; // timepoint that voting starts
+        uint256 votingEndPoint; // timepoint that voting ends
         uint256 noVotes; // current number of NO votes for the Proposal
         uint256 yesVotes; // current number of YES votes for the Proposal
         uint256 abstainVotes; // current number of ABSTAIN votes for the Proposal
@@ -71,7 +73,7 @@ contract LinearERC721VotingV1 is
     /** ERC-721 address to its voting weight per NFT id.  */
     mapping(address => uint256) public tokenWeights;
 
-    /** Number of blocks a new Proposal can be voted on. */
+    /** Time (seconds or blocks) that a new Proposal can be voted on. */
     uint32 public votingPeriod;
 
     /**
@@ -92,10 +94,12 @@ contract LinearERC721VotingV1 is
     /** The denominator to use when calculating basis (1,000,000). */
     uint256 public constant BASIS_DENOMINATOR = 1_000_000;
 
+    ClockMode private _clockMode;
+
     event VotingPeriodUpdated(uint32 votingPeriod);
     event QuorumThresholdUpdated(uint256 quorumThreshold);
     event ProposerThresholdUpdated(uint256 proposerThreshold);
-    event ProposalInitialized(uint32 proposalId, uint48 votingEndTimestamp);
+    event ProposalInitialized(uint32 proposalId, uint256 votingEndPoint);
     event Voted(
         address voter,
         uint32 proposalId,
@@ -125,11 +129,12 @@ contract LinearERC721VotingV1 is
      * @param _tokens Array of ERC-721 token addresses that can vote
      * @param _weights Array of voting weights for each token
      * @param _proposalInitializer Address that is allowed to initialize Proposals
-     * @param _votingPeriod The voting time period (in blocks)
+     * @param _votingPeriod The voting time period (in units determined by _initialClockMode)
      * @param _quorumThreshold Total voting weight required to achieve quorum
      * @param _proposerThreshold Required voting weight to submit proposals
      * @param _basisNumerator The numerator for basis calculation
      * @param _lightAccountFactory The address of the light account factory
+     * @param _initialClockMode The clock mode for this strategy instance
      */
     function initialize(
         address _owner,
@@ -140,11 +145,14 @@ contract LinearERC721VotingV1 is
         uint256 _quorumThreshold,
         uint256 _proposerThreshold,
         uint256 _basisNumerator,
-        address _lightAccountFactory
+        address _lightAccountFactory,
+        ClockMode _initialClockMode
     ) public initializer {
         if (_tokens.length != _weights.length) {
             revert InvalidParams();
         }
+
+        _clockMode = _initialClockMode;
 
         for (uint i = 0; i < _tokens.length; ) {
             _addGovernanceToken(_tokens[i], _weights[i]);
@@ -188,7 +196,7 @@ contract LinearERC721VotingV1 is
     /**
      * Updates the voting time period for new Proposals.
      *
-     * @param _votingPeriod voting time period (in blocks)
+     * @param _votingPeriod voting time period (in units determined by _clockMode)
      */
     function updateVotingPeriod(
         uint32 _votingPeriod
@@ -248,8 +256,8 @@ contract LinearERC721VotingV1 is
      * @return noVotes current count of "NO" votes
      * @return yesVotes current count of "YES" votes
      * @return abstainVotes current count of "ABSTAIN" votes
-     * @return startTimestamp timestamp voting starts
-     * @return endTimestamp timestamp voting ends
+     * @return startPoint timepoint voting starts
+     * @return endPoint timepoint voting ends
      */
     function getProposalVotes(
         uint32 _proposalId
@@ -261,15 +269,16 @@ contract LinearERC721VotingV1 is
             uint256 noVotes,
             uint256 yesVotes,
             uint256 abstainVotes,
-            uint48 startTimestamp,
-            uint48 endTimestamp
+            uint256 startPoint,
+            uint256 endPoint
         )
     {
-        noVotes = proposalVotes[_proposalId].noVotes;
-        yesVotes = proposalVotes[_proposalId].yesVotes;
-        abstainVotes = proposalVotes[_proposalId].abstainVotes;
-        startTimestamp = proposalVotes[_proposalId].votingStartTimestamp;
-        endTimestamp = proposalVotes[_proposalId].votingEndTimestamp;
+        ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
+        noVotes = currentProposalVotes.noVotes;
+        yesVotes = currentProposalVotes.yesVotes;
+        abstainVotes = currentProposalVotes.abstainVotes;
+        startPoint = currentProposalVotes.votingStartPoint;
+        endPoint = currentProposalVotes.votingEndPoint;
     }
 
     /**
@@ -351,29 +360,25 @@ contract LinearERC721VotingV1 is
         bytes memory _data
     ) public virtual override onlyProposalInitializer {
         uint32 proposalId = abi.decode(_data, (uint32));
-        uint48 _votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
+        uint256 startPoint = ClockModeLib.getCurrentPoint(_clockMode);
+        uint256 endPoint = startPoint + votingPeriod;
 
-        proposalVotes[proposalId].votingEndTimestamp = _votingEndTimestamp;
-        proposalVotes[proposalId].votingStartTimestamp = uint48(
-            block.timestamp
-        );
+        proposalVotes[proposalId].votingStartPoint = startPoint;
+        proposalVotes[proposalId].votingEndPoint = endPoint;
 
-        emit ProposalInitialized(proposalId, _votingEndTimestamp);
+        emit ProposalInitialized(proposalId, endPoint);
     }
 
     /** @inheritdoc BaseStrategyV1*/
     function isPassed(
         uint32 _proposalId
     ) public view virtual override returns (bool) {
-        return (block.timestamp >
-            proposalVotes[_proposalId].votingEndTimestamp && // voting period has ended
+        uint256 currentPoint = ClockModeLib.getCurrentPoint(_clockMode);
+        ProposalVotes storage currentProposal = proposalVotes[_proposalId];
+        return (currentPoint > currentProposal.votingEndPoint &&
             quorumThreshold <=
-            proposalVotes[_proposalId].yesVotes +
-                proposalVotes[_proposalId].abstainVotes && // yes + abstain votes meets the quorum
-            meetsBasis(
-                proposalVotes[_proposalId].yesVotes,
-                proposalVotes[_proposalId].noVotes
-            )); // yes votes meets the basis
+            currentProposal.yesVotes + currentProposal.abstainVotes &&
+            meetsBasis(currentProposal.yesVotes, currentProposal.noVotes));
     }
 
     /** @inheritdoc BaseStrategyV1*/
@@ -393,11 +398,17 @@ contract LinearERC721VotingV1 is
         return totalWeight >= proposerThreshold;
     }
 
-    /** @inheritdoc BaseStrategyV1*/
-    function votingEndTimestamp(
+    function getClockMode() public view virtual override returns (ClockMode) {
+        return _clockMode;
+    }
+
+    function getProposalVotingPeriodPoints(
         uint32 _proposalId
-    ) public view virtual override returns (uint48) {
-        return proposalVotes[_proposalId].votingEndTimestamp;
+    ) public view virtual override returns (uint256, uint256) {
+        return (
+            proposalVotes[_proposalId].votingStartPoint,
+            proposalVotes[_proposalId].votingEndPoint
+        );
     }
 
     /** Internal implementation of `addGovernanceToken` */
@@ -501,15 +512,17 @@ contract LinearERC721VotingV1 is
 
         ProposalVotes storage proposal = proposalVotes[_proposalId];
 
-        if (proposal.votingEndTimestamp == 0) revert InvalidProposal();
+        if (proposal.votingEndPoint == 0) revert InvalidProposal();
 
-        if (block.timestamp > proposal.votingEndTimestamp) {
+        uint256 currentPoint = ClockModeLib.getCurrentPoint(_clockMode);
+
+        if (currentPoint > proposal.votingEndPoint) {
             if (!_votingPeriodEnded[_proposalId]) {
                 _votingPeriodEnded[_proposalId] = true;
                 emit VotingPeriodEnded(
                     _proposalId,
-                    proposal.votingEndTimestamp,
-                    uint48(block.timestamp)
+                    proposal.votingEndPoint,
+                    currentPoint
                 );
                 return;
             }

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -4,9 +4,7 @@ pragma solidity ^0.8.30;
 import {Version} from "../Version.sol";
 import {BaseStrategyV1} from "./BaseStrategyV1.sol";
 import {ERC4337VoterSupportV1} from "./ERC4337VoterSupportV1.sol";
-import {ClockModeLib} from "../../libs/ClockModeLib.sol";
 import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
-import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
 import {IBaseVotingBasisPercentV1} from "../../interfaces/decent/deployables/IBaseVotingBasisPercentV1.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -52,8 +50,8 @@ contract LinearERC721VotingV1 is
      * Defines the current state of votes on a particular Proposal.
      */
     struct ProposalVotes {
-        uint256 votingStartPoint; // timepoint that voting starts
-        uint256 votingEndPoint; // timepoint that voting ends
+        uint48 votingStartTime; // timestamp that voting starts
+        uint48 votingEndTime; // timestamp that voting ends
         uint256 noVotes; // current number of NO votes for the Proposal
         uint256 yesVotes; // current number of YES votes for the Proposal
         uint256 abstainVotes; // current number of ABSTAIN votes for the Proposal
@@ -73,7 +71,7 @@ contract LinearERC721VotingV1 is
     /** ERC-721 address to its voting weight per NFT id.  */
     mapping(address => uint256) public tokenWeights;
 
-    /** Time (seconds or blocks) that a new Proposal can be voted on. */
+    /** Time that a new Proposal can be voted on. */
     uint32 public votingPeriod;
 
     /**
@@ -94,12 +92,10 @@ contract LinearERC721VotingV1 is
     /** The denominator to use when calculating basis (1,000,000). */
     uint256 public constant BASIS_DENOMINATOR = 1_000_000;
 
-    ClockMode private _clockMode;
-
     event VotingPeriodUpdated(uint32 votingPeriod);
     event QuorumThresholdUpdated(uint256 quorumThreshold);
     event ProposerThresholdUpdated(uint256 proposerThreshold);
-    event ProposalInitialized(uint32 proposalId, uint256 votingEndPoint);
+    event ProposalInitialized(uint32 proposalId, uint48 votingEndTime);
     event Voted(
         address voter,
         uint32 proposalId,
@@ -129,12 +125,11 @@ contract LinearERC721VotingV1 is
      * @param _tokens Array of ERC-721 token addresses that can vote
      * @param _weights Array of voting weights for each token
      * @param _proposalInitializer Address that is allowed to initialize Proposals
-     * @param _votingPeriod The voting time period (in units determined by _initialClockMode)
+     * @param _votingPeriod The voting time period (in seconds)
      * @param _quorumThreshold Total voting weight required to achieve quorum
      * @param _proposerThreshold Required voting weight to submit proposals
      * @param _basisNumerator The numerator for basis calculation
      * @param _lightAccountFactory The address of the light account factory
-     * @param _initialClockMode The clock mode for this strategy instance
      */
     function initialize(
         address _owner,
@@ -145,14 +140,11 @@ contract LinearERC721VotingV1 is
         uint256 _quorumThreshold,
         uint256 _proposerThreshold,
         uint256 _basisNumerator,
-        address _lightAccountFactory,
-        ClockMode _initialClockMode
+        address _lightAccountFactory
     ) public initializer {
         if (_tokens.length != _weights.length) {
             revert InvalidParams();
         }
-
-        _clockMode = _initialClockMode;
 
         for (uint i = 0; i < _tokens.length; ) {
             _addGovernanceToken(_tokens[i], _weights[i]);
@@ -196,7 +188,7 @@ contract LinearERC721VotingV1 is
     /**
      * Updates the voting time period for new Proposals.
      *
-     * @param _votingPeriod voting time period (in units determined by _clockMode)
+     * @param _votingPeriod voting time period (in seconds)
      */
     function updateVotingPeriod(
         uint32 _votingPeriod
@@ -256,8 +248,8 @@ contract LinearERC721VotingV1 is
      * @return noVotes current count of "NO" votes
      * @return yesVotes current count of "YES" votes
      * @return abstainVotes current count of "ABSTAIN" votes
-     * @return startPoint timepoint voting starts
-     * @return endPoint timepoint voting ends
+     * @return startTime timestamp voting starts
+     * @return endTime timestamp voting ends
      */
     function getProposalVotes(
         uint32 _proposalId
@@ -269,16 +261,16 @@ contract LinearERC721VotingV1 is
             uint256 noVotes,
             uint256 yesVotes,
             uint256 abstainVotes,
-            uint256 startPoint,
-            uint256 endPoint
+            uint48 startTime,
+            uint48 endTime
         )
     {
         ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
         noVotes = currentProposalVotes.noVotes;
         yesVotes = currentProposalVotes.yesVotes;
         abstainVotes = currentProposalVotes.abstainVotes;
-        startPoint = currentProposalVotes.votingStartPoint;
-        endPoint = currentProposalVotes.votingEndPoint;
+        startTime = currentProposalVotes.votingStartTime;
+        endTime = currentProposalVotes.votingEndTime;
     }
 
     /**
@@ -360,22 +352,22 @@ contract LinearERC721VotingV1 is
         bytes memory _data
     ) public virtual override onlyProposalInitializer {
         uint32 proposalId = abi.decode(_data, (uint32));
-        uint256 startPoint = ClockModeLib.getCurrentPoint(_clockMode);
-        uint256 endPoint = startPoint + votingPeriod;
+        uint48 startTime = uint48(block.timestamp);
+        uint48 endTime = startTime + votingPeriod;
 
-        proposalVotes[proposalId].votingStartPoint = startPoint;
-        proposalVotes[proposalId].votingEndPoint = endPoint;
+        proposalVotes[proposalId].votingStartTime = startTime;
+        proposalVotes[proposalId].votingEndTime = endTime;
 
-        emit ProposalInitialized(proposalId, endPoint);
+        emit ProposalInitialized(proposalId, endTime);
     }
 
     /** @inheritdoc BaseStrategyV1*/
     function isPassed(
         uint32 _proposalId
     ) public view virtual override returns (bool) {
-        uint256 currentPoint = ClockModeLib.getCurrentPoint(_clockMode);
+        uint48 currentTime = uint48(block.timestamp);
         ProposalVotes storage currentProposal = proposalVotes[_proposalId];
-        return (currentPoint > currentProposal.votingEndPoint &&
+        return (currentTime > currentProposal.votingEndTime &&
             quorumThreshold <=
             currentProposal.yesVotes + currentProposal.abstainVotes &&
             meetsBasis(currentProposal.yesVotes, currentProposal.noVotes));
@@ -398,16 +390,12 @@ contract LinearERC721VotingV1 is
         return totalWeight >= proposerThreshold;
     }
 
-    function getClockMode() public view virtual override returns (ClockMode) {
-        return _clockMode;
-    }
-
-    function getProposalVotingPeriodPoints(
+    function getVotingTimestamps(
         uint32 _proposalId
-    ) public view virtual override returns (uint256, uint256) {
+    ) public view virtual override returns (uint48 startTime, uint48 endTime) {
         return (
-            proposalVotes[_proposalId].votingStartPoint,
-            proposalVotes[_proposalId].votingEndPoint
+            proposalVotes[_proposalId].votingStartTime,
+            proposalVotes[_proposalId].votingEndTime
         );
     }
 
@@ -512,17 +500,17 @@ contract LinearERC721VotingV1 is
 
         ProposalVotes storage proposal = proposalVotes[_proposalId];
 
-        if (proposal.votingEndPoint == 0) revert InvalidProposal();
+        if (proposal.votingEndTime == 0) revert InvalidProposal();
 
-        uint256 currentPoint = ClockModeLib.getCurrentPoint(_clockMode);
+        uint48 currentTime = uint48(block.timestamp);
 
-        if (currentPoint > proposal.votingEndPoint) {
+        if (currentTime > proposal.votingEndTime) {
             if (!_votingPeriodEnded[_proposalId]) {
                 _votingPeriodEnded[_proposalId] = true;
                 emit VotingPeriodEnded(
                     _proposalId,
-                    proposal.votingEndPoint,
-                    currentPoint
+                    proposal.votingEndTime,
+                    currentTime
                 );
                 return;
             }

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.30;
 
 import {LinearERC721VotingV1} from "./LinearERC721VotingV1.sol";
 import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1.sol";
-import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
 
 /**
  * An [Azorius](./Azorius.md) [BaseStrategy](./BaseStrategy.md) implementation that
@@ -24,7 +23,6 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
         uint256 quorumThreshold;
         uint256 basisNumerator;
         address lightAccountFactory;
-        ClockMode initialClockMode;
     }
 
     struct HatsProposalCreationWhitelistParams {
@@ -51,14 +49,6 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
         LinearERC721VotingParams memory _linearVotingParams,
         HatsProposalCreationWhitelistParams memory _hatsParams
     ) public initializer {
-        initializeLinearERC721Voting(_owner, _linearVotingParams);
-        initializeHatsProposalCreationWhitelist(_owner, _hatsParams);
-    }
-
-    function initializeLinearERC721Voting(
-        address _owner,
-        LinearERC721VotingParams memory _linearVotingParams
-    ) private {
         LinearERC721VotingV1.initialize(
             _owner,
             _linearVotingParams.tokens,
@@ -68,15 +58,9 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
             _linearVotingParams.quorumThreshold,
             0, // _proposerThreshold is zero because we only care about the hat check
             _linearVotingParams.basisNumerator,
-            _linearVotingParams.lightAccountFactory,
-            _linearVotingParams.initialClockMode
+            _linearVotingParams.lightAccountFactory
         );
-    }
 
-    function initializeHatsProposalCreationWhitelist(
-        address _owner,
-        HatsProposalCreationWhitelistParams memory _hatsParams
-    ) private {
         HatsProposalCreationWhitelistV1.initialize(
             _owner,
             _hatsParams.hatsContract,

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -49,6 +49,7 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
         LinearERC721VotingParams memory _linearVotingParams,
         HatsProposalCreationWhitelistParams memory _hatsParams
     ) public initializer {
+        // Initialize LinearERC721VotingV1
         LinearERC721VotingV1.initialize(
             _owner,
             _linearVotingParams.tokens,
@@ -61,6 +62,7 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
             _linearVotingParams.lightAccountFactory
         );
 
+        // Initialize HatsProposalCreationWhitelistV1
         HatsProposalCreationWhitelistV1.initialize(
             _owner,
             _hatsParams.hatsContract,

--- a/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {LinearERC721VotingV1} from "./LinearERC721VotingV1.sol";
 import {HatsProposalCreationWhitelistV1} from "./HatsProposalCreationWhitelistV1.sol";
+import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
 
 /**
  * An [Azorius](./Azorius.md) [BaseStrategy](./BaseStrategy.md) implementation that
@@ -23,6 +24,7 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
         uint256 quorumThreshold;
         uint256 basisNumerator;
         address lightAccountFactory;
+        ClockMode initialClockMode;
     }
 
     struct HatsProposalCreationWhitelistParams {
@@ -49,7 +51,14 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
         LinearERC721VotingParams memory _linearVotingParams,
         HatsProposalCreationWhitelistParams memory _hatsParams
     ) public initializer {
-        // Initialize LinearERC721VotingV1
+        initializeLinearERC721Voting(_owner, _linearVotingParams);
+        initializeHatsProposalCreationWhitelist(_owner, _hatsParams);
+    }
+
+    function initializeLinearERC721Voting(
+        address _owner,
+        LinearERC721VotingParams memory _linearVotingParams
+    ) private {
         LinearERC721VotingV1.initialize(
             _owner,
             _linearVotingParams.tokens,
@@ -59,10 +68,15 @@ contract LinearERC721VotingWithHatsProposalCreationV1 is
             _linearVotingParams.quorumThreshold,
             0, // _proposerThreshold is zero because we only care about the hat check
             _linearVotingParams.basisNumerator,
-            _linearVotingParams.lightAccountFactory
+            _linearVotingParams.lightAccountFactory,
+            _linearVotingParams.initialClockMode
         );
+    }
 
-        // Initialize HatsProposalCreationWhitelistV1
+    function initializeHatsProposalCreationWhitelist(
+        address _owner,
+        HatsProposalCreationWhitelistParams memory _hatsParams
+    ) private {
         HatsProposalCreationWhitelistV1.initialize(
             _owner,
             _hatsParams.hatsContract,


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/261

Fixes [ENG-861](https://linear.app/decent-labs/issue/ENG-861/refactor-linearerc721votingv1-and-withhats-variant-for-clockmode)

This commit refactors `LinearERC721VotingV1` and its "WithHats" variant (`LinearERC721VotingWithHatsProposalCreationV1`) to integrate the `ClockMode` system. This allows the strategy to explicitly define and use either block-based or timestamp-based timing for its operations.

Key changes in `LinearERC721VotingV1`:
- Imports `ClockModeLib` and `ClockMode`.
- Adds `ClockMode private _clockMode;`.
- The `initialize` function now accepts an `_initialClockMode` parameter to set the strategy's clock mode.
- `ProposalVotes` struct updated to use `votingStartPoint` and `votingEndPoint` (both `uint256`).
- The `votingPeriod` parameter and state variable are now understood as units (seconds or blocks) determined by `_clockMode`. NatSpec updated.
- Core logic (`initializeProposal`, `isPassed`, `isProposer`) now uses `ClockModeLib.getCurrentPoint(_clockMode)` and the stored `votingStartPoint`/`votingEndPoint`.
- The `ProposalInitialized` event emits `votingEndPoint` (uint256).
- Implements the new `IBaseStrategyV1` interface:
    - Adds `getClockMode()` returning `_clockMode`.
    - Replaces `votingEndTimestamp()` with `getProposalVotingPeriodPoints()`, returning `votingStartPoint` and `votingEndPoint`.
- The `_vote` internal function logic updated to use `ClockModeLib.getCurrentPoint(_clockMode)` and `proposal.votingEndPoint` for time checks and event emission.

Changes in `LinearERC721VotingWithHatsProposalCreationV1`:
- `LinearERC721VotingParams` struct now includes an `initialClockMode` field.
- The main `initialize` function is split into `initializeLinearERC721Voting` and `initializeHatsProposalCreationWhitelist` for clarity.
- The `initialClockMode` is passed through to the `LinearERC721VotingV1.initialize` call.

**Important Note:** While `LinearERC20VotingV1` and `LinearERC721VotingV1` are now updated, other parts of the system, particularly tests and potentially other specialized strategies or dependent contracts, might still be broken. **Compilation errors and test failures are still expected** across the broader project. These will be addressed in the final subsequent commits.