### PR TITLE
feat(governance): Implement `ERC20AdapterV1` and Associated Tests

### DIFF
--- a/contracts/deployables/strategies/adapters/ERC20AdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20AdapterV1.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {ITokenAdapterV1} from "../../../interfaces/decent/deployables/ITokenAdapterV1.sol";
+import {ITokenAdapterBaseV1} from "../../../interfaces/decent/deployables/ITokenAdapterBaseV1.sol";
+import {IStrategyBaseV1} from "../../../interfaces/decent/deployables/IStrategyBaseV1.sol";
+import {ClockMode} from "../../../interfaces/decent/ClockMode.sol";
+import {Version} from "../../Version.sol";
+import {ClockModeLib} from "../../../libs/ClockModeLib.sol";
+import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+contract ERC20AdapterV1 is
+    ITokenAdapterV1,
+    Initializable,
+    OwnableUpgradeable,
+    UUPSUpgradeable,
+    ERC165,
+    Version
+{
+    IVotes public token;
+    IStrategyBaseV1 public strategy;
+    uint256 public proposerThreshold;
+    uint256 public weightPerToken;
+    ClockMode internal tokenClockMode;
+
+    mapping(uint32 => mapping(address => bool))
+        internal _hasCastedVoteForProposal;
+
+    uint16 public constant VERSION = 1;
+
+    event AdapterParametersUpdated(
+        uint256 newProposerThreshold,
+        uint256 newWeightPerToken
+    );
+
+    error InvalidTokenAddress();
+    error InvalidStrategyAddress();
+    error ProposalNotReadyForSnapshot();
+    error ERC20AlreadyVoted();
+    error InvalidWeightPerToken();
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address _initialOwner,
+        address _token,
+        address _strategy,
+        uint256 _proposerThreshold,
+        uint256 _weightPerToken
+    ) external initializer {
+        __Ownable_init(_initialOwner);
+        __UUPSUpgradeable_init();
+
+        if (_token == address(0)) revert InvalidTokenAddress();
+        if (_strategy == address(0)) revert InvalidStrategyAddress();
+
+        _updateWeightPerToken(_weightPerToken);
+        _updateProposerThreshold(_proposerThreshold);
+
+        token = IVotes(_token);
+        strategy = IStrategyBaseV1(_strategy);
+        tokenClockMode = ClockModeLib.getClockMode(_token);
+
+        emit AdapterParametersUpdated(proposerThreshold, weightPerToken);
+    }
+
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner {}
+
+    function updateProposerThreshold(
+        uint256 _newProposerThreshold
+    ) external onlyOwner {
+        _updateProposerThreshold(_newProposerThreshold);
+        emit AdapterParametersUpdated(proposerThreshold, weightPerToken);
+    }
+
+    function updateWeightPerToken(
+        uint256 _newWeightPerToken
+    ) external onlyOwner {
+        _updateWeightPerToken(_newWeightPerToken);
+        emit AdapterParametersUpdated(proposerThreshold, weightPerToken);
+    }
+
+    function _updateProposerThreshold(uint256 _newProposerThreshold) internal {
+        proposerThreshold = _newProposerThreshold;
+    }
+
+    function _updateWeightPerToken(uint256 _newWeightPerToken) internal {
+        if (_newWeightPerToken == 0) revert InvalidWeightPerToken();
+        weightPerToken = _newWeightPerToken;
+    }
+
+    function _getVoteWeightDetails(
+        address _voter,
+        uint32 _proposalId
+    ) internal view returns (uint256 weight) {
+        uint256 rawVotes;
+        if (tokenClockMode == ClockMode.Timestamp) {
+            (uint48 startTimestamp, ) = strategy.getVotingTimestamps(
+                _proposalId
+            );
+            if (startTimestamp == 0) revert ProposalNotReadyForSnapshot();
+            rawVotes = token.getPastVotes(_voter, startTimestamp);
+        } else {
+            uint32 startBlock = strategy.getVotingStartBlock(_proposalId);
+            if (startBlock == 0) revert ProposalNotReadyForSnapshot();
+            rawVotes = token.getPastVotes(_voter, startBlock);
+        }
+        weight = rawVotes * weightPerToken;
+    }
+
+    function weightOf(
+        address _voter,
+        uint32 _proposalId,
+        bytes calldata
+    ) external view override returns (uint256 weight) {
+        if (_hasCastedVoteForProposal[_proposalId][_voter]) {
+            return 0;
+        }
+        weight = _getVoteWeightDetails(_voter, _proposalId);
+    }
+
+    function recordVote(
+        address _voter,
+        uint32 _proposalId,
+        bytes calldata
+    ) external override returns (uint256 weightCasted) {
+        if (_hasCastedVoteForProposal[_proposalId][_voter]) {
+            revert ERC20AlreadyVoted();
+        }
+        _hasCastedVoteForProposal[_proposalId][_voter] = true;
+
+        weightCasted = _getVoteWeightDetails(_voter, _proposalId);
+
+        emit VoteRecorded(_voter, _proposalId, weightCasted, bytes(""));
+    }
+
+    function isProposer(
+        address _proposer
+    ) external view override returns (bool) {
+        uint256 rawVotes = token.getVotes(_proposer);
+        return (rawVotes * weightPerToken) >= proposerThreshold;
+    }
+
+    function getVersion() public pure override returns (uint16) {
+        return VERSION;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view override(ERC165, Version) returns (bool) {
+        return
+            interfaceId == type(ITokenAdapterV1).interfaceId ||
+            interfaceId == type(ITokenAdapterBaseV1).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/interfaces/decent/deployables/ITokenAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/ITokenAdapterBaseV1.sol
@@ -2,6 +2,13 @@
 pragma solidity ^0.8.30;
 
 interface ITokenAdapterBaseV1 {
+    event VoteRecorded(
+        address indexed voter,
+        uint32 indexed proposalId,
+        uint256 weightCasted,
+        bytes adapterVoteData
+    );
+
     function isProposer(address _proposer) external view returns (bool);
 
     function recordVote(

--- a/contracts/interfaces/decent/deployables/ITokenAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/ITokenAdapterV1.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {ITokenAdapterBaseV1} from "./ITokenAdapterBaseV1.sol";
+
+interface ITokenAdapterV1 is ITokenAdapterBaseV1 {
+    function weightOf(
+        address _voter,
+        uint32 _proposalId,
+        bytes calldata _adapterVoteData
+    ) external view returns (uint256 weight);
+}

--- a/contracts/mocks/MockERC20Votes.sol
+++ b/contracts/mocks/MockERC20Votes.sol
@@ -51,6 +51,15 @@ contract MockERC20Votes is ERC20, ERC20Permit, IVotes {
     }
 
     /**
+     * @dev Burns tokens from the specified address
+     * @param from The address to burn tokens from
+     * @param amount The amount of tokens to burn
+     */
+    function burn(address from, uint256 amount) external {
+        _burn(from, amount);
+    }
+
+    /**
      * @dev Sets a specific past voting weight for an account at a specific timepoint
      * @param account The account to set past votes for
      * @param timepoint The timepoint to set votes at

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -12,6 +12,7 @@ contract MockVotingStrategy is IStrategyBaseV1 {
     address public proposer;
     mapping(uint32 => bool) private _isPassed;
     mapping(uint32 => TimestampPoints) private _proposalTimestamps;
+    mapping(uint32 => uint32) public mockVotingStartBlock;
 
     constructor(address _proposer) {
         proposer = _proposer;
@@ -42,7 +43,9 @@ contract MockVotingStrategy is IStrategyBaseV1 {
 
     function getVotingStartBlock(
         uint32 _proposalId
-    ) external view override returns (uint32 votingStartBlock) {}
+    ) external view override returns (uint32 votingStartBlock) {
+        return mockVotingStartBlock[_proposalId];
+    }
 
     // mock setters
 
@@ -59,5 +62,12 @@ contract MockVotingStrategy is IStrategyBaseV1 {
             startTimestamp,
             endTimestamp
         );
+    }
+
+    function setVotingStartBlock(
+        uint32 proposalId,
+        uint32 startBlock
+    ) external {
+        mockVotingStartBlock[proposalId] = startBlock;
     }
 }

--- a/test/deployables/strategies/adapters/ERC20AdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20AdapterV1.test.ts
@@ -1,0 +1,782 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import type { ContractTransactionResponse } from 'ethers';
+import { ethers } from 'hardhat';
+import {
+  ERC1967Proxy__factory,
+  ERC20AdapterV1,
+  ERC20AdapterV1__factory,
+  IERC165__factory,
+  ITokenAdapterBaseV1__factory,
+  ITokenAdapterV1__factory,
+  IVersion__factory,
+  MockERC20Votes,
+  MockERC20Votes__factory,
+  MockVotingStrategy,
+  MockVotingStrategy__factory,
+} from '../../../../typechain-types';
+import { calculateInterfaceId } from '../../../helpers/utils';
+import { runUUPSUpgradeabilityTests } from '../../../helpers/uupsUpgradeabilityTests';
+
+// Modified helper function to return deployment tx hash
+async function deployERC20AdapterProxy(
+  proxyDeployer: SignerWithAddress,
+  implementationAddress: string,
+  ownerAddress: string,
+  tokenAddress: string,
+  strategyAddress: string,
+  proposerThreshold: bigint,
+  weightPerToken: bigint,
+): Promise<{ adapter: ERC20AdapterV1; deployTx: ContractTransactionResponse }> {
+  const initData = ERC20AdapterV1__factory.createInterface().encodeFunctionData('initialize', [
+    ownerAddress,
+    tokenAddress,
+    strategyAddress,
+    proposerThreshold,
+    weightPerToken,
+  ]);
+  const proxyContractFactory = new ERC1967Proxy__factory(proxyDeployer);
+  const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
+  await proxy.waitForDeployment();
+
+  const adapter = ERC20AdapterV1__factory.connect(await proxy.getAddress(), proxyDeployer);
+  const deployTx = proxy.deploymentTransaction();
+  if (!deployTx) {
+    throw new Error('Proxy deployment transaction not found');
+  }
+  return { adapter, deployTx };
+}
+
+describe('ERC20AdapterV1', () => {
+  let deployerG: SignerWithAddress;
+  let ownerG: SignerWithAddress;
+  let erc20AdapterImplementationAddressG: string;
+
+  const DEFAULT_PROPOSER_THRESHOLD = ethers.parseUnits('100', 18);
+  const DEFAULT_WEIGHT_PER_TOKEN = 1n;
+
+  async function deployGlobalFixture() {
+    const [deployer, owner, user1, user2, nonOwner] = await ethers.getSigners();
+    const adapterImplFactory = new ERC20AdapterV1__factory(deployer);
+    const deployedAdapterImpl = await adapterImplFactory.deploy();
+    await deployedAdapterImpl.waitForDeployment();
+
+    // Assign to global vars
+    deployerG = deployer;
+    ownerG = owner;
+    erc20AdapterImplementationAddressG = await deployedAdapterImpl.getAddress();
+
+    // Only return what's needed if this fixture is for global one-time setup
+    // For deploying fresh mocks per test suite, a different fixture or direct deployment is better.
+    return {
+      deployer,
+      owner,
+      user1,
+      user2,
+      nonOwner,
+      erc20AdapterImplementationAddress: erc20AdapterImplementationAddressG,
+    };
+  }
+
+  // This specialized fixture is for deploying fresh mocks for specific test suites
+  async function deployMocksAndSignersFixture() {
+    const [deployer, owner, user1, user2, nonOwner] = await ethers.getSigners();
+
+    const deployedMockToken = await new MockERC20Votes__factory(deployer).deploy();
+
+    const deployedMockStrategy = await new MockVotingStrategy__factory(deployer).deploy(
+      user1.address,
+    ); // user1 as default mock proposer
+
+    // Mint and delegate on the fresh mockToken
+    await deployedMockToken.mint(user1.address, ethers.parseUnits('1000', 18));
+    await deployedMockToken.mint(user2.address, ethers.parseUnits('500', 18));
+    await deployedMockToken.connect(user1).delegate(user1.address);
+    await deployedMockToken.connect(user2).delegate(user2.address);
+
+    return {
+      deployer,
+      ownerSigner: owner,
+      user1Signer: user1,
+      user2Signer: user2,
+      nonOwnerSigner: nonOwner,
+      mockToken: deployedMockToken,
+      mockStrategy: deployedMockStrategy,
+    };
+  }
+
+  before(async () => {
+    // Load global (one-time) deployments like the adapter implementation address
+    await loadFixture(deployGlobalFixture);
+  });
+
+  let ownerSigner: SignerWithAddress;
+  let nonOwnerSigner: SignerWithAddress;
+  let mockToken: MockERC20Votes;
+  let mockStrategy: MockVotingStrategy;
+  let deployer: SignerWithAddress;
+  let user1Signer: SignerWithAddress;
+  let user2Signer: SignerWithAddress;
+
+  beforeEach(async () => {
+    const {
+      ownerSigner: oSigner,
+      nonOwnerSigner: nSigner,
+      mockToken: mToken,
+      mockStrategy: mStrategy,
+      deployer: dDeployer,
+      user1Signer: vSigner,
+      user2Signer: v2Signer,
+    } = await loadFixture(deployMocksAndSignersFixture);
+
+    user1Signer = vSigner;
+    user2Signer = v2Signer;
+    ownerSigner = oSigner;
+    nonOwnerSigner = nSigner;
+    mockToken = mToken;
+    mockStrategy = mStrategy;
+    deployer = dDeployer;
+  });
+
+  describe('Initialization', () => {
+    it('should initialize correctly with valid parameters and emit event', async () => {
+      const { adapter: erc20Adapter, deployTx } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        ownerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        DEFAULT_PROPOSER_THRESHOLD,
+        DEFAULT_WEIGHT_PER_TOKEN,
+      );
+
+      // Check the event on the deployment transaction hash.
+      // Provide the proxy instance (erc20Adapter) to .to.emit(),
+      // as the event is emitted from the proxy's address due to delegatecall.
+      await expect(deployTx.hash)
+        .to.emit(erc20Adapter, 'AdapterParametersUpdated')
+        .withArgs(DEFAULT_PROPOSER_THRESHOLD, DEFAULT_WEIGHT_PER_TOKEN);
+
+      expect(await erc20Adapter.owner()).to.equal(ownerSigner.address);
+      expect(await erc20Adapter.token()).to.equal(await mockToken.getAddress());
+      expect(await erc20Adapter.strategy()).to.equal(await mockStrategy.getAddress());
+      expect(await erc20Adapter.proposerThreshold()).to.equal(DEFAULT_PROPOSER_THRESHOLD);
+      expect(await erc20Adapter.weightPerToken()).to.equal(DEFAULT_WEIGHT_PER_TOKEN);
+    });
+
+    it('should revert if token address is zero', async () => {
+      const erc20AdapterImplementation = ERC20AdapterV1__factory.connect(
+        erc20AdapterImplementationAddressG,
+        deployerG,
+      );
+
+      await expect(
+        deployERC20AdapterProxy(
+          deployer,
+          erc20AdapterImplementationAddressG,
+          ownerSigner.address,
+          ethers.ZeroAddress,
+          await mockStrategy.getAddress(),
+          DEFAULT_PROPOSER_THRESHOLD,
+          DEFAULT_WEIGHT_PER_TOKEN,
+        ),
+      ).to.be.revertedWithCustomError(erc20AdapterImplementation, 'InvalidTokenAddress');
+    });
+
+    it('should revert if strategy address is zero', async () => {
+      const erc20AdapterImplementation = ERC20AdapterV1__factory.connect(
+        erc20AdapterImplementationAddressG,
+        deployerG,
+      );
+
+      await expect(
+        deployERC20AdapterProxy(
+          deployer,
+          erc20AdapterImplementationAddressG,
+          ownerSigner.address,
+          await mockToken.getAddress(),
+          ethers.ZeroAddress,
+          DEFAULT_PROPOSER_THRESHOLD,
+          DEFAULT_WEIGHT_PER_TOKEN,
+        ),
+      ).to.be.revertedWithCustomError(erc20AdapterImplementation, 'InvalidStrategyAddress');
+    });
+
+    it('should revert if weightPerToken is zero', async () => {
+      const erc20AdapterImplementation = ERC20AdapterV1__factory.connect(
+        erc20AdapterImplementationAddressG,
+        deployerG,
+      );
+
+      await expect(
+        deployERC20AdapterProxy(
+          deployer,
+          erc20AdapterImplementationAddressG,
+          ownerSigner.address,
+          await mockToken.getAddress(),
+          await mockStrategy.getAddress(),
+          DEFAULT_PROPOSER_THRESHOLD,
+          0n,
+        ),
+      ).to.be.revertedWithCustomError(erc20AdapterImplementation, 'InvalidWeightPerToken');
+    });
+
+    it('should not allow reinitialization', async () => {
+      const { adapter: erc20Adapter } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        ownerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        DEFAULT_PROPOSER_THRESHOLD,
+        DEFAULT_WEIGHT_PER_TOKEN,
+      );
+
+      await expect(
+        erc20Adapter.initialize(
+          ownerSigner.address,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          0n,
+          0n,
+        ),
+      ).to.be.revertedWithCustomError(erc20Adapter, 'InvalidInitialization');
+    });
+
+    it('Should have initialization disabled in the implementation contract', async function () {
+      const implementationContract = ERC20AdapterV1__factory.connect(
+        erc20AdapterImplementationAddressG,
+        ownerG,
+      );
+
+      await expect(
+        implementationContract.initialize(
+          ownerSigner.address,
+          await mockToken.getAddress(),
+          await mockStrategy.getAddress(),
+          DEFAULT_PROPOSER_THRESHOLD,
+          DEFAULT_WEIGHT_PER_TOKEN,
+        ),
+      ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
+    });
+  });
+
+  describe('Owner Functions', () => {
+    let erc20Adapter: ERC20AdapterV1;
+    let currentOwnerSigner: SignerWithAddress;
+    let currentNonOwnerSigner: SignerWithAddress;
+
+    beforeEach(async () => {
+      currentOwnerSigner = ownerSigner;
+      currentNonOwnerSigner = nonOwnerSigner;
+
+      const { adapter } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        currentOwnerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        DEFAULT_PROPOSER_THRESHOLD,
+        DEFAULT_WEIGHT_PER_TOKEN,
+      );
+      erc20Adapter = adapter;
+    });
+
+    describe('updateProposerThreshold', () => {
+      const NEW_PROPOSER_THRESHOLD = ethers.parseUnits('200', 18);
+
+      it('should allow owner to update proposer threshold and emit event', async () => {
+        await expect(
+          erc20Adapter.connect(currentOwnerSigner).updateProposerThreshold(NEW_PROPOSER_THRESHOLD),
+        )
+          .to.emit(erc20Adapter, 'AdapterParametersUpdated')
+          .withArgs(NEW_PROPOSER_THRESHOLD, DEFAULT_WEIGHT_PER_TOKEN);
+
+        expect(await erc20Adapter.proposerThreshold()).to.equal(NEW_PROPOSER_THRESHOLD);
+      });
+
+      it('should not allow non-owner to update proposer threshold', async () => {
+        await expect(
+          erc20Adapter
+            .connect(currentNonOwnerSigner)
+            .updateProposerThreshold(NEW_PROPOSER_THRESHOLD),
+        )
+          .to.be.revertedWithCustomError(erc20Adapter, 'OwnableUnauthorizedAccount')
+          .withArgs(currentNonOwnerSigner.address);
+      });
+
+      it('should allow updating to zero proposer threshold', async () => {
+        await expect(erc20Adapter.connect(currentOwnerSigner).updateProposerThreshold(0n))
+          .to.emit(erc20Adapter, 'AdapterParametersUpdated')
+          .withArgs(0n, DEFAULT_WEIGHT_PER_TOKEN);
+
+        expect(await erc20Adapter.proposerThreshold()).to.equal(0n);
+      });
+    });
+
+    describe('updateWeightPerToken', () => {
+      const NEW_WEIGHT_PER_TOKEN = 2n;
+
+      it('should allow owner to update weight per token and emit event', async () => {
+        await expect(
+          erc20Adapter.connect(currentOwnerSigner).updateWeightPerToken(NEW_WEIGHT_PER_TOKEN),
+        )
+          .to.emit(erc20Adapter, 'AdapterParametersUpdated')
+          .withArgs(DEFAULT_PROPOSER_THRESHOLD, NEW_WEIGHT_PER_TOKEN);
+        expect(await erc20Adapter.weightPerToken()).to.equal(NEW_WEIGHT_PER_TOKEN);
+      });
+
+      it('should not allow non-owner to update weight per token', async () => {
+        await expect(
+          erc20Adapter.connect(currentNonOwnerSigner).updateWeightPerToken(NEW_WEIGHT_PER_TOKEN),
+        )
+          .to.be.revertedWithCustomError(erc20Adapter, 'OwnableUnauthorizedAccount')
+          .withArgs(currentNonOwnerSigner.address);
+      });
+
+      it('should revert if new weightPerToken is zero', async () => {
+        await expect(
+          erc20Adapter.connect(currentOwnerSigner).updateWeightPerToken(0n),
+        ).to.be.revertedWithCustomError(erc20Adapter, 'InvalidWeightPerToken');
+      });
+    });
+  });
+
+  describe('weightOf', () => {
+    const proposalId = 1;
+    const mockExtraData = ethers.ZeroHash;
+    let adapter: ERC20AdapterV1;
+
+    async function setupAdapterForWeightOf(clockMode: 0 | 1, customWeightPerToken?: bigint) {
+      await mockToken.setClockMode(clockMode);
+      const { adapter: deployedAdapter } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        ownerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        DEFAULT_PROPOSER_THRESHOLD,
+        customWeightPerToken || DEFAULT_WEIGHT_PER_TOKEN,
+      );
+      adapter = deployedAdapter;
+    }
+
+    describe('Timestamp Mode', () => {
+      beforeEach(async () => {
+        await setupAdapterForWeightOf(0);
+      });
+
+      it('should return correct weight based on past votes at startTimestamp', async () => {
+        const expectedRawVotes = ethers.parseUnits('50', 18);
+        const votingStartTimestamp = (await time.latest()) + 100;
+        await time.increaseTo(votingStartTimestamp - 50);
+        await mockToken.mint(user1Signer.address, expectedRawVotes);
+        await mockToken.connect(user1Signer).delegate(user1Signer.address);
+        await mockToken.setPastVotes(user1Signer.address, votingStartTimestamp, expectedRawVotes);
+        await mockStrategy.setVotingTimestamps(
+          proposalId,
+          votingStartTimestamp,
+          votingStartTimestamp + 1000,
+        );
+        const weight = await adapter.weightOf(user1Signer.address, proposalId, mockExtraData);
+        expect(weight).to.equal(expectedRawVotes * DEFAULT_WEIGHT_PER_TOKEN);
+      });
+
+      it('should correctly apply custom weightPerToken', async () => {
+        const customWeight = 5n;
+        await setupAdapterForWeightOf(0, customWeight);
+
+        const expectedRawVotes = ethers.parseUnits('50', 18);
+        const votingStartTimestamp = (await time.latest()) + 100;
+        await time.increaseTo(votingStartTimestamp - 50);
+        await mockToken.mint(user1Signer.address, expectedRawVotes);
+        await mockToken.connect(user1Signer).delegate(user1Signer.address);
+        await mockToken.setPastVotes(user1Signer.address, votingStartTimestamp, expectedRawVotes);
+        await mockStrategy.setVotingTimestamps(
+          proposalId,
+          votingStartTimestamp,
+          votingStartTimestamp + 1000,
+        );
+
+        const weight = await adapter.weightOf(user1Signer.address, proposalId, mockExtraData);
+        expect(weight).to.equal(expectedRawVotes * customWeight);
+      });
+
+      it('should revert if strategy returns startTimestamp as 0', async () => {
+        await mockStrategy.setVotingTimestamps(proposalId, 0, 1000);
+        await expect(
+          adapter.weightOf(user1Signer.address, proposalId, mockExtraData),
+        ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
+      });
+    });
+
+    describe('BlockNumber Mode', () => {
+      beforeEach(async () => {
+        await setupAdapterForWeightOf(1);
+      });
+
+      it('should return correct weight based on past votes at startBlock', async () => {
+        const expectedRawVotes = ethers.parseUnits('75', 18);
+        await mockToken.mint(user1Signer.address, expectedRawVotes);
+        await mockToken.connect(user1Signer).delegate(user1Signer.address);
+        const snapshotBlockNumber = (await time.latestBlock()) + 5;
+        await mockToken.setPastVotes(user1Signer.address, snapshotBlockNumber, expectedRawVotes);
+        await mockStrategy.setVotingStartBlock(proposalId, snapshotBlockNumber);
+        const weight = await adapter.weightOf(user1Signer.address, proposalId, mockExtraData);
+        expect(weight).to.equal(expectedRawVotes * DEFAULT_WEIGHT_PER_TOKEN);
+      });
+
+      it('should revert if strategy returns startBlock as 0', async () => {
+        await mockStrategy.setVotingStartBlock(proposalId, 0);
+        await expect(
+          adapter.weightOf(user1Signer.address, proposalId, mockExtraData),
+        ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
+      });
+    });
+
+    it('should return 0 if voter has already casted a vote for the proposal', async () => {
+      await setupAdapterForWeightOf(0); // Default to timestamp mode
+      const votingStartTimestamp = (await time.latest()) + 100;
+      await mockStrategy.setVotingTimestamps(
+        proposalId,
+        votingStartTimestamp,
+        votingStartTimestamp + 1000,
+      );
+      await mockToken.setPastVotes(
+        user1Signer.address,
+        votingStartTimestamp,
+        ethers.parseUnits('10', 18),
+      );
+      await adapter.connect(user1Signer).recordVote(user1Signer.address, proposalId, mockExtraData);
+      const weight = await adapter.weightOf(user1Signer.address, proposalId, mockExtraData);
+      expect(weight).to.equal(0);
+    });
+  });
+
+  describe('recordVote', () => {
+    const proposalId = 1;
+    const mockExtraData = ethers.ZeroHash;
+    const expectedEventAdapterVoteData = '0x';
+
+    let adapter: ERC20AdapterV1;
+    let token: MockERC20Votes;
+    let strategy: MockVotingStrategy;
+    let voter: SignerWithAddress;
+    let owner: SignerWithAddress;
+    let currentDeployer: SignerWithAddress;
+
+    async function setupAdapterForRecordVote(clockMode: 0 | 1, customWeightPerToken?: bigint) {
+      const {
+        ownerSigner: fixtureOwner,
+        user1Signer: fixtureVoter,
+        deployer: fixDeployer,
+        mockToken: fToken,
+        mockStrategy: fStrategy,
+      } = await loadFixture(deployMocksAndSignersFixture);
+
+      owner = fixtureOwner;
+      voter = fixtureVoter;
+      token = fToken;
+      strategy = fStrategy;
+      currentDeployer = fixDeployer;
+
+      await token.setClockMode(clockMode);
+      const { adapter: deployedAdapter } = await deployERC20AdapterProxy(
+        currentDeployer,
+        erc20AdapterImplementationAddressG,
+        owner.address,
+        await token.getAddress(),
+        await strategy.getAddress(),
+        DEFAULT_PROPOSER_THRESHOLD,
+        customWeightPerToken || DEFAULT_WEIGHT_PER_TOKEN,
+      );
+      adapter = deployedAdapter;
+    }
+
+    it('should record vote, return casted weight, set flag, and emit VoteRecorded event', async () => {
+      await setupAdapterForRecordVote(0);
+      const expectedRawVotes = ethers.parseUnits('120', 18);
+      const votingStartTimestamp = (await time.latest()) + 200;
+      await time.increaseTo(votingStartTimestamp - 100);
+      await token.mint(voter.address, expectedRawVotes);
+      await token.connect(voter).delegate(voter.address);
+      await token.setPastVotes(voter.address, votingStartTimestamp, expectedRawVotes);
+      await strategy.setVotingTimestamps(
+        proposalId,
+        votingStartTimestamp,
+        votingStartTimestamp + 1000,
+      );
+
+      const expectedWeightCasted = expectedRawVotes * DEFAULT_WEIGHT_PER_TOKEN;
+
+      const weightCastedStatically = await adapter
+        .connect(voter)
+        .recordVote.staticCall(voter.address, proposalId, mockExtraData);
+      expect(weightCastedStatically).to.equal(expectedWeightCasted);
+
+      await expect(adapter.connect(voter).recordVote(voter.address, proposalId, mockExtraData))
+        .to.emit(adapter, 'VoteRecorded')
+        .withArgs(voter.address, proposalId, expectedWeightCasted, expectedEventAdapterVoteData);
+
+      const weightAfterVote = await adapter.weightOf(voter.address, proposalId, mockExtraData);
+      expect(weightAfterVote).to.equal(0);
+    });
+
+    it('should correctly apply custom weightPerToken on recordVote and emit event', async () => {
+      const customWeight = 3n;
+      await setupAdapterForRecordVote(0, customWeight);
+      const expectedRawVotes = ethers.parseUnits('70', 18);
+      const votingStartTimestamp = (await time.latest()) + 200;
+      await time.increaseTo(votingStartTimestamp - 100);
+      await token.mint(voter.address, expectedRawVotes);
+      await token.connect(voter).delegate(voter.address);
+      await token.setPastVotes(voter.address, votingStartTimestamp, expectedRawVotes);
+      await strategy.setVotingTimestamps(
+        proposalId,
+        votingStartTimestamp,
+        votingStartTimestamp + 1000,
+      );
+
+      const expectedWeightCasted = expectedRawVotes * customWeight;
+
+      const weightCastedStatically = await adapter
+        .connect(voter)
+        .recordVote.staticCall(voter.address, proposalId, mockExtraData);
+      expect(weightCastedStatically).to.equal(expectedWeightCasted);
+
+      await expect(adapter.connect(voter).recordVote(voter.address, proposalId, mockExtraData))
+        .to.emit(adapter, 'VoteRecorded')
+        .withArgs(voter.address, proposalId, expectedWeightCasted, expectedEventAdapterVoteData);
+    });
+
+    it('should revert with ERC20AlreadyVoted if trying to vote again', async () => {
+      await setupAdapterForRecordVote(0);
+      const votingStartTimestamp = (await time.latest()) + 200;
+      await token.setPastVotes(voter.address, votingStartTimestamp, ethers.parseUnits('10', 18));
+      await strategy.setVotingTimestamps(
+        proposalId,
+        votingStartTimestamp,
+        votingStartTimestamp + 1000,
+      );
+      await adapter.recordVote(voter.address, proposalId, mockExtraData);
+      await expect(
+        adapter.recordVote(voter.address, proposalId, mockExtraData),
+      ).to.be.revertedWithCustomError(adapter, 'ERC20AlreadyVoted');
+    });
+
+    it('subsequent weightOf should return 0 after recordVote', async () => {
+      await setupAdapterForRecordVote(0);
+      const votingStartTimestamp = (await time.latest()) + 200;
+      await token.setPastVotes(voter.address, votingStartTimestamp, ethers.parseUnits('10', 18));
+      await strategy.setVotingTimestamps(
+        proposalId,
+        votingStartTimestamp,
+        votingStartTimestamp + 1000,
+      );
+      await adapter.recordVote(voter.address, proposalId, mockExtraData);
+      const weight = await adapter.weightOf(voter.address, proposalId, mockExtraData);
+      expect(weight).to.equal(0);
+    });
+
+    it('should revert with ProposalNotReadyForSnapshot if strategy returns startTimestamp as 0 (Timestamp Mode)', async () => {
+      await setupAdapterForRecordVote(0);
+      await strategy.setVotingTimestamps(proposalId, 0, 1000);
+      await expect(
+        adapter.recordVote(voter.address, proposalId, mockExtraData),
+      ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
+    });
+
+    it('should revert with ProposalNotReadyForSnapshot if strategy returns startBlock as 0 (BlockNumber Mode)', async () => {
+      await setupAdapterForRecordVote(1);
+      await strategy.setVotingStartBlock(proposalId, 0);
+      await expect(
+        adapter.recordVote(voter.address, proposalId, mockExtraData),
+      ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
+    });
+  });
+
+  describe('isProposer', () => {
+    let adapter: ERC20AdapterV1;
+
+    const SUITE_WEIGHT_PER_TOKEN = 2n;
+    const SUITE_RAW_VOTES_THRESHOLD = ethers.parseUnits('100', 18);
+    const SUITE_EFFECTIVE_PROPOSER_THRESHOLD = SUITE_RAW_VOTES_THRESHOLD * SUITE_WEIGHT_PER_TOKEN;
+
+    beforeEach(async () => {
+      const { adapter: deployedAdapter } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        ownerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        SUITE_EFFECTIVE_PROPOSER_THRESHOLD,
+        SUITE_WEIGHT_PER_TOKEN,
+      );
+      adapter = deployedAdapter;
+    });
+
+    it('should return true if user meets proposer threshold (with suite weightPerToken)', async () => {
+      await mockToken.mint(user1Signer.address, SUITE_RAW_VOTES_THRESHOLD);
+      await mockToken.connect(user1Signer).delegate(user1Signer.address);
+      void expect(await adapter.isProposer(user1Signer.address)).to.be.true;
+    });
+
+    it('should return true if user exceeds proposer threshold (with suite weightPerToken)', async () => {
+      const rawVotesExceeding = SUITE_RAW_VOTES_THRESHOLD + ethers.parseUnits('1', 18);
+      await mockToken.mint(user1Signer.address, rawVotesExceeding);
+      await mockToken.connect(user1Signer).delegate(user1Signer.address);
+      void expect(await adapter.isProposer(user1Signer.address)).to.be.true;
+    });
+
+    it('should return false if user is below proposer threshold (with suite weightPerToken)', async () => {
+      const rawVotesBelow = SUITE_RAW_VOTES_THRESHOLD - ethers.parseUnits('1', 18);
+      const currentBal = await mockToken.balanceOf(user2Signer.address);
+      await mockToken.burn(user2Signer.address, currentBal - rawVotesBelow);
+      await mockToken.connect(user2Signer).delegate(user2Signer.address);
+      void expect(await adapter.isProposer(user2Signer.address)).to.be.false;
+    });
+
+    it('should return true if proposer threshold is 0, regardless of balance (with suite weightPerToken > 0)', async () => {
+      const { adapter: adapterWithZeroThreshold } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        ownerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        0n,
+        SUITE_WEIGHT_PER_TOKEN,
+      );
+
+      await mockToken.mint(user1Signer.address, ethers.parseUnits('1', 18));
+      await mockToken.connect(user1Signer).delegate(user1Signer.address);
+      void expect(await adapterWithZeroThreshold.isProposer(user1Signer.address)).to.be.true;
+      const currentBalance = await mockToken.balanceOf(user2Signer.address);
+      await mockToken.burn(user2Signer.address, currentBalance);
+      await mockToken.connect(user2Signer).delegate(user2Signer.address);
+      void expect(await adapterWithZeroThreshold.isProposer(user2Signer.address)).to.be.true;
+    });
+
+    it('should correctly factor in a *different* custom weightPerToken for isProposer', async () => {
+      const customWeightForThisTest = 5n;
+      const rawVotesForCustomTest = ethers.parseUnits('30', 18);
+      const effectiveThresholdForCustomTest = rawVotesForCustomTest * customWeightForThisTest;
+
+      const { adapter: adapterCustomWeight } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        ownerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        effectiveThresholdForCustomTest,
+        customWeightForThisTest,
+      );
+
+      const balProposer = await mockToken.balanceOf(user1Signer.address);
+      await mockToken.burn(user1Signer.address, balProposer - rawVotesForCustomTest);
+      await mockToken.connect(user1Signer).delegate(user1Signer.address);
+
+      void expect(await adapterCustomWeight.isProposer(user1Signer.address)).to.be.true;
+
+      const rawVotesBelowCustom = rawVotesForCustomTest - ethers.parseUnits('1', 18);
+      const balNonProposer = await mockToken.balanceOf(user2Signer.address);
+      await mockToken.burn(user2Signer.address, balNonProposer - rawVotesBelowCustom);
+      await mockToken.connect(user2Signer).delegate(user2Signer.address);
+      void expect(await adapterCustomWeight.isProposer(user2Signer.address)).to.be.false;
+    });
+  });
+
+  describe('getVersion()', () => {
+    it('should return the correct version', async () => {
+      const { adapter: erc20Adapter } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        ownerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        DEFAULT_PROPOSER_THRESHOLD,
+        DEFAULT_WEIGHT_PER_TOKEN,
+      );
+
+      expect(await erc20Adapter.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165 supportsInterface', () => {
+    let erc20Adapter: ERC20AdapterV1;
+    let iTokenAdapterV1InterfaceId: string;
+    let iTokenAdapterBaseV1InterfaceId: string;
+    let iVersionInterfaceId: string;
+    let iERC165InterfaceId: string;
+
+    beforeEach(async () => {
+      const { adapter } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        ownerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        DEFAULT_PROPOSER_THRESHOLD,
+        DEFAULT_WEIGHT_PER_TOKEN,
+      );
+      erc20Adapter = adapter;
+
+      iTokenAdapterV1InterfaceId = calculateInterfaceId(
+        ITokenAdapterV1__factory.createInterface(),
+        [ITokenAdapterBaseV1__factory.createInterface()],
+      );
+      iTokenAdapterBaseV1InterfaceId = calculateInterfaceId(
+        ITokenAdapterBaseV1__factory.createInterface(),
+      );
+      iVersionInterfaceId = calculateInterfaceId(IVersion__factory.createInterface());
+      iERC165InterfaceId = calculateInterfaceId(IERC165__factory.createInterface());
+    });
+
+    it('should support ITokenAdapterV1', async () => {
+      void expect(await erc20Adapter.supportsInterface(iTokenAdapterV1InterfaceId)).to.be.true;
+    });
+
+    it('should support ITokenAdapterBaseV1', async () => {
+      void expect(await erc20Adapter.supportsInterface(iTokenAdapterBaseV1InterfaceId)).to.be.true;
+    });
+
+    it('should support IVersion', async () => {
+      void expect(await erc20Adapter.supportsInterface(iVersionInterfaceId)).to.be.true;
+    });
+
+    it('should support IERC165', async () => {
+      void expect(await erc20Adapter.supportsInterface(iERC165InterfaceId)).to.be.true;
+    });
+
+    it('should not support a random interfaceId', async () => {
+      void expect(await erc20Adapter.supportsInterface('0x12345678')).to.be.false;
+    });
+  });
+
+  describe('UUPS Upgradeability', () => {
+    let erc20AdapterProxy: ERC20AdapterV1;
+
+    beforeEach(async () => {
+      const { adapter } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        ownerSigner.address,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        DEFAULT_PROPOSER_THRESHOLD,
+        DEFAULT_WEIGHT_PER_TOKEN,
+      );
+      erc20AdapterProxy = adapter;
+    });
+
+    runUUPSUpgradeabilityTests({
+      getContract: () => erc20AdapterProxy,
+      createNewImplementation: async () => {
+        const newImplementation = await new ERC20AdapterV1__factory(deployer).deploy();
+        return newImplementation;
+      },
+      owner: () => ownerSigner,
+      nonOwner: () => nonOwnerSigner,
+    });
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/272

Fixes [ENG-964](https://linear.app/decent-labs/issue/ENG-964/implement-and-test-erc20adapterv1-for-strategyv1)

**High-Level Context:**

This Pull Request introduces `ERC20AdapterV1.sol`, the first concrete token adapter for our new modular `StrategyV1` voting engine. This adapter enables `StrategyV1` to support governance proposals based on `IVotes`-compliant ERC20 tokens (e.g., OpenZeppelin's `ERC20Votes`). It handles weight calculation, vote recording, and proposer eligibility checks specific to these types of tokens, including respecting their `ClockMode` (timestamp or block number) for snapshotting. This PR also includes updates to mock contracts and a comprehensive test suite for `ERC20AdapterV1`.

This is a crucial step following the introduction of `StrategyV1` and `AzoriusV1`'s shift to a single-strategy model, making a significant part of the new governance architecture functional.

**Specific Changes in this PR:**

1.  **`ERC20AdapterV1.sol` (New Contract):**
    *   **File Location:** `contracts/deployables/strategies/adapters/ERC20AdapterV1.sol`.
    *   **Core Functionality:** An adapter to calculate voting weight and proposer status based on an ERC20Votes-compatible token, and to record votes.
    *   **Interfaces Implemented:** `ITokenAdapterV1`, `Initializable`, `OwnableUpgradeable`, `UUPSUpgradeable`, `ERC165`, `Version`.
    *   **State Variables:**
        *   `token`: Stores the `IVotes` token instance.
        *   `strategy`: Stores the `IStrategyBaseV1` instance (which `StrategyV1` implements) to query for proposal snapshot details (start time/block).
        *   `proposerThreshold`: Minimum weighted votes for an address to be a proposer.
        *   `weightPerToken`: Multiplier for raw token balance to get voting weight.
        *   `tokenClockMode`: Stores the `ClockMode` (Timestamp or BlockNumber) of the underlying `token`, determined via `ClockModeLib`.
        *   `_hasCastedVoteForProposal`: Mapping `(uint32 => mapping(address => bool))` to ensure a voter's ERC20 balance (via this adapter) is used only once per proposal.
    *   **Events:** `AdapterParametersUpdated`.
    *   **Errors:** `InvalidTokenAddress`, `InvalidStrategyAddress`, `ProposalNotReadyForSnapshot`, `ERC20AlreadyVoted`, `InvalidWeightPerToken`.
    *   **Constructor & `initialize(...)`:**
        *   Validates token and strategy addresses, and `_weightPerToken > 0`.
        *   Determines and stores `tokenClockMode` using `ClockModeLib.getClockMode(_token)`.
    *   **Owner Functions:** `_authorizeUpgrade`, `updateProposerThreshold`, `updateWeightPerToken` (with internal helpers and validation).
    *   **`_getVoteWeightDetails(...)` (Internal Helper):**
        *   Retrieves `startTimestamp` (from `strategy.getVotingTimestamps`) or `startBlock` (from `strategy.getVotingStartBlock`) based on `tokenClockMode`.
        *   Reverts with `ProposalNotReadyForSnapshot` if the relevant start point is zero.
        *   Returns `token.getPastVotes(_voter, timepoint) * weightPerToken`.
    *   **`ITokenAdapterV1` Implementation:**
        *   `weightOf(...)`: Returns 0 if `_hasCastedVoteForProposal` is true; otherwise, calls `_getVoteWeightDetails`.
        *   `recordVote(...)`: Reverts with `ERC20AlreadyVoted` if already voted. Sets `_hasCastedVoteForProposal` to true. Returns weight from `_getVoteWeightDetails`.
        *   `isProposer(...)`: Returns `(token.getVotes(_proposer) * weightPerToken) >= proposerThreshold`.
    *   **Version & ERC165:** Implements `getVersion()` and `supportsInterface()` (for `ITokenAdapterV1`, `ITokenAdapterBaseV1`, and `ERC165`).

2.  **Interface `ITokenAdapterV1.sol` Finalization:**
    *   The interface now includes `weightOf(address _voter, uint32 _proposalId, bytes calldata _adapterVoteData) external view returns (uint256 weight);`. This function was pending in the interface definition shown in the previous diff's context.

3.  **`MockERC20Votes.sol` Update:**
    *   Added a `burn(address from, uint256 amount)` function to allow for more flexible test setups where token balances need to be reduced.

4.  **`MockVotingStrategy.sol` Update:**
    *   Added `mapping(uint32 => uint32) public mockVotingStartBlock;` and a corresponding setter `setVotingStartBlock(...)`. This allows tests to properly mock the `getVotingStartBlock()` behavior of a strategy, which is now consumed by `ERC20AdapterV1` when operating in `BlockNumber` clock mode.

5.  **Test Suite `ERC20AdapterV1.test.ts` (New File):**
    *   Provides comprehensive unit tests for `ERC20AdapterV1`.
    *   Covers:
        *   Correct initialization and validation of parameters.
        *   Owner-restricted functions for updating `proposerThreshold` and `weightPerToken`.
        *   `weightOf` logic, including behavior for both Timestamp and BlockNumber modes (simulated by setting `mockToken.setClockMode` and mocking strategy's start time/block), and returning 0 if a vote has already been cast.
        *   `recordVote` logic, including correct weight calculation, setting the `_hasCastedVoteForProposal` flag, and reverting if a vote has already been cast.
        *   `isProposer` logic under various conditions.
        *   `getVersion()` and ERC165 `supportsInterface()` checks.
        *   UUPS Upgradeability.

**Impact and Status:**

*   This PR delivers a fully functional `ERC20AdapterV1`, enabling `StrategyV1` to work with common ERC20Votes tokens.
*   The adapter correctly handles different clock modes by querying the parent strategy for appropriate snapshot points (timestamp or block).
*   **Compilation Status:** All contracts involved in this PR and the core system should now compile successfully.
*   **Testing Status:** The new `ERC20AdapterV1.test.ts` suite specifically validates this adapter. **It is expected that the overall project test suite now passes**, as this PR (along with the preceding ones in this refactoring series) should bring all core components and their mocks into alignment. Any remaining failures would likely be in highly specific end-to-end scenarios or in derived contracts not yet fully adapted to the `StrategyV1` model.