### PR TITLE
refactor(Mocks): Update mock contracts to align with ClockMode refactor

### DIFF
--- a/contracts/mocks/MockERC20Votes.sol
+++ b/contracts/mocks/MockERC20Votes.sol
@@ -20,6 +20,14 @@ contract MockERC20Votes is ERC20, ERC20Permit, IVotes {
         ERC20Permit("Mock Voting Token")
     {}
 
+    function clock() public view returns (uint256) {
+        return block.timestamp;
+    }
+
+    function CLOCK_MODE() public pure returns (string memory) {
+        return "mode=timestamp";
+    }
+
     /**
      * @dev Mints tokens to the specified address
      * @param to The address to mint tokens to
@@ -30,29 +38,29 @@ contract MockERC20Votes is ERC20, ERC20Permit, IVotes {
     }
 
     /**
-     * @dev Sets a specific past voting weight for an account at a specific timestamp
+     * @dev Sets a specific past voting weight for an account at a specific timepoint
      * @param account The account to set past votes for
-     * @param timestamp The timestamp to set votes at
+     * @param timepoint The timepoint to set votes at
      * @param votes The amount of votes to set
      */
     function setPastVotes(
         address account,
-        uint256 timestamp,
+        uint256 timepoint,
         uint256 votes
     ) external {
-        _mockPastVotes[account][timestamp] = votes;
+        _mockPastVotes[account][timepoint] = votes;
     }
 
     /**
-     * @dev Sets a specific past total supply for a specific timestamp
-     * @param timestamp The timestamp to set total supply at
+     * @dev Sets a specific past total supply for a specific timepoint
+     * @param timepoint The timepoint to set total supply at
      * @param totalSupply The total supply to set
      */
     function setPastTotalSupply(
-        uint256 timestamp,
+        uint256 timepoint,
         uint256 totalSupply
     ) external {
-        _mockPastTotalSupply[timestamp] = totalSupply;
+        _mockPastTotalSupply[timepoint] = totalSupply;
     }
 
     /**
@@ -97,12 +105,12 @@ contract MockERC20Votes is ERC20, ERC20Permit, IVotes {
      */
     function getPastVotes(
         address account,
-        uint256 timestamp
+        uint256 timepoint
     ) public view override returns (uint256) {
-        if (_mockPastVotes[account][timestamp] > 0) {
-            return _mockPastVotes[account][timestamp];
+        if (_mockPastVotes[account][timepoint] > 0) {
+            return _mockPastVotes[account][timepoint];
         }
-        // If no explicit value is set for this timestamp, return the current balance
+        // If no explicit value is set for this timepoint, return the current balance
         // In a real implementation, this would use a checkpoint system
         return balanceOf(account);
     }
@@ -111,12 +119,12 @@ contract MockERC20Votes is ERC20, ERC20Permit, IVotes {
      * @dev Enhanced implementation that properly handles historical snapshots
      */
     function getPastTotalSupply(
-        uint256 timestamp
+        uint256 timepoint
     ) public view override returns (uint256) {
-        if (_mockPastTotalSupply[timestamp] > 0) {
-            return _mockPastTotalSupply[timestamp];
+        if (_mockPastTotalSupply[timepoint] > 0) {
+            return _mockPastTotalSupply[timepoint];
         }
-        // If no explicit value is set for this timestamp, return the current total supply
+        // If no explicit value is set for this timepoint, return the current total supply
         // In a real implementation, this would use a checkpoint system
         return totalSupply();
     }

--- a/contracts/mocks/MockLinearERC20VotingV1.sol
+++ b/contracts/mocks/MockLinearERC20VotingV1.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.30;
 
 // Mirror the struct for getProposalVotes return values
 struct ProposalPeriod {
-    uint256 startPoint;
-    uint256 endPoint;
+    uint48 startTime;
+    uint48 endTime;
 }
 
 // Mirror the struct from IERC20Votes
@@ -15,7 +15,7 @@ struct Checkpoint208 {
 
 contract MockLinearERC20VotingV1 {
     // Mapping: proposalId => ProposalPeriod
-    mapping(uint32 => ProposalPeriod) public getProposalVotingPeriodPoints;
+    mapping(uint32 => ProposalPeriod) public getVotingTimestamps;
     // Mapping: proposalId => votingPeriodEnded
     mapping(uint32 => bool) public votingPeriodEnded;
     // Mapping: proposalId => voter => hasVoted
@@ -32,11 +32,11 @@ contract MockLinearERC20VotingV1 {
         // Mock implementation - just for interface matching
     }
 
-    function setProposalPeriod(
+    function setVotingTimestamps(
         uint32 proposalId,
         ProposalPeriod calldata data
     ) external {
-        getProposalVotingPeriodPoints[proposalId] = data;
+        getVotingTimestamps[proposalId] = data;
     }
 
     function setVotingPeriodEnded(uint32 proposalId, bool ended) external {

--- a/contracts/mocks/MockLinearERC20VotingV1.sol
+++ b/contracts/mocks/MockLinearERC20VotingV1.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.30;
 
 // Mirror the struct for getProposalVotes return values
 struct ProposalPeriod {
-    uint48 startTimestamp;
-    uint48 endTimestamp;
+    uint256 startPoint;
+    uint256 endPoint;
 }
 
 // Mirror the struct from IERC20Votes
@@ -15,7 +15,7 @@ struct Checkpoint208 {
 
 contract MockLinearERC20VotingV1 {
     // Mapping: proposalId => ProposalPeriod
-    mapping(uint32 => ProposalPeriod) public getProposalPeriod;
+    mapping(uint32 => ProposalPeriod) public getProposalVotingPeriodPoints;
     // Mapping: proposalId => votingPeriodEnded
     mapping(uint32 => bool) public votingPeriodEnded;
     // Mapping: proposalId => voter => hasVoted
@@ -36,7 +36,7 @@ contract MockLinearERC20VotingV1 {
         uint32 proposalId,
         ProposalPeriod calldata data
     ) external {
-        getProposalPeriod[proposalId] = data;
+        getProposalVotingPeriodPoints[proposalId] = data;
     }
 
     function setVotingPeriodEnded(uint32 proposalId, bool ended) external {

--- a/contracts/mocks/MockLinearERC721VotingV1.sol
+++ b/contracts/mocks/MockLinearERC721VotingV1.sol
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+// Mirror the struct for getProposalVotes return values
+struct ProposalPeriod {
+    uint256 startPoint;
+    uint256 endPoint;
+}
+
 contract MockLinearERC721VotingV1 {
-    // Mapping: proposalId => endTimestamp
-    mapping(uint32 => uint48) public votingEndTimestamp;
+    // Mapping: proposalId => ProposalPeriod
+    mapping(uint32 => ProposalPeriod) public getProposalVotingPeriodPoints;
     // Mapping: proposalId => votingPeriodEnded
     mapping(uint32 => bool) public votingPeriodEnded;
     // Mapping: proposalId => tokenAddress => tokenId => hasVoted
@@ -21,11 +27,11 @@ contract MockLinearERC721VotingV1 {
         // Mock implementation - just for interface matching
     }
 
-    function setVotingEndTimestamp(
+    function setProposalPeriod(
         uint32 proposalId,
-        uint48 endTimestamp
+        ProposalPeriod calldata data
     ) external {
-        votingEndTimestamp[proposalId] = endTimestamp;
+        getProposalVotingPeriodPoints[proposalId] = data;
     }
 
     function setVotingPeriodEnded(uint32 proposalId, bool ended) external {

--- a/contracts/mocks/MockLinearERC721VotingV1.sol
+++ b/contracts/mocks/MockLinearERC721VotingV1.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.30;
 
 // Mirror the struct for getProposalVotes return values
 struct ProposalPeriod {
-    uint256 startPoint;
-    uint256 endPoint;
+    uint48 startTime;
+    uint48 endTime;
 }
 
 contract MockLinearERC721VotingV1 {
     // Mapping: proposalId => ProposalPeriod
-    mapping(uint32 => ProposalPeriod) public getProposalVotingPeriodPoints;
+    mapping(uint32 => ProposalPeriod) public getVotingTimestamps;
     // Mapping: proposalId => votingPeriodEnded
     mapping(uint32 => bool) public votingPeriodEnded;
     // Mapping: proposalId => tokenAddress => tokenId => hasVoted
@@ -27,11 +27,11 @@ contract MockLinearERC721VotingV1 {
         // Mock implementation - just for interface matching
     }
 
-    function setProposalPeriod(
+    function setVotingTimestamps(
         uint32 proposalId,
         ProposalPeriod calldata data
     ) external {
-        getProposalVotingPeriodPoints[proposalId] = data;
+        getVotingTimestamps[proposalId] = data;
     }
 
     function setVotingPeriodEnded(uint32 proposalId, bool ended) external {

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -5,20 +5,17 @@ import {IBaseStrategyV1} from "../interfaces/decent/deployables/IBaseStrategyV1.
 import {ClockMode} from "../interfaces/decent/ClockMode.sol";
 
 contract MockVotingStrategy is IBaseStrategyV1 {
-    struct PeriodPoints {
-        uint256 startPoint;
-        uint256 endPoint;
+    struct TimestampPoints {
+        uint48 startTime;
+        uint48 endTime;
     }
 
     address public proposer;
     mapping(uint32 => bool) private _isPassed;
-    mapping(uint32 => PeriodPoints) private _proposalPeriodPoints;
-
-    ClockMode private currentClockMode;
+    mapping(uint32 => TimestampPoints) private _proposalTimestamps;
 
     constructor(address _proposer) {
         proposer = _proposer;
-        currentClockMode = ClockMode.Timestamp;
     }
 
     function initializeProposal(bytes memory) external override {}
@@ -33,27 +30,19 @@ contract MockVotingStrategy is IBaseStrategyV1 {
         return _proposer == proposer;
     }
 
-    function setClockMode(ClockMode _newMode) external {
-        currentClockMode = _newMode;
-    }
-
-    function getClockMode() external view override returns (ClockMode) {
-        return currentClockMode;
-    }
-
-    function getProposalVotingPeriodPoints(
+    function getVotingTimestamps(
         uint32 proposalId
-    ) external view override returns (uint256, uint256) {
-        PeriodPoints memory periodPoints = _proposalPeriodPoints[proposalId];
-        return (periodPoints.startPoint, periodPoints.endPoint);
+    ) external view override returns (uint48, uint48) {
+        TimestampPoints memory timestamps = _proposalTimestamps[proposalId];
+        return (timestamps.startTime, timestamps.endTime);
     }
 
-    function setProposalPeriodPoints(
+    function setProposalTimestamps(
         uint32 proposalId,
-        uint256 startPoint,
-        uint256 endPoint
+        uint48 startTime,
+        uint48 endTime
     ) external {
-        _proposalPeriodPoints[proposalId] = PeriodPoints(startPoint, endPoint);
+        _proposalTimestamps[proposalId] = TimestampPoints(startTime, endTime);
     }
 
     function setIsPassed(uint32 proposalId, bool passed) external {

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -2,19 +2,26 @@
 pragma solidity ^0.8.30;
 
 import {IBaseStrategyV1} from "../interfaces/decent/deployables/IBaseStrategyV1.sol";
+import {ClockMode} from "../interfaces/decent/ClockMode.sol";
 
 contract MockVotingStrategy is IBaseStrategyV1 {
+    struct PeriodPoints {
+        uint256 startPoint;
+        uint256 endPoint;
+    }
+
     address public proposer;
     mapping(uint32 => bool) private _isPassed;
-    mapping(uint32 => uint48) private _votingEndTimestamp;
+    mapping(uint32 => PeriodPoints) private _proposalPeriodPoints;
+
+    ClockMode private currentClockMode;
 
     constructor(address _proposer) {
         proposer = _proposer;
+        currentClockMode = ClockMode.Timestamp;
     }
 
-    // required by IBaseStrategyV1
-
-    function initializeProposal(bytes memory _data) external override {}
+    function initializeProposal(bytes memory) external override {}
 
     function isPassed(uint32 proposalId) external view override returns (bool) {
         return _isPassed[proposalId];
@@ -26,19 +33,27 @@ contract MockVotingStrategy is IBaseStrategyV1 {
         return _proposer == proposer;
     }
 
-    function votingEndTimestamp(
-        uint32 proposalId
-    ) external view override returns (uint48) {
-        return _votingEndTimestamp[proposalId];
+    function setClockMode(ClockMode _newMode) external {
+        currentClockMode = _newMode;
     }
 
-    // setters, for testing
+    function getClockMode() external view override returns (ClockMode) {
+        return currentClockMode;
+    }
 
-    function setVotingEndTimestamp(
+    function getProposalVotingPeriodPoints(
+        uint32 proposalId
+    ) external view override returns (uint256, uint256) {
+        PeriodPoints memory periodPoints = _proposalPeriodPoints[proposalId];
+        return (periodPoints.startPoint, periodPoints.endPoint);
+    }
+
+    function setProposalPeriodPoints(
         uint32 proposalId,
-        uint48 endTimestamp
+        uint256 startPoint,
+        uint256 endPoint
     ) external {
-        _votingEndTimestamp[proposalId] = endTimestamp;
+        _proposalPeriodPoints[proposalId] = PeriodPoints(startPoint, endPoint);
     }
 
     function setIsPassed(uint32 proposalId, bool passed) external {

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -37,7 +37,7 @@ contract MockVotingStrategy is IBaseStrategyV1 {
         return (timestamps.startTime, timestamps.endTime);
     }
 
-    function setProposalTimestamps(
+    function setVotingTimestamps(
         uint32 proposalId,
         uint48 startTime,
         uint48 endTime

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
@@ -2,12 +2,17 @@
 pragma solidity ^0.8.30;
 
 import {BaseStrategyV1} from "../../../../deployables/strategies/BaseStrategyV1.sol";
+import {ClockMode} from "../../../../interfaces/decent/ClockMode.sol";
+import {ClockModeLib} from "../../../../libs/ClockModeLib.sol";
 
 /**
  * A concrete implementation of BaseStrategyV1 for testing purposes.
  */
 contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
-    event ConcreteFunctionCalled();
+    uint32 public constant CONCRETE_VOTING_PERIOD_SECONDS = 100;
+    uint32 public constant CONCRETE_VOTING_PERIOD_BLOCKS = 10;
+
+    ClockMode private currentClockMode;
 
     /**
      * Sets up the concrete strategy contract.
@@ -19,49 +24,48 @@ contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
         address _proposalInitializer
     ) public override initializer {
         BaseStrategyV1.initialize(_owner, _proposalInitializer);
-
+        currentClockMode = ClockMode.Timestamp; // Default clock mode
         emit StrategySetUp(_proposalInitializer, _owner);
     }
 
-    /**
-     * A concrete function that uses the onlyAzorius modifier for testing.
-     */
+    function setClockMode(ClockMode _newMode) external {
+        currentClockMode = _newMode;
+    }
+
     function concreteOnlyProposalInitializerFunction()
         external
         onlyProposalInitializer
-    {
-        emit ConcreteFunctionCalled();
-    }
+    {}
 
-    /**
-     * Concrete implementation of the abstract initializeProposal function.
-     */
     function initializeProposal(
         bytes memory
-    ) external override onlyProposalInitializer {
-        emit ConcreteFunctionCalled();
-    }
+    ) external override onlyProposalInitializer {}
 
-    /**
-     * Concrete implementation of the abstract isPassed function.
-     */
     function isPassed(uint32) external pure override returns (bool) {
         return true;
     }
 
-    /**
-     * Concrete implementation of the abstract isProposer function.
-     */
     function isProposer(address) external pure override returns (bool) {
         return true;
     }
 
-    /**
-     * Concrete implementation of the abstract votingEndTimestamp function.
-     */
-    function votingEndTimestamp(
+    function getClockMode() public view override returns (ClockMode) {
+        return currentClockMode;
+    }
+
+    function getProposalVotingPeriodPoints(
         uint32
-    ) external view override returns (uint48) {
-        return uint48(block.timestamp) + 100;
+    ) public view override returns (uint256 startPoint, uint256 endPoint) {
+        ClockMode mode = getClockMode();
+        uint256 currentPoint = ClockModeLib.getCurrentPoint(mode);
+
+        if (mode == ClockMode.Timestamp) {
+            startPoint = currentPoint;
+            endPoint = currentPoint + CONCRETE_VOTING_PERIOD_SECONDS;
+        } else {
+            startPoint = currentPoint;
+            endPoint = currentPoint + CONCRETE_VOTING_PERIOD_BLOCKS;
+        }
+        return (startPoint, endPoint);
     }
 }

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
@@ -2,18 +2,11 @@
 pragma solidity ^0.8.30;
 
 import {BaseStrategyV1} from "../../../../deployables/strategies/BaseStrategyV1.sol";
-import {ClockMode} from "../../../../interfaces/decent/ClockMode.sol";
-import {ClockModeLib} from "../../../../libs/ClockModeLib.sol";
 
 /**
  * A concrete implementation of BaseStrategyV1 for testing purposes.
  */
 contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
-    uint32 public constant CONCRETE_VOTING_PERIOD_SECONDS = 100;
-    uint32 public constant CONCRETE_VOTING_PERIOD_BLOCKS = 10;
-
-    ClockMode private currentClockMode;
-
     /**
      * Sets up the concrete strategy contract.
      * @param _owner The owner of the contract
@@ -24,12 +17,7 @@ contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
         address _proposalInitializer
     ) public override initializer {
         BaseStrategyV1.initialize(_owner, _proposalInitializer);
-        currentClockMode = ClockMode.Timestamp; // Default clock mode
         emit StrategySetUp(_proposalInitializer, _owner);
-    }
-
-    function setClockMode(ClockMode _newMode) external {
-        currentClockMode = _newMode;
     }
 
     function concreteOnlyProposalInitializerFunction()
@@ -49,23 +37,9 @@ contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
         return true;
     }
 
-    function getClockMode() public view override returns (ClockMode) {
-        return currentClockMode;
-    }
-
-    function getProposalVotingPeriodPoints(
+    function getVotingTimestamps(
         uint32
-    ) public view override returns (uint256 startPoint, uint256 endPoint) {
-        ClockMode mode = getClockMode();
-        uint256 currentPoint = ClockModeLib.getCurrentPoint(mode);
-
-        if (mode == ClockMode.Timestamp) {
-            startPoint = currentPoint;
-            endPoint = currentPoint + CONCRETE_VOTING_PERIOD_SECONDS;
-        } else {
-            startPoint = currentPoint;
-            endPoint = currentPoint + CONCRETE_VOTING_PERIOD_BLOCKS;
-        }
-        return (startPoint, endPoint);
+    ) public view override returns (uint48 startTime, uint48 endTime) {
+        return (uint48(block.timestamp), uint48(block.timestamp) + 100);
     }
 }


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/263

Fixes [ENG-863](https://linear.app/decent-labs/issue/ENG-863/update-mock-contracts-for-clockmode-refactor-compatibility)

This commit updates various mock contracts (`MockERC20Votes`, `MockLinearERC20VotingV1`, `MockLinearERC721VotingV1`, `MockVotingStrategy`, and `ConcreteBaseStrategyV1`) to be compatible with the extensive `ClockMode` and time handling refactoring recently performed on the core strategy and Azorius contracts.

Key changes:
- **`MockERC20Votes`**:
    - Added `clock()` and `CLOCK_MODE()` functions to simulate an ERC6372-compliant token operating in timestamp mode.
    - Renamed `timestamp` parameter to `timepoint` in `setPastVotes` and `setPastTotalSupply` and their corresponding getter functions (`getPastVotes`, `getPastTotalSupply`) to reflect that these can be block numbers or timestamps.
- **`MockLinearERC20VotingV1`**:
    - Renamed `getProposalPeriod` mapping and setter to `getProposalVotingPeriodPoints` and `setProposalPeriod` respectively.
    - `ProposalPeriod` struct now uses `startPoint` and `endPoint` (both `uint256`).
- **`MockLinearERC721VotingV1`**:
    - Renamed `votingEndTimestamp` mapping and `setVotingEndTimestamp` setter to `getProposalVotingPeriodPoints` and `setProposalPeriod` respectively.
    - Added a `ProposalPeriod` struct with `startPoint` and `endPoint` (both `uint256`) to be used by the mapping.
- **`MockVotingStrategy`**:
    - Implements `getClockMode()` (defaulting to `ClockMode.Timestamp`) and `setClockMode()`.
    - Replaces `votingEndTimestamp` and `setVotingEndTimestamp` with `getProposalVotingPeriodPoints` and `setProposalPeriodPoints`, which handle `startPoint` and `endPoint`.
    - Added internal `PeriodPoints` struct.
- **`ConcreteBaseStrategyV1`**:
    - Implements `getClockMode()` and `setClockMode()`.
    - `getProposalVotingPeriodPoints` now correctly returns start and end points based on the `currentClockMode` (using `ClockModeLib.getCurrentPoint`) and predefined constants for seconds or blocks.

**Important Note:** With these changes, all core contracts and their mocks should now **compile successfully**. However, the **test suite is still expected to fail**. The tests themselves need to be updated to reflect the new interfaces, the `ClockMode` logic, and the changes in how time-related data is handled and asserted. These test updates will be addressed in the final commit of this refactoring series.