### PR TITLE
refactor(CoreContracts): Enhance extensibility by marking functions as virtual

### DIFF
--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -83,7 +83,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         address _strategy,
         uint32 _timelockPeriod,
         uint32 _executionPeriod
-    ) public initializer {
+    ) public virtual initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
 
@@ -99,7 +99,9 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         emit AzoriusSetUp(msg.sender, _owner, _avatar, _target);
     }
 
-    function setUp(bytes memory initializeParams) public override initializer {
+    function setUp(
+        bytes memory initializeParams
+    ) public virtual override initializer {
         (
             address _owner,
             address _avatar,
@@ -127,17 +129,19 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
 
     function updateTimelockPeriod(
         uint32 _timelockPeriod
-    ) external override onlyOwner {
+    ) external virtual override onlyOwner {
         _updateTimelockPeriod(_timelockPeriod);
     }
 
     function updateExecutionPeriod(
         uint32 _executionPeriod
-    ) external override onlyOwner {
+    ) external virtual override onlyOwner {
         _updateExecutionPeriod(_executionPeriod);
     }
 
-    function updateStrategy(address _strategy) external override onlyOwner {
+    function updateStrategy(
+        address _strategy
+    ) external virtual override onlyOwner {
         _updateStrategy(_strategy);
     }
 
@@ -145,7 +149,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         Transaction[] calldata _transactions,
         string calldata _metadata,
         bytes memory _data
-    ) external override {
+    ) external virtual override {
         if (!strategy.isProposer(msg.sender)) revert InvalidProposer();
 
         bytes32[] memory txHashes = new bytes32[](_transactions.length);
@@ -186,7 +190,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         uint256[] memory _values,
         bytes[] memory _data,
         Enum.Operation[] memory _operations
-    ) external override {
+    ) external virtual override {
         if (_targets.length == 0) revert InvalidTxs();
         if (
             _targets.length != _values.length ||
@@ -217,13 +221,13 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
     function getProposalTxHash(
         uint32 _proposalId,
         uint32 _txIndex
-    ) external view override returns (bytes32) {
+    ) external view virtual override returns (bytes32) {
         return proposals[_proposalId].txHashes[_txIndex];
     }
 
     function getProposalTxHashes(
         uint32 _proposalId
-    ) external view override returns (bytes32[] memory) {
+    ) external view virtual override returns (bytes32[] memory) {
         return proposals[_proposalId].txHashes;
     }
 
@@ -232,6 +236,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
     )
         external
         view
+        virtual
         override
         returns (
             address _strategy,
@@ -251,7 +256,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
 
     function proposalState(
         uint32 _proposalId
-    ) public view override returns (ProposalState) {
+    ) public view virtual override returns (ProposalState) {
         if (_proposalId >= totalProposalCount) revert InvalidProposal();
         Proposal memory _proposal = proposals[_proposalId];
         IStrategyBaseV1 _strategy = IStrategyBaseV1(_proposal.strategy);
@@ -288,7 +293,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         bytes memory _data,
         Enum.Operation _operation,
         uint256 _nonce
-    ) public view override returns (bytes memory) {
+    ) public view virtual override returns (bytes memory) {
         uint256 chainId = block.chainid;
         bytes32 domainSeparator = keccak256(
             abi.encode(DOMAIN_SEPARATOR_TYPEHASH, chainId, this)
@@ -317,7 +322,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         uint256 _value,
         bytes memory _data,
         Enum.Operation _operation
-    ) public view override returns (bytes32) {
+    ) public view virtual override returns (bytes32) {
         return keccak256(generateTxHashData(_to, _value, _data, _operation, 0));
     }
 
@@ -327,7 +332,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         uint256 _value,
         bytes memory _data,
         Enum.Operation _operation
-    ) internal returns (bytes32 txHash) {
+    ) internal virtual returns (bytes32 txHash) {
         if (proposalState(_proposalId) != ProposalState.EXECUTABLE)
             revert ProposalNotExecutable();
         txHash = getTxHash(_target, _value, _data, _operation);
@@ -342,17 +347,17 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         if (!exec(_target, _value, _data, _operation)) revert TxFailed();
     }
 
-    function _updateTimelockPeriod(uint32 _timelockPeriod) internal {
+    function _updateTimelockPeriod(uint32 _timelockPeriod) internal virtual {
         timelockPeriod = _timelockPeriod;
         emit TimelockPeriodUpdated(_timelockPeriod);
     }
 
-    function _updateExecutionPeriod(uint32 _executionPeriod) internal {
+    function _updateExecutionPeriod(uint32 _executionPeriod) internal virtual {
         executionPeriod = _executionPeriod;
         emit ExecutionPeriodUpdated(_executionPeriod);
     }
 
-    function _updateStrategy(address _strategy) internal {
+    function _updateStrategy(address _strategy) internal virtual {
         if (_strategy == address(0)) revert InvalidStrategy();
         strategy = IStrategyBaseV1(_strategy);
         emit StrategyUpdated(_strategy);

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -124,7 +124,7 @@ contract StrategyV1 is
 
     function updateVotingPeriod(
         uint32 _newVotingPeriod
-    ) external override onlyOwner {
+    ) external virtual override onlyOwner {
         _updateVotingPeriod(_newVotingPeriod);
         emit StrategyParametersUpdated(
             votingPeriod,
@@ -135,7 +135,7 @@ contract StrategyV1 is
 
     function updateQuorumThreshold(
         uint256 _newQuorumThreshold
-    ) external override onlyOwner {
+    ) external virtual override onlyOwner {
         _updateQuorumThreshold(_newQuorumThreshold);
         emit StrategyParametersUpdated(
             votingPeriod,
@@ -146,7 +146,7 @@ contract StrategyV1 is
 
     function updateBasisNumerator(
         uint256 _newBasisNumerator
-    ) external override onlyOwner {
+    ) external virtual override onlyOwner {
         _updateBasisNumerator(_newBasisNumerator);
         emit StrategyParametersUpdated(
             votingPeriod,
@@ -155,11 +155,15 @@ contract StrategyV1 is
         );
     }
 
-    function addTokenAdapter(address _adapter) public override onlyOwner {
+    function addTokenAdapter(
+        address _adapter
+    ) public virtual override onlyOwner {
         _addTokenAdapter(_adapter);
     }
 
-    function removeTokenAdapter(address _adapter) external override onlyOwner {
+    function removeTokenAdapter(
+        address _adapter
+    ) external virtual override onlyOwner {
         if (_adapter == address(0)) revert TokenAdapterIsZeroAddress();
         uint256 adapterCount = tokenAdapters.length;
         if (adapterCount == 0) revert TokenAdapterNotFound();
@@ -175,7 +179,13 @@ contract StrategyV1 is
         revert TokenAdapterNotFound();
     }
 
-    function getTokenAdapterCount() external view override returns (uint256) {
+    function getTokenAdapterCount()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         return tokenAdapters.length;
     }
 
@@ -360,16 +370,20 @@ contract StrategyV1 is
         return details.votingStartBlock;
     }
 
-    function _updateVotingPeriod(uint32 _newVotingPeriod) internal {
+    function _updateVotingPeriod(uint32 _newVotingPeriod) internal virtual {
         if (_newVotingPeriod == 0) revert InvalidVotingPeriod();
         votingPeriod = _newVotingPeriod;
     }
 
-    function _updateQuorumThreshold(uint256 _newQuorumThreshold) internal {
+    function _updateQuorumThreshold(
+        uint256 _newQuorumThreshold
+    ) internal virtual {
         quorumThreshold = _newQuorumThreshold;
     }
 
-    function _updateBasisNumerator(uint256 _newBasisNumerator) internal {
+    function _updateBasisNumerator(
+        uint256 _newBasisNumerator
+    ) internal virtual {
         if (
             _newBasisNumerator >= BASIS_DENOMINATOR ||
             _newBasisNumerator < BASIS_DENOMINATOR / 2
@@ -378,7 +392,7 @@ contract StrategyV1 is
         basisNumerator = _newBasisNumerator;
     }
 
-    function _addTokenAdapter(address _adapter) internal {
+    function _addTokenAdapter(address _adapter) internal virtual {
         if (_adapter == address(0)) revert TokenAdapterIsZeroAddress();
         for (uint256 i = 0; i < tokenAdapters.length; i++) {
             if (address(tokenAdapters[i]) == _adapter)

--- a/contracts/deployables/strategies/adapters/ERC20TokenAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20TokenAdapterV1.sol
@@ -53,7 +53,7 @@ contract ERC20TokenAdapterV1 is
         address _strategy,
         uint256 _proposerThreshold,
         uint256 _weightPerToken
-    ) external initializer {
+    ) external virtual initializer {
         __Ownable_init(_initialOwner);
         __UUPSUpgradeable_init();
 
@@ -72,7 +72,7 @@ contract ERC20TokenAdapterV1 is
 
     function _authorizeUpgrade(
         address newImplementation
-    ) internal override onlyOwner {}
+    ) internal virtual override onlyOwner {}
 
     function updateProposerThreshold(
         uint256 _newProposerThreshold
@@ -83,7 +83,7 @@ contract ERC20TokenAdapterV1 is
 
     function updateWeightPerToken(
         uint256 _newWeightPerToken
-    ) external onlyOwner {
+    ) external virtual onlyOwner {
         _updateWeightPerToken(_newWeightPerToken);
         emit TokenAdapterParametersUpdated(proposerThreshold, weightPerToken);
     }
@@ -92,7 +92,9 @@ contract ERC20TokenAdapterV1 is
         proposerThreshold = _newProposerThreshold;
     }
 
-    function _updateWeightPerToken(uint256 _newWeightPerToken) internal {
+    function _updateWeightPerToken(
+        uint256 _newWeightPerToken
+    ) internal virtual {
         if (_newWeightPerToken == 0) revert InvalidWeightPerToken();
         weightPerToken = _newWeightPerToken;
     }
@@ -100,7 +102,7 @@ contract ERC20TokenAdapterV1 is
     function _getVoteWeightDetails(
         address _voter,
         uint32 _proposalId
-    ) internal view returns (uint256 weight) {
+    ) internal view virtual returns (uint256 weight) {
         uint256 rawVotes;
         if (tokenClockMode == ClockMode.Timestamp) {
             (uint48 startTimestamp, ) = strategy.getVotingTimestamps(
@@ -120,7 +122,7 @@ contract ERC20TokenAdapterV1 is
         address _voter,
         uint32 _proposalId,
         bytes calldata
-    ) external view override returns (uint256 weight) {
+    ) external view virtual override returns (uint256 weight) {
         if (_hasCastedVoteForProposal[_proposalId][_voter]) {
             return 0;
         }
@@ -131,7 +133,7 @@ contract ERC20TokenAdapterV1 is
         address _voter,
         uint32 _proposalId,
         bytes calldata
-    ) external override returns (uint256 weightCasted) {
+    ) external virtual override returns (uint256 weightCasted) {
         if (_hasCastedVoteForProposal[_proposalId][_voter]) {
             revert ERC20AlreadyVoted();
         }
@@ -149,13 +151,13 @@ contract ERC20TokenAdapterV1 is
         return (rawVotes * weightPerToken) >= proposerThreshold;
     }
 
-    function getVersion() public pure override returns (uint16) {
+    function getVersion() public pure virtual override returns (uint16) {
         return VERSION;
     }
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view override(ERC165, Version) returns (bool) {
+    ) public view virtual override(ERC165, Version) returns (bool) {
         return
             interfaceId == type(ITokenAdapterV1).interfaceId ||
             interfaceId == type(ITokenAdapterBaseV1).interfaceId ||

--- a/contracts/deployables/strategies/adapters/ERC721TokenAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721TokenAdapterV1.sol
@@ -47,7 +47,7 @@ contract ERC721TokenAdapterV1 is
         address _strategy,
         uint256 _weightPerNft,
         uint256 _proposerThreshold
-    ) external initializer {
+    ) external virtual initializer {
         __Ownable_init(_initialOwner);
         __UUPSUpgradeable_init();
 
@@ -65,9 +65,11 @@ contract ERC721TokenAdapterV1 is
 
     function _authorizeUpgrade(
         address newImplementation
-    ) internal override onlyOwner {}
+    ) internal virtual override onlyOwner {}
 
-    function updateWeightPerNft(uint256 _newWeightPerNft) external onlyOwner {
+    function updateWeightPerNft(
+        uint256 _newWeightPerNft
+    ) external virtual onlyOwner {
         _updateWeightPerNft(_newWeightPerNft);
         emit TokenAdapterParametersUpdated(weightPerNft, proposerThreshold);
     }
@@ -79,7 +81,7 @@ contract ERC721TokenAdapterV1 is
         emit TokenAdapterParametersUpdated(weightPerNft, proposerThreshold);
     }
 
-    function _updateWeightPerNft(uint256 _newWeightPerNft) internal {
+    function _updateWeightPerNft(uint256 _newWeightPerNft) internal virtual {
         if (_newWeightPerNft == 0) revert InvalidWeightPerNft();
         weightPerNft = _newWeightPerNft;
     }
@@ -95,6 +97,7 @@ contract ERC721TokenAdapterV1 is
     )
         internal
         view
+        virtual
         returns (
             uint256[] memory validTokenIdsForThisCall,
             uint256 totalCalculatedWeight
@@ -144,7 +147,7 @@ contract ERC721TokenAdapterV1 is
         address _voter,
         uint32 _proposalId,
         bytes calldata _adapterVoteData
-    ) external view override returns (uint256 weight) {
+    ) external view virtual override returns (uint256 weight) {
         (, uint256 totalCalculatedWeight) = _getValidUnvotedTokenIdsAndWeight(
             _voter,
             _proposalId,
@@ -157,7 +160,7 @@ contract ERC721TokenAdapterV1 is
         address _voter,
         uint32 _proposalId,
         bytes calldata _adapterVoteData
-    ) external override returns (uint256 weightCasted) {
+    ) external virtual override returns (uint256 weightCasted) {
         (
             uint256[] memory validTokenIdsToRecord,
             uint256 totalCalculatedWeight
@@ -181,13 +184,13 @@ contract ERC721TokenAdapterV1 is
         return (token.balanceOf(_proposer) * weightPerNft) >= proposerThreshold;
     }
 
-    function getVersion() public pure override returns (uint16) {
+    function getVersion() public pure virtual override returns (uint16) {
         return VERSION;
     }
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view override(ERC165, Version) returns (bool) {
+    ) public view virtual override(ERC165, Version) returns (bool) {
         return
             interfaceId == type(ITokenAdapterV1).interfaceId ||
             interfaceId == type(ITokenAdapterBaseV1).interfaceId ||


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/275

Fixes [ENG-967](https://linear.app/decent-labs/issue/ENG-967/enhance-core-contract-extensibility-by-marking-functions-as-virtual)

**High-Level Context:**

This Pull Request is part of a broader architectural refactoring aimed at creating a more modular, flexible, and extensible governance system. A key aspect of enabling this future extensibility is ensuring that our core contracts (`AzoriusV1`, `StrategyV1`, and its Token Adapters) can be easily inherited from and their behaviors customized by derived contracts. This PR focuses on applying the `virtual` keyword to functions across these core components.

**Specific Changes in this PR:**

Across the following contracts, numerous `public` and `external` functions, particularly those already marked `override` or base `initialize` functions, have been made `virtual`. Additionally, several key `internal` helper functions have also been marked `virtual` to allow for more granular customization in child contracts:

1.  **`AzoriusV1.sol`:**
    *   Functions such as `initialize`, `setUp`, `updateTimelockPeriod`, `updateExecutionPeriod`, `updateStrategy`, `submitProposal`, `executeProposal`, `getProposalTxHash`, `getProposalTxHashes`, `getProposal`, `proposalState`, `generateTxHashData`, and `getTxHash` are now `virtual`.
    *   Internal helpers like `_updateTimelockPeriod`, `_updateExecutionPeriod`, `_updateStrategy`, and `_executeProposalTransaction` are now `virtual`.

2.  **`StrategyV1.sol`:**
    *   Functions including `initialize`, parameter updaters (`updateVotingPeriod`, etc.), adapter management (`addTokenAdapter`, etc.), `initializeProposal`, `isPassed`, `isQuorumMet`, `isBasisMet`, `isProposer`, `getVotingTimestamps`, `getVotingStartBlock`, and `vote` are now `virtual`.
    *   Internal helpers like `_updateVotingPeriod`, `_updateQuorumThreshold`, `_updateBasisNumerator`, and `_addTokenAdapter` are now `virtual`.

3.  **`ERC20TokenAdapterV1.sol`:**
    *   Functions such as `initialize`, parameter updaters, `weightOf`, `recordVote`, `isProposer`, `getVersion`, and `supportsInterface` are now `virtual`.
    *   Internal helpers `_updateProposerThreshold`, `_updateWeightPerToken`, `_getVoteWeightDetails`, and `_authorizeUpgrade` are now `virtual`.

4.  **`ERC721TokenAdapterV1.sol`:**
    *   Functions such as `initialize`, parameter updaters, `weightOf`, `recordVote`, `isProposer`, `getVersion`, and `supportsInterface` are now `virtual`.
    *   Internal helpers `_updateWeightPerNft`, `_updateProposerThreshold`, `_getValidUnvotedTokenIdsAndWeight`, and `_authorizeUpgrade` are now `virtual`.

**Impact and Status:**

*   **Enhanced Extensibility:** This change significantly improves the ability for developers to extend and customize the behavior of these core governance contracts without needing to fork or completely rewrite them.
*   **No Functional Change (Intended):** The addition of `virtual` should not, by itself, alter the current operational logic of these contracts.
*   **Compilation Status:** All contracts modified in this PR should compile successfully.
*   **Testing Status:** While the contracts compile, **the existing test suite may still have failures or require minor adjustments.** This is because tests might not have anticipated `virtual` on all these functions, or there might be subtle interactions if any mocks were tightly coupled to non-virtual implementations. However, the core logic remains unchanged, so most tests *should* pass after recompilation. Full verification via the test suite is crucial.

This PR is a preparatory step, ensuring our foundational contracts are designed for future growth and adaptation within the evolving governance landscape.