### PR TITLE
Refactor: Standardize Voting Period Timestamps, Introduce Clock Mode Support, and Enhance Testability

### DIFF
--- a/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
@@ -14,9 +14,9 @@ interface ILinearERC20VotingV1 {
         address account
     ) external view returns (bool);
 
-    function getProposalPeriod(
+    function getVotingTimestamps(
         uint32 proposalId
-    ) external view returns (uint48, uint48);
+    ) external view returns (uint48 startTime, uint48 endTime);
 
     function votingPeriodEnded(uint32 proposalId) external view returns (bool);
 
@@ -77,7 +77,7 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
         // get the proposal start and end timestamps to determine if the proposal exists
         (uint48 startTimestamp, uint48 endTimestamp) = ILinearERC20VotingV1(
             votingContract
-        ).getProposalPeriod(proposalId);
+        ).getVotingTimestamps(proposalId);
 
         // Check if proposal exists (will have non-zero endTimestamp if it exists)
         if (endTimestamp == 0) {

--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -21,9 +21,9 @@ interface ILinearERC721VotingV1 {
         uint256 tokenId
     ) external view returns (bool);
 
-    function votingEndTimestamp(
+    function getVotingTimestamps(
         uint32 proposalId
-    ) external view returns (uint48);
+    ) external view returns (uint48 startTime, uint48 endTime);
 
     function getTokenWeight(
         address tokenAddress
@@ -83,8 +83,8 @@ contract LinearERC721VotingV1ValidatorV1 is
         }
 
         // Get voting end timestamp to determine if the proposal exists
-        uint256 endTimestamp = ILinearERC721VotingV1(votingContract)
-            .votingEndTimestamp(proposalId);
+        (, uint48 endTimestamp) = ILinearERC721VotingV1(votingContract)
+            .getVotingTimestamps(proposalId);
 
         // Check if proposal exists (will have non-zero endTimestamp if it exists)
         if (endTimestamp == 0) {

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -387,8 +387,9 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         if (_proposal.strategy == address(0)) revert InvalidProposal();
 
         IBaseStrategyV1 _strategy = IBaseStrategyV1(_proposal.strategy);
-
-        uint48 votingEndTimestamp = _strategy.votingEndTimestamp(_proposalId);
+        (, uint48 votingEndTimestamp) = _strategy.getVotingTimestamps(
+            _proposalId
+        );
 
         if (block.timestamp <= votingEndTimestamp) {
             return ProposalState.ACTIVE;

--- a/contracts/deployables/strategies/BaseStrategyV1.sol
+++ b/contracts/deployables/strategies/BaseStrategyV1.sol
@@ -67,10 +67,11 @@ abstract contract BaseStrategyV1 is
     function isProposer(address _address) external view virtual returns (bool);
 
     /** @inheritdoc IBaseStrategyV1*/
-    function votingEndTimestamp(
+    function getVotingTimestamps(
         uint32 _proposalId
-    ) external view virtual returns (uint48);
+    ) external view virtual returns (uint48 startTime, uint48 endTime);
 
+    /** @inheritdoc ERC165*/
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {

--- a/contracts/deployables/strategies/LinearERC20VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC20VotingV1.sol
@@ -4,9 +4,11 @@ pragma solidity ^0.8.30;
 import {Version} from "../Version.sol";
 import {BaseStrategyV1} from "./BaseStrategyV1.sol";
 import {ERC4337VoterSupportV1} from "./ERC4337VoterSupportV1.sol";
-import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+import {ClockModeLib} from "../../libs/ClockModeLib.sol";
 import {IBaseQuorumPercentV1} from "../../interfaces/decent/deployables/IBaseQuorumPercentV1.sol";
+import {ClockMode} from "../../interfaces/decent/ClockMode.sol";
 import {IBaseVotingBasisPercentV1} from "../../interfaces/decent/deployables/IBaseVotingBasisPercentV1.sol";
+import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -44,7 +46,8 @@ contract LinearERC20VotingV1 is
      * Defines the current state of votes on a particular Proposal.
      */
     struct ProposalVotes {
-        uint48 votingStartTimestamp; // time that voting starts at
+        uint48 votingStartTimestamp; // time that voting starts
+        uint32 votingStartBlock; // block that voting starts
         uint48 votingEndTimestamp; // time that voting ends
         uint256 noVotes; // current number of NO votes for the Proposal
         uint256 yesVotes; // current number of YES votes for the Proposal
@@ -74,6 +77,8 @@ contract LinearERC20VotingV1 is
 
     /** `proposalId` to `ProposalVotes`, the voting state of a Proposal. */
     mapping(uint256 => ProposalVotes) internal proposalVotes;
+
+    ClockMode public governanceClockMode;
 
     event VotingPeriodUpdated(uint32 votingPeriod);
     event RequiredProposerWeightUpdated(uint256 requiredProposerWeight);
@@ -116,6 +121,7 @@ contract LinearERC20VotingV1 is
         if (address(_governanceToken) == address(0))
             revert InvalidTokenAddress();
         governanceToken = IVotes(_governanceToken);
+        governanceClockMode = ClockModeLib.getClockMode(_governanceToken);
 
         BaseStrategyV1.initialize(_owner, _proposalInitializer);
         __ERC4337VoterSupportV1_init(_lightAccountFactory);
@@ -204,7 +210,9 @@ contract LinearERC20VotingV1 is
      * @return yesVotes current count of "YES" votes
      * @return abstainVotes current count of "ABSTAIN" votes
      * @return startTimestamp timestamp voting starts
+     * @return startBlock block number voting starts
      * @return endTimestamp timestamp voting ends
+     * @return votingSupply the total voting supply at the time of proposal creation
      */
     function getProposalVotes(
         uint32 _proposalId
@@ -217,15 +225,18 @@ contract LinearERC20VotingV1 is
             uint256 yesVotes,
             uint256 abstainVotes,
             uint48 startTimestamp,
+            uint32 startBlock,
             uint48 endTimestamp,
             uint256 votingSupply
         )
     {
-        noVotes = proposalVotes[_proposalId].noVotes;
-        yesVotes = proposalVotes[_proposalId].yesVotes;
-        abstainVotes = proposalVotes[_proposalId].abstainVotes;
-        startTimestamp = proposalVotes[_proposalId].votingStartTimestamp;
-        endTimestamp = proposalVotes[_proposalId].votingEndTimestamp;
+        ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
+        noVotes = currentProposalVotes.noVotes;
+        yesVotes = currentProposalVotes.yesVotes;
+        abstainVotes = currentProposalVotes.abstainVotes;
+        startTimestamp = currentProposalVotes.votingStartTimestamp;
+        startBlock = currentProposalVotes.votingStartBlock;
+        endTimestamp = currentProposalVotes.votingEndTimestamp;
         votingSupply = getProposalVotingSupply(_proposalId);
     }
 
@@ -234,14 +245,15 @@ contract LinearERC20VotingV1 is
         bytes memory _data
     ) public virtual override onlyProposalInitializer {
         uint32 proposalId = abi.decode(_data, (uint32));
-        uint48 _votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
+        uint48 votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
 
-        proposalVotes[proposalId].votingEndTimestamp = _votingEndTimestamp;
         proposalVotes[proposalId].votingStartTimestamp = uint48(
             block.timestamp
         );
+        proposalVotes[proposalId].votingStartBlock = uint32(block.number);
+        proposalVotes[proposalId].votingEndTimestamp = votingEndTimestamp;
 
-        emit ProposalInitialized(proposalId, _votingEndTimestamp);
+        emit ProposalInitialized(proposalId, votingEndTimestamp);
     }
 
     /**
@@ -262,16 +274,16 @@ contract LinearERC20VotingV1 is
     function isPassed(
         uint32 _proposalId
     ) public view virtual override returns (bool) {
-        return (block.timestamp >
-            proposalVotes[_proposalId].votingEndTimestamp && // voting period has ended
+        ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
+        return (block.timestamp > currentProposalVotes.votingEndTimestamp && // voting period has ended
             meetsQuorum(
                 getProposalVotingSupply(_proposalId),
-                proposalVotes[_proposalId].yesVotes,
-                proposalVotes[_proposalId].abstainVotes
+                currentProposalVotes.yesVotes,
+                currentProposalVotes.abstainVotes
             ) && // yes + abstain votes meets the quorum
             meetsBasis(
-                proposalVotes[_proposalId].yesVotes,
-                proposalVotes[_proposalId].noVotes
+                currentProposalVotes.yesVotes,
+                currentProposalVotes.noVotes
             )); // yes votes meets the basis
     }
 
@@ -288,7 +300,9 @@ contract LinearERC20VotingV1 is
     ) public view virtual returns (uint256) {
         return
             governanceToken.getPastTotalSupply(
-                proposalVotes[_proposalId].votingStartTimestamp
+                governanceClockMode == ClockMode.Timestamp
+                    ? proposalVotes[_proposalId].votingStartTimestamp
+                    : proposalVotes[_proposalId].votingStartBlock
             );
     }
 
@@ -306,7 +320,9 @@ contract LinearERC20VotingV1 is
         return
             governanceToken.getPastVotes(
                 _voter,
-                proposalVotes[_proposalId].votingStartTimestamp
+                governanceClockMode == ClockMode.Timestamp
+                    ? proposalVotes[_proposalId].votingStartTimestamp
+                    : proposalVotes[_proposalId].votingStartBlock
             );
     }
 
@@ -314,24 +330,20 @@ contract LinearERC20VotingV1 is
     function isProposer(
         address _address
     ) public view virtual override returns (bool) {
+        uint256 lastPoint = ClockModeLib.getCurrentPoint(governanceClockMode) -
+            1;
         return
-            governanceToken.getPastVotes(_address, block.timestamp - 1) >=
+            governanceToken.getPastVotes(_address, lastPoint) >=
             requiredProposerWeight;
     }
 
-    /** @inheritdoc BaseStrategyV1*/
-    function votingEndTimestamp(
+    function getVotingTimestamps(
         uint32 _proposalId
-    ) public view virtual override returns (uint48) {
-        return proposalVotes[_proposalId].votingEndTimestamp;
-    }
-
-    function getProposalPeriod(
-        uint32 _proposalId
-    ) public view virtual returns (uint48, uint48) {
+    ) public view virtual override returns (uint48, uint48) {
+        ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
         return (
-            proposalVotes[_proposalId].votingStartTimestamp,
-            proposalVotes[_proposalId].votingEndTimestamp
+            currentProposalVotes.votingStartTimestamp,
+            currentProposalVotes.votingEndTimestamp
         );
     }
 

--- a/contracts/deployables/strategies/LinearERC721VotingV1.sol
+++ b/contracts/deployables/strategies/LinearERC721VotingV1.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.30;
 
 import {Version} from "../Version.sol";
-import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
 import {BaseStrategyV1} from "./BaseStrategyV1.sol";
 import {ERC4337VoterSupportV1} from "./ERC4337VoterSupportV1.sol";
-import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
 import {IBaseVotingBasisPercentV1} from "../../interfaces/decent/deployables/IBaseVotingBasisPercentV1.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -50,7 +50,7 @@ contract LinearERC721VotingV1 is
      * Defines the current state of votes on a particular Proposal.
      */
     struct ProposalVotes {
-        uint48 votingStartTimestamp; // timestamp that voting starts at
+        uint48 votingStartTimestamp; // timestamp that voting starts
         uint48 votingEndTimestamp; // timestamp that voting ends
         uint256 noVotes; // current number of NO votes for the Proposal
         uint256 yesVotes; // current number of YES votes for the Proposal
@@ -71,7 +71,7 @@ contract LinearERC721VotingV1 is
     /** ERC-721 address to its voting weight per NFT id.  */
     mapping(address => uint256) public tokenWeights;
 
-    /** Number of blocks a new Proposal can be voted on. */
+    /** Time that a new Proposal can be voted on. */
     uint32 public votingPeriod;
 
     /**
@@ -125,7 +125,7 @@ contract LinearERC721VotingV1 is
      * @param _tokens Array of ERC-721 token addresses that can vote
      * @param _weights Array of voting weights for each token
      * @param _proposalInitializer Address that is allowed to initialize Proposals
-     * @param _votingPeriod The voting time period (in blocks)
+     * @param _votingPeriod The voting time period (in seconds)
      * @param _quorumThreshold Total voting weight required to achieve quorum
      * @param _proposerThreshold Required voting weight to submit proposals
      * @param _basisNumerator The numerator for basis calculation
@@ -188,7 +188,7 @@ contract LinearERC721VotingV1 is
     /**
      * Updates the voting time period for new Proposals.
      *
-     * @param _votingPeriod voting time period (in blocks)
+     * @param _votingPeriod voting time period (in seconds)
      */
     function updateVotingPeriod(
         uint32 _votingPeriod
@@ -265,11 +265,12 @@ contract LinearERC721VotingV1 is
             uint48 endTimestamp
         )
     {
-        noVotes = proposalVotes[_proposalId].noVotes;
-        yesVotes = proposalVotes[_proposalId].yesVotes;
-        abstainVotes = proposalVotes[_proposalId].abstainVotes;
-        startTimestamp = proposalVotes[_proposalId].votingStartTimestamp;
-        endTimestamp = proposalVotes[_proposalId].votingEndTimestamp;
+        ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
+        noVotes = currentProposalVotes.noVotes;
+        yesVotes = currentProposalVotes.yesVotes;
+        abstainVotes = currentProposalVotes.abstainVotes;
+        startTimestamp = currentProposalVotes.votingStartTimestamp;
+        endTimestamp = currentProposalVotes.votingEndTimestamp;
     }
 
     /**
@@ -351,29 +352,25 @@ contract LinearERC721VotingV1 is
         bytes memory _data
     ) public virtual override onlyProposalInitializer {
         uint32 proposalId = abi.decode(_data, (uint32));
-        uint48 _votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
+        uint48 votingEndTimestamp = uint48(block.timestamp) + votingPeriod;
 
-        proposalVotes[proposalId].votingEndTimestamp = _votingEndTimestamp;
         proposalVotes[proposalId].votingStartTimestamp = uint48(
             block.timestamp
         );
+        proposalVotes[proposalId].votingEndTimestamp = votingEndTimestamp;
 
-        emit ProposalInitialized(proposalId, _votingEndTimestamp);
+        emit ProposalInitialized(proposalId, votingEndTimestamp);
     }
 
     /** @inheritdoc BaseStrategyV1*/
     function isPassed(
         uint32 _proposalId
     ) public view virtual override returns (bool) {
-        return (block.timestamp >
-            proposalVotes[_proposalId].votingEndTimestamp && // voting period has ended
+        ProposalVotes storage currentProposal = proposalVotes[_proposalId];
+        return (block.timestamp > currentProposal.votingEndTimestamp && // voting period has ended
             quorumThreshold <=
-            proposalVotes[_proposalId].yesVotes +
-                proposalVotes[_proposalId].abstainVotes && // yes + abstain votes meets the quorum
-            meetsBasis(
-                proposalVotes[_proposalId].yesVotes,
-                proposalVotes[_proposalId].noVotes
-            )); // yes votes meets the basis
+            currentProposal.yesVotes + currentProposal.abstainVotes && // yes + abstain votes meets the quorum
+            meetsBasis(currentProposal.yesVotes, currentProposal.noVotes)); // yes votes meets the basis
     }
 
     /** @inheritdoc BaseStrategyV1*/
@@ -393,11 +390,14 @@ contract LinearERC721VotingV1 is
         return totalWeight >= proposerThreshold;
     }
 
-    /** @inheritdoc BaseStrategyV1*/
-    function votingEndTimestamp(
+    function getVotingTimestamps(
         uint32 _proposalId
-    ) public view virtual override returns (uint48) {
-        return proposalVotes[_proposalId].votingEndTimestamp;
+    ) public view virtual override returns (uint48, uint48) {
+        ProposalVotes storage currentProposalVotes = proposalVotes[_proposalId];
+        return (
+            currentProposalVotes.votingStartTimestamp,
+            currentProposalVotes.votingEndTimestamp
+        );
     }
 
     /** Internal implementation of `addGovernanceToken` */

--- a/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseStrategyV1.sol
@@ -42,12 +42,12 @@ interface IBaseStrategyV1 {
     function isProposer(address _address) external view returns (bool);
 
     /**
-     * Returns the absolute timestamp that voting ends on a given Proposal.
-     *
-     * @param _proposalId proposalId to check
-     * @return uint48 timestamp when voting ends on the Proposal
+     * @notice Returns the start and end timestamps of a proposal's voting period.
+     * @param _proposalId The ID of the proposal.
+     * @return startTime The start timestamp of the voting period.
+     * @return endTime The end timestamp of the voting period.
      */
-    function votingEndTimestamp(
+    function getVotingTimestamps(
         uint32 _proposalId
-    ) external view returns (uint48);
+    ) external view returns (uint48 startTime, uint48 endTime);
 }

--- a/contracts/mocks/MockERC20Votes.sol
+++ b/contracts/mocks/MockERC20Votes.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+import {ClockMode} from "../interfaces/decent/ClockMode.sol";
 
 /**
  * @title MockERC20Votes
@@ -12,13 +13,33 @@ import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
  */
 contract MockERC20Votes is ERC20, ERC20Permit, IVotes {
     mapping(address => mapping(uint256 => uint256)) private _mockPastVotes;
+    mapping(address => mapping(uint256 => bool))
+        private _hasMockPastVoteBeenSet;
     mapping(uint256 => uint256) private _mockPastTotalSupply;
+    mapping(uint256 => bool) private _hasMockPastTotalSupplyBeenSet;
     mapping(address => address) private _delegates;
+    string public clockMode;
 
     constructor()
         ERC20("Mock Voting Token", "MVT")
         ERC20Permit("Mock Voting Token")
-    {}
+    {
+        clockMode = "mode=timestamp";
+    }
+
+    function clock() public view returns (uint256) {
+        return block.timestamp;
+    }
+
+    function setClockMode(ClockMode _clockMode) public {
+        clockMode = _clockMode == ClockMode.Timestamp
+            ? "mode=timestamp"
+            : "mode=blocknumber&from=default";
+    }
+
+    function CLOCK_MODE() public view returns (string memory) {
+        return clockMode;
+    }
 
     /**
      * @dev Mints tokens to the specified address
@@ -30,29 +51,31 @@ contract MockERC20Votes is ERC20, ERC20Permit, IVotes {
     }
 
     /**
-     * @dev Sets a specific past voting weight for an account at a specific timestamp
+     * @dev Sets a specific past voting weight for an account at a specific timepoint
      * @param account The account to set past votes for
-     * @param timestamp The timestamp to set votes at
+     * @param timepoint The timepoint to set votes at
      * @param votes The amount of votes to set
      */
     function setPastVotes(
         address account,
-        uint256 timestamp,
+        uint256 timepoint,
         uint256 votes
     ) external {
-        _mockPastVotes[account][timestamp] = votes;
+        _mockPastVotes[account][timepoint] = votes;
+        _hasMockPastVoteBeenSet[account][timepoint] = true;
     }
 
     /**
-     * @dev Sets a specific past total supply for a specific timestamp
-     * @param timestamp The timestamp to set total supply at
+     * @dev Sets a specific past total supply for a specific timepoint
+     * @param timepoint The timepoint to set total supply at
      * @param totalSupply The total supply to set
      */
     function setPastTotalSupply(
-        uint256 timestamp,
+        uint256 timepoint,
         uint256 totalSupply
     ) external {
-        _mockPastTotalSupply[timestamp] = totalSupply;
+        _mockPastTotalSupply[timepoint] = totalSupply;
+        _hasMockPastTotalSupplyBeenSet[timepoint] = true;
     }
 
     /**
@@ -97,12 +120,12 @@ contract MockERC20Votes is ERC20, ERC20Permit, IVotes {
      */
     function getPastVotes(
         address account,
-        uint256 timestamp
+        uint256 timepoint
     ) public view override returns (uint256) {
-        if (_mockPastVotes[account][timestamp] > 0) {
-            return _mockPastVotes[account][timestamp];
+        if (_hasMockPastVoteBeenSet[account][timepoint]) {
+            return _mockPastVotes[account][timepoint];
         }
-        // If no explicit value is set for this timestamp, return the current balance
+        // If no explicit value is set for this timepoint, return the current balance
         // In a real implementation, this would use a checkpoint system
         return balanceOf(account);
     }
@@ -111,12 +134,12 @@ contract MockERC20Votes is ERC20, ERC20Permit, IVotes {
      * @dev Enhanced implementation that properly handles historical snapshots
      */
     function getPastTotalSupply(
-        uint256 timestamp
+        uint256 timepoint
     ) public view override returns (uint256) {
-        if (_mockPastTotalSupply[timestamp] > 0) {
-            return _mockPastTotalSupply[timestamp];
+        if (_hasMockPastTotalSupplyBeenSet[timepoint]) {
+            return _mockPastTotalSupply[timepoint];
         }
-        // If no explicit value is set for this timestamp, return the current total supply
+        // If no explicit value is set for this timepoint, return the current total supply
         // In a real implementation, this would use a checkpoint system
         return totalSupply();
     }

--- a/contracts/mocks/MockLightAccountFactory.sol
+++ b/contracts/mocks/MockLightAccountFactory.sol
@@ -14,10 +14,33 @@ contract MockLightAccountFactory is ILightAccountFactory {
         _accountAddresses[owner][salt] = account;
     }
 
+    /**
+     * @dev Returns a deterministically calculated mock address for a given owner and salt.
+     * If an expected address was set via `setExpectedAddress`, it returns that.
+     * Otherwise, it falls back to a calculated address (though not strictly CREATE2).
+     */
     function getAddress(
-        address owner,
-        uint256 salt
-    ) external view override returns (address) {
-        return _accountAddresses[owner][salt];
+        address _owner,
+        uint256 _salt
+    ) public view override returns (address accountAddress) {
+        if (_accountAddresses[_owner][_salt] != address(0)) {
+            return _accountAddresses[_owner][_salt];
+        }
+
+        // Fallback: A simplified way to generate a pseudo-random, owner-dependent address for testing.
+        // This path would typically be used if we weren't pre-setting the address.
+        bytes32 MOCK_FACTORY_SALT = keccak256(
+            abi.encodePacked("MockLightAccountFactory.salt")
+        );
+        bytes32 hash = keccak256(
+            abi.encodePacked(
+                bytes1(0xff),
+                address(this),
+                _owner,
+                MOCK_FACTORY_SALT,
+                _salt
+            )
+        );
+        return address(uint160(uint256(hash)));
     }
 }

--- a/contracts/mocks/MockLinearERC20VotingV1.sol
+++ b/contracts/mocks/MockLinearERC20VotingV1.sol
@@ -15,7 +15,7 @@ struct Checkpoint208 {
 
 contract MockLinearERC20VotingV1 {
     // Mapping: proposalId => ProposalPeriod
-    mapping(uint32 => ProposalPeriod) public getProposalPeriod;
+    mapping(uint32 => ProposalPeriod) public getVotingTimestamps;
     // Mapping: proposalId => votingPeriodEnded
     mapping(uint32 => bool) public votingPeriodEnded;
     // Mapping: proposalId => voter => hasVoted
@@ -32,11 +32,11 @@ contract MockLinearERC20VotingV1 {
         // Mock implementation - just for interface matching
     }
 
-    function setProposalPeriod(
+    function setVotingTimestamps(
         uint32 proposalId,
         ProposalPeriod calldata data
     ) external {
-        getProposalPeriod[proposalId] = data;
+        getVotingTimestamps[proposalId] = data;
     }
 
     function setVotingPeriodEnded(uint32 proposalId, bool ended) external {

--- a/contracts/mocks/MockLinearERC721VotingV1.sol
+++ b/contracts/mocks/MockLinearERC721VotingV1.sol
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+// Mirror the struct for getProposalVotes return values
+struct ProposalPeriod {
+    uint48 startTimestamp;
+    uint48 endTimestamp;
+}
+
 contract MockLinearERC721VotingV1 {
-    // Mapping: proposalId => endTimestamp
-    mapping(uint32 => uint48) public votingEndTimestamp;
+    // Mapping: proposalId => ProposalPeriod
+    mapping(uint32 => ProposalPeriod) public getVotingTimestamps;
     // Mapping: proposalId => votingPeriodEnded
     mapping(uint32 => bool) public votingPeriodEnded;
     // Mapping: proposalId => tokenAddress => tokenId => hasVoted
@@ -21,11 +27,11 @@ contract MockLinearERC721VotingV1 {
         // Mock implementation - just for interface matching
     }
 
-    function setVotingEndTimestamp(
+    function setVotingTimestamps(
         uint32 proposalId,
-        uint48 endTimestamp
+        ProposalPeriod calldata data
     ) external {
-        votingEndTimestamp[proposalId] = endTimestamp;
+        getVotingTimestamps[proposalId] = data;
     }
 
     function setVotingPeriodEnded(uint32 proposalId, bool ended) external {

--- a/contracts/mocks/MockOwnership.sol
+++ b/contracts/mocks/MockOwnership.sol
@@ -3,8 +3,14 @@ pragma solidity ^0.8.30;
 
 import {IOwnershipV1} from "../interfaces/decent/deployables/IOwnershipV1.sol";
 
+// Minimal interface for the voting strategy contract that MockOwnership will call
+interface IVotingStrategy {
+    function vote(uint32 proposalId, uint8 voteType) external;
+}
+
 /**
  * A mock contract implementing IOwnershipV1 for testing purposes.
+ * Includes a method to call an external vote function.
  */
 contract MockOwnership is IOwnershipV1 {
     address private _owner;
@@ -22,8 +28,21 @@ contract MockOwnership is IOwnershipV1 {
 
     /**
      * Updates the owner address for testing.
+     * Note: In a real Ownable contract, this would be restricted.
      */
     function setOwner(address newOwner) external {
         _owner = newOwner;
+    }
+
+    /**
+     * Allows this contract to call the vote function on an external strategy contract.
+     * The msg.sender to the strategy's vote() will be this MockOwnership contract.
+     */
+    function callExternalVote(
+        address strategyAddress,
+        uint32 proposalId,
+        uint8 voteType
+    ) external {
+        IVotingStrategy(strategyAddress).vote(proposalId, voteType);
     }
 }

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -4,17 +4,20 @@ pragma solidity ^0.8.30;
 import {IBaseStrategyV1} from "../interfaces/decent/deployables/IBaseStrategyV1.sol";
 
 contract MockVotingStrategy is IBaseStrategyV1 {
+    struct TimestampPoints {
+        uint48 startTimestamp;
+        uint48 endTimestamp;
+    }
+
     address public proposer;
     mapping(uint32 => bool) private _isPassed;
-    mapping(uint32 => uint48) private _votingEndTimestamp;
+    mapping(uint32 => TimestampPoints) private _proposalTimestamps;
 
     constructor(address _proposer) {
         proposer = _proposer;
     }
 
-    // required by IBaseStrategyV1
-
-    function initializeProposal(bytes memory _data) external override {}
+    function initializeProposal(bytes memory) external override {}
 
     function isPassed(uint32 proposalId) external view override returns (bool) {
         return _isPassed[proposalId];
@@ -26,19 +29,22 @@ contract MockVotingStrategy is IBaseStrategyV1 {
         return _proposer == proposer;
     }
 
-    function votingEndTimestamp(
+    function getVotingTimestamps(
         uint32 proposalId
-    ) external view override returns (uint48) {
-        return _votingEndTimestamp[proposalId];
+    ) external view override returns (uint48, uint48) {
+        TimestampPoints memory timestamps = _proposalTimestamps[proposalId];
+        return (timestamps.startTimestamp, timestamps.endTimestamp);
     }
 
-    // setters, for testing
-
-    function setVotingEndTimestamp(
+    function setVotingTimestamps(
         uint32 proposalId,
+        uint48 startTimestamp,
         uint48 endTimestamp
     ) external {
-        _votingEndTimestamp[proposalId] = endTimestamp;
+        _proposalTimestamps[proposalId] = TimestampPoints(
+            startTimestamp,
+            endTimestamp
+        );
     }
 
     function setIsPassed(uint32 proposalId, bool passed) external {

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteBaseStrategyV1.sol
@@ -7,8 +7,6 @@ import {BaseStrategyV1} from "../../../../deployables/strategies/BaseStrategyV1.
  * A concrete implementation of BaseStrategyV1 for testing purposes.
  */
 contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
-    event ConcreteFunctionCalled();
-
     /**
      * Sets up the concrete strategy contract.
      * @param _owner The owner of the contract
@@ -19,49 +17,29 @@ contract ConcreteBaseStrategyV1 is BaseStrategyV1 {
         address _proposalInitializer
     ) public override initializer {
         BaseStrategyV1.initialize(_owner, _proposalInitializer);
-
         emit StrategySetUp(_proposalInitializer, _owner);
     }
 
-    /**
-     * A concrete function that uses the onlyAzorius modifier for testing.
-     */
     function concreteOnlyProposalInitializerFunction()
         external
         onlyProposalInitializer
-    {
-        emit ConcreteFunctionCalled();
-    }
+    {}
 
-    /**
-     * Concrete implementation of the abstract initializeProposal function.
-     */
     function initializeProposal(
         bytes memory
-    ) external override onlyProposalInitializer {
-        emit ConcreteFunctionCalled();
-    }
+    ) external override onlyProposalInitializer {}
 
-    /**
-     * Concrete implementation of the abstract isPassed function.
-     */
     function isPassed(uint32) external pure override returns (bool) {
         return true;
     }
 
-    /**
-     * Concrete implementation of the abstract isProposer function.
-     */
     function isProposer(address) external pure override returns (bool) {
         return true;
     }
 
-    /**
-     * Concrete implementation of the abstract votingEndTimestamp function.
-     */
-    function votingEndTimestamp(
+    function getVotingTimestamps(
         uint32
-    ) external view override returns (uint48) {
-        return uint48(block.timestamp) + 100;
+    ) public view override returns (uint48, uint48) {
+        return (uint48(block.timestamp), uint48(block.timestamp) + 100);
     }
 }

--- a/test/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.test.ts
@@ -57,7 +57,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
       };
 
       // Set up proposal votes data with safe timestamps
-      await mockERC20Strategy.setProposalPeriod(_proposalId, proposalPeriod);
+      await mockERC20Strategy.setVotingTimestamps(_proposalId, proposalPeriod);
 
       // Set up voting state
       await mockERC20Strategy.setVotingPeriodEnded(_proposalId, false);
@@ -148,7 +148,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
       void expect(validResult).to.be.true;
 
       // Now set the proposal to non-existent (endTimestamp = 0)
-      await mockERC20Strategy.setProposalPeriod(proposalId, {
+      await mockERC20Strategy.setVotingTimestamps(proposalId, {
         startTimestamp: 0,
         endTimestamp: 0, // Zero end timestamp indicates non-existent proposal
       });
@@ -491,7 +491,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
           const { calldata } = await setupVoteOperation(proposalId, voteTypes.YES, voter.address);
 
           // Override proposal to start at timestamp 0
-          await mockERC20Strategy.setProposalPeriod(proposalId, {
+          await mockERC20Strategy.setVotingTimestamps(proposalId, {
             startTimestamp: 0,
             endTimestamp: 100,
           });
@@ -625,18 +625,18 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
       const expectedStart = currentTimestamp;
       const expectedEnd = currentTimestamp + 100;
 
-      await mockERC20Strategy.setProposalPeriod(proposalId, {
+      await mockERC20Strategy.setVotingTimestamps(proposalId, {
         startTimestamp: expectedStart,
         endTimestamp: expectedEnd,
       });
 
-      const [actualStart, actualEnd] = await mockERC20Strategy.getProposalPeriod(proposalId);
+      const [actualStart, actualEnd] = await mockERC20Strategy.getVotingTimestamps(proposalId);
       expect(actualStart).to.equal(expectedStart);
       expect(actualEnd).to.equal(expectedEnd);
     });
 
     it('Should return zeros for non-existent proposal', async function () {
-      const [startTimestamp, endTimestamp] = await mockERC20Strategy.getProposalPeriod(999); // Using an unused proposal ID
+      const [startTimestamp, endTimestamp] = await mockERC20Strategy.getVotingTimestamps(999); // Using an unused proposal ID
       expect(startTimestamp).to.equal(0);
       expect(endTimestamp).to.equal(0);
     });
@@ -644,21 +644,22 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
     it('Should return updated values after modifying proposal period', async function () {
       // Set initial values
       const currentTimestamp = await time.latest();
-      await mockERC20Strategy.setProposalPeriod(proposalId, {
+      await mockERC20Strategy.setVotingTimestamps(proposalId, {
         startTimestamp: currentTimestamp,
-        endTimestamp: currentTimestamp + 100,
+        endTimestamp: currentTimestamp + 10,
       });
 
       // Update to new values
       const newStart = currentTimestamp + 50;
       const newEnd = currentTimestamp + 150;
-      await mockERC20Strategy.setProposalPeriod(proposalId, {
+      await mockERC20Strategy.setVotingTimestamps(proposalId, {
         startTimestamp: newStart,
         endTimestamp: newEnd,
       });
 
       // Verify the update
-      const [startTimestamp, endTimestamp] = await mockERC20Strategy.getProposalPeriod(proposalId);
+      const [startTimestamp, endTimestamp] =
+        await mockERC20Strategy.getVotingTimestamps(proposalId);
       expect(startTimestamp).to.equal(newStart);
       expect(endTimestamp).to.equal(newEnd);
     });

--- a/test/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.test.ts
@@ -62,7 +62,10 @@ describe('LinearERC721VotingV1ValidatorV1', function () {
       _tokenIds: number[],
     ) {
       const currentTimestamp = await time.latest();
-      await mockERC721Strategy.setVotingEndTimestamp(_proposalId, currentTimestamp + 100);
+      await mockERC721Strategy.setVotingTimestamps(_proposalId, {
+        startTimestamp: currentTimestamp,
+        endTimestamp: currentTimestamp + 100,
+      });
 
       // Set up token weight
       for (let i = 0; i < _tokenAddresses.length; i++) {
@@ -197,7 +200,10 @@ describe('LinearERC721VotingV1ValidatorV1', function () {
       void expect(validResult).to.be.true;
 
       // Now set the proposal to non-existent
-      await mockERC721Strategy.setVotingEndTimestamp(proposalId, 0);
+      await mockERC721Strategy.setVotingTimestamps(proposalId, {
+        startTimestamp: 0,
+        endTimestamp: 0,
+      });
 
       const invalidResult = await validator.validateOperation(
         ethers.ZeroAddress,

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { mine, time } from '@nomicfoundation/hardhat-network-helpers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -1064,7 +1064,11 @@ describe('AzoriusV1', () => {
         // Set voting end block to future block and mark as passed by default
         const currentBlockTimestamp = await time.latest();
 
-        await mockStrategy.setVotingEndTimestamp(proposalId, currentBlockTimestamp + 10);
+        await mockStrategy.setVotingTimestamps(
+          proposalId,
+          currentBlockTimestamp,
+          currentBlockTimestamp + 10,
+        );
         await mockStrategy.setIsPassed(proposalId, true);
       });
 
@@ -1072,20 +1076,22 @@ describe('AzoriusV1', () => {
         // Initially active (voting not ended)
         expect(await azorius.proposalState(proposalId)).to.equal(0); // ACTIVE
 
+        const currentBlockTimestamp = await time.latest();
+
         // End voting immediately
-        await mockStrategy.setVotingEndTimestamp(proposalId, await time.latest());
+        await mockStrategy.setVotingTimestamps(proposalId, 0, currentBlockTimestamp);
 
         // Should be in timelock since we set isPassed to true in beforeEach
         expect(await azorius.proposalState(proposalId)).to.equal(1); // TIMELOCKED
 
         // Move past timelock
-        await mine(TIMELOCK_PERIOD);
+        await time.increase(TIMELOCK_PERIOD);
 
         // Should be executable
         expect(await azorius.proposalState(proposalId)).to.equal(2); // EXECUTABLE
 
         // Move past execution period
-        await mine(EXECUTION_PERIOD);
+        await time.increase(EXECUTION_PERIOD);
 
         // Should be expired
         expect(await azorius.proposalState(proposalId)).to.equal(4); // EXPIRED
@@ -1096,10 +1102,12 @@ describe('AzoriusV1', () => {
         await mockToken.mint(await avatar.getAddress(), 1000);
 
         // End voting immediately
-        await mockStrategy.setVotingEndTimestamp(proposalId, await time.latest());
+        const currentBlockTimestamp = await time.latest();
+        const votingEnd = currentBlockTimestamp + 10;
+        await mockStrategy.setVotingTimestamps(proposalId, currentBlockTimestamp, votingEnd);
 
         // Move past timelock
-        await mine(TIMELOCK_PERIOD);
+        await time.increaseTo(votingEnd + TIMELOCK_PERIOD);
 
         // Enable the module on the avatar to be able to execute the proposal
         await avatar.enableModule(await azorius.getAddress());
@@ -1119,7 +1127,7 @@ describe('AzoriusV1', () => {
 
       it('should not execute proposal before timelock period', async () => {
         // Set voting to passed
-        await mockStrategy.setVotingEndTimestamp(proposalId, 0);
+        await mockStrategy.setVotingTimestamps(proposalId, 0, 0);
         await mockStrategy.setIsPassed(proposalId, true);
 
         await expect(
@@ -1135,11 +1143,11 @@ describe('AzoriusV1', () => {
 
       it('should not execute proposal after execution period', async () => {
         // Set voting to passed
-        await mockStrategy.setVotingEndTimestamp(proposalId, 0);
+        await mockStrategy.setVotingTimestamps(proposalId, 0, 0);
         await mockStrategy.setIsPassed(proposalId, true);
 
         // Move past timelock and execution period
-        await mine(TIMELOCK_PERIOD + EXECUTION_PERIOD + 1);
+        await time.increase(TIMELOCK_PERIOD + EXECUTION_PERIOD + 1);
 
         await expect(
           azorius.executeProposal(
@@ -1159,7 +1167,11 @@ describe('AzoriusV1', () => {
           const currentTimestamp = await time.latest();
 
           // Set a future voting end timestamp
-          await mockStrategy.setVotingEndTimestamp(proposalId, currentTimestamp + 100);
+          await mockStrategy.setVotingTimestamps(
+            proposalId,
+            currentTimestamp,
+            currentTimestamp + 100,
+          );
           await mockStrategy.setIsPassed(proposalId, true);
         });
 
@@ -1192,7 +1204,11 @@ describe('AzoriusV1', () => {
           const currentTimestamp = await time.latest();
 
           // Set exact timestamps for voting end
-          await mockStrategy.setVotingEndTimestamp(proposalId, currentTimestamp + 100);
+          await mockStrategy.setVotingTimestamps(
+            proposalId,
+            currentTimestamp,
+            currentTimestamp + 100,
+          );
 
           // At exactly the voting end time
           await time.increaseTo(currentTimestamp + 100);
@@ -1248,9 +1264,9 @@ describe('AzoriusV1', () => {
           .submitProposal(await mockStrategy.getAddress(), '0x', [tx1, tx2], 'Test proposal');
 
         // Set voting to passed and move past timelock
-        await mockStrategy.setVotingEndTimestamp(0, 0);
+        await mockStrategy.setVotingTimestamps(0, 0, 0);
         await mockStrategy.setIsPassed(0, true);
-        await mine(TIMELOCK_PERIOD);
+        await time.increase(TIMELOCK_PERIOD);
 
         // Mint tokens to avatar for execution
         await mockToken.mint(await avatar.getAddress(), 1000);
@@ -1261,11 +1277,14 @@ describe('AzoriusV1', () => {
         beforeEach(async () => {
           // Get current block number
           const currentBlockTimestamp = await time.latest();
-          const votingEndTimestamp = currentBlockTimestamp + 10;
-          await mockStrategy.setVotingEndTimestamp(0, votingEndTimestamp);
+          await mockStrategy.setVotingTimestamps(
+            0,
+            currentBlockTimestamp,
+            currentBlockTimestamp + 10,
+          );
 
           // Move past voting and timelock period
-          await mine(10 + TIMELOCK_PERIOD);
+          await time.increase(10 + TIMELOCK_PERIOD);
         });
 
         it('should allow partial execution of proposal transactions', async () => {
@@ -1320,12 +1339,15 @@ describe('AzoriusV1', () => {
 
         // Get current block number and set up proposal state
         const currentBlockTimestamp = await time.latest();
-        const votingEndBlockTimestamp = currentBlockTimestamp + 10;
-        await mockStrategy.setVotingEndTimestamp(1, votingEndBlockTimestamp);
+        await mockStrategy.setVotingTimestamps(
+          1,
+          currentBlockTimestamp,
+          currentBlockTimestamp + 10,
+        );
         await mockStrategy.setIsPassed(1, true);
 
         // Move past voting and timelock period
-        await mine(10 + TIMELOCK_PERIOD);
+        await time.increase(10 + TIMELOCK_PERIOD);
 
         // Verify proposal is executable
         expect(await azorius.proposalState(1)).to.equal(2); // EXECUTABLE

--- a/test/deployables/strategies/LinearERC20VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC20VotingV1.test.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { mine, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
-import type { ContractTransactionResponse } from 'ethers';
+import type { BigNumberish } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
@@ -14,6 +14,8 @@ import {
   LinearERC20VotingV1__factory,
   MockERC20Votes,
   MockERC20Votes__factory,
+  MockLightAccountFactory,
+  MockLightAccountFactory__factory,
   MockOwnership,
   MockOwnership__factory,
 } from '../../../typechain-types';
@@ -25,25 +27,28 @@ describe('LinearERC20VotingV1', () => {
   let deployer: SignerWithAddress;
   let owner: SignerWithAddress;
   let nonOwner: SignerWithAddress;
-  let proposalInitializer: string;
+  let proposalInitializer: SignerWithAddress;
   let tokenHolder1: SignerWithAddress;
   let tokenHolder2: SignerWithAddress;
   let tokenHolder3: SignerWithAddress;
-  let lightAccountFactoryMock: SignerWithAddress;
 
   // Contracts
   let linearERC20VotingImplementation: LinearERC20VotingV1;
-  let linearERC20Voting: LinearERC20VotingV1;
   let mockToken: MockERC20Votes;
-  let mockOwnership: MockOwnership;
+  let lightAccountFactoryMock: MockLightAccountFactory;
 
   // Constants
   const VOTING_PERIOD = 100; // seconds
   const REQUIRED_PROPOSER_WEIGHT = 100; // 100 tokens to propose
   const QUORUM_NUMERATOR = 300000; // 30% of 1000000
   const BASIS_NUMERATOR = 500000; // 50% of 1000000
+  const BASIS_DENOMINATOR = 1_000_000; // From contract
 
-  // Vote types from the contract
+  enum ClockMode {
+    Timestamp = 0,
+    BlockNumber = 1,
+  }
+
   enum VoteType {
     NO = 0,
     YES = 1,
@@ -52,631 +57,50 @@ describe('LinearERC20VotingV1', () => {
 
   async function deployLinearERC20Voting(
     strategyOwner: SignerWithAddress,
-    governanceToken: string,
+    governanceTokenAddress: string,
     azoriusAddr: string,
-    lightAccountFactory: string,
+    lightAccountFactoryAddress: string,
+    customVotingPeriod: number = VOTING_PERIOD,
+    customRequiredProposerWeight: BigNumberish = REQUIRED_PROPOSER_WEIGHT,
+    customQuorumNumerator: number = QUORUM_NUMERATOR,
+    customBasisNumerator: number = BASIS_NUMERATOR,
   ): Promise<LinearERC20VotingV1> {
-    // Create the initialization data
     const initializeCalldata = LinearERC20VotingV1__factory.createInterface().encodeFunctionData(
       'initialize(address,address,address,uint32,uint256,uint256,uint256,address)',
       [
         strategyOwner.address,
-        governanceToken,
+        governanceTokenAddress,
         azoriusAddr,
-        VOTING_PERIOD,
-        REQUIRED_PROPOSER_WEIGHT,
-        QUORUM_NUMERATOR,
-        BASIS_NUMERATOR,
-        lightAccountFactory,
+        customVotingPeriod,
+        customRequiredProposerWeight,
+        customQuorumNumerator,
+        customBasisNumerator,
+        lightAccountFactoryAddress,
       ],
     );
 
-    // Deploy the proxy with the implementation
     const proxy = await new ERC1967Proxy__factory(strategyOwner).deploy(
       await linearERC20VotingImplementation.getAddress(),
       initializeCalldata,
     );
 
-    // Connect the proxy to the implementation contract type
     return LinearERC20VotingV1__factory.connect(await proxy.getAddress(), strategyOwner);
   }
 
   beforeEach(async () => {
-    [deployer, owner, nonOwner, tokenHolder1, tokenHolder2, tokenHolder3, lightAccountFactoryMock] =
+    [deployer, owner, nonOwner, proposalInitializer, tokenHolder1, tokenHolder2, tokenHolder3] =
       await ethers.getSigners();
 
-    // Use nonOwner address as a mock azorius address for testing
-    proposalInitializer = await nonOwner.getAddress();
-
-    // Deploy MockERC20Votes token
     mockToken = await new MockERC20Votes__factory(deployer).deploy();
 
-    // Deploy MockOwnership contract
-    mockOwnership = await new MockOwnership__factory(deployer).deploy(tokenHolder1.address);
-
-    // Mint tokens to token holders
-    await mockToken.mint(tokenHolder1.address, 1000);
-    await mockToken.mint(tokenHolder2.address, 1000);
-    await mockToken.mint(tokenHolder3.address, 1000);
-
-    // Deploy LinearERC20Voting implementation
     linearERC20VotingImplementation = await new LinearERC20VotingV1__factory(deployer).deploy();
 
-    // Deploy LinearERC20Voting strategy
-    linearERC20Voting = await deployLinearERC20Voting(
-      owner,
-      await mockToken.getAddress(),
-      proposalInitializer,
-      lightAccountFactoryMock.address,
-    );
-  });
-
-  describe('Initialization', () => {
-    it('should initialize with correct parameters', async () => {
-      expect(await linearERC20Voting.owner()).to.equal(owner.address);
-      expect(await linearERC20Voting.governanceToken()).to.equal(await mockToken.getAddress());
-      expect(await linearERC20Voting.proposalInitializer()).to.equal(proposalInitializer);
-      expect(await linearERC20Voting.votingPeriod()).to.equal(VOTING_PERIOD);
-      expect(await linearERC20Voting.requiredProposerWeight()).to.equal(REQUIRED_PROPOSER_WEIGHT);
-      expect(await linearERC20Voting.quorumNumerator()).to.equal(QUORUM_NUMERATOR);
-      expect(await linearERC20Voting.basisNumerator()).to.equal(BASIS_NUMERATOR);
-      expect(await linearERC20Voting.lightAccountFactory()).to.equal(
-        lightAccountFactoryMock.address,
-      );
-    });
-
-    it('should not allow reinitialization', async () => {
-      // Attempt to reinitialize - should revert
-      await expect(
-        linearERC20Voting[
-          'initialize(address,address,address,uint32,uint256,uint256,uint256,address)'
-        ](
-          owner.address,
-          await mockToken.getAddress(),
-          proposalInitializer,
-          VOTING_PERIOD,
-          REQUIRED_PROPOSER_WEIGHT,
-          QUORUM_NUMERATOR,
-          BASIS_NUMERATOR,
-          lightAccountFactoryMock.address,
-        ),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidInitialization');
-    });
-
-    it('should revert when initializing with zero token address', async () => {
-      // Create initialization data with zero address for token
-      const initializeCalldata = LinearERC20VotingV1__factory.createInterface().encodeFunctionData(
-        'initialize(address,address,address,uint32,uint256,uint256,uint256,address)',
-        [
-          owner.address,
-          ethers.ZeroAddress,
-          proposalInitializer,
-          VOTING_PERIOD,
-          REQUIRED_PROPOSER_WEIGHT,
-          QUORUM_NUMERATOR,
-          BASIS_NUMERATOR,
-          lightAccountFactoryMock.address,
-        ],
-      );
-
-      // Attempt to deploy a new proxy with invalid initialization - should revert
-      await expect(
-        new ERC1967Proxy__factory(owner).deploy(
-          await linearERC20VotingImplementation.getAddress(),
-          initializeCalldata,
-        ),
-      ).to.be.reverted;
-    });
-
-    it('should emit ProposalInitialized event when initializing a proposal', async () => {
-      const proposalId = 200;
-      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-
-      // Get current block timestmp to calculate expected end timestamp
-      const currentBlockTimestamp = await time.latest();
-
-      // +1 because the proposal will be in the next block, and that block's timestamp will be increased by one second
-      const expectedEndTimestamp = currentBlockTimestamp + 1 + VOTING_PERIOD;
-
-      await expect(linearERC20Voting.connect(nonOwner).initializeProposal(initializeData))
-        .to.emit(linearERC20Voting, 'ProposalInitialized')
-        .withArgs(proposalId, expectedEndTimestamp);
-    });
-  });
-
-  describe('Owner Functions', () => {
-    it('should allow owner to update voting period', async () => {
-      const newVotingPeriod = 200;
-      await linearERC20Voting.connect(owner).updateVotingPeriod(newVotingPeriod);
-      expect(await linearERC20Voting.votingPeriod()).to.equal(newVotingPeriod);
-    });
-
-    it('should not allow non-owner to update voting period', async () => {
-      const newVotingPeriod = 200;
-      await expect(
-        linearERC20Voting.connect(nonOwner).updateVotingPeriod(newVotingPeriod),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should allow owner to update required proposer weight', async () => {
-      const newRequiredProposerWeight = 200;
-      await linearERC20Voting
-        .connect(owner)
-        .updateRequiredProposerWeight(newRequiredProposerWeight);
-      expect(await linearERC20Voting.requiredProposerWeight()).to.equal(newRequiredProposerWeight);
-    });
-
-    it('should not allow non-owner to update required proposer weight', async () => {
-      const newRequiredProposerWeight = 200;
-      await expect(
-        linearERC20Voting.connect(nonOwner).updateRequiredProposerWeight(newRequiredProposerWeight),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should allow owner to update basis numerator', async () => {
-      const newBasisNumerator = 600000;
-      await linearERC20Voting.connect(owner).updateBasisNumerator(newBasisNumerator);
-      expect(await linearERC20Voting.basisNumerator()).to.equal(newBasisNumerator);
-    });
-
-    it('should not allow non-owner to update basis numerator', async () => {
-      const newBasisNumerator = 600000;
-      await expect(
-        linearERC20Voting.connect(nonOwner).updateBasisNumerator(newBasisNumerator),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should emit BasisNumeratorUpdated event when basisNumerator is updated', async () => {
-      const newBasisNumerator = 700000; // 70%
-      await expect(linearERC20Voting.connect(owner).updateBasisNumerator(newBasisNumerator))
-        .to.emit(linearERC20Voting, 'BasisNumeratorUpdated')
-        .withArgs(newBasisNumerator);
-    });
-
-    it('should revert when basisNumerator is greater than BASIS_DENOMINATOR', async () => {
-      const invalidBasisNumerator = 1000001; // BASIS_DENOMINATOR + 1
-      await expect(
-        linearERC20Voting.connect(owner).updateBasisNumerator(invalidBasisNumerator),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidBasisNumerator');
-    });
-
-    it('should revert when basisNumerator is less than BASIS_DENOMINATOR / 2', async () => {
-      const invalidBasisNumerator = 499999; // BASIS_DENOMINATOR / 2 - 1
-      await expect(
-        linearERC20Voting.connect(owner).updateBasisNumerator(invalidBasisNumerator),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidBasisNumerator');
-    });
-
-    it('should allow basisNumerator to be equal to BASIS_DENOMINATOR / 2', async () => {
-      const newBasisNumerator = 500000; // BASIS_DENOMINATOR / 2
-      await linearERC20Voting.connect(owner).updateBasisNumerator(newBasisNumerator);
-      expect(await linearERC20Voting.basisNumerator()).to.equal(newBasisNumerator);
-    });
-
-    it('should allow basisNumerator to be equal to BASIS_DENOMINATOR', async () => {
-      const newBasisNumerator = 1000000; // BASIS_DENOMINATOR
-      await linearERC20Voting.connect(owner).updateBasisNumerator(newBasisNumerator);
-      expect(await linearERC20Voting.basisNumerator()).to.equal(newBasisNumerator);
-    });
-  });
-
-  describe('Proposal Functions', () => {
-    it('should allow only authorized account to initialize proposal', async () => {
-      // Mock proposal ID
-      const proposalId = 1;
-      // Mock data for initializing a proposal
-      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-
-      // Only authorized account can initialize proposals
-      await expect(
-        linearERC20Voting.connect(owner).initializeProposal(initializeData),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'ProposalInitializerUnauthorizedAccount');
-
-      // Test with authorized account
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
-
-      // Check that proposal was initialized correctly
-      const votingEndTimestamp = await linearERC20Voting.votingEndTimestamp(proposalId);
-      expect(votingEndTimestamp).to.not.equal(0);
-    });
-
-    it('should determine proposer status based on voting weight', async () => {
-      // This test focuses on whether an address is considered a proposer based on its voting weight
-
-      // First, update required proposer weight to 500 tokens
-      await linearERC20Voting.connect(owner).updateRequiredProposerWeight(500);
-
-      // Delegate to tokenHolder1 (who has 1000 tokens > 500 required)
-      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
-
-      // tokenHolder1 should be a proposer with 1000 tokens > 500 required
-      void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.true;
-
-      // Update required proposer weight to 1500 tokens (higher than tokenHolder1's balance)
-      await linearERC20Voting.connect(owner).updateRequiredProposerWeight(1500);
-
-      // Now tokenHolder1 should NOT be a proposer with 1000 tokens < 1500 required
-      void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.false;
-    });
-  });
-
-  describe('Voting Functions', () => {
-    const proposalId = 1;
-
-    beforeEach(async () => {
-      // Delegate tokens to voters
-      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
-      await mockToken.connect(tokenHolder2).delegate(tokenHolder2.address);
-      await mockToken.connect(tokenHolder3).delegate(tokenHolder3.address);
-
-      // Initialize a proposal using the azorius mock account
-      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
-    });
-
-    it('should allow users to vote on a proposal', async () => {
-      // Cast votes
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-      await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.NO);
-      await linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.ABSTAIN);
-
-      // Get proposal votes
-      const [noVotes, yesVotes, abstainVotes, , ,] =
-        await linearERC20Voting.getProposalVotes(proposalId);
-
-      // Check vote counts (each holder has 1000 tokens)
-      expect(yesVotes).to.equal(1000);
-      expect(noVotes).to.equal(1000);
-      expect(abstainVotes).to.equal(1000);
-    });
-
-    it('should correctly track if an address has voted', async () => {
-      void expect(await linearERC20Voting.hasVoted(proposalId, tokenHolder1.address)).to.be.false;
-
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-
-      void expect(await linearERC20Voting.hasVoted(proposalId, tokenHolder1.address)).to.be.true;
-    });
-
-    it('should not allow voting twice', async () => {
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-
-      await expect(
-        linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.NO),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'AlreadyVoted');
-    });
-
-    describe('voting period ended', () => {
-      let noVotesBefore: bigint;
-      let yesVotesBefore: bigint;
-      let abstainVotesBefore: bigint;
-      let initialVoteTx: ContractTransactionResponse;
-      let endTimestamp: bigint;
-
-      beforeEach(async () => {
-        // Get initial vote counts
-        [noVotesBefore, yesVotesBefore, abstainVotesBefore, , endTimestamp] =
-          await linearERC20Voting.getProposalVotes(proposalId);
-
-        // Mine blocks to advance past the voting period
-        await time.increaseTo(Number(endTimestamp) + 1);
-
-        // First vote to mark the period as ended
-        initialVoteTx = await linearERC20Voting
-          .connect(tokenHolder1)
-          .vote(proposalId, VoteType.YES);
-      });
-
-      it('should handle first vote after voting period ends correctly', async () => {
-        // Verify event emission
-        await expect(initialVoteTx).to.emit(linearERC20Voting, 'VotingPeriodEnded');
-
-        // Verify no votes were actually counted
-        const [noVotesAfter, yesVotesAfter, abstainVotesAfter, , ,] =
-          await linearERC20Voting.getProposalVotes(proposalId);
-        expect(noVotesAfter).to.equal(noVotesBefore, 'NO votes should not change');
-        expect(yesVotesAfter).to.equal(yesVotesBefore, 'YES votes should not change');
-        expect(abstainVotesAfter).to.equal(abstainVotesBefore, 'ABSTAIN votes should not change');
-
-        // Verify the voting period is marked as ended
-        void expect(await linearERC20Voting.votingPeriodEnded(proposalId)).to.be.true;
-      });
-
-      it('should revert on votes after voting period is marked as ended', async () => {
-        // Verify subsequent votes revert
-        await expect(
-          linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES),
-        ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
-
-        await expect(
-          linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.NO),
-        ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
-
-        // Verify even the same account that marked it as ended can't vote again
-        await expect(
-          linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.ABSTAIN),
-        ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
-      });
-    });
-
-    it('should revert on invalid vote type', async () => {
-      // Valid vote types are 0, 1, 2 (NO, YES, ABSTAIN)
-      const invalidVoteType = 3;
-
-      await expect(
-        linearERC20Voting.connect(tokenHolder1).vote(proposalId, invalidVoteType),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidVote');
-    });
-  });
-
-  describe('isPassed Logic', () => {
-    const proposalId = 1;
-    let proposalBeginTimestamp: number;
-
-    beforeEach(async () => {
-      // Delegate tokens to voters
-      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
-      await mockToken.connect(tokenHolder2).delegate(tokenHolder2.address);
-      await mockToken.connect(tokenHolder3).delegate(tokenHolder3.address);
-
-      // Initialize a proposal using the azorius mock account
-      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
-      proposalBeginTimestamp = await time.latest();
-    });
-
-    it('should pass when yes > no and meets quorum', async () => {
-      // Cast votes: 1500 YES, 500 NO, enough for both quorum and basis
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-      await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
-      await linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.NO);
-
-      // Mine blocks to end the voting period
-      await time.increaseTo(proposalBeginTimestamp + VOTING_PERIOD + 1);
-
-      // Proposal should pass
-      void expect(await linearERC20Voting.isPassed(proposalId)).to.be.true;
-    });
-
-    it('should fail when voting period is not over', async () => {
-      // Cast votes: 2000 YES, 1000 NO
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-      await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
-      await linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.NO);
-
-      // Voting period not over yet
-      void expect(await linearERC20Voting.isPassed(proposalId)).to.be.false;
-    });
-
-    it('should fail when quorum is not met', async () => {
-      // Only 1000 tokens voting (33% of 3000), below QUORUM_NUMERATOR of 300000 (30%)
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-
-      // Update quorum to 40% to make this test fail
-      await linearERC20Voting.connect(owner).updateQuorumNumerator(400000);
-
-      // Mine timestamp to end the voting period
-      await time.increaseTo(proposalBeginTimestamp + VOTING_PERIOD + 1);
-
-      // Proposal should fail due to insufficient quorum
-      void expect(await linearERC20Voting.isPassed(proposalId)).to.be.false;
-    });
-
-    it('should fail when basis is not met', async () => {
-      // Cast votes: 900 YES, 1100 NO, YES votes not high enough vs NO
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.NO);
-      await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.NO);
-      await linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.YES);
-
-      // Mine timestamp to end the voting period
-      await time.increaseTo(proposalBeginTimestamp + VOTING_PERIOD + 1);
-
-      // Proposal should fail due to insufficient basis (YES < NO)
-      void expect(await linearERC20Voting.isPassed(proposalId)).to.be.false;
-    });
-  });
-
-  describe('Version', () => {
-    it('should return the correct version number', async () => {
-      expect(await linearERC20Voting.getVersion()).to.equal(1);
-    });
-  });
-
-  describe('UUPS Upgradeability', function () {
-    runUUPSUpgradeabilityTests({
-      getContract: () => linearERC20Voting,
-      createNewImplementation: async () => {
-        const newImplementation = await new LinearERC20VotingV1__factory(owner).deploy();
-        return newImplementation;
-      },
-      owner: () => owner,
-      nonOwner: () => nonOwner,
-    });
-  });
-
-  describe('Voting Weight and Supply Functions', () => {
-    const proposalId = 1;
-
-    beforeEach(async () => {
-      // Delegate tokens to voters
-      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
-      await mockToken.connect(tokenHolder2).delegate(tokenHolder2.address);
-      await mockToken.connect(tokenHolder3).delegate(tokenHolder3.address);
-
-      // Initialize a proposal using the azorius mock account
-      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
-
-      // Get the actual voting start block from the proposal
-      const [, , , startBlock, ,] = await linearERC20Voting.getProposalVotes(proposalId);
-
-      // Now set past total supply for the EXACT block where the proposal was initialized
-      await mockToken.setPastTotalSupply(startBlock, 3000);
-    });
-
-    it('should correctly calculate voting supply at proposal creation time', async () => {
-      // Verify the proposal voting supply is recorded correctly at proposal creation
-      const [, , , , , votingSupply] = await linearERC20Voting.getProposalVotes(proposalId);
-      expect(votingSupply).to.equal(3000);
-
-      // Mint more tokens (this won't affect past total supply at the proposal start block)
-      await mockToken.mint(tokenHolder1.address, 2000);
-
-      // The voting supply for the proposal should still be 3000
-      const [, , , , , votingSupplyAfterMint] =
-        await linearERC20Voting.getProposalVotes(proposalId);
-      expect(votingSupplyAfterMint).to.equal(3000);
-    });
-
-    it('should correctly calculate voting weight at proposal creation time', async () => {
-      // Check the voting weight for tokenHolder1
-      const votingWeight = await linearERC20Voting.getVotingWeight(
-        tokenHolder1.address,
-        proposalId,
-      );
-
-      // The voting weight should be 1000 (what we set for the block at proposal creation)
-      expect(votingWeight).to.equal(1000);
-
-      // Mine a block to get to a new block number
-      await mine(1);
-
-      // Change the votes for a future block
-      const newBlockNumber = await ethers.provider.getBlockNumber();
-      const newWeight = 2000;
-      await mockToken.setPastVotes(tokenHolder1.address, newBlockNumber, newWeight);
-
-      // The voting weight for the proposal should still be 1000, based on the snapshot at the
-      // time the proposal was created
-      const votingWeightAfterChange = await linearERC20Voting.getVotingWeight(
-        tokenHolder1.address,
-        proposalId,
-      );
-      expect(votingWeightAfterChange).to.equal(1000);
-    });
-
-    it('should correctly calculate quorum votes based on voting supply', async () => {
-      // Quorum is set to 30% of the total supply (QUORUM_NUMERATOR = 300000 out of 1000000)
-      // Total supply at proposal creation is 3000, so quorum should be 900 votes
-      const quorumVotesRequired = await linearERC20Voting.quorumVotes(proposalId);
-      expect(quorumVotesRequired).to.equal(900);
-
-      // Changing the quorum numerator should affect the required votes
-      await linearERC20Voting.connect(owner).updateQuorumNumerator(500000); // 50%
-      const newQuorumVotesRequired = await linearERC20Voting.quorumVotes(proposalId);
-      expect(newQuorumVotesRequired).to.equal(1500); // 50% of 3000
-
-      // Even if total supply changes after proposal creation, quorum should be based on original supply
-      const quorumAfterSupplyChange = await linearERC20Voting.quorumVotes(proposalId);
-      expect(quorumAfterSupplyChange).to.equal(1500); // Still 50% of 3000, not 6000
-    });
-
-    it('should directly call getProposalVotingSupply and return the correct value', async () => {
-      // Call getProposalVotingSupply directly
-      const votingSupply = await linearERC20Voting.getProposalVotingSupply(proposalId);
-      expect(votingSupply).to.equal(3000);
-
-      // Should match what getProposalVotes returns
-      const [, , , , , votesSupply] = await linearERC20Voting.getProposalVotes(proposalId);
-      expect(votingSupply).to.equal(votesSupply);
-
-      // Add some more tokens to test that the snapshot supply doesn't change
-      await mockToken.mint(tokenHolder1.address, 2000);
-      const votingSupplyAfterMint = await linearERC20Voting.getProposalVotingSupply(proposalId);
-      expect(votingSupplyAfterMint).to.equal(3000);
-    });
-  });
-
-  describe('Smart Account Support', () => {
-    const proposalId = 2;
-
-    beforeEach(async () => {
-      // Setup with tokens for the test
-      await mockToken.mint(await mockOwnership.getAddress(), 1000);
-
-      // Delegate tokens to the mock contract
-      await mockToken.connect(deployer).delegate(await mockOwnership.getAddress());
-
-      // Initialize the proposal
-      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
-    });
-
-    it('should correctly identify voter when using smart account', async () => {
-      // The MockOwnership contract has owner() set to tokenHolder1.address in the beforeEach
-
-      // We need to test that ERC4337VoterSupport correctly resolves the owner of the contract
-      // But we can't directly call from the contract's address, so we need to verify indirectly
-
-      // Vote from tokenHolder1 (which is the owner of mockOwnership)
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-
-      // Check votes were attributed correctly
-      const [, yesVotes, , , ,] = await linearERC20Voting.getProposalVotes(proposalId);
-      expect(yesVotes).to.equal(1000);
-
-      // Check that tokenHolder1 is marked as having voted
-      void expect(await linearERC20Voting.hasVoted(proposalId, tokenHolder1.address)).to.be.true;
-
-      // The test for ERC4337VoterSupport is more limited without advanced mocking
-      // But we can verify that the _voter function works by setting up additional tests in ERC4337VoterSupportV1.test.ts
-    });
-  });
-
-  describe('Edge Cases', () => {
-    it('should handle invalid proposals', async () => {
-      // Try to vote on a non-initialized proposal
-      const nonExistentProposalId = 999;
-
-      await expect(
-        linearERC20Voting.connect(tokenHolder1).vote(nonExistentProposalId, VoteType.YES),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidProposal');
-    });
-
-    it('should handle multiple concurrent proposals', async () => {
-      // Set up votes for test accounts
-      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
-      await mockToken.connect(tokenHolder2).delegate(tokenHolder2.address);
-
-      // Initialize the first proposal
-      const proposalId1 = 10;
-      const initializeData1 = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId1]);
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData1);
-
-      // Mine a block to simulate time passing
-      await mine(1);
-
-      // Initialize the second proposal
-      const proposalId2 = 20;
-      const initializeData2 = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId2]);
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData2);
-
-      // Vote differently on each proposal
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId1, VoteType.YES);
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId2, VoteType.NO);
-
-      await linearERC20Voting.connect(tokenHolder2).vote(proposalId1, VoteType.NO);
-      await linearERC20Voting.connect(tokenHolder2).vote(proposalId2, VoteType.YES);
-
-      // Check that votes are tracked independently
-      const [noVotes1, yesVotes1, , , ,] = await linearERC20Voting.getProposalVotes(proposalId1);
-      const [noVotes2, yesVotes2, , , ,] = await linearERC20Voting.getProposalVotes(proposalId2);
-
-      expect(yesVotes1).to.equal(1000);
-      expect(noVotes1).to.equal(1000);
-
-      expect(yesVotes2).to.equal(1000);
-      expect(noVotes2).to.equal(1000);
-
-      // Verify different hasVoted state per proposal
-      void expect(await linearERC20Voting.hasVoted(proposalId1, tokenHolder1.address)).to.be.true;
-      void expect(await linearERC20Voting.hasVoted(proposalId2, tokenHolder1.address)).to.be.true;
-      void expect(await linearERC20Voting.hasVoted(proposalId1, tokenHolder2.address)).to.be.true;
-      void expect(await linearERC20Voting.hasVoted(proposalId2, tokenHolder2.address)).to.be.true;
-    });
+    // Deploy the MockLightAccountFactory
+    lightAccountFactoryMock = await new MockLightAccountFactory__factory(deployer).deploy();
   });
 
   describe('ERC165', function () {
+    let linearERC20Voting: LinearERC20VotingV1;
     let iBaseStrategyV1InterfaceId: string;
     let iBaseQuorumPercentV1InterfaceId: string;
     let iBaseVotingBasisPercentV1InterfaceId: string;
@@ -684,7 +108,13 @@ describe('LinearERC20VotingV1', () => {
     let iERC165InterfaceId: string;
 
     beforeEach(async function () {
-      // Dynamically calculate interface IDs
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+
       const IBaseQuorumPercentV1Interface = IBaseQuorumPercentV1__factory.createInterface();
       iBaseQuorumPercentV1InterfaceId = calculateInterfaceId(IBaseQuorumPercentV1Interface);
 
@@ -738,324 +168,2423 @@ describe('LinearERC20VotingV1', () => {
     });
   });
 
-  describe('Timestamp-based voting', () => {
-    let proposalId: number;
+  describe('UUPS Upgradeability', function () {
+    let linearERC20Voting: LinearERC20VotingV1;
 
-    beforeEach(async () => {
-      // Initialize a proposal
-      proposalId = 100;
-      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
-
-      // Mint tokens to a voter for testing
-      await mockToken.mint(tokenHolder1.address, 1000);
-      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
-    });
-
-    it('should enforce voting end by timestamp', async () => {
-      // Get the voting end timestamp
-      const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
-
-      // Cast a vote before voting ends
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-
-      // Advance time to just after voting end
-      await time.increaseTo(Number(endTimestamp) + 1);
-
-      // First vote attempt after period ends should mark it as ended and return
-      const tx = await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
-      await expect(tx).to.emit(linearERC20Voting, 'VotingPeriodEnded');
-
-      // Try to vote after voting ended - should revert
-      await expect(
-        linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
-
-      // Subsequent vote attempts should revert
-      await expect(
-        linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.YES),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
-    });
-
-    it('should use timestamp for voting weight snapshot', async () => {
-      // Get the proposal start timestamp
-      const [, , , startTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
-
-      // Set the past votes to a specific value for testing at the proposal's start timestamp
-      await mockToken.setPastVotes(tokenHolder1.address, startTimestamp, 500);
-
-      // Check that the voting weight is determined by snapshot at start timestamp
-      const votingWeight = await linearERC20Voting.getVotingWeight(
-        tokenHolder1.address,
-        proposalId,
+    beforeEach(async function () {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
       );
-      expect(votingWeight).to.equal(500);
-
-      // If user gets more tokens now, voting weight shouldn't change for this proposal
-      const oldBalance = await mockToken.balanceOf(tokenHolder1.address);
-      await mockToken.mint(tokenHolder1.address, 500);
-
-      // Verify total balance increased
-      expect(await mockToken.balanceOf(tokenHolder1.address)).to.be.gt(oldBalance);
-
-      // But voting weight for this proposal should remain the same
-      const newWeight = await linearERC20Voting.getVotingWeight(tokenHolder1.address, proposalId);
-      expect(newWeight).to.equal(500);
     });
 
-    it('should determine proposal state based on timestamp', async () => {
-      // Set the past votes and total supply at the proposal's start timestamp
-      const [, , , startTimestamp, ,] = await linearERC20Voting.getProposalVotes(proposalId);
-      await mockToken.setPastVotes(tokenHolder1.address, startTimestamp, 600);
-      await mockToken.setPastTotalSupply(startTimestamp, 1000);
-
-      // Cast votes to meet quorum and basis requirements
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-
-      // Before voting end, proposal should not be passed
-      void expect(await linearERC20Voting.isPassed(proposalId)).to.be.false;
-
-      // Get voting end timestamp
-      const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
-
-      // Advance time to just after voting end
-      await time.increaseTo(Number(endTimestamp) + 1);
-
-      // Proposal should pass
-      void expect(await linearERC20Voting.isPassed(proposalId)).to.be.true;
-    });
-
-    it('should handle exact boundary conditions for timestamps', async () => {
-      // Get voting end timestamp
-      const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
-
-      // Advance time to 2 seconds before the voting end timestamp
-      await time.increaseTo(Number(endTimestamp) - 2);
-
-      // Should still be able to vote before end timestamp
-      await linearERC20Voting.connect(tokenHolder1).vote(proposalId, VoteType.YES);
-
-      // Advance to end timestamp
-      await time.increaseTo(Number(endTimestamp) + 1);
-
-      // First vote attempt after period ends should mark it as ended and return
-      const tx = await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
-      await expect(tx).to.emit(linearERC20Voting, 'VotingPeriodEnded');
-
-      // Subsequent vote attempts should revert
-      await expect(
-        linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.YES),
-      ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
-    });
-
-    describe('voting period ended events', () => {
-      it('should emit VotingPeriodEnded event with correct parameters', async () => {
-        // Get the voting end timestamp
-        const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
-
-        // Mine timestamp to advance past the voting period
-        await time.increaseTo(Number(endTimestamp) + 1);
-
-        // First vote attempt after period ends should emit event with correct parameters
-        const currentTimestamp = await time.latest();
-        const tx = await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
-
-        await expect(tx)
-          .to.emit(linearERC20Voting, 'VotingPeriodEnded')
-          .withArgs(proposalId, endTimestamp, currentTimestamp + 1);
-      });
-
-      it('should only emit VotingPeriodEnded event once', async () => {
-        // Get the voting end timestamp
-        const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
-
-        // Mine timestamp to advance past the voting period
-        await time.increaseTo(Number(endTimestamp) + 1);
-
-        // First vote attempt should emit event
-        const tx1 = await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
-        await expect(tx1).to.emit(linearERC20Voting, 'VotingPeriodEnded');
-
-        // Subsequent vote attempts should revert
-        await expect(
-          linearERC20Voting.connect(tokenHolder3).vote(proposalId, VoteType.YES),
-        ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
-      });
-
-      it('should update votingPeriodEnded state after emitting event', async () => {
-        // Get the voting end timestamp
-        const [, , , , endTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
-
-        // Mine timestamp to advance past the voting period
-        await time.increaseTo(Number(endTimestamp) + 1);
-
-        // votingPeriodEnded should initially be false
-        void expect(await linearERC20Voting.votingPeriodEnded(proposalId)).to.be.false;
-
-        // First vote attempt after period ends should update state
-        await linearERC20Voting.connect(tokenHolder2).vote(proposalId, VoteType.YES);
-
-        // Should now be true
-        void expect(await linearERC20Voting.votingPeriodEnded(proposalId)).to.be.true;
-      });
+    runUUPSUpgradeabilityTests({
+      getContract: () => linearERC20Voting,
+      createNewImplementation: async () => {
+        const newImplementation = await new LinearERC20VotingV1__factory(owner).deploy();
+        return newImplementation;
+      },
+      owner: () => owner,
+      nonOwner: () => nonOwner,
     });
   });
 
-  describe('Quorum Functionality', () => {
-    it('should allow owner to update quorumNumerator', async () => {
-      const newQuorumNumerator = 500000; // 50%
-      await linearERC20Voting.connect(owner).updateQuorumNumerator(newQuorumNumerator);
-      expect(await linearERC20Voting.quorumNumerator()).to.equal(newQuorumNumerator);
+  describe('Version', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+
+    beforeEach(async function () {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
     });
 
-    it('should emit QuorumNumeratorUpdated event when quorumNumerator is updated', async () => {
-      const newQuorumNumerator = 500000; // 50%
+    it('should return the correct version number', async () => {
+      expect(await linearERC20Voting.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('initialization function', () => {
+    it('should emit StrategySetUp event with correct parameters on successful initialization', async () => {
+      const testOwner = owner;
+      const testProposalInitializer = proposalInitializer;
+
+      const initializeCalldata = LinearERC20VotingV1__factory.createInterface().encodeFunctionData(
+        'initialize(address,address,address,uint32,uint256,uint256,uint256,address)',
+        [
+          testOwner.address,
+          await mockToken.getAddress(),
+          testProposalInitializer.address,
+          VOTING_PERIOD,
+          REQUIRED_PROPOSER_WEIGHT,
+          QUORUM_NUMERATOR,
+          BASIS_NUMERATOR,
+          lightAccountFactoryMock.target as string,
+        ],
+      );
+
+      const proxyFactory = new ERC1967Proxy__factory(testOwner);
+      const proxy = await proxyFactory.deploy(
+        await linearERC20VotingImplementation.getAddress(),
+        initializeCalldata,
+      );
+      await proxy.waitForDeployment();
+
+      const deploymentTx = proxy.deploymentTransaction();
+      if (!deploymentTx) throw new Error('Deployment transaction not found for proxy');
+
+      const proxyAsLinearVoting = LinearERC20VotingV1__factory.connect(
+        await proxy.getAddress(),
+        testOwner,
+      );
+
+      await expect(deploymentTx)
+        .to.emit(proxyAsLinearVoting, 'StrategySetUp')
+        .withArgs(testProposalInitializer.address, testOwner.address);
+    });
+
+    it('should initialize with correct parameters', async () => {
+      const linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+      expect(await linearERC20Voting.owner()).to.equal(owner.address);
+      expect(await linearERC20Voting.governanceToken()).to.equal(await mockToken.getAddress());
+      expect(await linearERC20Voting.proposalInitializer()).to.equal(proposalInitializer.address);
+      expect(await linearERC20Voting.votingPeriod()).to.equal(VOTING_PERIOD);
+      expect(await linearERC20Voting.requiredProposerWeight()).to.equal(REQUIRED_PROPOSER_WEIGHT);
+      expect(await linearERC20Voting.quorumNumerator()).to.equal(QUORUM_NUMERATOR);
+      expect(await linearERC20Voting.basisNumerator()).to.equal(BASIS_NUMERATOR);
+      expect(await linearERC20Voting.lightAccountFactory()).to.equal(
+        lightAccountFactoryMock.target as string,
+      );
+      expect(await linearERC20Voting.governanceClockMode()).to.equal(ClockMode.Timestamp);
+    });
+
+    it('should initialize with block number clock mode when governance token has block number clock mode', async () => {
+      await mockToken.setClockMode(ClockMode.BlockNumber);
+      const newInstance = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+      expect(await newInstance.governanceClockMode()).to.equal(ClockMode.BlockNumber);
+    });
+
+    it('should not allow reinitialization', async () => {
+      const linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+      await expect(
+        linearERC20Voting[
+          'initialize(address,address,address,uint32,uint256,uint256,uint256,address)'
+        ](
+          owner.address,
+          await mockToken.getAddress(),
+          proposalInitializer.address,
+          VOTING_PERIOD,
+          REQUIRED_PROPOSER_WEIGHT,
+          QUORUM_NUMERATOR,
+          BASIS_NUMERATOR,
+          lightAccountFactoryMock.target as string,
+        ),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidInitialization');
+    });
+
+    it('should revert when initializing with zero token address', async () => {
+      const initializeCalldata = LinearERC20VotingV1__factory.createInterface().encodeFunctionData(
+        'initialize(address,address,address,uint32,uint256,uint256,uint256,address)',
+        [
+          owner.address,
+          ethers.ZeroAddress,
+          proposalInitializer.address,
+          VOTING_PERIOD,
+          REQUIRED_PROPOSER_WEIGHT,
+          QUORUM_NUMERATOR,
+          BASIS_NUMERATOR,
+          lightAccountFactoryMock.target as string,
+        ],
+      );
+      await expect(
+        new ERC1967Proxy__factory(owner).deploy(
+          await linearERC20VotingImplementation.getAddress(),
+          initializeCalldata,
+        ),
+      ).to.be.revertedWithCustomError(linearERC20VotingImplementation, 'InvalidTokenAddress');
+    });
+
+    it('should revert if _quorumNumerator > 1_000_000 during initialization', async () => {
+      const invalidQuorumNumerator = 1_000_001;
+      await expect(
+        deployLinearERC20Voting(
+          owner,
+          await mockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+          VOTING_PERIOD,
+          REQUIRED_PROPOSER_WEIGHT,
+          invalidQuorumNumerator,
+          BASIS_NUMERATOR,
+        ),
+      ).to.be.revertedWithCustomError(linearERC20VotingImplementation, 'InvalidQuorumNumerator');
+    });
+
+    it('should revert if _basisNumerator > BASIS_DENOMINATOR during initialization', async () => {
+      const invalidBasisNumerator = 1_000_001;
+      await expect(
+        deployLinearERC20Voting(
+          owner,
+          await mockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+          VOTING_PERIOD,
+          REQUIRED_PROPOSER_WEIGHT,
+          QUORUM_NUMERATOR,
+          invalidBasisNumerator,
+        ),
+      ).to.be.revertedWithCustomError(linearERC20VotingImplementation, 'InvalidBasisNumerator');
+    });
+
+    it('should revert if _basisNumerator < BASIS_DENOMINATOR / 2 during initialization', async () => {
+      const invalidBasisNumerator = BASIS_DENOMINATOR / 2 - 1;
+      await expect(
+        deployLinearERC20Voting(
+          owner,
+          await mockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+          VOTING_PERIOD,
+          REQUIRED_PROPOSER_WEIGHT,
+          QUORUM_NUMERATOR,
+          invalidBasisNumerator,
+        ),
+      ).to.be.revertedWithCustomError(linearERC20VotingImplementation, 'InvalidBasisNumerator');
+    });
+
+    it('should allow _basisNumerator to be BASIS_DENOMINATOR / 2 during initialization', async () => {
+      const validBasisNumerator = BASIS_DENOMINATOR / 2;
+      const instance = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+        VOTING_PERIOD,
+        REQUIRED_PROPOSER_WEIGHT,
+        QUORUM_NUMERATOR,
+        validBasisNumerator,
+      );
+      expect(await instance.basisNumerator()).to.equal(validBasisNumerator);
+    });
+
+    it('should allow _basisNumerator to be BASIS_DENOMINATOR during initialization', async () => {
+      const validBasisNumerator = BASIS_DENOMINATOR;
+      const instance = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+        VOTING_PERIOD,
+        REQUIRED_PROPOSER_WEIGHT,
+        QUORUM_NUMERATOR,
+        validBasisNumerator,
+      );
+      expect(await instance.basisNumerator()).to.equal(validBasisNumerator);
+    });
+
+    it('should allow _quorumNumerator to be 0 during initialization', async () => {
+      const validQuorumNumerator = 0;
+      const instance = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+        VOTING_PERIOD,
+        REQUIRED_PROPOSER_WEIGHT,
+        validQuorumNumerator,
+        BASIS_NUMERATOR,
+      );
+      expect(await instance.quorumNumerator()).to.equal(validQuorumNumerator);
+    });
+
+    it('should allow _quorumNumerator to be 1_000_000 during initialization', async () => {
+      const validQuorumNumerator = 1_000_000;
+      const instance = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+        VOTING_PERIOD,
+        REQUIRED_PROPOSER_WEIGHT,
+        validQuorumNumerator,
+        BASIS_NUMERATOR,
+      );
+      expect(await instance.quorumNumerator()).to.equal(validQuorumNumerator);
+    });
+  });
+
+  describe('updateVotingPeriod function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+
+    beforeEach(async () => {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner, // contract owner
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+    });
+
+    it('should allow the owner to update the voting period and emit VotingPeriodUpdated event', async () => {
+      const newVotingPeriod = VOTING_PERIOD + 100;
+      await expect(linearERC20Voting.connect(owner).updateVotingPeriod(newVotingPeriod))
+        .to.emit(linearERC20Voting, 'VotingPeriodUpdated')
+        .withArgs(newVotingPeriod);
+      expect(await linearERC20Voting.votingPeriod()).to.equal(newVotingPeriod);
+    });
+
+    it('should not allow a non-owner to update the voting period', async () => {
+      const newVotingPeriod = VOTING_PERIOD + 100;
+      await expect(
+        linearERC20Voting.connect(nonOwner).updateVotingPeriod(newVotingPeriod),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'OwnableUnauthorizedAccount');
+    });
+  });
+
+  describe('updateRequiredProposerWeight function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+
+    beforeEach(async () => {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+    });
+
+    it('should allow the owner to update the required proposer weight and emit RequiredProposerWeightUpdated event', async () => {
+      const newWeight = REQUIRED_PROPOSER_WEIGHT + 100;
+      await expect(linearERC20Voting.connect(owner).updateRequiredProposerWeight(newWeight))
+        .to.emit(linearERC20Voting, 'RequiredProposerWeightUpdated')
+        .withArgs(newWeight);
+      expect(await linearERC20Voting.requiredProposerWeight()).to.equal(newWeight);
+    });
+
+    it('should not allow a non-owner to update the required proposer weight', async () => {
+      const newWeight = REQUIRED_PROPOSER_WEIGHT + 100;
+      await expect(
+        linearERC20Voting.connect(nonOwner).updateRequiredProposerWeight(newWeight),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'OwnableUnauthorizedAccount');
+    });
+  });
+
+  describe('updateQuorumNumerator function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    const QUORUM_DENOMINATOR_FROM_CONTRACT = 1_000_000; // Matching contract constant
+
+    beforeEach(async () => {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+    });
+
+    it('should allow the owner to update the quorum numerator and emit QuorumNumeratorUpdated event', async () => {
+      const newQuorumNumerator = QUORUM_NUMERATOR + 10000; // e.g., 31%
       await expect(linearERC20Voting.connect(owner).updateQuorumNumerator(newQuorumNumerator))
         .to.emit(linearERC20Voting, 'QuorumNumeratorUpdated')
         .withArgs(newQuorumNumerator);
+      expect(await linearERC20Voting.quorumNumerator()).to.equal(newQuorumNumerator);
     });
 
-    it('should not allow non-owner to update quorumNumerator', async () => {
-      const newQuorumNumerator = 500000; // 50%
+    it('should not allow a non-owner to update the quorum numerator', async () => {
+      const newQuorumNumerator = QUORUM_NUMERATOR + 10000;
       await expect(
         linearERC20Voting.connect(nonOwner).updateQuorumNumerator(newQuorumNumerator),
       ).to.be.revertedWithCustomError(linearERC20Voting, 'OwnableUnauthorizedAccount');
     });
 
-    it('should revert when quorumNumerator is greater than QUORUM_DENOMINATOR', async () => {
-      const invalidQuorumNumerator = 1_000_001; // QUORUM_DENOMINATOR + 1
+    it('should revert if quorumNumerator is greater than QUORUM_DENOMINATOR', async () => {
+      const invalidQuorumNumerator = QUORUM_DENOMINATOR_FROM_CONTRACT + 1;
       await expect(
         linearERC20Voting.connect(owner).updateQuorumNumerator(invalidQuorumNumerator),
       ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidQuorumNumerator');
     });
 
-    it('should allow quorumNumerator to be zero', async () => {
-      const newQuorumNumerator = 0;
-      await linearERC20Voting.connect(owner).updateQuorumNumerator(newQuorumNumerator);
-      expect(await linearERC20Voting.quorumNumerator()).to.equal(newQuorumNumerator);
+    it('should allow quorumNumerator to be 0', async () => {
+      const zeroQuorumNumerator = 0;
+      await expect(linearERC20Voting.connect(owner).updateQuorumNumerator(zeroQuorumNumerator))
+        .to.emit(linearERC20Voting, 'QuorumNumeratorUpdated')
+        .withArgs(zeroQuorumNumerator);
+      expect(await linearERC20Voting.quorumNumerator()).to.equal(zeroQuorumNumerator);
     });
 
     it('should allow quorumNumerator to be equal to QUORUM_DENOMINATOR', async () => {
-      const newQuorumNumerator = 1_000_000; // QUORUM_DENOMINATOR
-      await linearERC20Voting.connect(owner).updateQuorumNumerator(newQuorumNumerator);
-      expect(await linearERC20Voting.quorumNumerator()).to.equal(newQuorumNumerator);
+      const fullQuorumNumerator = QUORUM_DENOMINATOR_FROM_CONTRACT;
+      await expect(linearERC20Voting.connect(owner).updateQuorumNumerator(fullQuorumNumerator))
+        .to.emit(linearERC20Voting, 'QuorumNumeratorUpdated')
+        .withArgs(fullQuorumNumerator);
+      expect(await linearERC20Voting.quorumNumerator()).to.equal(fullQuorumNumerator);
+    });
+  });
+
+  describe('updateBasisNumerator function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    // BASIS_DENOMINATOR is already defined at the top level of the describe block
+
+    beforeEach(async () => {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
     });
 
-    it('should correctly calculate quorum based on total supply', async () => {
-      // Set up a proposal
-      const proposalId = 100;
+    it('should allow the owner to update the basis numerator and emit BasisNumeratorUpdated event', async () => {
+      const newBasisNumerator = BASIS_NUMERATOR + 10000; // e.g., 51%
+      await expect(linearERC20Voting.connect(owner).updateBasisNumerator(newBasisNumerator))
+        .to.emit(linearERC20Voting, 'BasisNumeratorUpdated')
+        .withArgs(newBasisNumerator);
+      expect(await linearERC20Voting.basisNumerator()).to.equal(newBasisNumerator);
+    });
+
+    it('should not allow a non-owner to update the basis numerator', async () => {
+      const newBasisNumerator = BASIS_NUMERATOR + 10000;
+      await expect(
+        linearERC20Voting.connect(nonOwner).updateBasisNumerator(newBasisNumerator),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'OwnableUnauthorizedAccount');
+    });
+
+    it('should revert if basisNumerator is greater than BASIS_DENOMINATOR', async () => {
+      const invalidBasisNumerator = BASIS_DENOMINATOR + 1;
+      await expect(
+        linearERC20Voting.connect(owner).updateBasisNumerator(invalidBasisNumerator),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidBasisNumerator');
+    });
+
+    it('should revert if basisNumerator is less than BASIS_DENOMINATOR / 2', async () => {
+      const invalidBasisNumerator = BASIS_DENOMINATOR / 2 - 1;
+      await expect(
+        linearERC20Voting.connect(owner).updateBasisNumerator(invalidBasisNumerator),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidBasisNumerator');
+    });
+
+    it('should allow basisNumerator to be equal to BASIS_DENOMINATOR / 2', async () => {
+      const halfBasisNumerator = BASIS_DENOMINATOR / 2;
+      await expect(linearERC20Voting.connect(owner).updateBasisNumerator(halfBasisNumerator))
+        .to.emit(linearERC20Voting, 'BasisNumeratorUpdated')
+        .withArgs(halfBasisNumerator);
+      expect(await linearERC20Voting.basisNumerator()).to.equal(halfBasisNumerator);
+    });
+
+    it('should allow basisNumerator to be equal to BASIS_DENOMINATOR', async () => {
+      const fullBasisNumerator = BASIS_DENOMINATOR;
+      await expect(linearERC20Voting.connect(owner).updateBasisNumerator(fullBasisNumerator))
+        .to.emit(linearERC20Voting, 'BasisNumeratorUpdated')
+        .withArgs(fullBasisNumerator);
+      expect(await linearERC20Voting.basisNumerator()).to.equal(fullBasisNumerator);
+    });
+  });
+
+  describe('vote function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    const PROPOSAL_ID = 1;
+    const DEFAULT_VOTING_WEIGHT = ethers.parseUnits('1000', 18);
+
+    async function initializeProposalForVoting(proposalId: number) {
       const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-      await linearERC20Voting.connect(nonOwner).initializeProposal(initializeData);
+      // Use the proposalInitializer account (mock Azorius) to initialize
+      await linearERC20Voting.connect(proposalInitializer).initializeProposal(initializeData);
+    }
 
-      // Get the proposal start timestamp
-      const [, , , startTimestamp] = await linearERC20Voting.getProposalVotes(proposalId);
+    beforeEach(async () => {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
 
-      // Set the past total supply to 1000 tokens
-      await mockToken.setPastTotalSupply(startTimestamp, 1000);
-
-      // With 30% quorum (300000/1000000), should require 300 votes
-      const quorumVotesRequired = await linearERC20Voting.quorumVotes(proposalId);
-      expect(quorumVotesRequired).to.equal(300);
-
-      // Update quorum to 50%
-      await linearERC20Voting.connect(owner).updateQuorumNumerator(500000);
-      const newQuorumVotesRequired = await linearERC20Voting.quorumVotes(proposalId);
-      expect(newQuorumVotesRequired).to.equal(500);
+      // Mint tokens and delegate for each token holder
+      for (const holder of [tokenHolder1, tokenHolder2, tokenHolder3]) {
+        await mockToken.mint(holder.address, DEFAULT_VOTING_WEIGHT);
+        await mockToken.connect(holder).delegate(holder.address);
+      }
     });
 
-    describe('meetsQuorum', () => {
-      it('should return true when yes + abstain votes exceed quorum threshold', async () => {
-        // With 30% quorum (300000/1000000), 1000 total supply requires 300 votes
-        // 400 votes (300 YES + 100 ABSTAIN) > 300 required
-        void expect(await linearERC20Voting.meetsQuorum(1000, 300, 100)).to.be.true;
+    it('should revert when voting on an uninitialized proposal (InvalidProposal)', async () => {
+      const nonExistentProposalId = 999;
+      await expect(
+        linearERC20Voting.connect(tokenHolder1).vote(nonExistentProposalId, VoteType.YES),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidProposal');
+    });
+
+    describe('when voting period has ended', () => {
+      let endTimestamp: bigint;
+
+      beforeEach(async () => {
+        await initializeProposalForVoting(PROPOSAL_ID);
+        const [, , , , , propEndTimestamp] = await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+        endTimestamp = propEndTimestamp;
+        // Advance time to just after the voting period ends
+        await time.increaseTo(Number(endTimestamp) + 1);
       });
 
-      it('should return true when yes + abstain votes equal quorum threshold', async () => {
-        // With 30% quorum (300000/1000000), 1000 total supply requires 300 votes
-        // 300 votes (250 YES + 50 ABSTAIN) = 300 required
-        void expect(await linearERC20Voting.meetsQuorum(1000, 250, 50)).to.be.true;
+      it('should handle the first vote after period ends: emit VotingPeriodEnded, not count vote, not mark as voted (return early)', async () => {
+        const tx = await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+        const receipt = await tx.wait();
+        if (!receipt) throw new Error('Transaction receipt not found');
+
+        const block = await ethers.provider.getBlock(receipt.blockNumber);
+        if (!block) throw new Error('Block not found for receipt');
+        const actualBlockTimestamp = block.timestamp;
+
+        await expect(tx)
+          .to.emit(linearERC20Voting, 'VotingPeriodEnded')
+          .withArgs(PROPOSAL_ID, endTimestamp, actualBlockTimestamp);
+
+        // Verify vote was not counted
+        const [noVotes, yesVotes, abstainVotes, , ,] =
+          await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+        expect(yesVotes).to.equal(0);
+        expect(noVotes).to.equal(0);
+        expect(abstainVotes).to.equal(0);
+
+        // Verify not marked as voted
+        void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID, tokenHolder1.address)).to.be
+          .false;
+        // Verify _votingPeriodEnded internal flag is set
+        void expect(await linearERC20Voting.votingPeriodEnded(PROPOSAL_ID)).to.be.true;
       });
 
-      it('should return false when yes + abstain votes are below quorum threshold', async () => {
-        // With 30% quorum (300000/1000000), 1000 total supply requires 300 votes
-        // 250 votes (200 YES + 50 ABSTAIN) < 300 required
-        void expect(await linearERC20Voting.meetsQuorum(1000, 200, 50)).to.be.false;
+      it('should revert on subsequent votes after period is marked ended (VotingEnded)', async () => {
+        // First vote marks it as ended
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+
+        // Subsequent vote
+        await expect(
+          linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO),
+        ).to.be.revertedWithCustomError(linearERC20Voting, 'VotingEnded');
+      });
+    });
+
+    it('should revert when voting twice on the same proposal (AlreadyVoted)', async () => {
+      await initializeProposalForVoting(PROPOSAL_ID);
+      await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+      await expect(
+        linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.NO),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'AlreadyVoted');
+    });
+
+    it('should revert when voting with an invalid _voteType (InvalidVote)', async () => {
+      await initializeProposalForVoting(PROPOSAL_ID);
+      const invalidVoteType = 3;
+      await expect(
+        linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, invalidVoteType as VoteType),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'InvalidVote');
+    });
+
+    // Tests for successful votes (YES, NO, ABSTAIN)
+    describe('when a vote is cast successfully', () => {
+      beforeEach(async () => {
+        // Ensure a proposal is initialized before each successful vote test
+        await initializeProposalForVoting(PROPOSAL_ID);
       });
 
-      it('should handle zero votes correctly', async () => {
-        // With 30% quorum (300000/1000000), 1000 total supply requires 300 votes
-        // 0 votes < 300 required
-        void expect(await linearERC20Voting.meetsQuorum(1000, 0, 0)).to.be.false;
+      it('should correctly record a YES vote, emit Voted event, and update hasVoted status', async () => {
+        const voter = tokenHolder1;
+        const expectedWeight = await linearERC20Voting.getVotingWeight(voter.address, PROPOSAL_ID);
+        expect(expectedWeight).to.equal(DEFAULT_VOTING_WEIGHT); // Sanity check weight
+
+        await expect(linearERC20Voting.connect(voter).vote(PROPOSAL_ID, VoteType.YES))
+          .to.emit(linearERC20Voting, 'Voted')
+          .withArgs(voter.address, PROPOSAL_ID, VoteType.YES, expectedWeight);
+
+        const [noVotes, yesVotes, abstainVotes, , ,] =
+          await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+        expect(yesVotes).to.equal(expectedWeight);
+        expect(noVotes).to.equal(0);
+        expect(abstainVotes).to.equal(0);
+        void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID, voter.address)).to.be.true;
       });
 
-      it('should handle zero total supply correctly', async () => {
-        // With 30% quorum (300000/1000000), 0 total supply requires 0 votes
-        // Any number of votes (including 0) should meet the quorum
-        void expect(await linearERC20Voting.meetsQuorum(0, 0, 0)).to.be.true;
+      it('should correctly record a NO vote, emit Voted event, and update hasVoted status', async () => {
+        const voter = tokenHolder2;
+        const expectedWeight = await linearERC20Voting.getVotingWeight(voter.address, PROPOSAL_ID);
+        expect(expectedWeight).to.equal(DEFAULT_VOTING_WEIGHT); // Sanity check weight
+
+        await expect(linearERC20Voting.connect(voter).vote(PROPOSAL_ID, VoteType.NO))
+          .to.emit(linearERC20Voting, 'Voted')
+          .withArgs(voter.address, PROPOSAL_ID, VoteType.NO, expectedWeight);
+
+        const [noVotes, yesVotes, abstainVotes, , ,] =
+          await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+        expect(noVotes).to.equal(expectedWeight);
+        expect(yesVotes).to.equal(0);
+        expect(abstainVotes).to.equal(0);
+        void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID, voter.address)).to.be.true;
+      });
+
+      it('should correctly record an ABSTAIN vote, emit Voted event, and update hasVoted status', async () => {
+        const voter = tokenHolder3;
+        const expectedWeight = await linearERC20Voting.getVotingWeight(voter.address, PROPOSAL_ID);
+        expect(expectedWeight).to.equal(DEFAULT_VOTING_WEIGHT); // Sanity check weight
+
+        await expect(linearERC20Voting.connect(voter).vote(PROPOSAL_ID, VoteType.ABSTAIN))
+          .to.emit(linearERC20Voting, 'Voted')
+          .withArgs(voter.address, PROPOSAL_ID, VoteType.ABSTAIN, expectedWeight);
+
+        const [noVotes, yesVotes, abstainVotes, , ,] =
+          await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+        expect(abstainVotes).to.equal(expectedWeight);
+        expect(noVotes).to.equal(0);
+        expect(yesVotes).to.equal(0);
+        void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID, voter.address)).to.be.true;
+      });
+
+      it('should use voting weight snapshotted at proposal creation (Timestamp mode)', async () => {
+        const voter = tokenHolder1;
+        // Initialize proposal for this specific test to get its unique start time
+        const specificProposalId = PROPOSAL_ID + 100; // Ensure a fresh proposal ID
+        await initializeProposalForVoting(specificProposalId);
+        const [, , , propStartTimestamp, , ,] = // Read supply before explicit set for logging
+          await linearERC20Voting.getProposalVotes(specificProposalId);
+
+        // Explicitly set past votes and total supply for the proposal's start timestamp
+        const currentTotalSupply = await mockToken.totalSupply();
+        await mockToken.setPastVotes(voter.address, propStartTimestamp, DEFAULT_VOTING_WEIGHT);
+        await mockToken.setPastTotalSupply(propStartTimestamp, currentTotalSupply);
+
+        const initialWeight = await linearERC20Voting.getVotingWeight(
+          voter.address,
+          specificProposalId,
+        );
+        expect(initialWeight).to.equal(DEFAULT_VOTING_WEIGHT);
+
+        // Mint more tokens to the voter *after* proposal initialization
+        const extraTokens = ethers.parseUnits('500', 18);
+        await mockToken.mint(voter.address, extraTokens);
+        // Note: No need to re-delegate for ERC20Votes if already delegated to self for balance to be picked up by getVotes.
+        // getPastVotes relies on checkpoints created by transfers/delegations.
+
+        // Vote
+        await linearERC20Voting.connect(voter).vote(specificProposalId, VoteType.YES);
+
+        // Check that the vote used the initial weight, not the new total balance
+        const [, yesVotes, , , ,] = await linearERC20Voting.getProposalVotes(specificProposalId);
+        expect(yesVotes).to.equal(initialWeight); // Should still be DEFAULT_VOTING_WEIGHT
+      });
+    });
+
+    describe('when governance token is in BlockNumber clock mode', () => {
+      let blockNumberVotingStrategy: LinearERC20VotingV1;
+      const VOTE_START_BLOCK_WEIGHT = ethers.parseUnits('700', 18);
+      const LATER_BLOCK_WEIGHT = ethers.parseUnits('1200', 18);
+
+      beforeEach(async () => {
+        // Revert to using global mockToken and remove dedicated blockNumberMockToken logic
+        await mockToken.setClockMode(ClockMode.BlockNumber);
+
+        await mockToken.mint(tokenHolder1.address, VOTE_START_BLOCK_WEIGHT);
+        await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+
+        blockNumberVotingStrategy = await deployLinearERC20Voting(
+          owner,
+          await mockToken.getAddress(), // Use global mockToken
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+        );
+
+        // Initialize a proposal. The startBlock will be captured here.
+        const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [PROPOSAL_ID]);
+        await blockNumberVotingStrategy
+          .connect(proposalInitializer)
+          .initializeProposal(initializeData);
+        const [, , , , propStartBlock, ,] = // Read supply before explicit set for logging
+          await blockNumberVotingStrategy.getProposalVotes(PROPOSAL_ID);
+
+        // Explicitly set past votes and total supply for the proposal's start block
+        const currentTotalSupply = await mockToken.totalSupply(); // Use global mockToken
+        await mockToken.setPastVotes(
+          // Use global mockToken
+          tokenHolder1.address,
+          propStartBlock,
+          VOTE_START_BLOCK_WEIGHT,
+        );
+        await mockToken.setPastTotalSupply(propStartBlock, currentTotalSupply); // Use global mockToken
+
+        const additionalTokens = LATER_BLOCK_WEIGHT - VOTE_START_BLOCK_WEIGHT;
+        await mockToken.mint(tokenHolder1.address, additionalTokens); // Use global mockToken
+      });
+
+      it('should use voting weight snapshotted at proposal startBlock (BlockNumber mode)', async () => {
+        const voter = tokenHolder1;
+
+        const weightFromStrategy = await blockNumberVotingStrategy.getVotingWeight(
+          voter.address,
+          PROPOSAL_ID,
+        );
+
+        expect(weightFromStrategy).to.equal(VOTE_START_BLOCK_WEIGHT);
+        await expect(blockNumberVotingStrategy.connect(voter).vote(PROPOSAL_ID, VoteType.YES))
+          .to.emit(blockNumberVotingStrategy, 'Voted')
+          .withArgs(voter.address, PROPOSAL_ID, VoteType.YES, VOTE_START_BLOCK_WEIGHT);
+
+        const [, yesVotes, , , ,] = await blockNumberVotingStrategy.getProposalVotes(PROPOSAL_ID);
+        expect(yesVotes).to.equal(VOTE_START_BLOCK_WEIGHT);
+      });
+    });
+
+    describe('when voter is a smart contract (Ownable)', () => {
+      let mockOwnershipInstance: MockOwnership;
+      let contractVotingStrategy: LinearERC20VotingV1;
+      let eoaOwnerOfMockOwnership: SignerWithAddress;
+      let scTestMockToken: MockERC20Votes; // Isolated token for this suite
+      const CONTRACT_VOTER_PROPOSAL_ID = 2;
+      const EOA_OWNER_VOTE_WEIGHT = ethers.parseUnits('300', 18);
+
+      beforeEach(async () => {
+        eoaOwnerOfMockOwnership = tokenHolder1;
+
+        // Deploy a new mock token for this test suite to avoid state interference
+        scTestMockToken = await new MockERC20Votes__factory(deployer).deploy();
+
+        mockOwnershipInstance = await new MockOwnership__factory(deployer).deploy(
+          eoaOwnerOfMockOwnership.address,
+        );
+        await mockOwnershipInstance.waitForDeployment();
+
+        // Configure the MockLightAccountFactory to return the mockOwnershipInstance address
+        // when getAddress is called with eoaOwnerOfMockOwnership.address and salt 0.
+        // Salt 0 is what SmartAccountValidationV1 uses.
+        await lightAccountFactoryMock.setAccountAddress(
+          eoaOwnerOfMockOwnership.address,
+          0, // salt
+          await mockOwnershipInstance.getAddress(),
+        );
+
+        contractVotingStrategy = await deployLinearERC20Voting(
+          owner,
+          await scTestMockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+        );
+
+        await scTestMockToken.mint(eoaOwnerOfMockOwnership.address, EOA_OWNER_VOTE_WEIGHT);
+        await scTestMockToken
+          .connect(eoaOwnerOfMockOwnership)
+          .delegate(eoaOwnerOfMockOwnership.address);
+
+        const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(
+          ['uint32'],
+          [CONTRACT_VOTER_PROPOSAL_ID],
+        );
+        await contractVotingStrategy
+          .connect(proposalInitializer)
+          .initializeProposal(initializeData);
+
+        // Have the smart contract (MockOwnership) cast the vote
+        await expect(
+          mockOwnershipInstance
+            .connect(eoaOwnerOfMockOwnership)
+            .callExternalVote(
+              await contractVotingStrategy.getAddress(),
+              CONTRACT_VOTER_PROPOSAL_ID,
+              VoteType.YES,
+            ),
+        )
+          .to.emit(contractVotingStrategy, 'Voted')
+          .withArgs(
+            eoaOwnerOfMockOwnership.address,
+            CONTRACT_VOTER_PROPOSAL_ID,
+            VoteType.YES,
+            EOA_OWNER_VOTE_WEIGHT,
+          );
+      });
+
+      it("should correctly attribute vote to EOA owner of the contract and use EOA's weight", async () => {
+        const mockOwnershipAddress = await mockOwnershipInstance.getAddress();
+
+        const hasVotedEOA = await contractVotingStrategy.hasVoted(
+          CONTRACT_VOTER_PROPOSAL_ID,
+          eoaOwnerOfMockOwnership.address,
+        );
+        const hasVotedContract = await contractVotingStrategy.hasVoted(
+          CONTRACT_VOTER_PROPOSAL_ID,
+          mockOwnershipAddress,
+        );
+
+        void expect(hasVotedEOA).to.be.true;
+        void expect(hasVotedContract).to.be.false;
       });
     });
   });
 
-  describe('meetsBasis', () => {
-    // Test with default 50% basis
-    it('should return true when yes votes exceed the basis threshold', async () => {
-      const yesVotes = 60;
-      const noVotes = 40;
-      // 60 > ((60 + 40) * 500000 / 1000000) = 50, so it passes
+  describe('getProposalVotes function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    const PROPOSAL_ID = 3;
+    const WEIGHT_1 = ethers.parseUnits('100', 18);
+    const WEIGHT_2 = ethers.parseUnits('200', 18);
+    const WEIGHT_3 = ethers.parseUnits('300', 18);
+
+    beforeEach(async () => {
+      // Ensure mockToken is in a known state (e.g., Timestamp mode) if using global
+      await mockToken.setClockMode(ClockMode.Timestamp); // Explicitly set for these tests
+
+      // Deploy a new instance for this test suite to avoid interference
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+
+      await mockToken.mint(tokenHolder1.address, WEIGHT_1);
+      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+
+      await mockToken.mint(tokenHolder2.address, WEIGHT_2);
+      await mockToken.connect(tokenHolder2).delegate(tokenHolder2.address);
+
+      await mockToken.mint(tokenHolder3.address, WEIGHT_3);
+      await mockToken.connect(tokenHolder3).delegate(tokenHolder3.address);
+    });
+
+    it('should return all zero values for an uninitialized proposal', async () => {
+      const uninitializedProposalId = PROPOSAL_ID + 999;
+      const [noVotes, yesVotes, abstainVotes, startTimestamp, startBlock, endTimestamp, ,] =
+        await linearERC20Voting.getProposalVotes(uninitializedProposalId);
+
+      expect(noVotes).to.equal(0);
+      expect(yesVotes).to.equal(0);
+      expect(abstainVotes).to.equal(0);
+      expect(startTimestamp).to.equal(0);
+      expect(startBlock).to.equal(0);
+      expect(endTimestamp).to.equal(0);
+      // For an uninitialized proposal, proposalVotes[id].startBlock/Timestamp is 0.
+      // MockERC20Votes.getPastTotalSupply(0) without prior setPastTotalSupply(0, x)
+      // will return current mockToken.totalSupply() due to its fallback.
+      // This might be non-zero if tokens were minted. A stricter check might involve
+      // ensuring the strategy *intends* for supply to be 0 for an uninitialized proposal.
+      // However, the key is that timestamps/blocks are 0.
+      // Let's set mock past total supply for 0 to 0 for a clean test of this case.
+      await mockToken.setPastTotalSupply(0, 0);
+      const [, , , , , , newVotingSupply] =
+        await linearERC20Voting.getProposalVotes(uninitializedProposalId);
+      expect(newVotingSupply).to.equal(0);
+    });
+
+    it('should return correct values for an initialized proposal, before any votes', async () => {
+      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [PROPOSAL_ID]);
+
+      // Predict start block/timestamp. Actual values will be from the transaction receipt.
+      const tx = await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(initializeData);
+      const receipt = await tx.wait();
+      if (!receipt) throw new Error('Transaction receipt not found for proposal initialization');
+
+      const block = await ethers.provider.getBlock(receipt.blockNumber);
+      if (!block) throw new Error('Block not found for receipt');
+
+      const actualStartTimestamp = block.timestamp;
+      const actualStartBlock = receipt.blockNumber;
+      const expectedEndTimestamp = actualStartTimestamp + VOTING_PERIOD;
+
+      // Set past total supply at the actual start block/timestamp
+      // The mock will use timestamp or block based on its CLOCK_MODE setting
+      const initialTotalSupply = await mockToken.totalSupply(); // Supply at time of initialization
+      const timepointForSupply =
+        (await mockToken.CLOCK_MODE()) === 'mode=timestamp'
+          ? actualStartTimestamp
+          : actualStartBlock;
+      await mockToken.setPastTotalSupply(timepointForSupply, initialTotalSupply);
+
+      const [
+        noVotes,
+        yesVotes,
+        abstainVotes,
+        startTimestamp,
+        startBlock,
+        endTimestamp,
+        votingSupply,
+      ] = await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+
+      expect(noVotes).to.equal(0);
+      expect(yesVotes).to.equal(0);
+      expect(abstainVotes).to.equal(0);
+      expect(startTimestamp).to.equal(actualStartTimestamp);
+      expect(startBlock).to.equal(actualStartBlock);
+      expect(endTimestamp).to.equal(expectedEndTimestamp);
+      expect(votingSupply).to.equal(initialTotalSupply);
+    });
+
+    it('should return correct values for an initialized proposal, after some votes', async () => {
+      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [PROPOSAL_ID]);
+      const initTx = await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(initializeData);
+      const receipt = await initTx.wait();
+      if (!receipt) throw new Error('Receipt not found');
+      const block = await ethers.provider.getBlock(receipt.blockNumber);
+      if (!block) throw new Error('Block not found');
+
+      const proposalCreationTimestamp = block.timestamp;
+      const proposalCreationBlock = receipt.blockNumber;
+      const expectedEndTimestamp = proposalCreationTimestamp + VOTING_PERIOD;
+
+      // Determine the correct timepoint for historical queries based on token's clock mode
+      const tokenClockMode = await mockToken.CLOCK_MODE();
+      const timepoint =
+        tokenClockMode === 'mode=timestamp' ? proposalCreationTimestamp : proposalCreationBlock;
+
+      // Set historical total supply
+      const initialTotalSupply = await mockToken.totalSupply(); // Total supply just after proposal init
+      await mockToken.setPastTotalSupply(timepoint, initialTotalSupply);
+
+      // Set historical votes for each voter at the proposal creation timepoint
+      // These are the weights that should be used for voting
+      await mockToken.setPastVotes(tokenHolder1.address, timepoint, WEIGHT_1);
+      await mockToken.setPastVotes(tokenHolder2.address, timepoint, WEIGHT_2);
+      await mockToken.setPastVotes(tokenHolder3.address, timepoint, WEIGHT_3);
+
+      // Cast votes
+      await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+      await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO);
+      await linearERC20Voting.connect(tokenHolder3).vote(PROPOSAL_ID, VoteType.ABSTAIN);
+
+      const [
+        noVotes,
+        yesVotes,
+        abstainVotes,
+        startTimestamp,
+        startBlock,
+        endTimestamp,
+        votingSupply,
+      ] = await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+
+      expect(yesVotes).to.equal(WEIGHT_1);
+      expect(noVotes).to.equal(WEIGHT_2);
+      expect(abstainVotes).to.equal(WEIGHT_3);
+      expect(startTimestamp).to.equal(proposalCreationTimestamp);
+      expect(startBlock).to.equal(proposalCreationBlock);
+      expect(endTimestamp).to.equal(expectedEndTimestamp);
+      expect(votingSupply).to.equal(initialTotalSupply);
+    });
+
+    it('should retrieve the same correct values after voting period has ended (no new votes)', async () => {
+      const initializeData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [PROPOSAL_ID]);
+      const initTx = await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(initializeData);
+      const receipt = await initTx.wait();
+      if (!receipt) throw new Error('Receipt not found');
+      const block = await ethers.provider.getBlock(receipt.blockNumber);
+      if (!block) throw new Error('Block not found');
+
+      const proposalCreationTimestamp = block.timestamp;
+      const proposalCreationBlock = receipt.blockNumber;
+      const expectedEndTimestamp = proposalCreationTimestamp + VOTING_PERIOD;
+
+      const tokenClockMode = await mockToken.CLOCK_MODE();
+      const timepoint =
+        tokenClockMode === 'mode=timestamp' ? proposalCreationTimestamp : proposalCreationBlock;
+
+      const initialTotalSupply = await mockToken.totalSupply();
+      await mockToken.setPastTotalSupply(timepoint, initialTotalSupply);
+
+      await mockToken.setPastVotes(tokenHolder1.address, timepoint, WEIGHT_1);
+      await mockToken.setPastVotes(tokenHolder2.address, timepoint, WEIGHT_2);
+      await mockToken.setPastVotes(tokenHolder3.address, timepoint, WEIGHT_3);
+
+      await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+      await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO);
+      await linearERC20Voting.connect(tokenHolder3).vote(PROPOSAL_ID, VoteType.ABSTAIN);
+
+      // Advance time past voting period
+      await time.increaseTo(expectedEndTimestamp + 1);
+
+      const [
+        noVotes,
+        yesVotes,
+        abstainVotes,
+        startTimestamp,
+        startBlock,
+        endTimestamp,
+        votingSupply,
+      ] = await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+
+      expect(yesVotes).to.equal(WEIGHT_1);
+      expect(noVotes).to.equal(WEIGHT_2);
+      expect(abstainVotes).to.equal(WEIGHT_3);
+      expect(startTimestamp).to.equal(proposalCreationTimestamp);
+      expect(startBlock).to.equal(proposalCreationBlock);
+      expect(endTimestamp).to.equal(expectedEndTimestamp);
+      expect(votingSupply).to.equal(initialTotalSupply);
+    });
+  });
+
+  describe('initializeProposal function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    const PROPOSAL_ID = 1; // A non-zero proposal ID
+    let encodedProposalIdData: string;
+
+    beforeEach(async () => {
+      // Deploy with proposalInitializer as the one who can initialize proposals
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address, // azorius address
+        lightAccountFactoryMock.target as string,
+        VOTING_PERIOD,
+      );
+      encodedProposalIdData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [PROPOSAL_ID]);
+    });
+
+    it('should revert if called by an address other than the proposalInitializer', async () => {
+      await expect(
+        linearERC20Voting.connect(nonOwner).initializeProposal(encodedProposalIdData),
+      ).to.be.revertedWithCustomError(linearERC20Voting, 'ProposalInitializerUnauthorizedAccount');
+    });
+
+    it('should successfully initialize a proposal, set timestamps/block, and emit ProposalInitialized event', async () => {
+      // Ensure mockToken is in Timestamp mode for consistent interaction if any part of it relies on it,
+      // though initializeProposal itself is mode-agnostic for start/end times.
+      await mockToken.setClockMode(ClockMode.Timestamp);
+
+      const tx = await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalIdData);
+      const receipt = await tx.wait();
+      if (!receipt) throw new Error('No receipt');
+      const block = await ethers.provider.getBlock(receipt.blockNumber);
+      if (!block) throw new Error('No block');
+      const currentBlockTimestamp = block.timestamp;
+      const currentBlockNumber = receipt.blockNumber;
+
+      const expectedEndTimestamp = currentBlockTimestamp + VOTING_PERIOD;
+
+      const [
+        ,
+        ,
+        ,
+        // noVotes, yesVotes, abstainVotes are 0 initially
+        retrievedStartTimestamp,
+        retrievedStartBlock,
+        retrievedEndTimestamp,
+        // votingSupply (tested separately)
+        ,
+      ] = await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+
+      expect(retrievedStartTimestamp).to.equal(currentBlockTimestamp);
+      expect(retrievedEndTimestamp).to.equal(expectedEndTimestamp);
+      expect(retrievedStartBlock).to.equal(currentBlockNumber);
+
+      // Check proposal is marked as initialized (e.g., endTimestamp is not 0)
+      expect(retrievedEndTimestamp).to.not.equal(0);
+      // Check voting period not ended - this checks the _votingPeriodEnded flag via a view function
+      // votingPeriodEnded is a mapping in BaseStrategyV1.sol, false by default
+      void expect(await linearERC20Voting.votingPeriodEnded(PROPOSAL_ID)).to.be.false;
+
+      await expect(tx)
+        .to.emit(linearERC20Voting, 'ProposalInitialized')
+        .withArgs(PROPOSAL_ID, expectedEndTimestamp);
+    });
+
+    it('should allow re-initializing an existing proposal, overwriting its details and re-emitting the event', async () => {
+      // Initial initialization
+      await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalIdData);
+      const [, , , initialStartTimestamp, initialStartBlock, initialEndTimestamp, ,] =
+        await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+
+      // Advance time to ensure subsequent block.timestamp and block number are different
+      await time.increase(VOTING_PERIOD / 2);
+
+      // Re-initialize the same proposal
+      const reinitTx = await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalIdData);
+      const reinitReceipt = await reinitTx.wait();
+      if (!reinitReceipt) throw new Error('No receipt for re-initialization');
+      const reinitBlock = await ethers.provider.getBlock(reinitReceipt.blockNumber);
+      if (!reinitBlock) throw new Error('No block for re-initialization');
+      const newBlockTimestamp = reinitBlock.timestamp;
+      const newBlockNumber = reinitReceipt.blockNumber;
+
+      const newExpectedEndTimestamp = newBlockTimestamp + VOTING_PERIOD;
+
+      const [
+        ,
+        ,
+        ,
+        // votes
+        newStartTimestamp,
+        newStartBlock,
+        newEndTimestamp, // supply
+        ,
+      ] = await linearERC20Voting.getProposalVotes(PROPOSAL_ID);
+
+      expect(newStartTimestamp).to.not.equal(initialStartTimestamp);
+      expect(newStartTimestamp).to.equal(newBlockTimestamp);
+      expect(newEndTimestamp).to.not.equal(initialEndTimestamp);
+      expect(newEndTimestamp).to.equal(newExpectedEndTimestamp);
+      expect(newStartBlock).to.not.equal(initialStartBlock);
+      expect(newStartBlock).to.equal(newBlockNumber);
+
+      await expect(reinitTx)
+        .to.emit(linearERC20Voting, 'ProposalInitialized')
+        .withArgs(PROPOSAL_ID, newExpectedEndTimestamp);
+    });
+  });
+
+  describe('hasVoted function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    const PROPOSAL_ID_1 = 1;
+    const PROPOSAL_ID_2 = 2;
+    let encodedProposalId1Data: string;
+    let encodedProposalId2Data: string;
+    const DEFAULT_VOTING_WEIGHT = ethers.parseUnits('100', 18);
+
+    beforeEach(async () => {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+
+      encodedProposalId1Data = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint32'],
+        [PROPOSAL_ID_1],
+      );
+      encodedProposalId2Data = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint32'],
+        [PROPOSAL_ID_2],
+      );
+
+      // Mint and delegate for tokenHolder1 for voting
+      await mockToken.mint(tokenHolder1.address, DEFAULT_VOTING_WEIGHT);
+      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+    });
+
+    it('should return false for an uninitialized proposal', async () => {
+      const uninitializedProposalId = 999;
+      void expect(await linearERC20Voting.hasVoted(uninitializedProposalId, tokenHolder1.address))
+        .to.be.false;
+    });
+
+    it('should return false for an initialized proposal if the address has not voted', async () => {
+      await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalId1Data);
+      void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID_1, tokenHolder1.address)).to.be
+        .false;
+    });
+
+    it('should return true for an initialized proposal after the address has voted', async () => {
+      await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalId1Data);
+      await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID_1, VoteType.YES);
+      void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID_1, tokenHolder1.address)).to.be.true;
+    });
+
+    it('should return false if checking the smart contract address after its EOA owner voted via the contract', async () => {
+      // Setup for smart contract voting (similar to 'vote function' tests)
+      const eoaOwnerOfMock = tokenHolder2; // Use a different holder for clarity
+      await mockToken.mint(eoaOwnerOfMock.address, DEFAULT_VOTING_WEIGHT);
+      await mockToken.connect(eoaOwnerOfMock).delegate(eoaOwnerOfMock.address);
+
+      const mockOwnershipInstance = await new MockOwnership__factory(deployer).deploy(
+        eoaOwnerOfMock.address,
+      );
+      await mockOwnershipInstance.waitForDeployment();
+      const mockOwnershipAddress = await mockOwnershipInstance.getAddress();
+
+      await lightAccountFactoryMock.setAccountAddress(
+        eoaOwnerOfMock.address,
+        0, // salt
+        mockOwnershipAddress,
+      );
+
+      // Initialize proposal
+      await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalId1Data);
+
+      // EOA owner calls the smart contract to vote
+      await mockOwnershipInstance
+        .connect(eoaOwnerOfMock)
+        .callExternalVote(await linearERC20Voting.getAddress(), PROPOSAL_ID_1, VoteType.YES);
+
+      // hasVoted for the EOA owner should be true
+      void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID_1, eoaOwnerOfMock.address)).to.be
+        .true;
+      // hasVoted for the smart contract itself should be false, as the EOA is the voter
+      void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID_1, mockOwnershipAddress)).to.be
+        .false;
+    });
+
+    it('should correctly distinguish voted status between multiple proposals for the same voter', async () => {
+      // Initialize both proposals
+      await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalId1Data);
+      await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalId2Data);
+
+      // Vote on PROPOSAL_ID_1 only
+      await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID_1, VoteType.YES);
+
+      // Check voted status
+      void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID_1, tokenHolder1.address)).to.be.true;
+      void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID_2, tokenHolder1.address)).to.be
+        .false;
+
+      // Now vote on PROPOSAL_ID_2
+      await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID_2, VoteType.NO);
+      void expect(await linearERC20Voting.hasVoted(PROPOSAL_ID_2, tokenHolder1.address)).to.be.true;
+    });
+  });
+
+  describe('isPassed function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    const PROPOSAL_ID = 4;
+    let encodedProposalIdData: string;
+
+    // Default weights for voters
+    const WEIGHT_VOTER_YES = ethers.parseUnits('600', 18); // 60%
+    const WEIGHT_VOTER_NO = ethers.parseUnits('300', 18); // 30%
+    const WEIGHT_VOTER_ABSTAIN = ethers.parseUnits('100', 18); // 10%
+    // Total supply from these three default voters = 1000
+
+    // Default constants for strategy, can be overridden in specific tests by re-deploying or using setters
+    const DEFAULT_TEST_QUORUM_NUMERATOR = 300_000; // 30% of 1,000,000 (i.e., 30% of total supply)
+    const DEFAULT_TEST_BASIS_NUMERATOR = 500_001; // >50% (e.g. 50.0001% requires YES > NO)
+    const DEFAULT_TEST_VOTING_PERIOD = 100;
+
+    // Helper to initialize and set up mock past votes/supply for a proposal
+    async function setupProposalForPassingTests(
+      proposalId: number,
+      config: {
+        voter1Weight?: bigint;
+        voter2Weight?: bigint;
+        voter3Weight?: bigint;
+        totalSupply: bigint;
+        quorumNumerator?: number;
+        basisNumerator?: number;
+        votingPeriod?: number;
+      },
+    ) {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+        config.votingPeriod ?? DEFAULT_TEST_VOTING_PERIOD,
+        REQUIRED_PROPOSER_WEIGHT,
+        config.quorumNumerator ?? DEFAULT_TEST_QUORUM_NUMERATOR,
+        config.basisNumerator ?? DEFAULT_TEST_BASIS_NUMERATOR,
+      );
+
+      encodedProposalIdData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
+      const initTx = await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalIdData);
+      const receipt = await initTx.wait();
+      if (!receipt) throw new Error('Proposal initialization failed');
+      const block = await ethers.provider.getBlock(receipt.blockNumber);
+      if (!block) throw new Error('Block not found');
+
+      const timepoint =
+        (await mockToken.CLOCK_MODE()) === 'mode=timestamp' ? block.timestamp : receipt.blockNumber;
+
+      await mockToken.setPastTotalSupply(timepoint, config.totalSupply);
+      await mockToken.setPastVotes(tokenHolder1.address, timepoint, config.voter1Weight ?? 0n);
+      await mockToken.setPastVotes(tokenHolder2.address, timepoint, config.voter2Weight ?? 0n);
+      await mockToken.setPastVotes(tokenHolder3.address, timepoint, config.voter3Weight ?? 0n);
+
+      // Ensure other potential signers (if any used in a test) have 0 past votes unless specified by config for tokenHolders 1-3
+      const allSigners = await ethers.getSigners();
+      for (const signer of allSigners) {
+        if (
+          ![tokenHolder1.address, tokenHolder2.address, tokenHolder3.address].includes(
+            signer.address,
+          )
+        ) {
+          await mockToken.setPastVotes(signer.address, timepoint, 0n);
+        }
+      }
+
+      return {
+        startTimestamp: block.timestamp,
+        endTimestamp: block.timestamp + (config.votingPeriod ?? DEFAULT_TEST_VOTING_PERIOD),
+      };
+    }
+
+    beforeEach(async () => {
+      // Standard deployment, but past votes are set by the helper for proposal-specific snapshots
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+        DEFAULT_TEST_VOTING_PERIOD,
+        REQUIRED_PROPOSER_WEIGHT,
+        DEFAULT_TEST_QUORUM_NUMERATOR,
+        DEFAULT_TEST_BASIS_NUMERATOR,
+      );
+
+      // Mint tokens for default voters. These weights are used for setPastVotes in helper.
+      await mockToken.mint(tokenHolder1.address, WEIGHT_VOTER_YES);
+      await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+      await mockToken.mint(tokenHolder2.address, WEIGHT_VOTER_NO);
+      await mockToken.connect(tokenHolder2).delegate(tokenHolder2.address);
+      await mockToken.mint(tokenHolder3.address, WEIGHT_VOTER_ABSTAIN);
+      await mockToken.connect(tokenHolder3).delegate(tokenHolder3.address);
+    });
+
+    it('should return false for an uninitialized proposal', async () => {
+      const uninitializedProposalId = 999;
+      void expect(await linearERC20Voting.isPassed(uninitializedProposalId)).to.be.false;
+    });
+
+    it('should return false if voting period has not ended, even if other conditions met', async () => {
+      const totalSupply = WEIGHT_VOTER_YES + WEIGHT_VOTER_NO + WEIGHT_VOTER_ABSTAIN;
+      await setupProposalForPassingTests(PROPOSAL_ID, {
+        totalSupply,
+        voter1Weight: WEIGHT_VOTER_YES, // Voter1 will vote YES
+      });
+
+      await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+      // Not advancing time
+      void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.false;
+    });
+
+    describe('after voting period has ended', () => {
+      it('should PASS if quorum and basis are met (YES > NO)', async () => {
+        const totalSupply = WEIGHT_VOTER_YES + WEIGHT_VOTER_NO + WEIGHT_VOTER_ABSTAIN; // 1000
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply,
+          voter1Weight: WEIGHT_VOTER_YES,
+          voter2Weight: WEIGHT_VOTER_NO,
+          voter3Weight: WEIGHT_VOTER_ABSTAIN,
+        });
+
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+        await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO);
+        await linearERC20Voting.connect(tokenHolder3).vote(PROPOSAL_ID, VoteType.ABSTAIN);
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.true;
+      });
+
+      it('should FAIL if quorum is not met, even if basis is met', async () => {
+        const smallWeight = ethers.parseUnits('100', 18);
+        const totalSupplyForTest = ethers.parseUnits('600', 18); // Quorum will be 30% of this = 180
+
+        // Voter1 has smallWeight, which is less than quorum
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply: totalSupplyForTest,
+          voter1Weight: smallWeight,
+          // voter2Weight, voter3Weight default to 0n by helper if not specified
+        });
+
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES); // 100 YES
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should FAIL if basis is not met (e.g. YES <= NO), even if quorum is met', async () => {
+        const totalSupply = WEIGHT_VOTER_YES + WEIGHT_VOTER_NO + WEIGHT_VOTER_ABSTAIN; // 1000
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply,
+          // For this test, tokenHolder2 (normally NO voter) will vote YES with NO_WEIGHT
+          // And tokenHolder1 (normally YES voter) will vote NO with YES_WEIGHT
+          voter1Weight: WEIGHT_VOTER_YES, // This will be used for NO vote by tokenHolder1
+          voter2Weight: WEIGHT_VOTER_NO, // This will be used for YES vote by tokenHolder2
+          voter3Weight: WEIGHT_VOTER_ABSTAIN,
+        });
+
+        // tokenHolder2 votes YES with its configured WEIGHT_VOTER_NO
+        await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.YES);
+        // tokenHolder1 votes NO with its configured WEIGHT_VOTER_YES
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.NO);
+        await linearERC20Voting.connect(tokenHolder3).vote(PROPOSAL_ID, VoteType.ABSTAIN);
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should PASS if quorum is 0%, basis met, and period ended', async () => {
+        const totalSupply = WEIGHT_VOTER_YES + WEIGHT_VOTER_NO; // 900
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply,
+          voter1Weight: WEIGHT_VOTER_YES,
+          voter2Weight: WEIGHT_VOTER_NO,
+          quorumNumerator: 0, // 0% quorum
+        });
+
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+        await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO);
+        // No abstain votes, total votes = 900. Quorum 0% of 900 = 0. Meets quorum.
+        // Basis: >50%. YES(600) / (YES(600)+NO(300)) = 66.6%. Meets basis.
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.true;
+      });
+
+      it('should FAIL if basis is 100% and any NO votes exist, even if quorum met', async () => {
+        const totalSupply = WEIGHT_VOTER_YES + WEIGHT_VOTER_NO; // 900
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply,
+          voter1Weight: WEIGHT_VOTER_YES,
+          voter2Weight: WEIGHT_VOTER_NO,
+          basisNumerator: BASIS_DENOMINATOR, // 100% basis
+        });
+
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+        await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO);
+        // Quorum: 30% of 900 = 270. YES(600) + ABSTAIN(0) = 600. Meets quorum.
+        // Basis: 100%. YES(600) / (YES(600)+NO(300)) = 66.6%. Fails 100% basis.
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should FAIL if basis is 50% (requires YES > NO) and YES == NO, even if quorum met', async () => {
+        const equalWeight = ethers.parseUnits('300', 18);
+        const totalSupply = equalWeight + equalWeight; // 600
+
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply,
+          voter1Weight: equalWeight,
+          voter2Weight: equalWeight,
+          basisNumerator: BASIS_DENOMINATOR / 2, // 50% basis
+        });
+
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+        await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO);
+        // Quorum: 30% of 600 = 180. YES(300) + ABSTAIN(0) = 300. Meets quorum.
+        // Basis: 50%. YES(300) / (YES(300)+NO(300)) = 50%. Does NOT meet basis (requires >50%).
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should PASS if basis is 50% (requires YES > NO) and YES > NO slightly, and quorum met', async () => {
+        const yesSlightlyMore = ethers.parseUnits('301', 18);
+        const noSlightlyLess = ethers.parseUnits('300', 18);
+        const totalSupply = yesSlightlyMore + noSlightlyLess; // 601
+
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply,
+          voter1Weight: yesSlightlyMore,
+          voter2Weight: noSlightlyLess,
+          basisNumerator: BASIS_DENOMINATOR / 2, // 50% basis
+        });
+
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+        await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO);
+        // Quorum: 30% of 601 = 180.3. YES(301) + ABSTAIN(0) = 301. Meets quorum.
+        // Basis: 50%. YES(301) > (YES(301)+NO(300))*0.5 = 300.5. Meets basis.
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.true;
+      });
+
+      it('should FAIL if basis is 100% and any NO votes exist, even if quorum met', async () => {
+        const totalSupply = WEIGHT_VOTER_YES + WEIGHT_VOTER_NO; // 900
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply,
+          voter1Weight: WEIGHT_VOTER_YES,
+          voter2Weight: WEIGHT_VOTER_NO,
+          basisNumerator: BASIS_DENOMINATOR, // 100% basis
+        });
+
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+        await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO);
+        // Quorum: 30% of 900 = 270. YES(600) + ABSTAIN(0) = 600. Meets quorum.
+        // Basis: 100%. YES(600) / (YES(600)+NO(300)) = 66.6%. Fails 100% basis.
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should FAIL if basis is 100% and only YES votes exist (due to strict `>` in meetsBasis), even if quorum met', async () => {
+        const totalSupply = WEIGHT_VOTER_YES; // 600
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply,
+          voter1Weight: WEIGHT_VOTER_YES,
+          basisNumerator: BASIS_DENOMINATOR, // 100% basis
+        });
+        // Quorum: DEFAULT_TEST_QUORUM_NUMERATOR (30%) of 600 = 180. YES(600) + ABSTAIN(0) = 600. Meets quorum.
+        // Basis: 100%. Contract is `YES > (YES+NO)*100%/100%` => `YES > YES+NO`.
+        // If NO=0, this is `YES > YES` which is false.
+
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES); // 600 YES
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.false; // Corrected expectation from true to false
+      });
+
+      it('should FAIL if basis is 50% (requires YES > NO) and YES == NO, even if quorum met', async () => {
+        const equalWeight = ethers.parseUnits('300', 18);
+        const totalSupply = equalWeight + equalWeight; // 600
+
+        const { endTimestamp } = await setupProposalForPassingTests(PROPOSAL_ID, {
+          totalSupply,
+          voter1Weight: equalWeight,
+          voter2Weight: equalWeight,
+          basisNumerator: BASIS_DENOMINATOR / 2, // 50% basis
+        });
+
+        await linearERC20Voting.connect(tokenHolder1).vote(PROPOSAL_ID, VoteType.YES);
+        await linearERC20Voting.connect(tokenHolder2).vote(PROPOSAL_ID, VoteType.NO);
+        // Quorum: 30% of 600 = 180. YES(300) + ABSTAIN(0) = 300. Meets quorum.
+        // Basis: 50%. YES(300) / (YES(300)+NO(300)) = 50%. Does NOT meet basis (requires >50%).
+
+        await time.increaseTo(endTimestamp + 1);
+        void expect(await linearERC20Voting.isPassed(PROPOSAL_ID)).to.be.false;
+      });
+    });
+  });
+
+  describe('getProposalVotingSupply function', () => {
+    const PROPOSAL_ID = 5;
+    let encodedProposalIdData: string;
+    const INITIAL_TOTAL_SUPPLY = ethers.parseUnits('1000', 18);
+    const LATER_TOTAL_SUPPLY = ethers.parseUnits('2000', 18);
+
+    beforeEach(() => {
+      encodedProposalIdData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [PROPOSAL_ID]);
+    });
+
+    it('should return 0 for an uninitialized proposal (regardless of mode)', async () => {
+      // Deploy a strategy instance (mode doesn't matter for uninitialized)
+      const linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+      // For an uninitialized proposal, timestamps/blocks are 0.
+      // MockERC20Votes.getPastTotalSupply(0) without prior setPastTotalSupply(0, x)
+      // might return current mockToken.totalSupply(). So, explicitly set supply at 0 to 0.
+      await mockToken.setPastTotalSupply(0, 0n);
+      void expect(await linearERC20Voting.getProposalVotingSupply(PROPOSAL_ID)).to.equal(0);
+    });
+
+    describe('when token is in Timestamp mode', () => {
+      let linearERC20Voting: LinearERC20VotingV1;
+      let proposalStartTimestamp: number;
+
+      beforeEach(async () => {
+        await mockToken.setClockMode(ClockMode.Timestamp);
+        linearERC20Voting = await deployLinearERC20Voting(
+          owner,
+          await mockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+        );
+
+        // Mint initial supply
+        await mockToken.mint(deployer.address, INITIAL_TOTAL_SUPPLY); // Mint to someone, total supply changes
+
+        // Initialize proposal - this captures the current block.timestamp as votingStartTimestamp
+        const initTx = await linearERC20Voting
+          .connect(proposalInitializer)
+          .initializeProposal(encodedProposalIdData);
+        const receipt = await initTx.wait();
+        if (!receipt) throw new Error('Proposal init failed');
+        const block = await ethers.provider.getBlock(receipt.blockNumber);
+        if (!block) throw new Error('Block not found');
+        proposalStartTimestamp = block.timestamp;
+
+        // Set the past total supply at the exact proposalStartTimestamp
+        await mockToken.setPastTotalSupply(proposalStartTimestamp, INITIAL_TOTAL_SUPPLY);
+      });
+
+      it('should return the total supply snapshotted at proposal creation (votingStartTimestamp)', async () => {
+        void expect(await linearERC20Voting.getProposalVotingSupply(PROPOSAL_ID)).to.equal(
+          INITIAL_TOTAL_SUPPLY,
+        );
+      });
+
+      it('should not be affected by total supply changes after proposal creation timestamp', async () => {
+        // Verify initial snapshot first
+        void expect(await linearERC20Voting.getProposalVotingSupply(PROPOSAL_ID)).to.equal(
+          INITIAL_TOTAL_SUPPLY,
+        );
+
+        // Mint more tokens, advancing time beyond the snapshot point
+        await time.increase(10); // Ensure we are past the proposalStartTimestamp if it was very recent
+        await mockToken.mint(deployer.address, LATER_TOTAL_SUPPLY - INITIAL_TOTAL_SUPPLY); // Increase total supply
+
+        // The supply for the proposal should still be the snapshotted one
+        void expect(await linearERC20Voting.getProposalVotingSupply(PROPOSAL_ID)).to.equal(
+          INITIAL_TOTAL_SUPPLY,
+        );
+      });
+    });
+
+    describe('when token is in BlockNumber mode', () => {
+      let linearERC20Voting: LinearERC20VotingV1;
+      let proposalStartBlock: number;
+      let blockNumberMockToken: MockERC20Votes; // Use a dedicated token for block number mode tests for isolation
+
+      beforeEach(async () => {
+        blockNumberMockToken = await new MockERC20Votes__factory(deployer).deploy();
+        await blockNumberMockToken.setClockMode(ClockMode.BlockNumber);
+
+        linearERC20Voting = await deployLinearERC20Voting(
+          owner,
+          await blockNumberMockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+        );
+
+        // Mint initial supply to the blockNumberMockToken
+        await blockNumberMockToken.mint(deployer.address, INITIAL_TOTAL_SUPPLY);
+
+        // Initialize proposal - this captures the current block.number as votingStartBlock
+        const initTx = await linearERC20Voting
+          .connect(proposalInitializer)
+          .initializeProposal(encodedProposalIdData);
+        const receipt = await initTx.wait();
+        if (!receipt) throw new Error('Proposal init failed');
+        proposalStartBlock = receipt.blockNumber;
+
+        // Set the past total supply at the exact proposalStartBlock for the blockNumberMockToken
+        await blockNumberMockToken.setPastTotalSupply(proposalStartBlock, INITIAL_TOTAL_SUPPLY);
+      });
+
+      it('should return the total supply snapshotted at proposal creation (votingStartBlock)', async () => {
+        void expect(await linearERC20Voting.getProposalVotingSupply(PROPOSAL_ID)).to.equal(
+          INITIAL_TOTAL_SUPPLY,
+        );
+      });
+
+      it('should not be affected by total supply changes after proposal creation block', async () => {
+        // Verify initial snapshot first
+        void expect(await linearERC20Voting.getProposalVotingSupply(PROPOSAL_ID)).to.equal(
+          INITIAL_TOTAL_SUPPLY,
+        );
+
+        // Mint more tokens, advancing blocks beyond the snapshot point
+        await mine(); // Mine a block
+        await blockNumberMockToken.mint(
+          deployer.address,
+          LATER_TOTAL_SUPPLY - INITIAL_TOTAL_SUPPLY,
+        ); // Increase total supply
+        await mine(); // Mine another to ensure mint transaction is processed and new block is queryable
+
+        // The supply for the proposal should still be the snapshotted one
+        void expect(await linearERC20Voting.getProposalVotingSupply(PROPOSAL_ID)).to.equal(
+          INITIAL_TOTAL_SUPPLY,
+        );
+      });
+    });
+  });
+
+  describe('getVotingWeight function', () => {
+    const PROPOSAL_ID = 6;
+    let encodedProposalIdData: string;
+    const SNAPSHOT_VOTING_WEIGHT = ethers.parseUnits('500', 18);
+    const LATER_VOTING_WEIGHT = ethers.parseUnits('1000', 18);
+
+    beforeEach(() => {
+      encodedProposalIdData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [PROPOSAL_ID]);
+    });
+
+    it('should return 0 for an uninitialized proposal (regardless of mode)', async () => {
+      const linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+      // votingStartTimestamp/Block for uninitialized proposal is 0.
+      // MockERC20Votes.getPastVotes(voter, 0) without prior setPastVotes(voter, 0, x) returns 0.
+      void expect(
+        await linearERC20Voting.getVotingWeight(tokenHolder1.address, PROPOSAL_ID),
+      ).to.equal(0);
+    });
+
+    describe('when token is in Timestamp mode', () => {
+      let linearERC20Voting: LinearERC20VotingV1;
+      let proposalStartTimestamp: number;
+
+      beforeEach(async () => {
+        await mockToken.setClockMode(ClockMode.Timestamp);
+        linearERC20Voting = await deployLinearERC20Voting(
+          owner,
+          await mockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+        );
+
+        // Initialize proposal - this captures the current block.timestamp as votingStartTimestamp
+        const initTx = await linearERC20Voting
+          .connect(proposalInitializer)
+          .initializeProposal(encodedProposalIdData);
+        const receipt = await initTx.wait();
+        if (!receipt) throw new Error('Proposal init failed');
+        const block = await ethers.provider.getBlock(receipt.blockNumber);
+        if (!block) throw new Error('Block not found');
+        proposalStartTimestamp = block.timestamp;
+
+        // Set the past votes for tokenHolder1 at the exact proposalStartTimestamp
+        await mockToken.setPastVotes(
+          tokenHolder1.address,
+          proposalStartTimestamp,
+          SNAPSHOT_VOTING_WEIGHT,
+        );
+        // Ensure tokenHolder2 has 0 votes at snapshot time for another test case
+        await mockToken.setPastVotes(tokenHolder2.address, proposalStartTimestamp, 0n);
+      });
+
+      it('should return the voting weight snapshotted at proposal creation (votingStartTimestamp)', async () => {
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder1.address, PROPOSAL_ID),
+        ).to.equal(SNAPSHOT_VOTING_WEIGHT);
+      });
+
+      it('should not be affected by voting weight changes after proposal creation timestamp', async () => {
+        // Verify initial snapshot first
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder1.address, PROPOSAL_ID),
+        ).to.equal(SNAPSHOT_VOTING_WEIGHT);
+
+        // Mint more tokens and delegate to tokenHolder1 *after* the snapshot point
+        await time.increase(10); // Ensure we are past the proposalStartTimestamp
+        await mockToken.mint(tokenHolder1.address, LATER_VOTING_WEIGHT);
+        await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address); // Updates current votes
+        // For ERC20Votes, getPastVotes relies on checkpoints. A transfer/delegate/mint that changes balance creates a checkpoint.
+        // We can explicitly set a new past vote for a *new* timestamp if needed, but current `getVotes` would reflect LATER_VOTING_WEIGHT.
+
+        // The weight for the proposal should still be the snapshotted one
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder1.address, PROPOSAL_ID),
+        ).to.equal(SNAPSHOT_VOTING_WEIGHT);
+      });
+
+      it('should return 0 for a voter with no votes at snapshot time, even if they get votes later', async () => {
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder2.address, PROPOSAL_ID),
+        ).to.equal(0);
+
+        await time.increase(10);
+        await mockToken.mint(tokenHolder2.address, LATER_VOTING_WEIGHT);
+        await mockToken.connect(tokenHolder2).delegate(tokenHolder2.address);
+
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder2.address, PROPOSAL_ID),
+        ).to.equal(0);
+      });
+    });
+
+    describe('when token is in BlockNumber mode', () => {
+      let linearERC20Voting: LinearERC20VotingV1;
+      let proposalStartBlock: number;
+      let blockNumberMockToken: MockERC20Votes;
+
+      beforeEach(async () => {
+        blockNumberMockToken = await new MockERC20Votes__factory(deployer).deploy();
+        await blockNumberMockToken.setClockMode(ClockMode.BlockNumber);
+
+        linearERC20Voting = await deployLinearERC20Voting(
+          owner,
+          await blockNumberMockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+        );
+
+        // Initialize proposal - this captures the current block.number as votingStartBlock
+        const initTx = await linearERC20Voting
+          .connect(proposalInitializer)
+          .initializeProposal(encodedProposalIdData);
+        const receipt = await initTx.wait();
+        if (!receipt) throw new Error('Proposal init failed');
+        proposalStartBlock = receipt.blockNumber;
+
+        // Set past votes for tokenHolder1 at the exact proposalStartBlock
+        await blockNumberMockToken.setPastVotes(
+          tokenHolder1.address,
+          proposalStartBlock,
+          SNAPSHOT_VOTING_WEIGHT,
+        );
+        // Ensure tokenHolder2 has 0 votes at snapshot time
+        await blockNumberMockToken.setPastVotes(tokenHolder2.address, proposalStartBlock, 0n);
+      });
+
+      it('should return the voting weight snapshotted at proposal creation (votingStartBlock)', async () => {
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder1.address, PROPOSAL_ID),
+        ).to.equal(SNAPSHOT_VOTING_WEIGHT);
+      });
+
+      it('should not be affected by voting weight changes after proposal creation block', async () => {
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder1.address, PROPOSAL_ID),
+        ).to.equal(SNAPSHOT_VOTING_WEIGHT);
+
+        // Mint more tokens and delegate *after* the snapshot block
+        await mine(); // Advance a block
+        await blockNumberMockToken.mint(tokenHolder1.address, LATER_VOTING_WEIGHT);
+        await blockNumberMockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await mine(); // Ensure mint/delegate processed
+
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder1.address, PROPOSAL_ID),
+        ).to.equal(SNAPSHOT_VOTING_WEIGHT);
+      });
+
+      it('should return 0 for a voter with no votes at snapshot block, even if they get votes later', async () => {
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder2.address, PROPOSAL_ID),
+        ).to.equal(0);
+
+        await mine();
+        await blockNumberMockToken.mint(tokenHolder2.address, LATER_VOTING_WEIGHT);
+        await blockNumberMockToken.connect(tokenHolder2).delegate(tokenHolder2.address);
+        await mine();
+
+        void expect(
+          await linearERC20Voting.getVotingWeight(tokenHolder2.address, PROPOSAL_ID),
+        ).to.equal(0);
+      });
+    });
+  });
+
+  describe('isProposer function', () => {
+    const TEST_REQUIRED_PROPOSER_WEIGHT = ethers.parseUnits('100', 18);
+
+    describe('when token is in Timestamp mode', () => {
+      let linearERC20Voting: LinearERC20VotingV1;
+
+      beforeEach(async () => {
+        await mockToken.setClockMode(ClockMode.Timestamp);
+        linearERC20Voting = await deployLinearERC20Voting(
+          owner,
+          await mockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+          VOTING_PERIOD, // Default voting period
+          TEST_REQUIRED_PROPOSER_WEIGHT, // Specific required weight for these tests
+        );
+      });
+
+      it('should return false if voter weight is less than requiredProposerWeight', async () => {
+        await mockToken.mint(tokenHolder1.address, (TEST_REQUIRED_PROPOSER_WEIGHT - 1n).toString());
+        await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await time.increase(10); // Advance time so current timestamp is ahead of delegation
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.false;
+      });
+
+      it('should return true if voter weight is equal to requiredProposerWeight', async () => {
+        await mockToken.mint(tokenHolder1.address, TEST_REQUIRED_PROPOSER_WEIGHT);
+        await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await time.increase(10);
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.true;
+      });
+
+      it('should return true if voter weight is greater than requiredProposerWeight', async () => {
+        await mockToken.mint(tokenHolder1.address, (TEST_REQUIRED_PROPOSER_WEIGHT + 1n).toString());
+        await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await time.increase(10);
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.true;
+      });
+
+      it('should reflect changes in voter weight over time', async () => {
+        // Initially not a proposer
+        await mockToken.mint(
+          tokenHolder1.address,
+          (TEST_REQUIRED_PROPOSER_WEIGHT - 10n).toString(),
+        );
+        await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await time.increase(10);
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.false;
+
+        // Gains enough weight
+        await mockToken.mint(tokenHolder1.address, 20n.toString()); // Total is now RPW + 10
+        // delegate again to checkpoint the new balance for getPastVotes at current time - 1
+        await mockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await time.increase(10);
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.true;
+      });
+
+      it('should return true if requiredProposerWeight is 0, even with 0 voter weight', async () => {
+        const zeroWeightVoting = await deployLinearERC20Voting(
+          owner,
+          await mockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+          VOTING_PERIOD,
+          0, // Zero required weight
+        );
+        // tokenHolder1 has 0 weight by default if no mint/delegate
+        await time.increase(10);
+        void expect(await zeroWeightVoting.isProposer(tokenHolder1.address)).to.be.true;
+      });
+    });
+
+    describe('when token is in BlockNumber mode', () => {
+      let linearERC20Voting: LinearERC20VotingV1;
+      let blockNumberMockToken: MockERC20Votes;
+
+      beforeEach(async () => {
+        blockNumberMockToken = await new MockERC20Votes__factory(deployer).deploy();
+        await blockNumberMockToken.setClockMode(ClockMode.BlockNumber);
+        linearERC20Voting = await deployLinearERC20Voting(
+          owner,
+          await blockNumberMockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+          VOTING_PERIOD,
+          TEST_REQUIRED_PROPOSER_WEIGHT,
+        );
+      });
+
+      it('should return false if voter weight is less than required (checks block.number - 1)', async () => {
+        await blockNumberMockToken.mint(
+          tokenHolder1.address,
+          (TEST_REQUIRED_PROPOSER_WEIGHT - 1n).toString(),
+        );
+        await blockNumberMockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await mine(); // Mine block for mint/delegate
+        await mine(); // Mine another block so isProposer checks previous block
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.false;
+      });
+
+      it('should return true if voter weight is equal to required (checks block.number - 1)', async () => {
+        await blockNumberMockToken.mint(tokenHolder1.address, TEST_REQUIRED_PROPOSER_WEIGHT);
+        await blockNumberMockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await mine();
+        await mine();
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.true;
+      });
+
+      it('should return true if voter weight is greater than required (checks block.number - 1)', async () => {
+        await blockNumberMockToken.mint(
+          tokenHolder1.address,
+          (TEST_REQUIRED_PROPOSER_WEIGHT + 1n).toString(),
+        );
+        await blockNumberMockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await mine();
+        await mine();
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.true;
+      });
+
+      it('should reflect changes in voter weight over blocks', async () => {
+        await blockNumberMockToken.mint(
+          tokenHolder1.address,
+          (TEST_REQUIRED_PROPOSER_WEIGHT - 10n).toString(),
+        );
+        await blockNumberMockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await mine(); // Block N: Mint/Delegate happens
+        await mine(); // Block N+1: isProposer checks N (false)
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.false;
+
+        await blockNumberMockToken.mint(tokenHolder1.address, 20n.toString()); // Total is now RPW + 10
+        await blockNumberMockToken.connect(tokenHolder1).delegate(tokenHolder1.address);
+        await mine(); // Block N+2: New mint/delegate
+        await mine(); // Block N+3: isProposer checks N+2 (true)
+        void expect(await linearERC20Voting.isProposer(tokenHolder1.address)).to.be.true;
+      });
+
+      it('should return true if requiredProposerWeight is 0, even with 0 voter weight (BlockNumber mode)', async () => {
+        const zeroWeightVoting = await deployLinearERC20Voting(
+          owner,
+          await blockNumberMockToken.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+          VOTING_PERIOD,
+          0, // Zero required weight
+        );
+        // tokenHolder1 has 0 weight by default if no mint/delegate
+        await mine(); // Ensure a previous block exists
+        void expect(await zeroWeightVoting.isProposer(tokenHolder1.address)).to.be.true;
+      });
+    });
+  });
+
+  describe('getVotingTimestamps function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    const PROPOSAL_ID = 7;
+    let encodedProposalIdData: string;
+
+    beforeEach(async () => {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+      encodedProposalIdData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [PROPOSAL_ID]);
+    });
+
+    it('should return (0, 0) for an uninitialized proposal', async () => {
+      const uninitializedProposalId = PROPOSAL_ID + 999;
+      const [startTimestamp, endTimestamp] =
+        await linearERC20Voting.getVotingTimestamps(uninitializedProposalId);
+      expect(startTimestamp).to.equal(0);
+      expect(endTimestamp).to.equal(0);
+    });
+
+    it('should return correct start and end timestamps for an initialized proposal', async () => {
+      // Initialize the proposal
+      const initTx = await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalIdData);
+      const receipt = await initTx.wait();
+      if (!receipt) throw new Error('Proposal initialization failed');
+      const block = await ethers.provider.getBlock(receipt.blockNumber);
+      if (!block) throw new Error('Block not found for proposal initialization');
+
+      const expectedStartTimestamp = block.timestamp;
+      const expectedEndTimestamp = expectedStartTimestamp + VOTING_PERIOD;
+
+      const [actualStartTimestamp, actualEndTimestamp] =
+        await linearERC20Voting.getVotingTimestamps(PROPOSAL_ID);
+
+      expect(actualStartTimestamp).to.equal(expectedStartTimestamp);
+      expect(actualEndTimestamp).to.equal(expectedEndTimestamp);
+    });
+
+    it('should return updated timestamps if a proposal is re-initialized', async () => {
+      // Initial initialization
+      await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalIdData);
+
+      // Advance time and re-initialize
+      await time.increase(VOTING_PERIOD / 2);
+      const reinitTx = await linearERC20Voting
+        .connect(proposalInitializer)
+        .initializeProposal(encodedProposalIdData);
+      const reinitReceipt = await reinitTx.wait();
+      if (!reinitReceipt) throw new Error('Proposal re-initialization failed');
+      const reinitBlock = await ethers.provider.getBlock(reinitReceipt.blockNumber);
+      if (!reinitBlock) throw new Error('Block not found for re-initialization');
+
+      const newExpectedStartTimestamp = reinitBlock.timestamp;
+      const newExpectedEndTimestamp = newExpectedStartTimestamp + VOTING_PERIOD;
+
+      const [newActualStartTimestamp, newActualEndTimestamp] =
+        await linearERC20Voting.getVotingTimestamps(PROPOSAL_ID);
+
+      expect(newActualStartTimestamp).to.equal(newExpectedStartTimestamp);
+      expect(newActualEndTimestamp).to.equal(newExpectedEndTimestamp);
+    });
+  });
+
+  describe('quorumVotes function', () => {
+    const PROPOSAL_ID = 8;
+    let encodedProposalIdData: string;
+    const INITIAL_TOTAL_SUPPLY = ethers.parseUnits('10000', 18); // 10,000 tokens
+    const DEFAULT_QUORUM_NUMERATOR = 300_000; // 30%
+    const QUORUM_DENOMINATOR_FROM_CONTRACT = 1_000_000;
+
+    beforeEach(() => {
+      encodedProposalIdData = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [PROPOSAL_ID]);
+    });
+
+    it('should return 0 for an uninitialized proposal', async () => {
+      const linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+      );
+      // For uninitialized, proposalVotes[id].votingStartTimestamp/Block is 0.
+      // mockToken.getPastTotalSupply(0) without prior set will give current supply.
+      // So, set past total supply for timepoint 0 to 0 to ensure clean test.
+      await mockToken.setPastTotalSupply(0, 0n);
+      expect(await linearERC20Voting.quorumVotes(PROPOSAL_ID + 999)).to.equal(0);
+    });
+
+    describe('Timestamp mode', () => {
+      let linearERC20Voting: LinearERC20VotingV1;
+      let tokenTimestamp: MockERC20Votes;
+      let proposalStartTimestamp: number;
+
+      beforeEach(async () => {
+        tokenTimestamp = await new MockERC20Votes__factory(deployer).deploy();
+        await tokenTimestamp.setClockMode(ClockMode.Timestamp);
+        await tokenTimestamp.mint(deployer.address, INITIAL_TOTAL_SUPPLY); // Mint to set total supply
+
+        linearERC20Voting = await deployLinearERC20Voting(
+          owner,
+          await tokenTimestamp.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+          VOTING_PERIOD,
+          REQUIRED_PROPOSER_WEIGHT,
+          DEFAULT_QUORUM_NUMERATOR,
+        );
+
+        const initTx = await linearERC20Voting
+          .connect(proposalInitializer)
+          .initializeProposal(encodedProposalIdData);
+        const receipt = await initTx.wait();
+        if (!receipt) throw new Error('Proposal init failed');
+        const block = await ethers.provider.getBlock(receipt.blockNumber);
+        if (!block) throw new Error('Block not found');
+        proposalStartTimestamp = block.timestamp;
+
+        await tokenTimestamp.setPastTotalSupply(proposalStartTimestamp, INITIAL_TOTAL_SUPPLY);
+      });
+
+      it('should correctly calculate quorum votes based on initial supply and quorum numerator', async () => {
+        const expectedQuorumVotes =
+          (BigInt(DEFAULT_QUORUM_NUMERATOR) * INITIAL_TOTAL_SUPPLY) /
+          BigInt(QUORUM_DENOMINATOR_FROM_CONTRACT);
+        expect(await linearERC20Voting.quorumVotes(PROPOSAL_ID)).to.equal(expectedQuorumVotes);
+      });
+
+      it('should reflect an updated quorumNumerator in calculation', async () => {
+        const newQuorumNumerator = 400_000; // 40%
+        await linearERC20Voting.connect(owner).updateQuorumNumerator(newQuorumNumerator);
+
+        const expectedQuorumVotes =
+          (BigInt(newQuorumNumerator) * INITIAL_TOTAL_SUPPLY) /
+          BigInt(QUORUM_DENOMINATOR_FROM_CONTRACT);
+        expect(await linearERC20Voting.quorumVotes(PROPOSAL_ID)).to.equal(expectedQuorumVotes);
+      });
+
+      it('should not be affected by total supply changes after proposal initialization', async () => {
+        const expectedQuorumVotes =
+          (BigInt(DEFAULT_QUORUM_NUMERATOR) * INITIAL_TOTAL_SUPPLY) /
+          BigInt(QUORUM_DENOMINATOR_FROM_CONTRACT);
+        expect(await linearERC20Voting.quorumVotes(PROPOSAL_ID)).to.equal(expectedQuorumVotes);
+
+        await time.increase(10);
+        await tokenTimestamp.mint(deployer.address, ethers.parseUnits('5000', 18)); // Increase total supply
+
+        expect(await linearERC20Voting.quorumVotes(PROPOSAL_ID)).to.equal(expectedQuorumVotes);
+      });
+    });
+
+    describe('BlockNumber mode', () => {
+      let linearERC20Voting: LinearERC20VotingV1;
+      let tokenBlockNumber: MockERC20Votes;
+      let proposalStartBlock: number;
+
+      beforeEach(async () => {
+        tokenBlockNumber = await new MockERC20Votes__factory(deployer).deploy();
+        await tokenBlockNumber.setClockMode(ClockMode.BlockNumber);
+        await tokenBlockNumber.mint(deployer.address, INITIAL_TOTAL_SUPPLY);
+
+        linearERC20Voting = await deployLinearERC20Voting(
+          owner,
+          await tokenBlockNumber.getAddress(),
+          proposalInitializer.address,
+          lightAccountFactoryMock.target as string,
+          VOTING_PERIOD,
+          REQUIRED_PROPOSER_WEIGHT,
+          DEFAULT_QUORUM_NUMERATOR,
+        );
+
+        const initTx = await linearERC20Voting
+          .connect(proposalInitializer)
+          .initializeProposal(encodedProposalIdData);
+        const receipt = await initTx.wait();
+        if (!receipt) throw new Error('Proposal init failed');
+        proposalStartBlock = receipt.blockNumber;
+
+        await tokenBlockNumber.setPastTotalSupply(proposalStartBlock, INITIAL_TOTAL_SUPPLY);
+      });
+
+      it('should correctly calculate quorum votes based on initial supply and quorum numerator', async () => {
+        const expectedQuorumVotes =
+          (BigInt(DEFAULT_QUORUM_NUMERATOR) * INITIAL_TOTAL_SUPPLY) /
+          BigInt(QUORUM_DENOMINATOR_FROM_CONTRACT);
+        expect(await linearERC20Voting.quorumVotes(PROPOSAL_ID)).to.equal(expectedQuorumVotes);
+      });
+
+      it('should reflect an updated quorumNumerator in calculation', async () => {
+        const newQuorumNumerator = 600_000; // 60%
+        await linearERC20Voting.connect(owner).updateQuorumNumerator(newQuorumNumerator);
+
+        const expectedQuorumVotes =
+          (BigInt(newQuorumNumerator) * INITIAL_TOTAL_SUPPLY) /
+          BigInt(QUORUM_DENOMINATOR_FROM_CONTRACT);
+        expect(await linearERC20Voting.quorumVotes(PROPOSAL_ID)).to.equal(expectedQuorumVotes);
+      });
+
+      it('should not be affected by total supply changes after proposal initialization', async () => {
+        const expectedQuorumVotes =
+          (BigInt(DEFAULT_QUORUM_NUMERATOR) * INITIAL_TOTAL_SUPPLY) /
+          BigInt(QUORUM_DENOMINATOR_FROM_CONTRACT);
+        expect(await linearERC20Voting.quorumVotes(PROPOSAL_ID)).to.equal(expectedQuorumVotes);
+
+        await mine();
+        await tokenBlockNumber.mint(deployer.address, ethers.parseUnits('5000', 18));
+        await mine();
+
+        expect(await linearERC20Voting.quorumVotes(PROPOSAL_ID)).to.equal(expectedQuorumVotes);
+      });
+    });
+  });
+
+  describe('meetsQuorum function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    const TOTAL_SUPPLY = ethers.parseUnits('10000', 18); // 10,000 tokens
+    const DEFAULT_QUORUM_NUMERATOR = 300_000; // 30%
+    const QUORUM_DENOMINATOR_FROM_CONTRACT = 1_000_000;
+
+    beforeEach(async () => {
+      linearERC20Voting = await deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(), // mockToken is suitable as its address is needed, not its state
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+        VOTING_PERIOD,
+        REQUIRED_PROPOSER_WEIGHT,
+        DEFAULT_QUORUM_NUMERATOR, // Set the default quorum for the strategy instance
+      );
+    });
+
+    it('should return true if (yes + abstain) votes are greater than required quorum votes', async () => {
+      // Required: 10000 * 30% = 3000
+      const yesVotes = ethers.parseUnits('2000', 18);
+      const abstainVotes = ethers.parseUnits('1001', 18);
+      // Total: 3001 > 3000
+      void expect(await linearERC20Voting.meetsQuorum(TOTAL_SUPPLY, yesVotes, abstainVotes)).to.be
+        .true;
+    });
+
+    it('should return true if (yes + abstain) votes are equal to required quorum votes', async () => {
+      // Required: 10000 * 30% = 3000
+      const yesVotes = ethers.parseUnits('1500', 18);
+      const abstainVotes = ethers.parseUnits('1500', 18);
+      // Total: 3000 == 3000
+      void expect(await linearERC20Voting.meetsQuorum(TOTAL_SUPPLY, yesVotes, abstainVotes)).to.be
+        .true;
+    });
+
+    it('should return false if (yes + abstain) votes are less than required quorum votes', async () => {
+      // Required: 10000 * 30% = 3000
+      const yesVotes = ethers.parseUnits('1000', 18);
+      const abstainVotes = ethers.parseUnits('1999', 18);
+      // Total: 2999 < 3000
+      void expect(await linearERC20Voting.meetsQuorum(TOTAL_SUPPLY, yesVotes, abstainVotes)).to.be
+        .false;
+    });
+
+    it('should return true if quorumNumerator is 0, even with zero votes', async () => {
+      await linearERC20Voting.connect(owner).updateQuorumNumerator(0);
+      // Required: 10000 * 0% = 0
+      const yesVotes = 0n;
+      const abstainVotes = 0n;
+      // Total: 0 == 0
+      void expect(await linearERC20Voting.meetsQuorum(TOTAL_SUPPLY, yesVotes, abstainVotes)).to.be
+        .true;
+    });
+
+    it('should return false if quorumNumerator is 100% and (yes + abstain) < total supply', async () => {
+      await linearERC20Voting
+        .connect(owner)
+        .updateQuorumNumerator(QUORUM_DENOMINATOR_FROM_CONTRACT);
+      // Required: 10000 * 100% = 10000
+      const yesVotes = ethers.parseUnits('5000', 18);
+      const abstainVotes = ethers.parseUnits('4999', 18);
+      // Total: 9999 < 10000
+      void expect(await linearERC20Voting.meetsQuorum(TOTAL_SUPPLY, yesVotes, abstainVotes)).to.be
+        .false;
+    });
+
+    it('should return true if quorumNumerator is 100% and (yes + abstain) == total supply', async () => {
+      await linearERC20Voting
+        .connect(owner)
+        .updateQuorumNumerator(QUORUM_DENOMINATOR_FROM_CONTRACT);
+      // Required: 10000 * 100% = 10000
+      const yesVotes = ethers.parseUnits('5000', 18);
+      const abstainVotes = ethers.parseUnits('5000', 18);
+      // Total: 10000 == 10000
+      void expect(await linearERC20Voting.meetsQuorum(TOTAL_SUPPLY, yesVotes, abstainVotes)).to.be
+        .true;
+    });
+
+    it('should return true if total supply is 0 and quorumNumerator is > 0 (0 votes required)', async () => {
+      // Required: 0 * 30% = 0
+      const yesVotes = 0n;
+      const abstainVotes = 0n;
+      void expect(await linearERC20Voting.meetsQuorum(0n, yesVotes, abstainVotes)).to.be.true;
+    });
+
+    it('should handle large vote and supply numbers correctly within uint256 limits', async () => {
+      const testQuorumNumerator = 500_000n; // 50%
+      await linearERC20Voting.connect(owner).updateQuorumNumerator(testQuorumNumerator);
+
+      // Choose largeSupply such that largeSupply * testQuorumNumerator does not overflow ethers.MaxUint256.
+      // The largest such supply is ethers.MaxUint256 / testQuorumNumerator.
+      const largeSupply = ethers.MaxUint256 / testQuorumNumerator;
+
+      // Calculate the expected required votes threshold.
+      // The intermediate product (largeSupply * testQuorumNumerator) in the contract will be approximately ethers.MaxUint256
+      // (specifically, ethers.MaxUint256 - (ethers.MaxUint256 % testQuorumNumerator)), which does not overflow.
+      const calculatedRequiredVotes =
+        (largeSupply * testQuorumNumerator) / BigInt(QUORUM_DENOMINATOR_FROM_CONTRACT);
+
+      // Sanity check: calculatedRequiredVotes should be large and positive as MaxUint256 / DENOMINATOR is large.
+      expect(calculatedRequiredVotes).to.be.gt(0n);
+
+      // Case 1: Votes (_yesVotes + _abstainVotes) exactly meet the threshold.
+      void expect(await linearERC20Voting.meetsQuorum(largeSupply, calculatedRequiredVotes, 0n)).to
+        .be.true;
+
+      // Case 2: Votes barely meet the threshold using a combination.
+      // (_yesVotes = calculatedRequiredVotes - 1) + (_abstainVotes = 1) == calculatedRequiredVotes.
+      // This sum (calculatedRequiredVotes) will not overflow as it's derived from MaxUint256 / DENOMINATOR.
+      void expect(
+        await linearERC20Voting.meetsQuorum(largeSupply, calculatedRequiredVotes - 1n, 1n),
+      ).to.be.true;
+
+      // Case 3: Votes are one less than the threshold.
+      // (_yesVotes = calculatedRequiredVotes - 1) + (_abstainVotes = 0) == calculatedRequiredVotes - 1.
+      void expect(
+        await linearERC20Voting.meetsQuorum(largeSupply, calculatedRequiredVotes - 1n, 0n),
+      ).to.be.false;
+    });
+
+    it('should handle scenarios with only YES votes meeting quorum', async () => {
+      // Required: 10000 * 30% = 3000
+      const yesVotes = ethers.parseUnits('3000', 18);
+      const abstainVotes = 0n;
+      void expect(await linearERC20Voting.meetsQuorum(TOTAL_SUPPLY, yesVotes, abstainVotes)).to.be
+        .true;
+    });
+
+    it('should handle scenarios with only ABSTAIN votes meeting quorum', async () => {
+      // Required: 10000 * 30% = 3000
+      const yesVotes = 0n;
+      const abstainVotes = ethers.parseUnits('3000', 18);
+      void expect(await linearERC20Voting.meetsQuorum(TOTAL_SUPPLY, yesVotes, abstainVotes)).to.be
+        .true;
+    });
+  });
+
+  describe('meetsBasis function', () => {
+    let linearERC20Voting: LinearERC20VotingV1;
+    const BASIS_DENOMINATOR_FROM_CONTRACT = 1_000_000;
+
+    async function deployStrategyWithBasis(basisNumerator: number) {
+      return deployLinearERC20Voting(
+        owner,
+        await mockToken.getAddress(),
+        proposalInitializer.address,
+        lightAccountFactoryMock.target as string,
+        VOTING_PERIOD,
+        REQUIRED_PROPOSER_WEIGHT,
+        QUORUM_NUMERATOR, // Default quorum, not relevant for meetsBasis directly
+        basisNumerator,
+      );
+    }
+
+    it('should return true if yesVotes > ( (yesVotes + noVotes) * basisNumerator / DENOMINATOR ) ', async () => {
+      linearERC20Voting = await deployStrategyWithBasis(BASIS_DENOMINATOR_FROM_CONTRACT / 2); // 50% basis
+      const yesVotes = ethers.parseUnits('51', 18);
+      const noVotes = ethers.parseUnits('49', 18);
+      // 51 > ( (51+49) * 0.5 ) => 51 > 50. TRUE
       void expect(await linearERC20Voting.meetsBasis(yesVotes, noVotes)).to.be.true;
     });
 
-    it('should return false when yes votes equal the basis threshold', async () => {
-      const yesVotes = 50;
-      const noVotes = 50;
-      // 50 = ((50 + 50) * 500000 / 1000000) = 50, but we need >
+    it('should return false if yesVotes == ( (yesVotes + noVotes) * basisNumerator / DENOMINATOR ) due to strict >', async () => {
+      linearERC20Voting = await deployStrategyWithBasis(BASIS_DENOMINATOR_FROM_CONTRACT / 2); // 50% basis
+      const yesVotes = ethers.parseUnits('50', 18);
+      const noVotes = ethers.parseUnits('50', 18);
+      // 50 > ( (50+50) * 0.5 ) => 50 > 50. FALSE
       void expect(await linearERC20Voting.meetsBasis(yesVotes, noVotes)).to.be.false;
     });
 
-    it('should return false when yes votes are below the basis threshold', async () => {
-      const yesVotes = 49;
-      const noVotes = 51;
-      // 49 < ((49 + 51) * 500000 / 1000000) = 50
+    it('should return false if yesVotes < ( (yesVotes + noVotes) * basisNumerator / DENOMINATOR ) ', async () => {
+      linearERC20Voting = await deployStrategyWithBasis(BASIS_DENOMINATOR_FROM_CONTRACT / 2); // 50% basis
+      const yesVotes = ethers.parseUnits('49', 18);
+      const noVotes = ethers.parseUnits('51', 18);
+      // 49 > ( (49+51) * 0.5 ) => 49 > 50. FALSE
       void expect(await linearERC20Voting.meetsBasis(yesVotes, noVotes)).to.be.false;
     });
 
-    // Test with higher basis (e.g., 70%)
-    it('should work with higher basis threshold', async () => {
-      // Update to 70%
-      await linearERC20Voting.connect(owner).updateBasisNumerator(700000);
-
-      // Case where it passes with the new threshold
-      const yesVotes2 = 71;
-      const noVotes2 = 29;
-      // 71 > ((71 + 29) * 700000 / 1000000) = 70
-      void expect(await linearERC20Voting.meetsBasis(yesVotes2, noVotes2)).to.be.true;
-
-      // Case where it fails with the new threshold
-      const yesVotes3 = 69;
-      const noVotes3 = 31;
-      // 69 < ((69 + 31) * 700000 / 1000000) = 70
-      void expect(await linearERC20Voting.meetsBasis(yesVotes3, noVotes3)).to.be.false;
+    it('should return false with 0 yesVotes and 0 noVotes (0 > 0 is false)', async () => {
+      linearERC20Voting = await deployStrategyWithBasis(BASIS_DENOMINATOR_FROM_CONTRACT / 2); // 50% basis
+      void expect(await linearERC20Voting.meetsBasis(0n, 0n)).to.be.false;
     });
 
-    it('should handle zero votes correctly', async () => {
-      const yesVotes = 0;
-      const noVotes = 0;
-      // When both are 0, formula is 0 > (0 * 500000 / 1000000) which is 0 > 0, which is false
-      void expect(await linearERC20Voting.meetsBasis(yesVotes, noVotes)).to.be.false;
+    it('should return true if only yesVotes exist and basis is < 100%', async () => {
+      linearERC20Voting = await deployStrategyWithBasis(BASIS_DENOMINATOR_FROM_CONTRACT / 2); // 50% basis
+      const yesVotes = ethers.parseUnits('100', 18);
+      // 100 > ( (100+0) * 0.5 ) => 100 > 50. TRUE
+      void expect(await linearERC20Voting.meetsBasis(yesVotes, 0n)).to.be.true;
     });
 
-    it('should handle case where only yes votes exist', async () => {
-      const yesVotes = 100;
-      const noVotes = 0;
-      // 100 > ((100 + 0) * 500000 / 1000000) = 50
-      void expect(await linearERC20Voting.meetsBasis(yesVotes, noVotes)).to.be.true;
+    it('should return false if only noVotes exist (and yesVotes is 0)', async () => {
+      linearERC20Voting = await deployStrategyWithBasis(BASIS_DENOMINATOR_FROM_CONTRACT / 2); // 50% basis
+      const noVotes = ethers.parseUnits('100', 18);
+      // 0 > ( (0+100) * 0.5 ) => 0 > 50. FALSE
+      void expect(await linearERC20Voting.meetsBasis(0n, noVotes)).to.be.false;
     });
 
-    it('should handle case where only no votes exist', async () => {
-      const yesVotes = 0;
-      const noVotes = 100;
-      // 0 < ((0 + 100) * 500000 / 1000000) = 50
-      void expect(await linearERC20Voting.meetsBasis(yesVotes, noVotes)).to.be.false;
+    describe('with 75% basisNumerator', () => {
+      beforeEach(async () => {
+        linearERC20Voting = await deployStrategyWithBasis(
+          (BASIS_DENOMINATOR_FROM_CONTRACT * 3) / 4,
+        ); // 75% basis
+      });
+
+      it('should pass if yes are 76, no are 24 (76 > 75)', async () => {
+        const yesVotes = ethers.parseUnits('76', 18);
+        const noVotes = ethers.parseUnits('24', 18);
+        // 76 > ( (76+24) * 0.75 ) => 76 > 75. TRUE
+        void expect(await linearERC20Voting.meetsBasis(yesVotes, noVotes)).to.be.true;
+      });
+
+      it('should fail if yes are 75, no are 25 (75 > 75 is false)', async () => {
+        const yesVotes = ethers.parseUnits('75', 18);
+        const noVotes = ethers.parseUnits('25', 18);
+        // 75 > ( (75+25) * 0.75 ) => 75 > 75. FALSE
+        void expect(await linearERC20Voting.meetsBasis(yesVotes, noVotes)).to.be.false;
+      });
+    });
+
+    describe('with 100% basisNumerator', () => {
+      beforeEach(async () => {
+        linearERC20Voting = await deployStrategyWithBasis(BASIS_DENOMINATOR_FROM_CONTRACT); // 100% basis
+      });
+
+      it('should fail if only yesVotes exist (e.g., 100 YES, 0 NO -> 100 > 100 is false)', async () => {
+        const yesVotes = ethers.parseUnits('100', 18);
+        // 100 > ( (100+0) * 1.0 ) => 100 > 100. FALSE
+        void expect(await linearERC20Voting.meetsBasis(yesVotes, 0n)).to.be.false;
+      });
+
+      it('should fail if any noVotes exist (e.g., 100 YES, 1 NO -> 100 > 101 is false)', async () => {
+        const yesVotes = ethers.parseUnits('100', 18);
+        const noVotes = ethers.parseUnits('1', 18);
+        // 100 > ( (100+1) * 1.0 ) => 100 > 101. FALSE
+        void expect(await linearERC20Voting.meetsBasis(yesVotes, noVotes)).to.be.false;
+      });
+
+      it('should fail with 0 yesVotes and 0 noVotes (0 > 0 is false)', async () => {
+        void expect(await linearERC20Voting.meetsBasis(0n, 0n)).to.be.false;
+      });
     });
   });
 });

--- a/test/deployables/strategies/LinearERC721VotingV1.test.ts
+++ b/test/deployables/strategies/LinearERC721VotingV1.test.ts
@@ -456,7 +456,7 @@ describe('LinearERC721VotingV1', () => {
       await linearERC721Voting.connect(nonOwner).initializeProposal(initializeData);
 
       // Check that proposal was initialized correctly
-      const votingEndTimestamp = await linearERC721Voting.votingEndTimestamp(proposalId);
+      const [, votingEndTimestamp] = await linearERC721Voting.getVotingTimestamps(proposalId);
       expect(votingEndTimestamp).to.not.equal(0);
     });
 


### PR DESCRIPTION
Fixes [ENG-882](https://linear.app/decent-labs/issue/ENG-882/refactor-voting-period-logic-for-consistency-and-clock-mode-support)

This commit undertakes a significant refactoring to improve the consistency, flexibility, and testability of voting mechanisms across the smart contract suite. The core changes revolve around standardizing how proposal voting periods (start and end times) are managed and exposed, and introducing robust support for governance tokens that utilize different clock mechanisms (timestamp-based vs. block-number-based) for vote snapshots.

**1. Unification and Standardization of Voting Period Access:**

*   **Consistent Interface:** The functions `getProposalPeriod` (previously in `LinearERC20VotingV1ValidatorV1` and `LinearERC20VotingV1`) and `votingEndTimestamp` (previously in `ILinearERC721VotingV1`, `AzoriusV1`, `BaseStrategyV1`, `LinearERC721VotingV1`, and their mocks) have been consolidated into a single, standardized function:
    `getVotingTimestamps(uint32 proposalId) external view returns (uint48 startTime, uint48 endTime)`
*   **Affected Contracts & Interfaces:** This change is propagated through:
    *   Interfaces: `IBaseStrategyV1`.
    *   Core Strategy Contracts: `BaseStrategyV1`, `LinearERC20VotingV1`, `LinearERC721VotingV1`.
    *   Core Module: `AzoriusV1`.
    *   Validator Contracts: `LinearERC20VotingV1ValidatorV1`, `LinearERC721VotingV1ValidatorV1`.
    *   Mock/Concrete Implementations: `MockVotingStrategy`, `ConcreteBaseStrategyV1`, `MockLinearERC20VotingV1`, `MockLinearERC721VotingV1`.
*   **Improved Clarity:** This unification provides a clearer and more predictable API for all components that need to query the start and end times of a proposal's voting window. The return parameters are consistently named `startTime` and `endTime`.

**2. Introduction of Clock Mode Abstraction in `LinearERC20VotingV1`:**

*   **Support for Diverse ERC20Votes Tokens:** `LinearERC20VotingV1` now integrates `ClockModeLib` to dynamically determine and adapt to the clock mechanism (timestamp or block number) used by the underlying `governanceToken` (implementing `IVotes`). This is crucial for compatibility with tokens like OpenZeppelin's `ERC20Votes` which can operate in either mode.
*   **`governanceClockMode` State:** A new state variable `governanceClockMode` of type `ClockMode` is introduced and set during initialization based on the `governanceToken`.
*   **Enhanced `ProposalVotes` Struct:** The `ProposalVotes` struct in `LinearERC20VotingV1` has been augmented to include `votingStartBlock` in addition to `votingStartTime`. This allows the contract to store the relevant starting point regardless of the clock mode.
*   **Adaptive Snapshot Lookups:**
    *   `getProposalVotingSupply`: Now uses `governanceClockMode` to call `governanceToken.getPastTotalSupply` with either `proposalVotes[_proposalId].votingStartTime` (for timestamp mode) or `proposalVotes[_proposalId].votingStartBlock` (for block mode).
    *   `getVoterWeight`: Similarly adapts to call `governanceToken.getPastVotes` with the correct timepoint based on `governanceClockMode`.
    *   `isProposer`: The check for proposer eligibility now retrieves past votes using `ClockModeLib.getCurrentPoint(governanceClockMode) - 1`, ensuring it uses the correct latest finalized snapshot point.

**3. Standardization of Event Data and Naming:**

*   **Consistent Event Parameters:** Event emissions related to voting periods have been updated for consistency.
    *   In `ERC4337VoterSupportV1`, the `VotingPeriodEnded` event now emits `votingEndTime` and `currentTime` (previously `votingEndTimestamp` and `currentTimestamp`).
    *   In `LinearERC20VotingV1` and `LinearERC721VotingV1`, the `ProposalInitialized` event now emits `proposalId` and `votingEndTime` (previously `votingEndTimestamp`).
    *   The `VotingPeriodEnded` event (emitted from `_vote` in `LinearERC20VotingV1` and `LinearERC721VotingV1` via `ERC4337VoterSupportV1`) reflects the updated parameter names.
*   **Internal Variable Renaming:** Internal struct members like `votingStartTimestamp` and `votingEndTimestamp` within `ProposalVotes` (in `LinearERC20VotingV1` and `LinearERC721VotingV1`) have been renamed to `votingStartTime` and `votingEndTime` respectively.

**4. Enhancements to Mock Contracts for Improved Testability:**

*   **`MockERC20Votes` Alignment with `ERC20Votes`:**
    *   Introduced `clock() public view returns (uint256)` (returning `block.timestamp`) and `CLOCK_MODE() public pure returns (string memory)` (returning `"mode=timestamp"`).
    *   Functions `setPastVotes`, `getPastVotes`, `setPastTotalSupply`, and `getPastTotalSupply` now use `timepoint` as a parameter name instead of `timestamp`. This makes the mock more closely mirror the actual `ERC20Votes` interface and aids in testing clock-dependent logic.
*   **Mock Strategy Updates:** `MockLinearERC20VotingV1` and `MockLinearERC721VotingV1` now expose `setVotingTimestamps` and `getVotingTimestamps` to align with the interface changes. `MockVotingStrategy` also reflects this change.

**5. Comprehensive Test Suite Adaption:**

*   All affected test files have been meticulously updated to:
    *   Call the new `getVotingTimestamps` function.
    *   Adjust assertions for changed return values and struct member names (e.g., `proposalPeriod.startTime`, `proposalPeriod.endTime`).
    *   Update setup logic for proposal periods in mock contracts (e.g., using `mockERC20Strategy.setVotingTimestamps` instead of `setProposalPeriod`).
    *   Reflect changes in event parameter names and emitted values.
    *   Utilize the updated `MockERC20Votes` interface where applicable.
    *   In `AzoriusV1.test.ts`, time manipulation helpers like `time.increase` and `time.increaseTo` are used more consistently over `mine` where appropriate for timestamp-based logic.

This refactoring streamlines the handling of proposal timelines, significantly boosts the adaptability of the `LinearERC20VotingV1` strategy, and improves the overall robustness and clarity of the codebase.