### PR TITLE
feat(StrategyV1): Add Voting Start Block Tracking

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -32,6 +32,7 @@ contract StrategyV1 is
     struct ProposalVotingDetails {
         uint48 votingStartTimestamp;
         uint48 votingEndTimestamp;
+        uint32 votingStartBlock;
         uint256 yesVotes;
         uint256 noVotes;
         uint256 abstainVotes;
@@ -62,7 +63,8 @@ contract StrategyV1 is
     event ProposalInitialized(
         uint32 indexed proposalId,
         uint48 votingStartTimestamp,
-        uint48 votingEndTimestamp
+        uint48 votingEndTimestamp,
+        uint32 votingStartBlock
     );
 
     error InvalidAzoriusAddress();
@@ -190,6 +192,7 @@ contract StrategyV1 is
         ];
         proposal.votingStartTimestamp = uint48(block.timestamp);
         proposal.votingEndTimestamp = uint48(block.timestamp + votingPeriod);
+        proposal.votingStartBlock = uint32(block.number);
         proposal.yesVotes = 0;
         proposal.noVotes = 0;
         proposal.abstainVotes = 0;
@@ -197,7 +200,8 @@ contract StrategyV1 is
         emit ProposalInitialized(
             proposalId,
             proposal.votingStartTimestamp,
-            proposal.votingEndTimestamp
+            proposal.votingEndTimestamp,
+            proposal.votingStartBlock
         );
     }
 
@@ -343,6 +347,16 @@ contract StrategyV1 is
         ];
         if (details.votingEndTimestamp == 0) revert ProposalNotInitialized();
         return (details.votingStartTimestamp, details.votingEndTimestamp);
+    }
+
+    function getVotingStartBlock(
+        uint32 _proposalId
+    ) external view virtual override returns (uint32 votingStartBlock) {
+        ProposalVotingDetails storage details = proposalVotingDetails[
+            _proposalId
+        ];
+        if (details.votingEndTimestamp == 0) revert ProposalNotInitialized();
+        return details.votingStartBlock;
     }
 
     function _updateVotingPeriod(uint32 _newVotingPeriod) internal {

--- a/contracts/interfaces/decent/deployables/IStrategyBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyBaseV1.sol
@@ -15,4 +15,8 @@ interface IStrategyBaseV1 {
     function getVotingTimestamps(
         uint32 _proposalId
     ) external view returns (uint48 startTime, uint48 endTime);
+
+    function getVotingStartBlock(
+        uint32 _proposalId
+    ) external view returns (uint32 votingStartBlock);
 }

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -40,6 +40,10 @@ contract MockVotingStrategy is IStrategyBaseV1 {
         return (timestamps.startTimestamp, timestamps.endTimestamp);
     }
 
+    function getVotingStartBlock(
+        uint32 _proposalId
+    ) external view override returns (uint32 votingStartBlock) {}
+
     // mock setters
 
     function setIsPassed(uint32 proposalId, bool passed) external {

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -409,6 +409,7 @@ describe('StrategyV1', () => {
       const blockBefore = await ethers.provider.getBlock('latest');
       if (!blockBefore) throw new Error('Failed to get latest block');
       const timestampBefore = blockBefore.timestamp;
+      const blockNumberBefore = blockBefore.number;
 
       await expect(
         strategy
@@ -420,6 +421,7 @@ describe('StrategyV1', () => {
           defaultProposalId,
           timestampBefore + 1, // Approximate, depends on block mining time
           timestampBefore + 1 + DEFAULT_VOTING_PERIOD, // Approximate
+          blockNumberBefore + 1,
         );
 
       const proposalDetails = await strategy.proposalVotingDetails(defaultProposalId);
@@ -428,6 +430,7 @@ describe('StrategyV1', () => {
         timestampBefore + 1 + DEFAULT_VOTING_PERIOD,
         2,
       );
+      expect(proposalDetails.votingStartBlock).to.equal(blockNumberBefore + 1);
       expect(proposalDetails.yesVotes).to.equal(0);
       expect(proposalDetails.noVotes).to.equal(0);
       expect(proposalDetails.abstainVotes).to.equal(0);
@@ -487,7 +490,7 @@ describe('StrategyV1', () => {
     });
   });
 
-  describe('getVotingTimestamps', () => {
+  describe('getVotingTimestamps & getVotingStartBlock', () => {
     let proposalId: number;
     let encodedProposalId: string;
 
@@ -498,25 +501,35 @@ describe('StrategyV1', () => {
       await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
     });
 
-    it('should return correct timestamps after proposal initialization', async () => {
+    it('should return correct timestamps and block after proposal initialization', async () => {
       const blockBefore = await ethers.provider.getBlock('latest');
       if (!blockBefore) throw new Error('Failed to get latest block');
       const timestampBefore = blockBefore.timestamp;
+      const blockNumberBefore = blockBefore.number;
 
       await strategy
         .connect(azoriusMock)
         .initializeProposal(encodedProposalId, [], ethers.ZeroHash);
 
       const [startTime, endTime] = await strategy.getVotingTimestamps(proposalId);
+      const startBlock = await strategy.getVotingStartBlock(proposalId);
 
       expect(startTime).to.be.closeTo(timestampBefore + 1, 2);
       expect(endTime).to.be.closeTo(timestampBefore + 1 + DEFAULT_VOTING_PERIOD, 2);
+      expect(startBlock).to.equal(blockNumberBefore + 1);
     });
 
     it('getVotingTimestamps should revert if proposal is not initialized', async () => {
       const uninitializedProposalId = 999;
       await expect(
         strategy.getVotingTimestamps(uninitializedProposalId),
+      ).to.be.revertedWithCustomError(strategy, 'ProposalNotInitialized');
+    });
+
+    it('getVotingStartBlock should revert if proposal is not initialized', async () => {
+      const uninitializedProposalId = 999;
+      await expect(
+        strategy.getVotingStartBlock(uninitializedProposalId),
       ).to.be.revertedWithCustomError(strategy, 'ProposalNotInitialized');
     });
   });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/271

Fixes [ENG-963](https://linear.app/decent-labs/issue/ENG-963/add-voting-start-block-tracking-to-strategyv1)

**High-Level Context:**

This Pull Request is part of a larger ongoing refactor to make our governance strategy system more flexible, particularly in how it handles time and snapshotting for different types of governance tokens. A key aspect of this is to support tokens that use block numbers for their vote snapshots, in addition to those that use timestamps. This PR introduces the necessary state and interface changes to `StrategyV1` to record and expose the block number at which a proposal's voting period begins.

**Specific Changes in this PR:**

1.  **`StrategyV1.sol` Updates:**
    *   **`ProposalVotingDetails` Struct:** Added a new field `uint32 votingStartBlock;` to store the block number when a proposal's voting commences.
    *   **`ProposalInitialized` Event:** Modified to include `uint32 votingStartBlock` as an emitted parameter, providing this information off-chain.
    *   **`initializeProposal` Function:**
        *   Now captures `uint32(block.number)` and stores it in `proposal.votingStartBlock` when a proposal is initialized.
        *   Emits the `votingStartBlock` in the `ProposalInitialized` event.
    *   **New Function `getVotingStartBlock`:**
        *   Added `function getVotingStartBlock(uint32 _proposalId) external view virtual override returns (uint32 votingStartBlock);`.
        *   This function retrieves the stored `votingStartBlock` for a given proposal.
        *   It reverts with `ProposalNotInitialized` if the proposal details (specifically `votingEndTimestamp`) haven't been set, indicating the proposal doesn't exist or isn't properly initialized.

2.  **Interface `IStrategyBaseV1.sol` Update:**
    *   Added the function signature `getVotingStartBlock(uint32 _proposalId) external view returns (uint32 votingStartBlock);` to this base strategy interface. This ensures that contracts interacting with strategies through this base interface are aware of this new capability.

3.  **`MockVotingStrategy.sol` Update:**
    *   Added an empty mock implementation for the new `getVotingStartBlock` function to satisfy the updated interface requirements for testing purposes.

4.  **`StrategyV1.test.ts` Updates:**
    *   **`initializeProposal` Tests:** Assertions have been added to verify that the `ProposalInitialized` event correctly emits the `votingStartBlock`, and that the `proposalVotingDetails` struct stores the correct `votingStartBlock` after initialization.
    *   **`getVotingTimestamps & getVotingStartBlock` Tests:** This describe block was renamed (from just `getVotingTimestamps`). New tests were added specifically for `getVotingStartBlock` to:
        *   Confirm it returns the correct block number for an initialized proposal.
        *   Verify it reverts with `ProposalNotInitialized` when called for an uninitialized proposal ID.

**Impact and Status:**

*   This change enhances `StrategyV1` by enabling it to track and provide the starting block number of a proposal's voting period. This is a necessary piece of information for correctly calculating past voting weights for governance tokens that operate on a block number-based clock mode.
*   **Compilation Status:** The contracts modified in this PR (`StrategyV1.sol`, `IStrategyBaseV1.sol`, `MockVotingStrategy.sol`) should compile successfully.
*   **Testing Status:** The new tests in `StrategyV1.test.ts` specifically for `votingStartBlock` should pass. However, given this is part of a larger refactor, the **overall project test suite may still have failures.** Full end-to-end testing and integration with `ClockModeLib` (introduced in a previous related change) and ERC20/ERC721 Adapters that utilize this `votingStartBlock` will be covered in subsequent work and test expansions.