### PR TITLE
refactor(Validators): Adapt Paymaster Validators to new strategy interfaces

### DIFF
--- a/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
@@ -14,9 +14,9 @@ interface ILinearERC20VotingV1 {
         address account
     ) external view returns (bool);
 
-    function getProposalVotingPeriodPoints(
+    function getVotingTimestamps(
         uint32 proposalId
-    ) external view returns (uint256 startPoint, uint256 endPoint);
+    ) external view returns (uint48 startTime, uint48 endTime);
 
     function votingPeriodEnded(uint32 proposalId) external view returns (bool);
 
@@ -74,13 +74,13 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
             return false;
         }
 
-        // get the proposal start and end points to determine if the proposal exists
-        (uint256 startPoint, uint256 endPoint) = ILinearERC20VotingV1(
+        // get the proposal start and end timestamps to determine if the proposal exists
+        (uint48 startTime, uint48 endTime) = ILinearERC20VotingV1(
             votingContract
-        ).getProposalVotingPeriodPoints(proposalId);
+        ).getVotingTimestamps(proposalId);
 
-        // Check if proposal exists (will have non-zero endPoint if it exists)
-        if (endPoint == 0) {
+        // Check if proposal exists (will have non-zero endTime if it exists)
+        if (endTime == 0) {
             return false;
         }
 
@@ -116,8 +116,8 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
             return false;
         }
 
-        // Iterate backwards through checkpoints to find the relevant one for startPoint.
-        // This is potentially more efficient than binary search if startPoint is recent.
+        // Iterate backwards through checkpoints to find the relevant one for startTime.
+        // This is potentially more efficient than binary search if startTime is recent.
         uint256 votingWeight = 0;
         for (uint256 i = numCheckpoints; i > 0; i--) {
             // Checkpoint indices are 0-based, loop index 'i' is 1-based count.
@@ -126,26 +126,26 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
                 uint32(i - 1)
             );
 
-            // If this checkpoint's timepoint is after the proposal's endPoint,
-            // it implies the current timepoint is also after endPoint.
+            // If this checkpoint's timestamp is after the proposal's endTime,
+            // it implies the current timestamp is also after endTime.
             // Thus, the voting period has definitively ended, and any vote is invalid.
-            if (checkpoint.key > endPoint) {
+            if (checkpoint.key > endTime) {
                 return false; // Vote is invalid as the proposal has ended.
             }
 
-            // If the checkpoint timepoint is less than or equal to the proposal start point,
+            // If the checkpoint timestamp is less than or equal to the proposal startTime,
             // we've found the relevant voting weight.
-            if (checkpoint.key <= startPoint) {
+            if (checkpoint.key <= startTime) {
                 votingWeight = checkpoint.value;
                 break; // Exit loop once the correct checkpoint is found
             }
         }
-        // If the loop completes without finding a checkpoint where fromPoint <= startPoint,
+        // If the loop completes without finding a checkpoint where fromTime <= startTime,
         // (and the optimization above didn't trigger and return false),
-        // it means all checkpoints are after startPoint, so the weight at startPoint was 0.
+        // it means all checkpoints are after startTime, so the weight at startTime was 0.
         // votingWeight remains 0 in this case.
 
-        // Check if the user had any voting weight at the proposal start point
+        // Check if the user had any voting weight at the proposal startTime
         if (votingWeight == 0) {
             return false;
         }

--- a/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
@@ -14,9 +14,9 @@ interface ILinearERC20VotingV1 {
         address account
     ) external view returns (bool);
 
-    function getProposalPeriod(
+    function getProposalVotingPeriodPoints(
         uint32 proposalId
-    ) external view returns (uint48, uint48);
+    ) external view returns (uint256 startPoint, uint256 endPoint);
 
     function votingPeriodEnded(uint32 proposalId) external view returns (bool);
 
@@ -74,13 +74,13 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
             return false;
         }
 
-        // get the proposal start and end timestamps to determine if the proposal exists
-        (uint48 startTimestamp, uint48 endTimestamp) = ILinearERC20VotingV1(
+        // get the proposal start and end points to determine if the proposal exists
+        (uint256 startPoint, uint256 endPoint) = ILinearERC20VotingV1(
             votingContract
-        ).getProposalPeriod(proposalId);
+        ).getProposalVotingPeriodPoints(proposalId);
 
-        // Check if proposal exists (will have non-zero endTimestamp if it exists)
-        if (endTimestamp == 0) {
+        // Check if proposal exists (will have non-zero endPoint if it exists)
+        if (endPoint == 0) {
             return false;
         }
 
@@ -116,8 +116,8 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
             return false;
         }
 
-        // Iterate backwards through checkpoints to find the relevant one for startTimestamp.
-        // This is potentially more efficient than binary search if startTimestamp is recent.
+        // Iterate backwards through checkpoints to find the relevant one for startPoint.
+        // This is potentially more efficient than binary search if startPoint is recent.
         uint256 votingWeight = 0;
         for (uint256 i = numCheckpoints; i > 0; i--) {
             // Checkpoint indices are 0-based, loop index 'i' is 1-based count.
@@ -126,26 +126,26 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
                 uint32(i - 1)
             );
 
-            // If this checkpoint's timestamp is after the proposal's endTimestamp,
-            // it implies the current timestamp is also after endTimestamp.
+            // If this checkpoint's timepoint is after the proposal's endPoint,
+            // it implies the current timepoint is also after endPoint.
             // Thus, the voting period has definitively ended, and any vote is invalid.
-            if (checkpoint.key > endTimestamp) {
+            if (checkpoint.key > endPoint) {
                 return false; // Vote is invalid as the proposal has ended.
             }
 
-            // If the checkpoint timestamp is less than or equal to the proposal start timestamp,
+            // If the checkpoint timepoint is less than or equal to the proposal start point,
             // we've found the relevant voting weight.
-            if (checkpoint.key <= startTimestamp) {
+            if (checkpoint.key <= startPoint) {
                 votingWeight = checkpoint.value;
                 break; // Exit loop once the correct checkpoint is found
             }
         }
-        // If the loop completes without finding a checkpoint where fromTimestamp <= startTimestamp,
+        // If the loop completes without finding a checkpoint where fromPoint <= startPoint,
         // (and the optimization above didn't trigger and return false),
-        // it means all checkpoints are after startTimestamp, so the weight at startTimestamp was 0.
+        // it means all checkpoints are after startPoint, so the weight at startPoint was 0.
         // votingWeight remains 0 in this case.
 
-        // Check if the user had any voting weight at the proposal start timestamp
+        // Check if the user had any voting weight at the proposal start point
         if (votingWeight == 0) {
             return false;
         }

--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -21,9 +21,9 @@ interface ILinearERC721VotingV1 {
         uint256 tokenId
     ) external view returns (bool);
 
-    function getProposalVotingPeriodPoints(
+    function getVotingTimestamps(
         uint32 proposalId
-    ) external view returns (uint256 startPoint, uint256 endPoint);
+    ) external view returns (uint48 startTime, uint48 endTime);
 
     function getTokenWeight(
         address tokenAddress
@@ -82,12 +82,12 @@ contract LinearERC721VotingV1ValidatorV1 is
             return false;
         }
 
-        // Get proposal end point to determine if the proposal exists
-        (, uint256 endPoint) = ILinearERC721VotingV1(votingContract)
-            .getProposalVotingPeriodPoints(proposalId);
+        // Get proposal end timestamp to determine if the proposal exists
+        (, uint48 endTime) = ILinearERC721VotingV1(votingContract)
+            .getVotingTimestamps(proposalId);
 
-        // Check if proposal exists (will have non-zero endPoint if it exists)
-        if (endPoint == 0) {
+        // Check if proposal exists (will have non-zero endTime if it exists)
+        if (endTime == 0) {
             return false;
         }
 

--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -21,9 +21,9 @@ interface ILinearERC721VotingV1 {
         uint256 tokenId
     ) external view returns (bool);
 
-    function votingEndTimestamp(
+    function getProposalVotingPeriodPoints(
         uint32 proposalId
-    ) external view returns (uint48);
+    ) external view returns (uint256 startPoint, uint256 endPoint);
 
     function getTokenWeight(
         address tokenAddress
@@ -82,12 +82,12 @@ contract LinearERC721VotingV1ValidatorV1 is
             return false;
         }
 
-        // Get voting end timestamp to determine if the proposal exists
-        uint256 endTimestamp = ILinearERC721VotingV1(votingContract)
-            .votingEndTimestamp(proposalId);
+        // Get proposal end point to determine if the proposal exists
+        (, uint256 endPoint) = ILinearERC721VotingV1(votingContract)
+            .getProposalVotingPeriodPoints(proposalId);
 
-        // Check if proposal exists (will have non-zero endTimestamp if it exists)
-        if (endTimestamp == 0) {
+        // Check if proposal exists (will have non-zero endPoint if it exists)
+        if (endPoint == 0) {
             return false;
         }
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/262

Fixes [ENG-862](https://linear.app/decent-labs/issue/ENG-862/update-paymaster-validators-for-compatibility-with-new-strategy)

This commit updates `LinearERC20VotingV1ValidatorV1` and `LinearERC721VotingV1ValidatorV1` to align with the interface changes in their corresponding voting strategy contracts (`ILinearERC20VotingV1` and `ILinearERC721VotingV1`).

Key changes:
- **`LinearERC20VotingV1ValidatorV1`**:
    - The local `ILinearERC20VotingV1` interface now declares `getProposalVotingPeriodPoints(...) returns (uint256 startPoint, uint256 endPoint)` instead of `getProposalPeriod(...) returns (uint48, uint48)`.
    - In `validateOperation`, it now calls `votingContract.getProposalVotingPeriodPoints(proposalId)` to get `startPoint` and `endPoint`.
    - Logic for checking proposal existence and checkpoint iteration now uses these `startPoint` and `endPoint` values.
- **`LinearERC721VotingV1ValidatorV1`**:
    - The local `ILinearERC721VotingV1` interface now declares `getProposalVotingPeriodPoints(...) returns (uint256 startPoint, uint256 endPoint)` instead of `votingEndTimestamp(...) returns (uint48)`.
    - In `validateOperation`, it now calls `votingContract.getProposalVotingPeriodPoints(proposalId)` to get the `endPoint` (the `startPoint` is not directly used in the existing logic but is available).
    - Logic for checking proposal existence uses the new `endPoint`.

**Important Note:** These changes make the validators compatible with the *updated* strategy interfaces. However, the overall project, including tests and potentially other un-updated contracts, **will still experience compilation errors and test failures**. These are expected and will be resolved once all components are updated and tests are adjusted.