### PR TITLE
fix(Tests): Align test suite with ClockMode refactoring

### DIFF
--- a/test/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.test.ts
@@ -52,12 +52,12 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
       const currentTimestamp = await time.latest();
 
       const proposalPeriod = {
-        startPoint: currentTimestamp,
-        endPoint: currentTimestamp + 100,
+        startTime: currentTimestamp,
+        endTime: currentTimestamp + 100,
       };
 
       // Set up proposal votes data with safe timestamps
-      await mockERC20Strategy.setProposalPeriod(_proposalId, proposalPeriod);
+      await mockERC20Strategy.setVotingTimestamps(_proposalId, proposalPeriod);
 
       // Set up voting state
       await mockERC20Strategy.setVotingPeriodEnded(_proposalId, false);
@@ -148,9 +148,9 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
       void expect(validResult).to.be.true;
 
       // Now set the proposal to non-existent (endTimestamp = 0)
-      await mockERC20Strategy.setProposalPeriod(proposalId, {
-        startPoint: 0,
-        endPoint: 0, // Zero end timepoint
+      await mockERC20Strategy.setVotingTimestamps(proposalId, {
+        startTime: 0,
+        endTime: 0, // Zero end timepoint
       });
 
       const invalidResult = await validator.validateOperation(
@@ -237,11 +237,11 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set checkpoints that are all after the proposal start timestamp
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint + 1, // After proposal start
+              key: proposalPeriod.startTime + 1, // After proposal start
               value: 100n,
             },
             {
-              key: proposalPeriod.startPoint + 2, // Even later checkpoint
+              key: proposalPeriod.startTime + 2, // Even later checkpoint
               value: 200n,
             },
           ]);
@@ -266,7 +266,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set a checkpoint before proposal start but with zero votes
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint - 1, // Just before proposal start
+              key: proposalPeriod.startTime - 1, // Just before proposal start
               value: 0n, // Zero voting weight
             },
           ]);
@@ -293,7 +293,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set a single checkpoint before proposal start
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint - 1, // One timestamp before proposal start
+              key: proposalPeriod.startTime - 1, // One timestamp before proposal start
               value: 100n,
             },
           ]);
@@ -318,7 +318,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set a single checkpoint exactly at proposal start timestamp
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint, // Same as proposal start timestamp
+              key: proposalPeriod.startTime, // Same as proposal start timestamp
               value: 100n,
             },
           ]);
@@ -343,7 +343,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set a single checkpoint after proposal start timestamp
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint + 1, // One timestamp after proposal start
+              key: proposalPeriod.startTime + 1, // One timestamp after proposal start
               value: 100n, // Non-zero votes to ensure failure is due to timing
             },
           ]);
@@ -370,15 +370,15 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set multiple checkpoints before proposal start with different vote amounts
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint - 3, // Oldest checkpoint
+              key: proposalPeriod.startTime - 3, // Oldest checkpoint
               value: 50n,
             },
             {
-              key: proposalPeriod.startPoint - 2, // Middle checkpoint
+              key: proposalPeriod.startTime - 2, // Middle checkpoint
               value: 0n, // Zero votes - if this was used, validation would fail
             },
             {
-              key: proposalPeriod.startPoint - 1, // Most recent valid checkpoint
+              key: proposalPeriod.startTime - 1, // Most recent valid checkpoint
               value: 100n, // Non-zero votes - this should be used
             },
           ]);
@@ -403,15 +403,15 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set checkpoints both before and after proposal start
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint - 1, // Valid checkpoint before start
+              key: proposalPeriod.startTime - 1, // Valid checkpoint before start
               value: 0n, // Zero votes - this should be used, causing validation to fail
             },
             {
-              key: proposalPeriod.startPoint + 1, // After proposal start
+              key: proposalPeriod.startTime + 1, // After proposal start
               value: 100n, // Non-zero votes - this should be ignored
             },
             {
-              key: proposalPeriod.startPoint + 2, // Even later checkpoint
+              key: proposalPeriod.startTime + 2, // Even later checkpoint
               value: 200n, // Higher votes - should also be ignored
             },
           ]);
@@ -436,15 +436,15 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set checkpoints before, at, and after proposal start
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint - 2, // Earlier checkpoint
+              key: proposalPeriod.startTime - 2, // Earlier checkpoint
               value: 0n, // Should be ignored in favor of later checkpoint
             },
             {
-              key: proposalPeriod.startPoint, // Exactly at proposal start
+              key: proposalPeriod.startTime, // Exactly at proposal start
               value: 100n, // This should be used for validation
             },
             {
-              key: proposalPeriod.startPoint + 1, // After start
+              key: proposalPeriod.startTime + 1, // After start
               value: 0n, // Should be ignored
             },
           ]);
@@ -472,7 +472,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           const maxUint208 = 2n ** 208n - 1n;
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint - 1,
+              key: proposalPeriod.startTime - 1,
               value: maxUint208,
             },
           ]);
@@ -491,9 +491,9 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           const { calldata } = await setupVoteOperation(proposalId, voteTypes.YES, voter.address);
 
           // Override proposal to start at timestamp 0
-          await mockERC20Strategy.setProposalPeriod(proposalId, {
-            startPoint: 0,
-            endPoint: 100,
+          await mockERC20Strategy.setVotingTimestamps(proposalId, {
+            startTime: 0,
+            endTime: 100,
           });
 
           // Set checkpoint at timestamp 0
@@ -528,11 +528,11 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
               value: 50n,
             },
             {
-              key: Math.floor(proposalPeriod.startPoint / 2), // Checkpoint halfway between genesis and proposal start
+              key: Math.floor(proposalPeriod.startTime / 2), // Checkpoint halfway between genesis and proposal start
               value: 0n,
             },
             {
-              key: proposalPeriod.startPoint - 1, // Checkpoint just before proposal start
+              key: proposalPeriod.startTime - 1, // Checkpoint just before proposal start
               value: 100n, // This should be used
             },
           ]);
@@ -561,11 +561,11 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // - A newer one that is after endTimestamp (should trigger the optimization)
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startPoint - 10, // Older, valid checkpoint
+              key: proposalPeriod.startTime - 10, // Older, valid checkpoint
               value: 100n,
             },
             {
-              key: proposalPeriod.endPoint + 1, // Newer, after proposal end
+              key: proposalPeriod.endTime + 1, // Newer, after proposal end
               value: 50n, // Votes here don't matter as it should short-circuit
             },
           ]);
@@ -590,7 +590,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set up a single checkpoint that is after endTimestamp
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.endPoint + 5, // After proposal end
+              key: proposalPeriod.endTime + 5, // After proposal end
               value: 100n,
             },
           ]);
@@ -625,20 +625,18 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
       const expectedStart = currentTimestamp;
       const expectedEnd = currentTimestamp + 100;
 
-      await mockERC20Strategy.setProposalPeriod(proposalId, {
-        startPoint: expectedStart,
-        endPoint: expectedEnd,
+      await mockERC20Strategy.setVotingTimestamps(proposalId, {
+        startTime: expectedStart,
+        endTime: expectedEnd,
       });
 
-      const [actualStart, actualEnd] =
-        await mockERC20Strategy.getProposalVotingPeriodPoints(proposalId);
+      const [actualStart, actualEnd] = await mockERC20Strategy.getVotingTimestamps(proposalId);
       expect(actualStart).to.equal(expectedStart);
       expect(actualEnd).to.equal(expectedEnd);
     });
 
     it('Should return zeros for non-existent proposal', async function () {
-      const [startTimestamp, endTimestamp] =
-        await mockERC20Strategy.getProposalVotingPeriodPoints(999); // Using an unused proposal ID
+      const [startTimestamp, endTimestamp] = await mockERC20Strategy.getVotingTimestamps(999); // Using an unused proposal ID
       expect(startTimestamp).to.equal(0);
       expect(endTimestamp).to.equal(0);
     });
@@ -646,22 +644,22 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
     it('Should return updated values after modifying proposal period', async function () {
       // Set initial values
       const currentTimestamp = await time.latest();
-      await mockERC20Strategy.setProposalPeriod(proposalId, {
-        startPoint: currentTimestamp,
-        endPoint: currentTimestamp + 100,
+      await mockERC20Strategy.setVotingTimestamps(proposalId, {
+        startTime: currentTimestamp,
+        endTime: currentTimestamp + 10,
       });
 
       // Update to new values
       const newStart = currentTimestamp + 50;
       const newEnd = currentTimestamp + 150;
-      await mockERC20Strategy.setProposalPeriod(proposalId, {
-        startPoint: newStart,
-        endPoint: newEnd,
+      await mockERC20Strategy.setVotingTimestamps(proposalId, {
+        startTime: newStart,
+        endTime: newEnd,
       });
 
       // Verify the update
       const [startTimestamp, endTimestamp] =
-        await mockERC20Strategy.getProposalVotingPeriodPoints(proposalId);
+        await mockERC20Strategy.getVotingTimestamps(proposalId);
       expect(startTimestamp).to.equal(newStart);
       expect(endTimestamp).to.equal(newEnd);
     });

--- a/test/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.test.ts
@@ -52,8 +52,8 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
       const currentTimestamp = await time.latest();
 
       const proposalPeriod = {
-        startTimestamp: currentTimestamp,
-        endTimestamp: currentTimestamp + 100,
+        startPoint: currentTimestamp,
+        endPoint: currentTimestamp + 100,
       };
 
       // Set up proposal votes data with safe timestamps
@@ -149,8 +149,8 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
 
       // Now set the proposal to non-existent (endTimestamp = 0)
       await mockERC20Strategy.setProposalPeriod(proposalId, {
-        startTimestamp: 0,
-        endTimestamp: 0, // Zero end timestamp indicates non-existent proposal
+        startPoint: 0,
+        endPoint: 0, // Zero end timepoint
       });
 
       const invalidResult = await validator.validateOperation(
@@ -237,11 +237,11 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set checkpoints that are all after the proposal start timestamp
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp + 1, // After proposal start
+              key: proposalPeriod.startPoint + 1, // After proposal start
               value: 100n,
             },
             {
-              key: proposalPeriod.startTimestamp + 2, // Even later checkpoint
+              key: proposalPeriod.startPoint + 2, // Even later checkpoint
               value: 200n,
             },
           ]);
@@ -266,7 +266,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set a checkpoint before proposal start but with zero votes
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp - 1, // Just before proposal start
+              key: proposalPeriod.startPoint - 1, // Just before proposal start
               value: 0n, // Zero voting weight
             },
           ]);
@@ -293,7 +293,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set a single checkpoint before proposal start
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp - 1, // One timestamp before proposal start
+              key: proposalPeriod.startPoint - 1, // One timestamp before proposal start
               value: 100n,
             },
           ]);
@@ -318,7 +318,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set a single checkpoint exactly at proposal start timestamp
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp, // Same as proposal start timestamp
+              key: proposalPeriod.startPoint, // Same as proposal start timestamp
               value: 100n,
             },
           ]);
@@ -343,7 +343,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set a single checkpoint after proposal start timestamp
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp + 1, // One timestamp after proposal start
+              key: proposalPeriod.startPoint + 1, // One timestamp after proposal start
               value: 100n, // Non-zero votes to ensure failure is due to timing
             },
           ]);
@@ -370,15 +370,15 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set multiple checkpoints before proposal start with different vote amounts
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp - 3, // Oldest checkpoint
+              key: proposalPeriod.startPoint - 3, // Oldest checkpoint
               value: 50n,
             },
             {
-              key: proposalPeriod.startTimestamp - 2, // Middle checkpoint
+              key: proposalPeriod.startPoint - 2, // Middle checkpoint
               value: 0n, // Zero votes - if this was used, validation would fail
             },
             {
-              key: proposalPeriod.startTimestamp - 1, // Most recent valid checkpoint
+              key: proposalPeriod.startPoint - 1, // Most recent valid checkpoint
               value: 100n, // Non-zero votes - this should be used
             },
           ]);
@@ -403,15 +403,15 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set checkpoints both before and after proposal start
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp - 1, // Valid checkpoint before start
+              key: proposalPeriod.startPoint - 1, // Valid checkpoint before start
               value: 0n, // Zero votes - this should be used, causing validation to fail
             },
             {
-              key: proposalPeriod.startTimestamp + 1, // After proposal start
+              key: proposalPeriod.startPoint + 1, // After proposal start
               value: 100n, // Non-zero votes - this should be ignored
             },
             {
-              key: proposalPeriod.startTimestamp + 2, // Even later checkpoint
+              key: proposalPeriod.startPoint + 2, // Even later checkpoint
               value: 200n, // Higher votes - should also be ignored
             },
           ]);
@@ -436,15 +436,15 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set checkpoints before, at, and after proposal start
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp - 2, // Earlier checkpoint
+              key: proposalPeriod.startPoint - 2, // Earlier checkpoint
               value: 0n, // Should be ignored in favor of later checkpoint
             },
             {
-              key: proposalPeriod.startTimestamp, // Exactly at proposal start
+              key: proposalPeriod.startPoint, // Exactly at proposal start
               value: 100n, // This should be used for validation
             },
             {
-              key: proposalPeriod.startTimestamp + 1, // After start
+              key: proposalPeriod.startPoint + 1, // After start
               value: 0n, // Should be ignored
             },
           ]);
@@ -472,7 +472,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           const maxUint208 = 2n ** 208n - 1n;
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp - 1,
+              key: proposalPeriod.startPoint - 1,
               value: maxUint208,
             },
           ]);
@@ -492,8 +492,8 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
 
           // Override proposal to start at timestamp 0
           await mockERC20Strategy.setProposalPeriod(proposalId, {
-            startTimestamp: 0,
-            endTimestamp: 100,
+            startPoint: 0,
+            endPoint: 100,
           });
 
           // Set checkpoint at timestamp 0
@@ -528,11 +528,11 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
               value: 50n,
             },
             {
-              key: Math.floor(proposalPeriod.startTimestamp / 2), // Checkpoint halfway between genesis and proposal start
+              key: Math.floor(proposalPeriod.startPoint / 2), // Checkpoint halfway between genesis and proposal start
               value: 0n,
             },
             {
-              key: proposalPeriod.startTimestamp - 1, // Checkpoint just before proposal start
+              key: proposalPeriod.startPoint - 1, // Checkpoint just before proposal start
               value: 100n, // This should be used
             },
           ]);
@@ -561,11 +561,11 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // - A newer one that is after endTimestamp (should trigger the optimization)
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.startTimestamp - 10, // Older, valid checkpoint
+              key: proposalPeriod.startPoint - 10, // Older, valid checkpoint
               value: 100n,
             },
             {
-              key: proposalPeriod.endTimestamp + 1, // Newer, after proposal end
+              key: proposalPeriod.endPoint + 1, // Newer, after proposal end
               value: 50n, // Votes here don't matter as it should short-circuit
             },
           ]);
@@ -590,7 +590,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           // Set up a single checkpoint that is after endTimestamp
           await mockERC20Strategy.setCheckpoints(voter.address, [
             {
-              key: proposalPeriod.endTimestamp + 5, // After proposal end
+              key: proposalPeriod.endPoint + 5, // After proposal end
               value: 100n,
             },
           ]);
@@ -626,17 +626,19 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
       const expectedEnd = currentTimestamp + 100;
 
       await mockERC20Strategy.setProposalPeriod(proposalId, {
-        startTimestamp: expectedStart,
-        endTimestamp: expectedEnd,
+        startPoint: expectedStart,
+        endPoint: expectedEnd,
       });
 
-      const [actualStart, actualEnd] = await mockERC20Strategy.getProposalPeriod(proposalId);
+      const [actualStart, actualEnd] =
+        await mockERC20Strategy.getProposalVotingPeriodPoints(proposalId);
       expect(actualStart).to.equal(expectedStart);
       expect(actualEnd).to.equal(expectedEnd);
     });
 
     it('Should return zeros for non-existent proposal', async function () {
-      const [startTimestamp, endTimestamp] = await mockERC20Strategy.getProposalPeriod(999); // Using an unused proposal ID
+      const [startTimestamp, endTimestamp] =
+        await mockERC20Strategy.getProposalVotingPeriodPoints(999); // Using an unused proposal ID
       expect(startTimestamp).to.equal(0);
       expect(endTimestamp).to.equal(0);
     });
@@ -645,20 +647,21 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
       // Set initial values
       const currentTimestamp = await time.latest();
       await mockERC20Strategy.setProposalPeriod(proposalId, {
-        startTimestamp: currentTimestamp,
-        endTimestamp: currentTimestamp + 100,
+        startPoint: currentTimestamp,
+        endPoint: currentTimestamp + 100,
       });
 
       // Update to new values
       const newStart = currentTimestamp + 50;
       const newEnd = currentTimestamp + 150;
       await mockERC20Strategy.setProposalPeriod(proposalId, {
-        startTimestamp: newStart,
-        endTimestamp: newEnd,
+        startPoint: newStart,
+        endPoint: newEnd,
       });
 
       // Verify the update
-      const [startTimestamp, endTimestamp] = await mockERC20Strategy.getProposalPeriod(proposalId);
+      const [startTimestamp, endTimestamp] =
+        await mockERC20Strategy.getProposalVotingPeriodPoints(proposalId);
       expect(startTimestamp).to.equal(newStart);
       expect(endTimestamp).to.equal(newEnd);
     });

--- a/test/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.test.ts
@@ -62,9 +62,9 @@ describe('LinearERC721VotingV1ValidatorV1', function () {
       _tokenIds: number[],
     ) {
       const currentTimestamp = await time.latest();
-      await mockERC721Strategy.setProposalPeriod(_proposalId, {
-        startPoint: currentTimestamp,
-        endPoint: currentTimestamp + 100,
+      await mockERC721Strategy.setVotingTimestamps(_proposalId, {
+        startTime: currentTimestamp,
+        endTime: currentTimestamp + 100,
       });
 
       // Set up token weight
@@ -200,9 +200,9 @@ describe('LinearERC721VotingV1ValidatorV1', function () {
       void expect(validResult).to.be.true;
 
       // Now set the proposal to non-existent
-      await mockERC721Strategy.setProposalPeriod(proposalId, {
-        startPoint: 0,
-        endPoint: 0,
+      await mockERC721Strategy.setVotingTimestamps(proposalId, {
+        startTime: 0,
+        endTime: 0,
       });
 
       const invalidResult = await validator.validateOperation(

--- a/test/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.test.ts
@@ -62,7 +62,10 @@ describe('LinearERC721VotingV1ValidatorV1', function () {
       _tokenIds: number[],
     ) {
       const currentTimestamp = await time.latest();
-      await mockERC721Strategy.setVotingEndTimestamp(_proposalId, currentTimestamp + 100);
+      await mockERC721Strategy.setProposalPeriod(_proposalId, {
+        startPoint: currentTimestamp,
+        endPoint: currentTimestamp + 100,
+      });
 
       // Set up token weight
       for (let i = 0; i < _tokenAddresses.length; i++) {
@@ -197,7 +200,10 @@ describe('LinearERC721VotingV1ValidatorV1', function () {
       void expect(validResult).to.be.true;
 
       // Now set the proposal to non-existent
-      await mockERC721Strategy.setVotingEndTimestamp(proposalId, 0);
+      await mockERC721Strategy.setProposalPeriod(proposalId, {
+        startPoint: 0,
+        endPoint: 0,
+      });
 
       const invalidResult = await validator.validateOperation(
         ethers.ZeroAddress,

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -1064,7 +1064,7 @@ describe('AzoriusV1', () => {
         // Set voting end block to future block and mark as passed by default
         const currentBlockTimestamp = await time.latest();
 
-        await mockStrategy.setProposalPeriodPoints(
+        await mockStrategy.setVotingTimestamps(
           proposalId,
           currentBlockTimestamp,
           currentBlockTimestamp + 10,
@@ -1079,7 +1079,7 @@ describe('AzoriusV1', () => {
         const currentBlockTimestamp = await time.latest();
 
         // End voting immediately
-        await mockStrategy.setProposalPeriodPoints(proposalId, 0, currentBlockTimestamp);
+        await mockStrategy.setVotingTimestamps(proposalId, 0, currentBlockTimestamp);
 
         // Should be in timelock since we set isPassed to true in beforeEach
         expect(await azorius.proposalState(proposalId)).to.equal(1); // TIMELOCKED
@@ -1104,7 +1104,7 @@ describe('AzoriusV1', () => {
         // End voting immediately
         const currentBlockTimestamp = await time.latest();
         const votingEnd = currentBlockTimestamp + 10;
-        await mockStrategy.setProposalPeriodPoints(proposalId, currentBlockTimestamp, votingEnd);
+        await mockStrategy.setVotingTimestamps(proposalId, currentBlockTimestamp, votingEnd);
 
         // Move past timelock
         await time.increaseTo(votingEnd + TIMELOCK_PERIOD);
@@ -1127,7 +1127,7 @@ describe('AzoriusV1', () => {
 
       it('should not execute proposal before timelock period', async () => {
         // Set voting to passed
-        await mockStrategy.setProposalPeriodPoints(proposalId, 0, 0);
+        await mockStrategy.setVotingTimestamps(proposalId, 0, 0);
         await mockStrategy.setIsPassed(proposalId, true);
 
         await expect(
@@ -1143,7 +1143,7 @@ describe('AzoriusV1', () => {
 
       it('should not execute proposal after execution period', async () => {
         // Set voting to passed
-        await mockStrategy.setProposalPeriodPoints(proposalId, 0, 0);
+        await mockStrategy.setVotingTimestamps(proposalId, 0, 0);
         await mockStrategy.setIsPassed(proposalId, true);
 
         // Move past timelock and execution period
@@ -1167,7 +1167,7 @@ describe('AzoriusV1', () => {
           const currentTimestamp = await time.latest();
 
           // Set a future voting end timestamp
-          await mockStrategy.setProposalPeriodPoints(
+          await mockStrategy.setVotingTimestamps(
             proposalId,
             currentTimestamp,
             currentTimestamp + 100,
@@ -1204,7 +1204,7 @@ describe('AzoriusV1', () => {
           const currentTimestamp = await time.latest();
 
           // Set exact timestamps for voting end
-          await mockStrategy.setProposalPeriodPoints(
+          await mockStrategy.setVotingTimestamps(
             proposalId,
             currentTimestamp,
             currentTimestamp + 100,
@@ -1264,7 +1264,7 @@ describe('AzoriusV1', () => {
           .submitProposal(await mockStrategy.getAddress(), '0x', [tx1, tx2], 'Test proposal');
 
         // Set voting to passed and move past timelock
-        await mockStrategy.setProposalPeriodPoints(0, 0, 0);
+        await mockStrategy.setVotingTimestamps(0, 0, 0);
         await mockStrategy.setIsPassed(0, true);
         await time.increase(TIMELOCK_PERIOD);
 
@@ -1277,7 +1277,7 @@ describe('AzoriusV1', () => {
         beforeEach(async () => {
           // Get current block number
           const currentBlockTimestamp = await time.latest();
-          await mockStrategy.setProposalPeriodPoints(
+          await mockStrategy.setVotingTimestamps(
             0,
             currentBlockTimestamp,
             currentBlockTimestamp + 10,
@@ -1339,7 +1339,7 @@ describe('AzoriusV1', () => {
 
         // Get current block number and set up proposal state
         const currentBlockTimestamp = await time.latest();
-        await mockStrategy.setProposalPeriodPoints(
+        await mockStrategy.setVotingTimestamps(
           1,
           currentBlockTimestamp,
           currentBlockTimestamp + 10,

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { mine, time } from '@nomicfoundation/hardhat-network-helpers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -1064,7 +1064,11 @@ describe('AzoriusV1', () => {
         // Set voting end block to future block and mark as passed by default
         const currentBlockTimestamp = await time.latest();
 
-        await mockStrategy.setVotingEndTimestamp(proposalId, currentBlockTimestamp + 10);
+        await mockStrategy.setProposalPeriodPoints(
+          proposalId,
+          currentBlockTimestamp,
+          currentBlockTimestamp + 10,
+        );
         await mockStrategy.setIsPassed(proposalId, true);
       });
 
@@ -1072,20 +1076,22 @@ describe('AzoriusV1', () => {
         // Initially active (voting not ended)
         expect(await azorius.proposalState(proposalId)).to.equal(0); // ACTIVE
 
+        const currentBlockTimestamp = await time.latest();
+
         // End voting immediately
-        await mockStrategy.setVotingEndTimestamp(proposalId, await time.latest());
+        await mockStrategy.setProposalPeriodPoints(proposalId, 0, currentBlockTimestamp);
 
         // Should be in timelock since we set isPassed to true in beforeEach
         expect(await azorius.proposalState(proposalId)).to.equal(1); // TIMELOCKED
 
         // Move past timelock
-        await mine(TIMELOCK_PERIOD);
+        await time.increase(TIMELOCK_PERIOD);
 
         // Should be executable
         expect(await azorius.proposalState(proposalId)).to.equal(2); // EXECUTABLE
 
         // Move past execution period
-        await mine(EXECUTION_PERIOD);
+        await time.increase(EXECUTION_PERIOD);
 
         // Should be expired
         expect(await azorius.proposalState(proposalId)).to.equal(4); // EXPIRED
@@ -1096,10 +1102,12 @@ describe('AzoriusV1', () => {
         await mockToken.mint(await avatar.getAddress(), 1000);
 
         // End voting immediately
-        await mockStrategy.setVotingEndTimestamp(proposalId, await time.latest());
+        const currentBlockTimestamp = await time.latest();
+        const votingEnd = currentBlockTimestamp + 10;
+        await mockStrategy.setProposalPeriodPoints(proposalId, currentBlockTimestamp, votingEnd);
 
         // Move past timelock
-        await mine(TIMELOCK_PERIOD);
+        await time.increaseTo(votingEnd + TIMELOCK_PERIOD);
 
         // Enable the module on the avatar to be able to execute the proposal
         await avatar.enableModule(await azorius.getAddress());
@@ -1119,7 +1127,7 @@ describe('AzoriusV1', () => {
 
       it('should not execute proposal before timelock period', async () => {
         // Set voting to passed
-        await mockStrategy.setVotingEndTimestamp(proposalId, 0);
+        await mockStrategy.setProposalPeriodPoints(proposalId, 0, 0);
         await mockStrategy.setIsPassed(proposalId, true);
 
         await expect(
@@ -1135,11 +1143,11 @@ describe('AzoriusV1', () => {
 
       it('should not execute proposal after execution period', async () => {
         // Set voting to passed
-        await mockStrategy.setVotingEndTimestamp(proposalId, 0);
+        await mockStrategy.setProposalPeriodPoints(proposalId, 0, 0);
         await mockStrategy.setIsPassed(proposalId, true);
 
         // Move past timelock and execution period
-        await mine(TIMELOCK_PERIOD + EXECUTION_PERIOD + 1);
+        await time.increase(TIMELOCK_PERIOD + EXECUTION_PERIOD + 1);
 
         await expect(
           azorius.executeProposal(
@@ -1159,7 +1167,11 @@ describe('AzoriusV1', () => {
           const currentTimestamp = await time.latest();
 
           // Set a future voting end timestamp
-          await mockStrategy.setVotingEndTimestamp(proposalId, currentTimestamp + 100);
+          await mockStrategy.setProposalPeriodPoints(
+            proposalId,
+            currentTimestamp,
+            currentTimestamp + 100,
+          );
           await mockStrategy.setIsPassed(proposalId, true);
         });
 
@@ -1192,7 +1204,11 @@ describe('AzoriusV1', () => {
           const currentTimestamp = await time.latest();
 
           // Set exact timestamps for voting end
-          await mockStrategy.setVotingEndTimestamp(proposalId, currentTimestamp + 100);
+          await mockStrategy.setProposalPeriodPoints(
+            proposalId,
+            currentTimestamp,
+            currentTimestamp + 100,
+          );
 
           // At exactly the voting end time
           await time.increaseTo(currentTimestamp + 100);
@@ -1248,9 +1264,9 @@ describe('AzoriusV1', () => {
           .submitProposal(await mockStrategy.getAddress(), '0x', [tx1, tx2], 'Test proposal');
 
         // Set voting to passed and move past timelock
-        await mockStrategy.setVotingEndTimestamp(0, 0);
+        await mockStrategy.setProposalPeriodPoints(0, 0, 0);
         await mockStrategy.setIsPassed(0, true);
-        await mine(TIMELOCK_PERIOD);
+        await time.increase(TIMELOCK_PERIOD);
 
         // Mint tokens to avatar for execution
         await mockToken.mint(await avatar.getAddress(), 1000);
@@ -1261,11 +1277,14 @@ describe('AzoriusV1', () => {
         beforeEach(async () => {
           // Get current block number
           const currentBlockTimestamp = await time.latest();
-          const votingEndTimestamp = currentBlockTimestamp + 10;
-          await mockStrategy.setVotingEndTimestamp(0, votingEndTimestamp);
+          await mockStrategy.setProposalPeriodPoints(
+            0,
+            currentBlockTimestamp,
+            currentBlockTimestamp + 10,
+          );
 
           // Move past voting and timelock period
-          await mine(10 + TIMELOCK_PERIOD);
+          await time.increase(10 + TIMELOCK_PERIOD);
         });
 
         it('should allow partial execution of proposal transactions', async () => {
@@ -1320,12 +1339,15 @@ describe('AzoriusV1', () => {
 
         // Get current block number and set up proposal state
         const currentBlockTimestamp = await time.latest();
-        const votingEndBlockTimestamp = currentBlockTimestamp + 10;
-        await mockStrategy.setVotingEndTimestamp(1, votingEndBlockTimestamp);
+        await mockStrategy.setProposalPeriodPoints(
+          1,
+          currentBlockTimestamp,
+          currentBlockTimestamp + 10,
+        );
         await mockStrategy.setIsPassed(1, true);
 
         // Move past voting and timelock period
-        await mine(10 + TIMELOCK_PERIOD);
+        await time.increase(10 + TIMELOCK_PERIOD);
 
         // Verify proposal is executable
         expect(await azorius.proposalState(1)).to.equal(2); // EXECUTABLE

--- a/test/deployables/strategies/LinearERC20VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingV1.test.ts
@@ -276,8 +276,7 @@ describe('LinearERC20VotingV1', () => {
       await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
 
       // Check that proposal was initialized correctly
-      const [, votingEndTimestamp] =
-        await linearERC20Voting.getProposalVotingPeriodPoints(proposalId);
+      const [, votingEndTimestamp] = await linearERC20Voting.getVotingTimestamps(proposalId);
       expect(votingEndTimestamp).to.not.equal(0);
     });
 

--- a/test/deployables/strategies/LinearERC20VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingV1.test.ts
@@ -276,7 +276,8 @@ describe('LinearERC20VotingV1', () => {
       await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
 
       // Check that proposal was initialized correctly
-      const votingEndTimestamp = await linearERC20Voting.votingEndTimestamp(proposalId);
+      const [, votingEndTimestamp] =
+        await linearERC20Voting.getProposalVotingPeriodPoints(proposalId);
       expect(votingEndTimestamp).to.not.equal(0);
     });
 

--- a/test/deployables/strategies/LinearERC721VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingV1.test.ts
@@ -56,6 +56,11 @@ describe('LinearERC721VotingV1', () => {
     ABSTAIN = 2,
   }
 
+  enum ClockMode {
+    Timestamp,
+    BlockNumber,
+  }
+
   async function deployLinearERC721Voting(
     strategyOwner: SignerWithAddress,
     governanceTokens: { tokenAddress: string; weight: number }[],
@@ -67,7 +72,7 @@ describe('LinearERC721VotingV1', () => {
 
     // Create the initialization data
     const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-      'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
+      'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
       [
         strategyOwner.address,
         tokenAddresses,
@@ -78,6 +83,7 @@ describe('LinearERC721VotingV1', () => {
         PROPOSER_THRESHOLD,
         BASIS_NUMERATOR,
         lightAccountFactoryAddress,
+        ClockMode.Timestamp,
       ],
     );
 
@@ -168,7 +174,7 @@ describe('LinearERC721VotingV1', () => {
       // Try to call initialize again - should revert
       await expect(
         linearERC721Voting[
-          'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)'
+          'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)'
         ](
           owner.address,
           tokenAddresses,
@@ -179,6 +185,7 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
+          ClockMode.Timestamp,
         ),
       ).to.be.revertedWithCustomError(linearERC721Voting, 'InvalidInitialization');
     });
@@ -189,7 +196,7 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with mismatched arrays
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
         [
           owner.address,
           tokenAddresses,
@@ -200,6 +207,7 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
+          ClockMode.Timestamp,
         ],
       );
 
@@ -218,7 +226,7 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with invalid token weight
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
         [
           owner.address,
           tokenAddresses,
@@ -229,6 +237,7 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
+          ClockMode.Timestamp,
         ],
       );
 
@@ -247,7 +256,7 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with empty token arrays
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
         [
           owner.address,
           emptyTokenAddresses,
@@ -258,6 +267,7 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
+          ClockMode.Timestamp,
         ],
       );
 
@@ -456,7 +466,8 @@ describe('LinearERC721VotingV1', () => {
       await linearERC721Voting.connect(nonOwner).initializeProposal(initializeData);
 
       // Check that proposal was initialized correctly
-      const votingEndTimestamp = await linearERC721Voting.votingEndTimestamp(proposalId);
+      const [, votingEndTimestamp] =
+        await linearERC721Voting.getProposalVotingPeriodPoints(proposalId);
       expect(votingEndTimestamp).to.not.equal(0);
     });
 
@@ -969,7 +980,7 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with non-ERC721 token
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
         [
           owner.address,
           tokenAddresses,
@@ -980,6 +991,7 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
+          ClockMode.Timestamp,
         ],
       );
 

--- a/test/deployables/strategies/LinearERC721VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingV1.test.ts
@@ -56,11 +56,6 @@ describe('LinearERC721VotingV1', () => {
     ABSTAIN = 2,
   }
 
-  enum ClockMode {
-    Timestamp,
-    BlockNumber,
-  }
-
   async function deployLinearERC721Voting(
     strategyOwner: SignerWithAddress,
     governanceTokens: { tokenAddress: string; weight: number }[],
@@ -72,7 +67,7 @@ describe('LinearERC721VotingV1', () => {
 
     // Create the initialization data
     const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-      'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
+      'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
       [
         strategyOwner.address,
         tokenAddresses,
@@ -83,7 +78,6 @@ describe('LinearERC721VotingV1', () => {
         PROPOSER_THRESHOLD,
         BASIS_NUMERATOR,
         lightAccountFactoryAddress,
-        ClockMode.Timestamp,
       ],
     );
 
@@ -174,7 +168,7 @@ describe('LinearERC721VotingV1', () => {
       // Try to call initialize again - should revert
       await expect(
         linearERC721Voting[
-          'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)'
+          'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)'
         ](
           owner.address,
           tokenAddresses,
@@ -185,7 +179,6 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
-          ClockMode.Timestamp,
         ),
       ).to.be.revertedWithCustomError(linearERC721Voting, 'InvalidInitialization');
     });
@@ -196,7 +189,7 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with mismatched arrays
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
         [
           owner.address,
           tokenAddresses,
@@ -207,7 +200,6 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
-          ClockMode.Timestamp,
         ],
       );
 
@@ -226,7 +218,7 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with invalid token weight
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
         [
           owner.address,
           tokenAddresses,
@@ -237,7 +229,6 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
-          ClockMode.Timestamp,
         ],
       );
 
@@ -256,7 +247,7 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with empty token arrays
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
         [
           owner.address,
           emptyTokenAddresses,
@@ -267,7 +258,6 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
-          ClockMode.Timestamp,
         ],
       );
 
@@ -466,8 +456,7 @@ describe('LinearERC721VotingV1', () => {
       await linearERC721Voting.connect(nonOwner).initializeProposal(initializeData);
 
       // Check that proposal was initialized correctly
-      const [, votingEndTimestamp] =
-        await linearERC721Voting.getProposalVotingPeriodPoints(proposalId);
+      const [, votingEndTimestamp] = await linearERC721Voting.getVotingTimestamps(proposalId);
       expect(votingEndTimestamp).to.not.equal(0);
     });
 
@@ -980,7 +969,7 @@ describe('LinearERC721VotingV1', () => {
 
       // Create initialization data with non-ERC721 token
       const initializeCalldata = LinearERC721VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address,uint8)',
+        'initialize(address,address[],uint256[],address,uint32,uint256,uint256,uint256,address)',
         [
           owner.address,
           tokenAddresses,
@@ -991,7 +980,6 @@ describe('LinearERC721VotingV1', () => {
           PROPOSER_THRESHOLD,
           BASIS_NUMERATOR,
           lightAccountFactoryMock.address,
-          ClockMode.Timestamp,
         ],
       );
 

--- a/test/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.test.ts
@@ -31,11 +31,6 @@ import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTest
  */
 
 describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
-  enum ClockMode {
-    Timestamp,
-    BlockNumber,
-  }
-
   // Signers
   let deployer: SignerWithAddress;
   let owner: SignerWithAddress;
@@ -82,7 +77,6 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
       quorumThreshold: QUORUM_THRESHOLD,
       basisNumerator: BASIS_NUMERATOR,
       lightAccountFactory: lightAccountFactoryAddress,
-      initialClockMode: ClockMode.Timestamp,
     };
 
     const hatsParams = {
@@ -91,7 +85,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
     };
 
     const initializeCalldata = implementation.interface.encodeFunctionData(
-      'initialize(address,(address[],uint256[],address,uint32,uint256,uint256,address,uint8),(address,uint256[]))',
+      'initialize(address,(address[],uint256[],address,uint32,uint256,uint256,address),(address,uint256[]))',
       [strategyOwner.address, linearVotingParams, hatsParams],
     );
 
@@ -199,7 +193,6 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
           quorumThreshold: QUORUM_THRESHOLD,
           basisNumerator: BASIS_NUMERATOR,
           lightAccountFactory: lightAccountFactoryMock.address,
-          initialClockMode: ClockMode.Timestamp,
         };
 
         const hatsParams = {
@@ -210,7 +203,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
         // Create initialization data for a second attempt
         const initializeCalldata =
           linearERC721VotingWithHatsProposalCreationImplementation.interface.encodeFunctionData(
-            'initialize(address,(address[],uint256[],address,uint32,uint256,uint256,address,uint8),(address,uint256[]))',
+            'initialize(address,(address[],uint256[],address,uint32,uint256,uint256,address),(address,uint256[]))',
             [owner.address, linearVotingParams, hatsParams],
           );
 

--- a/test/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingWithHatsProposalCreationV1.test.ts
@@ -31,6 +31,11 @@ import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTest
  */
 
 describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
+  enum ClockMode {
+    Timestamp,
+    BlockNumber,
+  }
+
   // Signers
   let deployer: SignerWithAddress;
   let owner: SignerWithAddress;
@@ -77,6 +82,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
       quorumThreshold: QUORUM_THRESHOLD,
       basisNumerator: BASIS_NUMERATOR,
       lightAccountFactory: lightAccountFactoryAddress,
+      initialClockMode: ClockMode.Timestamp,
     };
 
     const hatsParams = {
@@ -85,7 +91,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
     };
 
     const initializeCalldata = implementation.interface.encodeFunctionData(
-      'initialize(address,(address[],uint256[],address,uint32,uint256,uint256,address),(address,uint256[]))',
+      'initialize(address,(address[],uint256[],address,uint32,uint256,uint256,address,uint8),(address,uint256[]))',
       [strategyOwner.address, linearVotingParams, hatsParams],
     );
 
@@ -193,6 +199,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
           quorumThreshold: QUORUM_THRESHOLD,
           basisNumerator: BASIS_NUMERATOR,
           lightAccountFactory: lightAccountFactoryMock.address,
+          initialClockMode: ClockMode.Timestamp,
         };
 
         const hatsParams = {
@@ -203,7 +210,7 @@ describe('LinearERC721VotingWithHatsProposalCreationV1', () => {
         // Create initialization data for a second attempt
         const initializeCalldata =
           linearERC721VotingWithHatsProposalCreationImplementation.interface.encodeFunctionData(
-            'initialize(address,(address[],uint256[],address,uint32,uint256,uint256,address),(address,uint256[]))',
+            'initialize(address,(address[],uint256[],address,uint32,uint256,uint256,address,uint8),(address,uint256[]))',
             [owner.address, linearVotingParams, hatsParams],
           );
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/264

Fixes [ENG-864](https://linear.app/decent-labs/issue/ENG-864/fix-test-suite-to-align-with-clockmode-refactor)

This commit updates the test suite across various files to align with the extensive `ClockMode` and time handling refactoring. Changes were made to ensure tests correctly interact with the updated interfaces of mock contracts, strategy contracts, and the Azorius module.

Key changes in test files:
- **Validator Tests (`LinearERC20VotingV1ValidatorV1.test.ts`, `LinearERC721VotingV1ValidatorV1.test.ts`):**
    - Updated `proposalPeriod` objects to use `startPoint` and `endPoint` instead of `startTimestamp` and `endTimestamp`.
    - Modified calls to mock strategy functions like `setProposalPeriod` to pass the new struct.
    - Adjusted assertions for `getProposalVotingPeriodPoints` (formerly `getProposalPeriod` or `votingEndTimestamp`).
- **`AzoriusV1.test.ts`**:
    - Replaced `setVotingEndTimestamp` calls on `mockStrategy` with `setProposalPeriodPoints`, providing both start and end points.
    - Adjusted `time.mine()` calls to `time.increase()` or `time.increaseTo()` where appropriate for timestamp-based testing, ensuring consistency with how `AzoriusV1` now uses `ClockModeLib` which defaults to `block.timestamp` if the strategy doesn't specify otherwise (and `MockVotingStrategy` was updated to default to timestamp mode).
- **Strategy Tests (`LinearERC20VotingV1.test.ts`, `LinearERC721VotingV1.test.ts`, `LinearERC721VotingWithHatsProposalCreationV1.test.ts`):**
    - Updated calls to `initialize` for `LinearERC721VotingV1` and its "WithHats" variant to include the new `ClockMode` parameter (defaulting to `ClockMode.Timestamp` for existing test logic).
    - Adjusted expectations for functions like `getProposalVotingPeriodPoints`.

With these changes, the existing test suite should now pass, validating the core functionality after the `ClockMode` refactor, primarily under the default timestamp-based operation. Further tests will be added to specifically cover block-number-based scenarios.