### PR TITLE
refactor(governance): Rename Adapters and Standardize Naming Conventions

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -52,8 +52,8 @@ contract StrategyV1 is
         uint256 quorumThreshold,
         uint256 basisNumerator
     );
-    event AdapterAdded(address indexed adapter, uint256 index);
-    event AdapterRemoved(address indexed adapter, uint256 index);
+    event TokenAdapterAdded(address indexed adapter, uint256 index);
+    event TokenAdapterRemoved(address indexed adapter, uint256 index);
     event Voted(
         address indexed voter,
         uint32 indexed proposalId,
@@ -70,10 +70,10 @@ contract StrategyV1 is
     error InvalidAzoriusAddress();
     error InvalidVotingPeriod();
     error InvalidBasisNumerator();
-    error AdapterIsZeroAddress();
-    error AdapterAlreadyExists();
-    error AdapterNotFound();
-    error NoAdapters();
+    error TokenAdapterIsZeroAddress();
+    error TokenAdapterAlreadyExists();
+    error TokenAdapterNotFound();
+    error NoTokenAdapters();
     error ProposalNotFoundOrNotActive();
     error NoVotingWeight();
     error InvalidVoteType();
@@ -107,7 +107,7 @@ contract StrategyV1 is
 
         if (_initialTokenAdapters.length > 0) {
             for (uint256 i = 0; i < _initialTokenAdapters.length; i++) {
-                _addAdapter(_initialTokenAdapters[i]);
+                _addTokenAdapter(_initialTokenAdapters[i]);
             }
         }
 
@@ -155,24 +155,24 @@ contract StrategyV1 is
         );
     }
 
-    function addAdapter(address _adapter) public override onlyOwner {
-        _addAdapter(_adapter);
+    function addTokenAdapter(address _adapter) public override onlyOwner {
+        _addTokenAdapter(_adapter);
     }
 
-    function removeAdapter(address _adapter) external override onlyOwner {
-        if (_adapter == address(0)) revert AdapterIsZeroAddress();
+    function removeTokenAdapter(address _adapter) external override onlyOwner {
+        if (_adapter == address(0)) revert TokenAdapterIsZeroAddress();
         uint256 adapterCount = tokenAdapters.length;
-        if (adapterCount == 0) revert AdapterNotFound();
+        if (adapterCount == 0) revert TokenAdapterNotFound();
 
         for (uint256 i = 0; i < adapterCount; i++) {
             if (address(tokenAdapters[i]) == _adapter) {
                 tokenAdapters[i] = tokenAdapters[adapterCount - 1];
                 tokenAdapters.pop();
-                emit AdapterRemoved(address(_adapter), i);
+                emit TokenAdapterRemoved(address(_adapter), i);
                 return;
             }
         }
-        revert AdapterNotFound();
+        revert TokenAdapterNotFound();
     }
 
     function getTokenAdapterCount() external view override returns (uint256) {
@@ -185,7 +185,7 @@ contract StrategyV1 is
         bytes memory
     ) external virtual override {
         if (msg.sender != azorius) revert InvalidAzoriusAddress();
-        if (tokenAdapters.length == 0) revert NoAdapters();
+        if (tokenAdapters.length == 0) revert NoTokenAdapters();
 
         ProposalVotingDetails storage proposal = proposalVotingDetails[
             proposalId
@@ -208,10 +208,10 @@ contract StrategyV1 is
     function vote(
         uint32 _proposalId,
         uint8 _voteType,
-        address[] calldata _adaptersToUse,
-        bytes[] calldata _adapterVoteData
+        address[] calldata _tokenAdaptersToUse,
+        bytes[] calldata _tokenAdapterVoteData
     ) external virtual override {
-        if (_adaptersToUse.length != _adapterVoteData.length)
+        if (_tokenAdaptersToUse.length != _tokenAdapterVoteData.length)
             revert MismatchedInputs();
 
         address resolvedVoter = voter(msg.sender);
@@ -229,13 +229,14 @@ contract StrategyV1 is
         uint256 totalWeightForThisVoteTransaction = 0;
         uint256 numConfiguredAdapters = tokenAdapters.length;
 
-        for (uint256 i = 0; i < _adaptersToUse.length; i++) {
+        for (uint256 i = 0; i < _tokenAdaptersToUse.length; i++) {
             bool isValidAndConfiguredAdapter = false;
             uint256 configuredAdapterIndex = 0;
 
             for (uint256 j = 0; j < numConfiguredAdapters; j++) {
                 if (
-                    tokenAdapters[j] == ITokenAdapterBaseV1(_adaptersToUse[i])
+                    tokenAdapters[j] ==
+                    ITokenAdapterBaseV1(_tokenAdaptersToUse[i])
                 ) {
                     isValidAndConfiguredAdapter = true;
                     configuredAdapterIndex = j;
@@ -249,7 +250,7 @@ contract StrategyV1 is
 
             totalWeightForThisVoteTransaction += tokenAdapters[
                 configuredAdapterIndex
-            ].recordVote(resolvedVoter, _proposalId, _adapterVoteData[i]);
+            ].recordVote(resolvedVoter, _proposalId, _tokenAdapterVoteData[i]);
         }
 
         if (totalWeightForThisVoteTransaction == 0) revert NoVotingWeight();
@@ -377,14 +378,14 @@ contract StrategyV1 is
         basisNumerator = _newBasisNumerator;
     }
 
-    function _addAdapter(address _adapter) internal {
-        if (_adapter == address(0)) revert AdapterIsZeroAddress();
+    function _addTokenAdapter(address _adapter) internal {
+        if (_adapter == address(0)) revert TokenAdapterIsZeroAddress();
         for (uint256 i = 0; i < tokenAdapters.length; i++) {
             if (address(tokenAdapters[i]) == _adapter)
-                revert AdapterAlreadyExists();
+                revert TokenAdapterAlreadyExists();
         }
         tokenAdapters.push(ITokenAdapterBaseV1(_adapter));
-        emit AdapterAdded(address(_adapter), tokenAdapters.length - 1);
+        emit TokenAdapterAdded(address(_adapter), tokenAdapters.length - 1);
     }
 
     function getVersion() public view virtual override returns (uint16) {

--- a/contracts/deployables/strategies/adapters/ERC20TokenAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20TokenAdapterV1.sol
@@ -13,7 +13,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-contract ERC20AdapterV1 is
+contract ERC20TokenAdapterV1 is
     ITokenAdapterV1,
     Initializable,
     OwnableUpgradeable,
@@ -32,7 +32,7 @@ contract ERC20AdapterV1 is
 
     uint16 public constant VERSION = 1;
 
-    event AdapterParametersUpdated(
+    event TokenAdapterParametersUpdated(
         uint256 newProposerThreshold,
         uint256 newWeightPerToken
     );
@@ -67,7 +67,7 @@ contract ERC20AdapterV1 is
         strategy = IStrategyBaseV1(_strategy);
         tokenClockMode = ClockModeLib.getClockMode(_token);
 
-        emit AdapterParametersUpdated(proposerThreshold, weightPerToken);
+        emit TokenAdapterParametersUpdated(proposerThreshold, weightPerToken);
     }
 
     function _authorizeUpgrade(
@@ -78,14 +78,14 @@ contract ERC20AdapterV1 is
         uint256 _newProposerThreshold
     ) external onlyOwner {
         _updateProposerThreshold(_newProposerThreshold);
-        emit AdapterParametersUpdated(proposerThreshold, weightPerToken);
+        emit TokenAdapterParametersUpdated(proposerThreshold, weightPerToken);
     }
 
     function updateWeightPerToken(
         uint256 _newWeightPerToken
     ) external onlyOwner {
         _updateWeightPerToken(_newWeightPerToken);
-        emit AdapterParametersUpdated(proposerThreshold, weightPerToken);
+        emit TokenAdapterParametersUpdated(proposerThreshold, weightPerToken);
     }
 
     function _updateProposerThreshold(uint256 _newProposerThreshold) internal {

--- a/contracts/deployables/strategies/adapters/ERC721TokenAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721TokenAdapterV1.sol
@@ -11,7 +11,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-contract ERC721AdapterV1 is
+contract ERC721TokenAdapterV1 is
     ITokenAdapterV1,
     Initializable,
     OwnableUpgradeable,
@@ -28,7 +28,7 @@ contract ERC721AdapterV1 is
 
     uint16 public constant VERSION = 1;
 
-    event AdapterParametersUpdated(
+    event TokenAdapterParametersUpdated(
         uint256 newWeightPerNft,
         uint256 newProposerThreshold
     );
@@ -60,7 +60,7 @@ contract ERC721AdapterV1 is
         _updateWeightPerNft(_weightPerNft);
         _updateProposerThreshold(_proposerThreshold);
 
-        emit AdapterParametersUpdated(weightPerNft, proposerThreshold);
+        emit TokenAdapterParametersUpdated(weightPerNft, proposerThreshold);
     }
 
     function _authorizeUpgrade(
@@ -69,14 +69,14 @@ contract ERC721AdapterV1 is
 
     function updateWeightPerNft(uint256 _newWeightPerNft) external onlyOwner {
         _updateWeightPerNft(_newWeightPerNft);
-        emit AdapterParametersUpdated(weightPerNft, proposerThreshold);
+        emit TokenAdapterParametersUpdated(weightPerNft, proposerThreshold);
     }
 
     function updateProposerThreshold(
         uint256 _newProposerThreshold
     ) external onlyOwner {
         _updateProposerThreshold(_newProposerThreshold);
-        emit AdapterParametersUpdated(weightPerNft, proposerThreshold);
+        emit TokenAdapterParametersUpdated(weightPerNft, proposerThreshold);
     }
 
     function _updateWeightPerNft(uint256 _newWeightPerNft) internal {

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -10,9 +10,9 @@ interface IStrategyV1 is IStrategyBaseV1 {
 
     function updateBasisNumerator(uint256 _newBasisNumerator) external;
 
-    function addAdapter(address _adapter) external;
+    function addTokenAdapter(address _adapter) external;
 
-    function removeAdapter(address _adapter) external;
+    function removeTokenAdapter(address _adapter) external;
 
     function getTokenAdapterCount() external view returns (uint256);
 
@@ -23,7 +23,7 @@ interface IStrategyV1 is IStrategyBaseV1 {
     function vote(
         uint32 _proposalId,
         uint8 _voteType,
-        address[] calldata _adaptersToUse,
-        bytes[] calldata _adapterVoteData
+        address[] calldata _tokenAdaptersToUse,
+        bytes[] calldata _tokenAdapterVoteData
     ) external;
 }

--- a/contracts/interfaces/decent/deployables/ITokenAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/ITokenAdapterBaseV1.sol
@@ -6,7 +6,7 @@ interface ITokenAdapterBaseV1 {
         address indexed voter,
         uint32 indexed proposalId,
         uint256 weightCasted,
-        bytes adapterVoteData
+        bytes tokenAdapterVoteData
     );
 
     function isProposer(address _proposer) external view returns (bool);
@@ -14,6 +14,6 @@ interface ITokenAdapterBaseV1 {
     function recordVote(
         address _voter,
         uint32 _proposalId,
-        bytes calldata _adapterVoteData
+        bytes calldata _tokenAdapterVoteData
     ) external returns (uint256 weightCasted);
 }

--- a/contracts/interfaces/decent/deployables/ITokenAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/ITokenAdapterV1.sol
@@ -7,6 +7,6 @@ interface ITokenAdapterV1 is ITokenAdapterBaseV1 {
     function weightOf(
         address _voter,
         uint32 _proposalId,
-        bytes calldata _adapterVoteData
+        bytes calldata _tokenAdapterVoteData
     ) external view returns (uint256 weight);
 }

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -255,8 +255,8 @@ describe('StrategyV1', () => {
     // --- addAdapter ---
     it('should allow owner to add a new adapter', async () => {
       const adapterAddress = await mockAdapter1.getAddress();
-      await expect(strategy.connect(owner).addAdapter(adapterAddress))
-        .to.emit(strategy, 'AdapterAdded')
+      await expect(strategy.connect(owner).addTokenAdapter(adapterAddress))
+        .to.emit(strategy, 'TokenAdapterAdded')
         .withArgs(adapterAddress, 0);
       expect(await strategy.tokenAdapters(0)).to.equal(adapterAddress);
       expect(await strategy.getTokenAdapterCount()).to.equal(1);
@@ -264,28 +264,28 @@ describe('StrategyV1', () => {
 
     it('should revert when non-owner tries to add an adapter', async () => {
       await expect(
-        strategy.connect(nonOwner).addAdapter(await mockAdapter1.getAddress()),
+        strategy.connect(nonOwner).addTokenAdapter(await mockAdapter1.getAddress()),
       ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
     });
 
     it('should revert when adding a zero address adapter', async () => {
       await expect(
-        strategy.connect(owner).addAdapter(ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(strategy, 'AdapterIsZeroAddress');
+        strategy.connect(owner).addTokenAdapter(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterIsZeroAddress');
     });
 
     it('should revert when adding an already existing adapter', async () => {
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
       await expect(
-        strategy.connect(owner).addAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'AdapterAlreadyExists');
+        strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterAlreadyExists');
     });
 
     it('should allow adding multiple different adapters', async () => {
       const adapter1Addr = await mockAdapter1.getAddress();
       const adapter2Addr = await mockAdapter2.getAddress();
-      await strategy.connect(owner).addAdapter(adapter1Addr);
-      await strategy.connect(owner).addAdapter(adapter2Addr);
+      await strategy.connect(owner).addTokenAdapter(adapter1Addr);
+      await strategy.connect(owner).addTokenAdapter(adapter2Addr);
       expect(await strategy.getTokenAdapterCount()).to.equal(2);
       expect(await strategy.tokenAdapters(0)).to.equal(adapter1Addr);
       expect(await strategy.tokenAdapters(1)).to.equal(adapter2Addr);
@@ -295,15 +295,15 @@ describe('StrategyV1', () => {
     it('should allow owner to remove an existing adapter', async () => {
       const adapter1Addr = await mockAdapter1.getAddress();
       const adapter2Addr = await mockAdapter2.getAddress();
-      await strategy.connect(owner).addAdapter(adapter1Addr);
-      await strategy.connect(owner).addAdapter(adapter2Addr);
+      await strategy.connect(owner).addTokenAdapter(adapter1Addr);
+      await strategy.connect(owner).addTokenAdapter(adapter2Addr);
 
       // To correctly test the emitted index, we need to know the exact removal logic
       // Assuming it swaps with last and pops:
       // If removing adapter1Addr (at index 0), adapter2Addr (at index 1) moves to 0.
       // The event should reflect the original index of the removed item.
-      await expect(strategy.connect(owner).removeAdapter(adapter1Addr))
-        .to.emit(strategy, 'AdapterRemoved')
+      await expect(strategy.connect(owner).removeTokenAdapter(adapter1Addr))
+        .to.emit(strategy, 'TokenAdapterRemoved')
         .withArgs(adapter1Addr, 0);
 
       expect(await strategy.getTokenAdapterCount()).to.equal(1);
@@ -313,11 +313,11 @@ describe('StrategyV1', () => {
     it('should allow owner to remove an existing adapter (removing last)', async () => {
       const adapter1Addr = await mockAdapter1.getAddress();
       const adapter2Addr = await mockAdapter2.getAddress();
-      await strategy.connect(owner).addAdapter(adapter1Addr);
-      await strategy.connect(owner).addAdapter(adapter2Addr);
+      await strategy.connect(owner).addTokenAdapter(adapter1Addr);
+      await strategy.connect(owner).addTokenAdapter(adapter2Addr);
 
-      await expect(strategy.connect(owner).removeAdapter(adapter2Addr))
-        .to.emit(strategy, 'AdapterRemoved')
+      await expect(strategy.connect(owner).removeTokenAdapter(adapter2Addr))
+        .to.emit(strategy, 'TokenAdapterRemoved')
         .withArgs(adapter2Addr, 1);
 
       expect(await strategy.getTokenAdapterCount()).to.equal(1);
@@ -326,48 +326,48 @@ describe('StrategyV1', () => {
 
     it('should correctly remove the only adapter in the list', async () => {
       const adapter1Addr = await mockAdapter1.getAddress();
-      await strategy.connect(owner).addAdapter(adapter1Addr);
+      await strategy.connect(owner).addTokenAdapter(adapter1Addr);
 
-      await expect(strategy.connect(owner).removeAdapter(adapter1Addr))
-        .to.emit(strategy, 'AdapterRemoved')
+      await expect(strategy.connect(owner).removeTokenAdapter(adapter1Addr))
+        .to.emit(strategy, 'TokenAdapterRemoved')
         .withArgs(adapter1Addr, 0);
       expect(await strategy.getTokenAdapterCount()).to.equal(0);
     });
 
     it('should revert when non-owner tries to remove an adapter', async () => {
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
       await expect(
-        strategy.connect(nonOwner).removeAdapter(await mockAdapter1.getAddress()),
+        strategy.connect(nonOwner).removeTokenAdapter(await mockAdapter1.getAddress()),
       ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
     });
 
     it('should revert when removing a zero address adapter', async () => {
       await expect(
-        strategy.connect(owner).removeAdapter(ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(strategy, 'AdapterIsZeroAddress');
+        strategy.connect(owner).removeTokenAdapter(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterIsZeroAddress');
     });
 
     it('should revert when removing an adapter that does not exist', async () => {
-      await strategy.connect(owner).addAdapter(await mockAdapter2.getAddress()); // Add a different one
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress()); // Add a different one
       await expect(
-        strategy.connect(owner).removeAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'AdapterNotFound');
+        strategy.connect(owner).removeTokenAdapter(await mockAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterNotFound');
     });
 
     it('should revert when removing from an empty list of adapters', async () => {
       await expect(
-        strategy.connect(owner).removeAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'AdapterNotFound');
+        strategy.connect(owner).removeTokenAdapter(await mockAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterNotFound');
     });
 
     // --- getTokenAdapterCount ---
     it('should return the correct number of adapters', async () => {
       expect(await strategy.getTokenAdapterCount()).to.equal(0);
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
       expect(await strategy.getTokenAdapterCount()).to.equal(1);
-      await strategy.connect(owner).addAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
       expect(await strategy.getTokenAdapterCount()).to.equal(2);
-      await strategy.connect(owner).removeAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).removeTokenAdapter(await mockAdapter1.getAddress());
       expect(await strategy.getTokenAdapterCount()).to.equal(1);
     });
   });
@@ -386,7 +386,7 @@ describe('StrategyV1', () => {
 
     it('should revert if called by a non-azorius address', async () => {
       // Ensure at least one adapter is set so NoAdapters isn't hit first
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
       await expect(
         strategy
           .connect(nonOwner)
@@ -400,11 +400,11 @@ describe('StrategyV1', () => {
         strategy
           .connect(azoriusMock)
           .initializeProposal(encodedDefaultProposalId, [], ethers.ZeroHash),
-      ).to.be.revertedWithCustomError(strategy, 'NoAdapters');
+      ).to.be.revertedWithCustomError(strategy, 'NoTokenAdapters');
     });
 
     it('should correctly initialize proposal details and emit event', async () => {
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
 
       const blockBefore = await ethers.provider.getBlock('latest');
       if (!blockBefore) throw new Error('Failed to get latest block');
@@ -437,7 +437,7 @@ describe('StrategyV1', () => {
     });
 
     it('should reset vote counts for a re-initialized proposal', async () => {
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
       await strategy
         .connect(azoriusMock)
         .initializeProposal(encodedDefaultProposalId, [], ethers.ZeroHash);
@@ -459,8 +459,8 @@ describe('StrategyV1', () => {
     });
 
     it('should return true if any adapter identifies the address as a proposer', async () => {
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
-      await strategy.connect(owner).addAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
 
       // mockAdapter1 says NO, mockAdapter2 says YES
       await mockAdapter1.connect(owner).setProposerStatus(user1.address, false);
@@ -470,8 +470,8 @@ describe('StrategyV1', () => {
     });
 
     it('should return false if no adapter identifies the address as a proposer', async () => {
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
-      await strategy.connect(owner).addAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
 
       await mockAdapter1.connect(owner).setProposerStatus(user1.address, false);
       await mockAdapter2.connect(owner).setProposerStatus(user1.address, false);
@@ -480,8 +480,8 @@ describe('StrategyV1', () => {
     });
 
     it('should return true if the first adapter identifies the address as a proposer', async () => {
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
-      await strategy.connect(owner).addAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
 
       await mockAdapter1.connect(owner).setProposerStatus(user1.address, true);
       await mockAdapter2.connect(owner).setProposerStatus(user1.address, false); // Should not be checked
@@ -498,7 +498,7 @@ describe('StrategyV1', () => {
       proposalId = 1;
       encodedProposalId = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
       // Ensure at least one adapter is added for initializeProposal to succeed
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
     });
 
     it('should return correct timestamps and block after proposal initialization', async () => {
@@ -545,7 +545,7 @@ describe('StrategyV1', () => {
       encodedProposalId = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
 
       // Add at least one adapter for most tests
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
       // Initialize the proposal by azoriusMock
       await strategy
         .connect(azoriusMock)
@@ -682,7 +682,7 @@ describe('StrategyV1', () => {
 
     it('should sum weights if multiple adapters are used in one vote call', async () => {
       // Add second adapter to the strategy for this test
-      await strategy.connect(owner).addAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
 
       const weight1 = 60;
       const weight2 = 40;
@@ -755,7 +755,7 @@ describe('StrategyV1', () => {
     });
 
     it('should revert if any adapter call reverts in a multi-adapter vote (all-or-nothing)', async () => {
-      await strategy.connect(owner).addAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
 
       await mockAdapter1.connect(owner).setWeight(user1.address, 10);
       await mockAdapter2.connect(owner).setWeight(user1.address, 20);
@@ -795,7 +795,7 @@ describe('StrategyV1', () => {
     // the strategy has an adapter and a proposal is initialized.
     beforeEach(async () => {
       // Ensure adapter is present on the strategy instance for these specific tests
-      await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
       // Initialize the proposal fresh for each isPassed test
       await strategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
     });
@@ -1043,7 +1043,7 @@ describe('StrategyV1', () => {
     beforeEach(async () => {
       const adapterCount = await strategy.getTokenAdapterCount();
       if (adapterCount === 0n) {
-        await strategy.connect(owner).addAdapter(await mockAdapter1.getAddress());
+        await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
       }
 
       await strategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);

--- a/test/deployables/strategies/adapters/ERC20TokenAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20TokenAdapterV1.test.ts
@@ -5,8 +5,8 @@ import type { ContractTransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  ERC20AdapterV1,
-  ERC20AdapterV1__factory,
+  ERC20TokenAdapterV1,
+  ERC20TokenAdapterV1__factory,
   IERC165__factory,
   ITokenAdapterBaseV1__factory,
   ITokenAdapterV1__factory,
@@ -28,8 +28,8 @@ async function deployERC20AdapterProxy(
   strategyAddress: string,
   proposerThreshold: bigint,
   weightPerToken: bigint,
-): Promise<{ adapter: ERC20AdapterV1; deployTx: ContractTransactionResponse }> {
-  const initData = ERC20AdapterV1__factory.createInterface().encodeFunctionData('initialize', [
+): Promise<{ adapter: ERC20TokenAdapterV1; deployTx: ContractTransactionResponse }> {
+  const initData = ERC20TokenAdapterV1__factory.createInterface().encodeFunctionData('initialize', [
     ownerAddress,
     tokenAddress,
     strategyAddress,
@@ -40,7 +40,7 @@ async function deployERC20AdapterProxy(
   const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
   await proxy.waitForDeployment();
 
-  const adapter = ERC20AdapterV1__factory.connect(await proxy.getAddress(), proxyDeployer);
+  const adapter = ERC20TokenAdapterV1__factory.connect(await proxy.getAddress(), proxyDeployer);
   const deployTx = proxy.deploymentTransaction();
   if (!deployTx) {
     throw new Error('Proxy deployment transaction not found');
@@ -48,7 +48,7 @@ async function deployERC20AdapterProxy(
   return { adapter, deployTx };
 }
 
-describe('ERC20AdapterV1', () => {
+describe('ERC20TokenAdapterV1', () => {
   let deployerG: SignerWithAddress;
   let ownerG: SignerWithAddress;
   let erc20AdapterImplementationAddressG: string;
@@ -58,7 +58,7 @@ describe('ERC20AdapterV1', () => {
 
   async function deployGlobalFixture() {
     const [deployer, owner, user1, user2, nonOwner] = await ethers.getSigners();
-    const adapterImplFactory = new ERC20AdapterV1__factory(deployer);
+    const adapterImplFactory = new ERC20TokenAdapterV1__factory(deployer);
     const deployedAdapterImpl = await adapterImplFactory.deploy();
     await deployedAdapterImpl.waitForDeployment();
 
@@ -155,7 +155,7 @@ describe('ERC20AdapterV1', () => {
       // Provide the proxy instance (erc20Adapter) to .to.emit(),
       // as the event is emitted from the proxy's address due to delegatecall.
       await expect(deployTx.hash)
-        .to.emit(erc20Adapter, 'AdapterParametersUpdated')
+        .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
         .withArgs(DEFAULT_PROPOSER_THRESHOLD, DEFAULT_WEIGHT_PER_TOKEN);
 
       expect(await erc20Adapter.owner()).to.equal(ownerSigner.address);
@@ -166,7 +166,7 @@ describe('ERC20AdapterV1', () => {
     });
 
     it('should revert if token address is zero', async () => {
-      const erc20AdapterImplementation = ERC20AdapterV1__factory.connect(
+      const erc20AdapterImplementation = ERC20TokenAdapterV1__factory.connect(
         erc20AdapterImplementationAddressG,
         deployerG,
       );
@@ -185,7 +185,7 @@ describe('ERC20AdapterV1', () => {
     });
 
     it('should revert if strategy address is zero', async () => {
-      const erc20AdapterImplementation = ERC20AdapterV1__factory.connect(
+      const erc20AdapterImplementation = ERC20TokenAdapterV1__factory.connect(
         erc20AdapterImplementationAddressG,
         deployerG,
       );
@@ -204,7 +204,7 @@ describe('ERC20AdapterV1', () => {
     });
 
     it('should revert if weightPerToken is zero', async () => {
-      const erc20AdapterImplementation = ERC20AdapterV1__factory.connect(
+      const erc20AdapterImplementation = ERC20TokenAdapterV1__factory.connect(
         erc20AdapterImplementationAddressG,
         deployerG,
       );
@@ -245,7 +245,7 @@ describe('ERC20AdapterV1', () => {
     });
 
     it('Should have initialization disabled in the implementation contract', async function () {
-      const implementationContract = ERC20AdapterV1__factory.connect(
+      const implementationContract = ERC20TokenAdapterV1__factory.connect(
         erc20AdapterImplementationAddressG,
         ownerG,
       );
@@ -263,7 +263,7 @@ describe('ERC20AdapterV1', () => {
   });
 
   describe('Owner Functions', () => {
-    let erc20Adapter: ERC20AdapterV1;
+    let erc20Adapter: ERC20TokenAdapterV1;
     let currentOwnerSigner: SignerWithAddress;
     let currentNonOwnerSigner: SignerWithAddress;
 
@@ -290,7 +290,7 @@ describe('ERC20AdapterV1', () => {
         await expect(
           erc20Adapter.connect(currentOwnerSigner).updateProposerThreshold(NEW_PROPOSER_THRESHOLD),
         )
-          .to.emit(erc20Adapter, 'AdapterParametersUpdated')
+          .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
           .withArgs(NEW_PROPOSER_THRESHOLD, DEFAULT_WEIGHT_PER_TOKEN);
 
         expect(await erc20Adapter.proposerThreshold()).to.equal(NEW_PROPOSER_THRESHOLD);
@@ -308,7 +308,7 @@ describe('ERC20AdapterV1', () => {
 
       it('should allow updating to zero proposer threshold', async () => {
         await expect(erc20Adapter.connect(currentOwnerSigner).updateProposerThreshold(0n))
-          .to.emit(erc20Adapter, 'AdapterParametersUpdated')
+          .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
           .withArgs(0n, DEFAULT_WEIGHT_PER_TOKEN);
 
         expect(await erc20Adapter.proposerThreshold()).to.equal(0n);
@@ -322,7 +322,7 @@ describe('ERC20AdapterV1', () => {
         await expect(
           erc20Adapter.connect(currentOwnerSigner).updateWeightPerToken(NEW_WEIGHT_PER_TOKEN),
         )
-          .to.emit(erc20Adapter, 'AdapterParametersUpdated')
+          .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
           .withArgs(DEFAULT_PROPOSER_THRESHOLD, NEW_WEIGHT_PER_TOKEN);
         expect(await erc20Adapter.weightPerToken()).to.equal(NEW_WEIGHT_PER_TOKEN);
       });
@@ -346,7 +346,7 @@ describe('ERC20AdapterV1', () => {
   describe('weightOf', () => {
     const proposalId = 1;
     const mockExtraData = ethers.ZeroHash;
-    let adapter: ERC20AdapterV1;
+    let adapter: ERC20TokenAdapterV1;
 
     async function setupAdapterForWeightOf(clockMode: 0 | 1, customWeightPerToken?: bigint) {
       await mockToken.setClockMode(clockMode);
@@ -459,7 +459,7 @@ describe('ERC20AdapterV1', () => {
     const mockExtraData = ethers.ZeroHash;
     const expectedEventAdapterVoteData = '0x';
 
-    let adapter: ERC20AdapterV1;
+    let adapter: ERC20TokenAdapterV1;
     let token: MockERC20Votes;
     let strategy: MockVotingStrategy;
     let voter: SignerWithAddress;
@@ -597,7 +597,7 @@ describe('ERC20AdapterV1', () => {
   });
 
   describe('isProposer', () => {
-    let adapter: ERC20AdapterV1;
+    let adapter: ERC20TokenAdapterV1;
 
     const SUITE_WEIGHT_PER_TOKEN = 2n;
     const SUITE_RAW_VOTES_THRESHOLD = ethers.parseUnits('100', 18);
@@ -703,7 +703,7 @@ describe('ERC20AdapterV1', () => {
   });
 
   describe('ERC165 supportsInterface', () => {
-    let erc20Adapter: ERC20AdapterV1;
+    let erc20Adapter: ERC20TokenAdapterV1;
     let iTokenAdapterV1InterfaceId: string;
     let iTokenAdapterBaseV1InterfaceId: string;
     let iVersionInterfaceId: string;
@@ -754,7 +754,7 @@ describe('ERC20AdapterV1', () => {
   });
 
   describe('UUPS Upgradeability', () => {
-    let erc20AdapterProxy: ERC20AdapterV1;
+    let erc20AdapterProxy: ERC20TokenAdapterV1;
 
     beforeEach(async () => {
       const { adapter } = await deployERC20AdapterProxy(
@@ -772,7 +772,7 @@ describe('ERC20AdapterV1', () => {
     runUUPSUpgradeabilityTests({
       getContract: () => erc20AdapterProxy,
       createNewImplementation: async () => {
-        const newImplementation = await new ERC20AdapterV1__factory(deployer).deploy();
+        const newImplementation = await new ERC20TokenAdapterV1__factory(deployer).deploy();
         return newImplementation;
       },
       owner: () => ownerSigner,

--- a/test/deployables/strategies/adapters/ERC721TokenAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721TokenAdapterV1.test.ts
@@ -5,8 +5,8 @@ import type { ContractTransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  ERC721AdapterV1,
-  ERC721AdapterV1__factory,
+  ERC721TokenAdapterV1,
+  ERC721TokenAdapterV1__factory,
   IERC165__factory,
   ITokenAdapterBaseV1__factory,
   ITokenAdapterV1__factory,
@@ -27,19 +27,19 @@ async function deployERC721AdapterProxy(
   strategyAddress: string,
   weightPerNft: bigint,
   proposerThreshold: bigint,
-): Promise<{ adapter: ERC721AdapterV1; deployTx: ContractTransactionResponse }> {
-  const initData = ERC721AdapterV1__factory.createInterface().encodeFunctionData('initialize', [
-    initialOwnerAddress,
-    tokenAddress,
-    strategyAddress,
-    weightPerNft,
-    proposerThreshold,
-  ]);
+): Promise<{ adapter: ERC721TokenAdapterV1; deployTx: ContractTransactionResponse }> {
+  const initData = ERC721TokenAdapterV1__factory.createInterface().encodeFunctionData(
+    'initialize',
+    [initialOwnerAddress, tokenAddress, strategyAddress, weightPerNft, proposerThreshold],
+  );
   const proxyContractFactory = new ERC1967Proxy__factory(proxyDeployer);
   const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
   await proxy.waitForDeployment();
 
-  const adapterInstance = ERC721AdapterV1__factory.connect(await proxy.getAddress(), proxyDeployer);
+  const adapterInstance = ERC721TokenAdapterV1__factory.connect(
+    await proxy.getAddress(),
+    proxyDeployer,
+  );
   const deployTxObj = proxy.deploymentTransaction();
   if (!deployTxObj) {
     throw new Error('Proxy deployment transaction not found for ERC721AdapterV1');
@@ -47,7 +47,7 @@ async function deployERC721AdapterProxy(
   return { adapter: adapterInstance, deployTx: deployTxObj };
 }
 
-describe('ERC721AdapterV1', () => {
+describe('ERC721TokenAdapterV1', () => {
   // Globally scoped (from first fixture load in `before`)
   let erc721AdapterImplementationAddressG: string;
   let deployerG: SignerWithAddress;
@@ -58,7 +58,7 @@ describe('ERC721AdapterV1', () => {
 
   async function deployGlobalERC721Fixture() {
     const [deployer] = await ethers.getSigners();
-    const adapterImplFactory = new ERC721AdapterV1__factory(deployer);
+    const adapterImplFactory = new ERC721TokenAdapterV1__factory(deployer);
     const deployedAdapterImpl = await adapterImplFactory.deploy();
     await deployedAdapterImpl.waitForDeployment();
     erc721AdapterImplementationAddressG = await deployedAdapterImpl.getAddress();
@@ -124,7 +124,7 @@ describe('ERC721AdapterV1', () => {
   });
 
   describe('Initialization', () => {
-    it('should initialize correctly, set owner, and emit AdapterParametersUpdated event', async () => {
+    it('should initialize correctly, set owner, and emit TokenAdapterParametersUpdated event', async () => {
       const {
         ownerSigner,
         mockNft,
@@ -143,7 +143,7 @@ describe('ERC721AdapterV1', () => {
       );
 
       await expect(deployTx)
-        .to.emit(erc721Adapter, 'AdapterParametersUpdated')
+        .to.emit(erc721Adapter, 'TokenAdapterParametersUpdated')
         .withArgs(DEFAULT_WEIGHT_PER_NFT, DEFAULT_NFT_PROPOSER_THRESHOLD);
 
       expect(await erc721Adapter.owner()).to.equal(ownerSigner.address);
@@ -157,7 +157,7 @@ describe('ERC721AdapterV1', () => {
       const { mockNft, deployer: fixtureDeployer } = await loadFixture(
         deployMocksAndSignersERC721Fixture,
       );
-      const erc721AdapterImplementation = ERC721AdapterV1__factory.connect(
+      const erc721AdapterImplementation = ERC721TokenAdapterV1__factory.connect(
         erc721AdapterImplementationAddressG,
         deployerG,
       );
@@ -178,7 +178,7 @@ describe('ERC721AdapterV1', () => {
       const { mockNft, deployer: fixtureDeployer } = await loadFixture(
         deployMocksAndSignersERC721Fixture,
       );
-      const erc721AdapterImplementation = ERC721AdapterV1__factory.connect(
+      const erc721AdapterImplementation = ERC721TokenAdapterV1__factory.connect(
         erc721AdapterImplementationAddressG,
         deployerG,
       );
@@ -201,7 +201,7 @@ describe('ERC721AdapterV1', () => {
         mockStrategy,
         deployer: fixtureDeployer,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
-      const erc721AdapterImplementation = ERC721AdapterV1__factory.connect(
+      const erc721AdapterImplementation = ERC721TokenAdapterV1__factory.connect(
         erc721AdapterImplementationAddressG,
         deployerG,
       );
@@ -250,7 +250,7 @@ describe('ERC721AdapterV1', () => {
         mockStrategy,
         deployer: fixtureDeployer,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
-      const implementationContract = ERC721AdapterV1__factory.connect(
+      const implementationContract = ERC721TokenAdapterV1__factory.connect(
         erc721AdapterImplementationAddressG,
         fixtureDeployer,
       );
@@ -267,7 +267,7 @@ describe('ERC721AdapterV1', () => {
   });
 
   describe('weightOf', () => {
-    let adapter: ERC721AdapterV1;
+    let adapter: ERC721TokenAdapterV1;
     let mockNft: MockERC721; // Explicitly type mockNft here
     let user1: SignerWithAddress;
     let user1TokenIds: bigint[];
@@ -388,7 +388,7 @@ describe('ERC721AdapterV1', () => {
   });
 
   describe('recordVote', () => {
-    let adapter: ERC721AdapterV1;
+    let adapter: ERC721TokenAdapterV1;
     let mockNft: MockERC721;
     let user1: SignerWithAddress;
     let user1TokenIds: bigint[];
@@ -553,7 +553,7 @@ describe('ERC721AdapterV1', () => {
   });
 
   describe('isProposer', () => {
-    let adapter: ERC721AdapterV1;
+    let adapter: ERC721TokenAdapterV1;
     let mockNft: MockERC721;
     let user1: SignerWithAddress; // Fixture user1 (has 3 NFTs: 0,1,2)
     let user2: SignerWithAddress; // Fixture user2 (has 2 NFTs: 3,4)
@@ -675,7 +675,7 @@ describe('ERC721AdapterV1', () => {
   });
 
   describe('ERC165 supportsInterface', () => {
-    let erc721Adapter: ERC721AdapterV1;
+    let erc721Adapter: ERC721TokenAdapterV1;
     let iTokenAdapterV1InterfaceId: string;
     let iTokenAdapterBaseV1InterfaceId: string;
     let iVersionInterfaceId: string;
@@ -732,7 +732,7 @@ describe('ERC721AdapterV1', () => {
   });
 
   describe('Owner Functions', () => {
-    let adapter: ERC721AdapterV1;
+    let adapter: ERC721TokenAdapterV1;
     let owner: SignerWithAddress;
     let nonOwner: SignerWithAddress;
     let deployer: SignerWithAddress; // This will be the fixture.deployer
@@ -764,7 +764,7 @@ describe('ERC721AdapterV1', () => {
 
       it('should allow owner to update weightPerNft and emit event', async () => {
         await expect(adapter.connect(owner).updateWeightPerNft(NEW_WEIGHT_PER_NFT))
-          .to.emit(adapter, 'AdapterParametersUpdated')
+          .to.emit(adapter, 'TokenAdapterParametersUpdated')
           .withArgs(NEW_WEIGHT_PER_NFT, await adapter.proposerThreshold()); // Current proposerThreshold
         expect(await adapter.weightPerNft()).to.equal(NEW_WEIGHT_PER_NFT);
       });
@@ -788,7 +788,7 @@ describe('ERC721AdapterV1', () => {
 
       it('should allow owner to update proposerThreshold and emit event', async () => {
         await expect(adapter.connect(owner).updateProposerThreshold(NEW_PROPOSER_THRESHOLD))
-          .to.emit(adapter, 'AdapterParametersUpdated')
+          .to.emit(adapter, 'TokenAdapterParametersUpdated')
           .withArgs(await adapter.weightPerNft(), NEW_PROPOSER_THRESHOLD); // Current weightPerNft
         expect(await adapter.proposerThreshold()).to.equal(NEW_PROPOSER_THRESHOLD);
       });
@@ -801,7 +801,7 @@ describe('ERC721AdapterV1', () => {
 
       it('should allow updating proposerThreshold to zero', async () => {
         await expect(adapter.connect(owner).updateProposerThreshold(0n))
-          .to.emit(adapter, 'AdapterParametersUpdated')
+          .to.emit(adapter, 'TokenAdapterParametersUpdated')
           .withArgs(await adapter.weightPerNft(), 0n);
         expect(await adapter.proposerThreshold()).to.equal(0n);
       });
@@ -809,7 +809,7 @@ describe('ERC721AdapterV1', () => {
   });
 
   describe('UUPS Upgradeability', () => {
-    let erc721AdapterProxy: ERC721AdapterV1;
+    let erc721AdapterProxy: ERC721TokenAdapterV1;
     let fixtureOwner: SignerWithAddress;
     let fixtureNonOwner: SignerWithAddress;
     let fixtureDeployer: SignerWithAddress;
@@ -841,7 +841,7 @@ describe('ERC721AdapterV1', () => {
     runUUPSUpgradeabilityTests({
       getContract: () => erc721AdapterProxy,
       createNewImplementation: async () => {
-        const newImplementation = await new ERC721AdapterV1__factory(fixtureDeployer).deploy();
+        const newImplementation = await new ERC721TokenAdapterV1__factory(fixtureDeployer).deploy();
         await newImplementation.waitForDeployment();
         return newImplementation;
       },


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/274

Fixes [ENG-966](https://linear.app/decent-labs/issue/ENG-966/standardize-tokenadapter-naming-across-strategy-and-adapter-contracts)

**High-Level Context:**

This Pull Request is part of the ongoing development of our new modular `StrategyV1` governance system. To improve clarity and consistency in our codebase, this PR focuses on renaming the concrete token adapter contracts and their associated events and errors to more explicitly include the "TokenAdapter" qualifier. This ensures that their purpose and relationship within the `StrategyV1` architecture are unambiguous.

**Specific Changes in this PR:**

1.  **Contract Renaming:**
    *   `ERC20AdapterV1.sol` has been renamed to `ERC20TokenAdapterV1.sol`.
    *   `ERC721AdapterV1.sol` has been renamed to `ERC721TokenAdapterV1.sol`.
    *   All import paths and contract name references in tests and other contracts have been updated accordingly.

2.  **Event Renaming in `StrategyV1.sol`:**
    *   `AdapterAdded` event is now `TokenAdapterAdded`.
    *   `AdapterRemoved` event is now `TokenAdapterRemoved`.

3.  **Error Renaming in `StrategyV1.sol`:**
    *   `AdapterIsZeroAddress` is now `TokenAdapterIsZeroAddress`.
    *   `AdapterAlreadyExists` is now `TokenAdapterAlreadyExists`.
    *   `AdapterNotFound` is now `TokenAdapterNotFound`.
    *   `NoAdapters` is now `NoTokenAdapters`.

4.  **Event Renaming in Adapter Contracts:**
    *   In both `ERC20TokenAdapterV1.sol` (formerly `ERC20AdapterV1.sol`) and `ERC721TokenAdapterV1.sol` (formerly `ERC721AdapterV1.sol`), the `AdapterParametersUpdated` event has been renamed to `TokenAdapterParametersUpdated`.

5.  **Variable Naming in `StrategyV1.sol` `vote` function:**
    *   Parameters `_adaptersToUse` and `_adapterVoteData` have been renamed to `_tokenAdaptersToUse` and `_tokenAdapterVoteData` for clarity.

6.  **Function Renaming in `StrategyV1.sol` and `IStrategyV1.sol`:**
    *   `addAdapter(address _adapter)` is now `addTokenAdapter(address _adapter)`.
    *   `removeAdapter(address _adapter)` is now `removeTokenAdapter(address _adapter)`.
    *   The internal helper `_addAdapter` in `StrategyV1.sol` is now `_addTokenAdapter`.

7.  **Interface `ITokenAdapterV1.sol`:**
    *   The `ITokenAdapterV1` interface now inherits from `ITokenAdapterBaseV1`.
    *   `ITokenAdapterBaseV1` contains `isProposer` and `recordVote`.
    *   `ITokenAdapterV1` (which extends Base) now solely contains `weightOf`.
    *   Parameter `_adapterVoteData` in `recordVote` (in `ITokenAdapterBaseV1`) renamed to `_tokenAdapterVoteData`.
    *   Event `VoteRecorded` in `ITokenAdapterBaseV1` parameter `adapterVoteData` renamed to `tokenAdapterVoteData`.

8.  **Test File Renaming and Updates:**
    *   `test/deployables/strategies/adapters/ERC20AdapterV1.test.ts` renamed to `ERC20TokenAdapterV1.test.ts`.
    *   `test/deployables/strategies/adapters/ERC721AdapterV1.test.ts` renamed to `ERC721TokenAdapterV1.test.ts`.
    *   All factory imports and type references within these test files and `StrategyV1.test.ts` have been updated to use the new contract names (e.g., `ERC20TokenAdapterV1__factory`).

**Impact and Status:**

*   This is primarily a naming convention and clarity improvement across the new strategy and adapter contracts. It does not introduce new functionality but makes the existing code more self-documenting.
*   **Compilation Status:** All contracts and tests should compile successfully with these changes.
*   **Testing Status:** All existing tests have been updated to reflect the renaming and should continue to pass, ensuring no regressions were introduced.

This refactoring helps solidify the naming conventions for the new modular strategy system, making it easier to understand and maintain as it evolves.