### PR TITLE
feat(StrategyV1): Implement Core Voting Logic and Outcome Determination

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -201,6 +201,104 @@ contract StrategyV1 is
         );
     }
 
+    function vote(
+        uint32 _proposalId,
+        uint8 _voteType,
+        address[] calldata _adaptersToUse,
+        bytes[] calldata _adapterVoteData
+    ) external virtual override {
+        if (_adaptersToUse.length != _adapterVoteData.length)
+            revert MismatchedInputs();
+
+        address resolvedVoter = voter(msg.sender);
+        ProposalVotingDetails storage proposal = proposalVotingDetails[
+            _proposalId
+        ];
+
+        if (
+            proposal.votingEndTimestamp == 0 ||
+            block.timestamp > proposal.votingEndTimestamp
+        ) {
+            revert ProposalNotFoundOrNotActive();
+        }
+
+        uint256 totalWeightForThisVoteTransaction = 0;
+        uint256 numConfiguredAdapters = tokenAdapters.length;
+
+        for (uint256 i = 0; i < _adaptersToUse.length; i++) {
+            bool isValidAndConfiguredAdapter = false;
+            uint256 configuredAdapterIndex = 0;
+
+            for (uint256 j = 0; j < numConfiguredAdapters; j++) {
+                if (
+                    tokenAdapters[j] == ITokenAdapterBaseV1(_adaptersToUse[i])
+                ) {
+                    isValidAndConfiguredAdapter = true;
+                    configuredAdapterIndex = j;
+                    break;
+                }
+            }
+
+            if (!isValidAndConfiguredAdapter) {
+                revert InvalidAdapterProvidedInVote();
+            }
+
+            totalWeightForThisVoteTransaction += tokenAdapters[
+                configuredAdapterIndex
+            ].recordVote(resolvedVoter, _proposalId, _adapterVoteData[i]);
+        }
+
+        if (totalWeightForThisVoteTransaction == 0) revert NoVotingWeight();
+
+        if (_voteType == uint8(VoteType.YES)) {
+            proposal.yesVotes += totalWeightForThisVoteTransaction;
+        } else if (_voteType == uint8(VoteType.NO)) {
+            proposal.noVotes += totalWeightForThisVoteTransaction;
+        } else if (_voteType == uint8(VoteType.ABSTAIN)) {
+            proposal.abstainVotes += totalWeightForThisVoteTransaction;
+        } else {
+            revert InvalidVoteType();
+        }
+
+        emit Voted(
+            resolvedVoter,
+            _proposalId,
+            VoteType(_voteType),
+            totalWeightForThisVoteTransaction
+        );
+    }
+
+    function isQuorumMet(
+        uint32 _proposalId
+    ) public view virtual override returns (bool) {
+        ProposalVotingDetails storage proposal = proposalVotingDetails[
+            _proposalId
+        ];
+
+        if (proposal.votingEndTimestamp == 0) {
+            revert ProposalNotInitialized();
+        }
+
+        uint256 totalVotesForQuorum = proposal.yesVotes + proposal.abstainVotes;
+        return totalVotesForQuorum >= quorumThreshold;
+    }
+
+    function isBasisMet(
+        uint32 _proposalId
+    ) public view virtual override returns (bool) {
+        ProposalVotingDetails storage proposal = proposalVotingDetails[
+            _proposalId
+        ];
+
+        if (proposal.votingEndTimestamp == 0) {
+            revert ProposalNotInitialized();
+        }
+
+        return
+            (proposal.yesVotes * BASIS_DENOMINATOR) >
+            ((proposal.yesVotes + proposal.noVotes) * basisNumerator);
+    }
+
     function isPassed(
         uint32 _proposalId
     ) external view virtual override returns (bool) {
@@ -216,7 +314,7 @@ contract StrategyV1 is
             return false;
         }
 
-        return true;
+        return isQuorumMet(_proposalId) && isBasisMet(_proposalId);
     }
 
     function isProposer(

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -15,4 +15,15 @@ interface IStrategyV1 is IStrategyBaseV1 {
     function removeAdapter(address _adapter) external;
 
     function getTokenAdapterCount() external view returns (uint256);
+
+    function isQuorumMet(uint32 _proposalId) external view returns (bool);
+
+    function isBasisMet(uint32 _proposalId) external view returns (bool);
+
+    function vote(
+        uint32 _proposalId,
+        uint8 _voteType,
+        address[] calldata _adaptersToUse,
+        bytes[] calldata _adapterVoteData
+    ) external;
 }

--- a/contracts/interfaces/decent/deployables/ITokenAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/ITokenAdapterBaseV1.sol
@@ -3,4 +3,10 @@ pragma solidity ^0.8.30;
 
 interface ITokenAdapterBaseV1 {
     function isProposer(address _proposer) external view returns (bool);
+
+    function recordVote(
+        address _voter,
+        uint32 _proposalId,
+        bytes calldata _adapterVoteData
+    ) external returns (uint256 weightCasted);
 }

--- a/contracts/mocks/MockLightAccount.sol
+++ b/contracts/mocks/MockLightAccount.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {ILightAccount} from "../interfaces/light-account/ILightAccount.sol";
+import {IStrategyV1} from "../interfaces/decent/deployables/IStrategyV1.sol";
 
 contract MockLightAccount is ILightAccount {
     address private _owner;
@@ -10,7 +11,7 @@ contract MockLightAccount is ILightAccount {
         _owner = initialOwner;
     }
 
-    function owner() external view returns (address) {
+    function owner() external view override returns (address) {
         return _owner;
     }
 
@@ -22,7 +23,20 @@ contract MockLightAccount is ILightAccount {
         address target,
         uint256 value,
         bytes calldata data
+    ) external override {
+        // Empty implementation - we only need this for generating calldata or other tests
+    }
+
+    // New function to interact with StrategyV1
+    function callStrategyVote(
+        IStrategyV1 strategy,
+        uint32 proposalId,
+        uint8 voteType,
+        address[] calldata adaptersToUse,
+        bytes[] calldata adapterVoteData
     ) external {
-        // Empty implementation - we only need this for generating calldata
+        // msg.sender here is the EOA calling MockLightAccount (e.g., relayer)
+        // When strategy.vote is called, msg.sender from StrategyV1's perspective will be address(this)
+        strategy.vote(proposalId, voteType, adaptersToUse, adapterVoteData);
     }
 }

--- a/contracts/mocks/MockTokenAdapter.sol
+++ b/contracts/mocks/MockTokenAdapter.sol
@@ -5,6 +5,38 @@ import {ITokenAdapterBaseV1} from "../interfaces/decent/deployables/ITokenAdapte
 
 contract MockTokenAdapter is ITokenAdapterBaseV1 {
     mapping(address => bool) public proposerStatusToReturn;
+    mapping(address => uint256) public weightsToReturn;
+    mapping(address => mapping(uint32 => mapping(bytes32 => uint256)))
+        public recordedVotesWeight;
+    mapping(address => mapping(uint32 => mapping(bytes32 => bool)))
+        public hasRecordedVote;
+    bool public shouldRevertRecordVote;
+    address public lastVoterForRecordVote;
+    uint32 public lastProposalIdForRecordVote;
+
+    function recordVote(
+        address _voter,
+        uint32 _proposalId,
+        bytes calldata _adapterVoteData
+    ) external override returns (uint256 weightCasted) {
+        if (shouldRevertRecordVote) {
+            revert("MockTokenAdapter: recordVote forced revert");
+        }
+
+        lastVoterForRecordVote = _voter;
+        lastProposalIdForRecordVote = _proposalId;
+
+        bytes32 dataHash = keccak256(_adapterVoteData);
+        uint256 weightToRecord = weightsToReturn[_voter];
+
+        if (hasRecordedVote[_voter][_proposalId][dataHash]) {
+            return 0;
+        }
+
+        recordedVotesWeight[_voter][_proposalId][dataHash] = weightToRecord;
+        hasRecordedVote[_voter][_proposalId][dataHash] = true;
+        return weightToRecord;
+    }
 
     function isProposer(
         address _proposer
@@ -16,5 +48,13 @@ contract MockTokenAdapter is ITokenAdapterBaseV1 {
 
     function setProposerStatus(address _proposer, bool _isProposer) external {
         proposerStatusToReturn[_proposer] = _isProposer;
+    }
+
+    function setWeight(address _voter, uint256 _weight) external {
+        weightsToReturn[_voter] = _weight;
+    }
+
+    function setShouldRevertOnRecordVote(bool _shouldRevert) external {
+        shouldRevertRecordVote = _shouldRevert;
     }
 }

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -1,4 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -6,6 +7,7 @@ import {
   IERC165__factory,
   IStrategyBaseV1__factory,
   IStrategyV1__factory,
+  MockLightAccount__factory,
   MockLightAccountFactory,
   MockLightAccountFactory__factory,
   MockTokenAdapter,
@@ -23,6 +25,7 @@ describe('StrategyV1', () => {
   let azoriusMock: SignerWithAddress; // To simulate calls from Azorius
   let nonOwner: SignerWithAddress;
   let user1: SignerWithAddress;
+  let voter1: SignerWithAddress, voter2: SignerWithAddress, voter3: SignerWithAddress;
 
   // Contract Instances
   let strategyImplementation: StrategyV1;
@@ -71,7 +74,8 @@ describe('StrategyV1', () => {
   }
 
   beforeEach(async () => {
-    [deployer, owner, azoriusMock, nonOwner, user1] = await ethers.getSigners();
+    [deployer, owner, azoriusMock, nonOwner, user1, voter2, voter3] = await ethers.getSigners();
+    voter1 = user1; // Alias for clarity in some tests
 
     strategyImplementation = await new StrategyV1__factory(deployer).deploy();
     await strategyImplementation.waitForDeployment();
@@ -483,7 +487,7 @@ describe('StrategyV1', () => {
     });
   });
 
-  describe('getVotingTimestamps & getProposalBlocks', () => {
+  describe('getVotingTimestamps', () => {
     let proposalId: number;
     let encodedProposalId: string;
 
@@ -517,6 +521,261 @@ describe('StrategyV1', () => {
     });
   });
 
+  describe('vote', () => {
+    let proposalId: number;
+    let encodedProposalId: string;
+    let adapter1Data: string; // abi.encode(tokenId[]) for ERC721, or empty for ERC20
+    let adapter2Data: string;
+
+    beforeEach(async () => {
+      proposalId = 1;
+      encodedProposalId = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
+
+      // Add at least one adapter for most tests
+      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      // Initialize the proposal by azoriusMock
+      await strategy
+        .connect(azoriusMock)
+        .initializeProposal(encodedProposalId, [], ethers.ZeroHash);
+
+      // Example adapter data (can be customized per test)
+      // For ERC20Adapter, this would typically be ethers.AbiCoder.defaultAbiCoder().encode([], []); (empty)
+      // For ERC721Adapter, ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[101, 102]]);
+      adapter1Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[1]]); // Mocking ERC721 style data
+      adapter2Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[2]]);
+
+      // Deploy MockLightAccount for ERC4337 tests if not already available globally
+      // For this specific test, we might deploy it inside if needed fresh
+    });
+
+    it('should revert if _adaptersToUse and _adapterVoteData lengths mismatch', async () => {
+      const adaptersToUse = [mockAdapter1]; // 1 adapter
+      const adapterVoteData: string[] = []; // 0 data entries
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1, adaptersToUse, adapterVoteData),
+      ).to.be.revertedWithCustomError(strategy, 'MismatchedInputs');
+    });
+
+    it('should revert if proposal is not initialized (votingEndTimestamp is 0)', async () => {
+      const uninitializedProposalId = 999;
+      await expect(
+        strategy.connect(user1).vote(uninitializedProposalId, 1, [mockAdapter1], [adapter1Data]),
+      ).to.be.revertedWithCustomError(strategy, 'ProposalNotFoundOrNotActive');
+    });
+
+    it('should revert if voting period has ended', async () => {
+      // Advance time beyond voting period
+      const proposalDetails = await strategy.proposalVotingDetails(proposalId);
+      await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1, [mockAdapter1], [adapter1Data]),
+      ).to.be.revertedWithCustomError(strategy, 'ProposalNotFoundOrNotActive');
+    });
+
+    it('should revert if total weight cast is zero (e.g., adapter.recordVote returns 0)', async () => {
+      await mockAdapter1.connect(owner).setWeight(user1.address, 0); // Ensure recordVote (via setWeight) returns 0
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1, [mockAdapter1], [adapter1Data]),
+      ).to.be.revertedWithCustomError(strategy, 'NoVotingWeight');
+    });
+
+    it('should revert on invalid voteType', async () => {
+      const invalidVoteType = 3; // VoteType enum is 0, 1, 2
+      await mockAdapter1.connect(owner).setWeight(user1.address, 10); // Give some weight
+      await expect(
+        strategy.connect(user1).vote(proposalId, invalidVoteType, [mockAdapter1], [adapter1Data]),
+      ).to.be.revertedWithCustomError(strategy, 'InvalidVoteType');
+    });
+
+    it('should revert with InvalidAdapterProvidedInVote if an adapter in _adaptersToUse is not configured in the strategy', async () => {
+      const unconfiguredAdapter = await new MockTokenAdapter__factory(deployer).deploy();
+      await unconfiguredAdapter.waitForDeployment();
+      const unconfiguredAdapterAddress = await unconfiguredAdapter.getAddress();
+
+      // mockAdapter1 is configured from the beforeEach of the parent 'vote' describe block
+      await mockAdapter1.setWeight(user1.address, 10);
+
+      const adaptersToUse = [await mockAdapter1.getAddress(), unconfiguredAdapterAddress];
+      const adapterDataArray = [adapter1Data, adapter1Data]; // Dummy data for both
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1 /* YES */, adaptersToUse, adapterDataArray),
+      ).to.be.revertedWithCustomError(strategy, 'InvalidAdapterProvidedInVote');
+    });
+
+    it('should correctly record a YES vote, update counts, and emit Voted event', async () => {
+      const voteWeight = 100;
+      await mockAdapter1.connect(owner).setWeight(user1.address, voteWeight);
+
+      const tx = await strategy
+        .connect(user1)
+        .vote(proposalId, 1 /* YES */, [mockAdapter1], [adapter1Data]);
+
+      await expect(tx)
+        .to.emit(strategy, 'Voted')
+        .withArgs(user1.address, proposalId, 1 /* YES */, voteWeight);
+
+      const proposalDetails = await strategy.proposalVotingDetails(proposalId);
+      expect(proposalDetails.yesVotes).to.equal(voteWeight);
+      expect(proposalDetails.noVotes).to.equal(0);
+      expect(proposalDetails.abstainVotes).to.equal(0);
+
+      // Verify adapter's recordVote was called (using our mock's state)
+      expect(await mockAdapter1.lastVoterForRecordVote()).to.equal(user1.address);
+      expect(await mockAdapter1.lastProposalIdForRecordVote()).to.equal(proposalId);
+      // Note: MockTokenAdapter currently doesn't store lastAdapterDataForRecordVote to save gas
+      // but we can check if it was recorded if needed by enhancing the mock.
+      expect(
+        await mockAdapter1.recordedVotesWeight(
+          user1.address,
+          proposalId,
+          ethers.keccak256(adapter1Data),
+        ),
+      ).to.equal(voteWeight);
+    });
+
+    it('should correctly record a NO vote', async () => {
+      const voteWeight = 50;
+      await mockAdapter1.connect(owner).setWeight(user1.address, voteWeight);
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 0 /* NO */, [mockAdapter1], [adapter1Data]),
+      )
+        .to.emit(strategy, 'Voted')
+        .withArgs(user1.address, proposalId, 0 /* NO */, voteWeight);
+
+      const proposalDetails = await strategy.proposalVotingDetails(proposalId);
+      expect(proposalDetails.noVotes).to.equal(voteWeight);
+      expect(proposalDetails.yesVotes).to.equal(0);
+      expect(proposalDetails.abstainVotes).to.equal(0);
+    });
+
+    it('should correctly record an ABSTAIN vote', async () => {
+      const voteWeight = 25;
+      await mockAdapter1.connect(owner).setWeight(user1.address, voteWeight);
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 2 /* ABSTAIN */, [mockAdapter1], [adapter1Data]),
+      )
+        .to.emit(strategy, 'Voted')
+        .withArgs(user1.address, proposalId, 2 /* ABSTAIN */, voteWeight);
+
+      const proposalDetails = await strategy.proposalVotingDetails(proposalId);
+      expect(proposalDetails.abstainVotes).to.equal(voteWeight);
+      expect(proposalDetails.yesVotes).to.equal(0);
+      expect(proposalDetails.noVotes).to.equal(0);
+    });
+
+    it('should sum weights if multiple adapters are used in one vote call', async () => {
+      // Add second adapter to the strategy for this test
+      await strategy.connect(owner).addAdapter(await mockAdapter2.getAddress());
+
+      const weight1 = 60;
+      const weight2 = 40;
+      await mockAdapter1.connect(owner).setWeight(user1.address, weight1);
+      await mockAdapter2.connect(owner).setWeight(user1.address, weight2); // user1 votes with both adapters
+
+      const adaptersToUse = [mockAdapter1, mockAdapter2];
+      const adapterVoteDataArray = [adapter1Data, adapter2Data]; // Assuming different data for each or just placeholders
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1 /* YES */, adaptersToUse, adapterVoteDataArray),
+      )
+        .to.emit(strategy, 'Voted')
+        .withArgs(user1.address, proposalId, 1 /* YES */, weight1 + weight2);
+
+      const proposalDetails = await strategy.proposalVotingDetails(proposalId);
+      expect(proposalDetails.yesVotes).to.equal(weight1 + weight2);
+    });
+
+    it('should support ERC4337 by using the resolved voter address', async () => {
+      const smartAccountOwner = user1;
+      const relayer = nonOwner;
+
+      // 1. Deploy MockLightAccount directly, owned by smartAccountOwner
+      const mockLightAccountDeployedFactory = new MockLightAccount__factory(deployer);
+      const mockSmartAccount = await mockLightAccountDeployedFactory.deploy(
+        smartAccountOwner.address,
+      );
+      await mockSmartAccount.waitForDeployment();
+      const mockSmartAccountAddress = await mockSmartAccount.getAddress();
+
+      // 2. IMPORTANT: Configure the lightAccountFactoryMock (used by StrategyV1) to correctly resolve this smart account
+      await lightAccountFactoryMock.setAccountAddress(
+        smartAccountOwner.address,
+        0,
+        mockSmartAccountAddress,
+      );
+
+      const voteWeight = 77;
+      // Set weight for the smartAccountOwner (user1) in the mock adapter
+      await mockAdapter1.connect(owner).setWeight(smartAccountOwner.address, voteWeight);
+
+      const tx = await mockSmartAccount
+        .connect(relayer)
+        .callStrategyVote(
+          await strategy.getAddress(),
+          proposalId,
+          1 /* YES */,
+          [await mockAdapter1.getAddress()],
+          [adapter1Data],
+        );
+
+      await expect(tx)
+        .to.emit(strategy, 'Voted')
+        .withArgs(smartAccountOwner.address, proposalId, 1 /* YES */, voteWeight);
+
+      const proposalDetails = await strategy.proposalVotingDetails(proposalId);
+      expect(proposalDetails.yesVotes).to.equal(voteWeight);
+
+      expect(await mockAdapter1.lastVoterForRecordVote()).to.equal(smartAccountOwner.address);
+    });
+
+    it('should revert if an adapter call to recordVote reverts', async () => {
+      await mockAdapter1.connect(owner).setWeight(user1.address, 10);
+      await mockAdapter1.setShouldRevertOnRecordVote(true); // Configure mock to revert
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1 /* YES */, [mockAdapter1], [adapter1Data]),
+      ).to.be.revertedWith('MockTokenAdapter: recordVote forced revert');
+    });
+
+    it('should revert if any adapter call reverts in a multi-adapter vote (all-or-nothing)', async () => {
+      await strategy.connect(owner).addAdapter(await mockAdapter2.getAddress());
+
+      await mockAdapter1.connect(owner).setWeight(user1.address, 10);
+      await mockAdapter2.connect(owner).setWeight(user1.address, 20);
+
+      await mockAdapter1.setShouldRevertOnRecordVote(false); // Adapter 1 should succeed initially
+      await mockAdapter2.setShouldRevertOnRecordVote(true); // Adapter 2 will revert
+
+      const adaptersToUse = [mockAdapter1, mockAdapter2];
+      const adapterDataForVoter1Adapter1 = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[777]],
+      );
+      const adapterDataForVoter1Adapter2 = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[888]],
+      );
+      const adapterVoteDataArray = [adapterDataForVoter1Adapter1, adapterDataForVoter1Adapter2];
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1 /* YES */, adaptersToUse, adapterVoteDataArray),
+      ).to.be.revertedWith('MockTokenAdapter: recordVote forced revert');
+
+      const proposalDetails = await strategy.proposalVotingDetails(proposalId);
+      expect(proposalDetails.yesVotes).to.equal(0);
+      expect(proposalDetails.noVotes).to.equal(0);
+      expect(proposalDetails.abstainVotes).to.equal(0);
+
+      const dataHashAdapter1 = ethers.keccak256(adapterDataForVoter1Adapter1);
+      void expect(await mockAdapter1.hasRecordedVote(user1.address, proposalId, dataHashAdapter1))
+        .to.be.false;
+    });
+  });
+
   describe('isPassed', () => {
     const PROPOSAL_ID = 1;
     // This beforeEach ensures that for each test in this describe block,
@@ -534,6 +793,71 @@ describe('StrategyV1', () => {
         strategy,
         'ProposalNotInitialized',
       );
+    });
+
+    it('should return false if voting period is not over', async () => {
+      // Proposal PROPOSAL_ID is initialized by this describe block's beforeEach.
+      await mockAdapter1.setWeight(voter1.address, DEFAULT_QUORUM_THRESHOLD + 10n);
+      await strategy
+        .connect(voter1)
+        .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+      void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.false; // Voting not over
+    });
+
+    it('should return true if quorum and basis are met and voting is over', async () => {
+      await mockAdapter1.setWeight(voter1.address, DEFAULT_QUORUM_THRESHOLD + 10n);
+      await strategy
+        .connect(voter1)
+        .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+
+      const proposalDetails = await strategy.proposalVotingDetails(PROPOSAL_ID);
+      await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
+
+      void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.true;
+    });
+
+    it('should return false if quorum is met but basis is not, after voting period', async () => {
+      await strategy.connect(owner).updateQuorumThreshold(50n);
+      await strategy.connect(owner).updateBasisNumerator(500_001n);
+
+      await mockAdapter1.setWeight(voter1.address, 50n);
+      await mockAdapter1.setWeight(voter2.address, 50n);
+      await mockAdapter1.setWeight(voter3.address, 10n);
+
+      await strategy
+        .connect(voter1)
+        .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+      await strategy
+        .connect(voter2)
+        .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+      await strategy
+        .connect(voter3)
+        .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
+
+      const proposalDetails = await strategy.proposalVotingDetails(PROPOSAL_ID);
+      await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
+
+      void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.false;
+    });
+
+    it('should return false if basis is met but quorum is not, after voting period', async () => {
+      await strategy.connect(owner).updateQuorumThreshold(100n);
+      await strategy.connect(owner).updateBasisNumerator(500_001n);
+
+      await mockAdapter1.setWeight(voter1.address, 60n);
+      await mockAdapter1.setWeight(voter2.address, 10n);
+
+      await strategy
+        .connect(voter1)
+        .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+      await strategy
+        .connect(voter2)
+        .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+
+      const proposalDetails = await strategy.proposalVotingDetails(PROPOSAL_ID);
+      await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
+
+      void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.false;
     });
   });
 
@@ -697,6 +1021,198 @@ describe('StrategyV1', () => {
   describe('Version', () => {
     it('should return the correct version', async () => {
       void expect(await strategy.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('Quorum and Basis Checks', () => {
+    const PROPOSAL_ID = 1;
+
+    beforeEach(async () => {
+      const adapterCount = await strategy.getTokenAdapterCount();
+      if (adapterCount === 0n) {
+        await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      }
+
+      await strategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+    });
+
+    describe('isQuorumMet', () => {
+      it('should revert if proposal not initialized', async () => {
+        await expect(strategy.isQuorumMet(999)).to.be.revertedWithCustomError(
+          strategy,
+          'ProposalNotInitialized',
+        );
+      });
+
+      it('should return true if quorum is met exactly (yes + abstain == threshold)', async () => {
+        const quorum = 100n;
+        await strategy.connect(owner).updateQuorumThreshold(quorum);
+        await mockAdapter1.setWeight(voter1.address, 60n);
+        await mockAdapter1.setWeight(voter2.address, 40n);
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        await strategy
+          .connect(voter2)
+          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
+      });
+
+      it('should return true if quorum is exceeded (yes + abstain > threshold)', async () => {
+        const quorum = 100n;
+        await strategy.connect(owner).updateQuorumThreshold(quorum);
+        await mockAdapter1.setWeight(voter1.address, 60n);
+        await mockAdapter1.setWeight(voter2.address, 41n); // Exceeds
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        await strategy
+          .connect(voter2)
+          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
+      });
+
+      it('should return false if quorum is not met (yes + abstain < threshold)', async () => {
+        const quorum = 100n;
+        await strategy.connect(owner).updateQuorumThreshold(quorum);
+        await mockAdapter1.setWeight(voter1.address, 50n);
+        await mockAdapter1.setWeight(voter2.address, 40n); // 90 total, < 100
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        await strategy
+          .connect(voter2)
+          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should return true if quorum threshold is 0, even with no votes contributing to quorum count', async () => {
+        await strategy.connect(owner).updateQuorumThreshold(0n);
+        await mockAdapter1.setWeight(voter1.address, 10n); // Only NO votes
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
+      });
+
+      it('should return false if only NO votes are cast and quorum threshold > 0', async () => {
+        const quorum = 100n;
+        await strategy.connect(owner).updateQuorumThreshold(quorum);
+        await mockAdapter1.setWeight(voter1.address, 150n); // Sufficient weight, but wrong type
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
+      });
+    });
+
+    describe('isBasisMet', () => {
+      it('should revert if proposal not initialized', async () => {
+        await expect(strategy.isBasisMet(999)).to.be.revertedWithCustomError(
+          strategy,
+          'ProposalNotInitialized',
+        );
+      });
+
+      it('should return true if basis is met (yes > no for >50% basis)', async () => {
+        // Default basis is 500,001 / 1,000,000 (requires yes > no)
+        await mockAdapter1.setWeight(voter1.address, 101n);
+        await mockAdapter1.setWeight(voter2.address, 100n);
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        await strategy
+          .connect(voter2)
+          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.true;
+      });
+
+      it('should return false if basis is not met (yes == no for >50% basis)', async () => {
+        await mockAdapter1.setWeight(voter1.address, 100n);
+        await mockAdapter1.setWeight(voter2.address, 100n);
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        await strategy
+          .connect(voter2)
+          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should return false if basis is not met (yes < no for >50% basis)', async () => {
+        await mockAdapter1.setWeight(voter1.address, 99n);
+        await mockAdapter1.setWeight(voter2.address, 100n);
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        await strategy
+          .connect(voter2)
+          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should return false if totalYesAndNoVotes is 0 (only abstain)', async () => {
+        await mockAdapter1.setWeight(voter1.address, 100n);
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should return true if basisNumerator is 500,000 (50%) and yes > no', async () => {
+        await strategy.connect(owner).updateBasisNumerator(500_000n);
+        await mockAdapter1.setWeight(voter1.address, 101n);
+        await mockAdapter1.setWeight(voter2.address, 100n);
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        await strategy
+          .connect(voter2)
+          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.true;
+      });
+
+      it('should return false if basisNumerator is 500,000 (50%) and yes == no', async () => {
+        await strategy.connect(owner).updateBasisNumerator(500_000n);
+        await mockAdapter1.setWeight(voter1.address, 100n);
+        await mockAdapter1.setWeight(voter2.address, 100n);
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        await strategy
+          .connect(voter2)
+          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+      });
+
+      it('should return true if basisNumerator is max valid (DENOMINATOR - 1) and yes > 0, no == 0', async () => {
+        const maxValidBasis = 1_000_000n - 1n;
+        await strategy.connect(owner).updateBasisNumerator(maxValidBasis);
+        await mockAdapter1.setWeight(voter1.address, 100n);
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        // (100 * 1M) > (100 * (1M-1)) => 100M > 100M - 100. This is true.
+        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.true;
+      });
+
+      it('should return false if basisNumerator is max valid (DENOMINATOR - 1) and yes > 0, no > 0', async () => {
+        const maxValidBasis = 1_000_000n - 1n;
+        await strategy.connect(owner).updateBasisNumerator(maxValidBasis);
+        await mockAdapter1.setWeight(voter1.address, 100n);
+        await mockAdapter1.setWeight(voter2.address, 1n); // Add one NO vote
+        await strategy
+          .connect(voter1)
+          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        await strategy
+          .connect(voter2)
+          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+        // yes = 100, no = 1, totalYesNo = 101
+        // (100 * 1M) > (101 * (1M-1))
+        // 100_000_000 > 101_000_000 - 101
+        // 100_000_000 > 100_999_899. This is false.
+        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/270

Fixes [ENG-932](https://linear.app/decent-labs/issue/ENG-932/implement-core-voting-logic-and-outcome-determination-in-strategyv1)

**High-Level Context:**

This Pull Request builds upon the foundational `StrategyV1` and Token Adapter infrastructure. It implements the core `vote` function within `StrategyV1`, enabling it to process votes using multiple token adapters. Additionally, it introduces the logic for determining proposal outcomes through `isPassed`, `isQuorumMet`, and `isBasisMet` functions. Corresponding updates are made to the `IStrategyV1` interface, as well as mock contracts, to support these new functionalities.

**Changes in this PR:**

**1. `StrategyV1.sol` Enhancements:**
    *   **`vote` Function Implementation:**
        *   Signature: `vote(uint32 _proposalId, uint8 _voteType, address[] calldata _adaptersToUse, bytes[] calldata _adapterVoteData)`
        *   Validates that `_adaptersToUse` and `_adapterVoteData` arrays have matching lengths (reverts with `MismatchedInputs` otherwise).
        *   Resolves the actual voter address using `ERC4337VoterSupportV1.voter(msg.sender)`.
        *   Checks if the proposal is active (reverts with `ProposalNotFoundOrNotActive` if `votingEndTimestamp == 0` or `block.timestamp > votingEndTimestamp`).
        *   Iterates through `_adaptersToUse`:
            *   Verifies that each adapter address provided in `_adaptersToUse` is a valid, configured adapter within `this.tokenAdapters` (reverts with `InvalidAdapterProvidedInVote` if not found).
            *   Calls `recordVote(resolvedVoter, _proposalId, _adapterVoteData[i])` on the corresponding configured adapter instance.
            *   Sums the `weightCasted` returned by each adapter.
        *   Reverts with `NoVotingWeight` if `totalWeightForThisVoteTransaction` is 0.
        *   Updates `proposal.yesVotes`, `proposal.noVotes`, or `proposal.abstainVotes` based on `_voteType`.
        *   Reverts with `InvalidVoteType` if `_voteType` is invalid.
        *   Emits a `Voted` event with `resolvedVoter`, `_proposalId`, `_voteType`, and `totalWeightForThisVoteTransaction`.
    *   **Quorum and Basis Logic:**
        *   `isQuorumMet(uint32 _proposalId)`: New `public view virtual override` function. Reverts with `ProposalNotInitialized` if `proposal.votingEndTimestamp == 0`. Returns `true` if `proposal.yesVotes + proposal.abstainVotes >= quorumThreshold`.
        *   `isBasisMet(uint32 _proposalId)`: New `public view virtual override` function. Reverts with `ProposalNotInitialized` if `proposal.votingEndTimestamp == 0`. Returns `false` if `proposal.yesVotes + proposal.noVotes == 0`. Otherwise, returns `(proposal.yesVotes * BASIS_DENOMINATOR) > ((proposal.yesVotes + proposal.noVotes) * basisNumerator)`.
    *   **`isPassed` Function Update:**
        *   Now calls `isQuorumMet(_proposalId) && isBasisMet(_proposalId)` after checking if the voting period is over.
    *   **`getVotingStartBlock` Function:**
        *   New `external view virtual override` function to return `proposalVotingDetails[_proposalId].votingStartBlock`. Reverts with `ProposalNotInitialized` if proposal doesn't exist.

**2. Interface Updates:**
    *   **`IStrategyV1.sol`:**
        *   Added `isQuorumMet(uint32 _proposalId) external view returns (bool);`
        *   Added `isBasisMet(uint32 _proposalId) external view returns (bool);`
        *   Added `getVotingStartBlock(uint32 _proposalId) external view returns (uint32 votingStartBlock);`
        *   Added the full `vote(uint32, uint8, address[], bytes[]) external;` function signature.

**3. Mock Contract Updates:**
    *   **`MockLightAccount.sol`:** Added `callStrategyVote(...)` to facilitate testing `StrategyV1.vote()` called by a smart account.
    *   **`MockTokenAdapter.sol`:**
        *   Implemented `weightOf(...)` returning `weightsToReturn[_voter]`.
        *   Implemented `recordVote(...)` which:
            *   Can be configured to revert via `setShouldRevertOnRecordVote`.
            *   Tracks `lastVoterForRecordVote`, `lastProposalIdForRecordVote`.
            *   Stores `recordedVotesWeight` and `hasRecordedVote` based on `keccak256(_adapterVoteData)`.
            *   Returns `0` if `hasRecordedVote` is true for the given data, otherwise returns `weightsToReturn[_voter]`.
    *   **`MockVotingStrategy.sol`:** Updated to implement the new functions from `IStrategyV1` (`isQuorumMet`, `isBasisMet`, `getVotingStartBlock`, and the new `vote` signature).

**Impact and Status:**

*   This PR implements the core voting and outcome determination mechanisms for the new `StrategyV1`.
*   **Compilation Status:** All contracts, including the newly introduced `StrategyV1`, `ERC20AdapterV1`, `ERC721AdapterV1`, and their interfaces, along with updated mocks, should now **compile successfully**.
*   **Testing Status:** The associated `StrategyV1.test.ts` introduces tests for the new `vote` logic, quorum, basis, and proposal outcome checks. While these specific tests should pass, the **overall project test suite may still require adjustments** in other areas (e.g., `AzoriusV1.test.ts` might need updates to how it sets up mock strategy states for `isPassed` to correctly reflect the new quorum/basis logic). End-to-end tests will be crucial.