### PR TITLE
refactor(StrategyV1)!: Decouple Proposer Logic into Separate Proposer Adapters

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IStrategyBaseV1} from "../../interfaces/decent/deployables/IStrategyBaseV1.sol";
 import {ITokenAdapterBaseV1} from "../../interfaces/decent/deployables/ITokenAdapterBaseV1.sol";
+import {IProposerAdapterBaseV1} from "../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {Version} from "../Version.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
@@ -40,6 +41,7 @@ contract StrategyV1 is
     mapping(uint32 => ProposalVotingDetails) public proposalVotingDetails;
 
     ITokenAdapterBaseV1[] public tokenAdapters;
+    IProposerAdapterBaseV1[] public proposerAdapters;
 
     enum VoteType {
         NO,
@@ -54,6 +56,8 @@ contract StrategyV1 is
     );
     event TokenAdapterAdded(address indexed adapter, uint256 index);
     event TokenAdapterRemoved(address indexed adapter, uint256 index);
+    event ProposerAdapterAdded(address indexed adapter, uint256 index);
+    event ProposerAdapterRemoved(address indexed adapter, uint256 index);
     event Voted(
         address indexed voter,
         uint32 indexed proposalId,
@@ -74,6 +78,9 @@ contract StrategyV1 is
     error TokenAdapterAlreadyExists();
     error TokenAdapterNotFound();
     error NoTokenAdapters();
+    error ProposerAdapterIsZeroAddress();
+    error ProposerAdapterAlreadyExists();
+    error ProposerAdapterNotFound();
     error ProposalNotFoundOrNotActive();
     error NoVotingWeight();
     error InvalidVoteType();
@@ -92,6 +99,7 @@ contract StrategyV1 is
         uint256 _quorumThreshold,
         uint256 _basisNumerator,
         address[] memory _initialTokenAdapters,
+        address[] memory _initialProposerAdapters,
         address _lightAccountFactory
     ) public virtual initializer {
         if (_azorius == address(0)) revert InvalidAzoriusAddress();
@@ -108,6 +116,12 @@ contract StrategyV1 is
         if (_initialTokenAdapters.length > 0) {
             for (uint256 i = 0; i < _initialTokenAdapters.length; i++) {
                 _addTokenAdapter(_initialTokenAdapters[i]);
+            }
+        }
+
+        if (_initialProposerAdapters.length > 0) {
+            for (uint256 i = 0; i < _initialProposerAdapters.length; i++) {
+                _addProposerAdapter(_initialProposerAdapters[i]);
             }
         }
 
@@ -187,6 +201,40 @@ contract StrategyV1 is
         returns (uint256)
     {
         return tokenAdapters.length;
+    }
+
+    function addProposerAdapter(
+        address _adapter
+    ) public virtual override onlyOwner {
+        _addProposerAdapter(_adapter);
+    }
+
+    function removeProposerAdapter(
+        address _adapter
+    ) external virtual override onlyOwner {
+        if (_adapter == address(0)) revert ProposerAdapterIsZeroAddress();
+        uint256 adapterCount = proposerAdapters.length;
+        if (adapterCount == 0) revert ProposerAdapterNotFound();
+
+        for (uint256 i = 0; i < adapterCount; i++) {
+            if (address(proposerAdapters[i]) == _adapter) {
+                proposerAdapters[i] = proposerAdapters[adapterCount - 1];
+                proposerAdapters.pop();
+                emit ProposerAdapterRemoved(address(_adapter), i);
+                return;
+            }
+        }
+        revert ProposerAdapterNotFound();
+    }
+
+    function getProposerAdapterCount()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        return proposerAdapters.length;
     }
 
     function initializeProposal(
@@ -335,9 +383,9 @@ contract StrategyV1 is
     function isProposer(
         address _address
     ) external view virtual override returns (bool) {
-        if (tokenAdapters.length == 0) return false;
-        for (uint256 i = 0; i < tokenAdapters.length; i++) {
-            if (tokenAdapters[i].isProposer(_address)) {
+        if (proposerAdapters.length == 0) return false;
+        for (uint256 i = 0; i < proposerAdapters.length; i++) {
+            if (proposerAdapters[i].isProposer(_address)) {
                 return true;
             }
         }
@@ -400,6 +448,19 @@ contract StrategyV1 is
         }
         tokenAdapters.push(ITokenAdapterBaseV1(_adapter));
         emit TokenAdapterAdded(address(_adapter), tokenAdapters.length - 1);
+    }
+
+    function _addProposerAdapter(address _adapter) internal virtual {
+        if (_adapter == address(0)) revert ProposerAdapterIsZeroAddress();
+        for (uint256 i = 0; i < proposerAdapters.length; i++) {
+            if (address(proposerAdapters[i]) == _adapter)
+                revert ProposerAdapterAlreadyExists();
+        }
+        proposerAdapters.push(IProposerAdapterBaseV1(_adapter));
+        emit ProposerAdapterAdded(
+            address(_adapter),
+            proposerAdapters.length - 1
+        );
     }
 
     function getVersion() public view virtual override returns (uint16) {

--- a/contracts/deployables/strategies/adapters/ERC20TokenAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20TokenAdapterV1.sol
@@ -23,7 +23,6 @@ contract ERC20TokenAdapterV1 is
 {
     IVotes public token;
     IStrategyBaseV1 public strategy;
-    uint256 public proposerThreshold;
     uint256 public weightPerToken;
     ClockMode internal tokenClockMode;
 
@@ -32,10 +31,7 @@ contract ERC20TokenAdapterV1 is
 
     uint16 public constant VERSION = 1;
 
-    event TokenAdapterParametersUpdated(
-        uint256 newProposerThreshold,
-        uint256 newWeightPerToken
-    );
+    event TokenAdapterParametersUpdated(uint256 newWeightPerToken);
 
     error InvalidTokenAddress();
     error InvalidStrategyAddress();
@@ -51,7 +47,6 @@ contract ERC20TokenAdapterV1 is
         address _initialOwner,
         address _token,
         address _strategy,
-        uint256 _proposerThreshold,
         uint256 _weightPerToken
     ) external virtual initializer {
         __Ownable_init(_initialOwner);
@@ -61,35 +56,23 @@ contract ERC20TokenAdapterV1 is
         if (_strategy == address(0)) revert InvalidStrategyAddress();
 
         _updateWeightPerToken(_weightPerToken);
-        _updateProposerThreshold(_proposerThreshold);
 
         token = IVotes(_token);
         strategy = IStrategyBaseV1(_strategy);
         tokenClockMode = ClockModeLib.getClockMode(_token);
 
-        emit TokenAdapterParametersUpdated(proposerThreshold, weightPerToken);
+        emit TokenAdapterParametersUpdated(weightPerToken);
     }
 
     function _authorizeUpgrade(
         address newImplementation
     ) internal virtual override onlyOwner {}
 
-    function updateProposerThreshold(
-        uint256 _newProposerThreshold
-    ) external onlyOwner {
-        _updateProposerThreshold(_newProposerThreshold);
-        emit TokenAdapterParametersUpdated(proposerThreshold, weightPerToken);
-    }
-
     function updateWeightPerToken(
         uint256 _newWeightPerToken
     ) external virtual onlyOwner {
         _updateWeightPerToken(_newWeightPerToken);
-        emit TokenAdapterParametersUpdated(proposerThreshold, weightPerToken);
-    }
-
-    function _updateProposerThreshold(uint256 _newProposerThreshold) internal {
-        proposerThreshold = _newProposerThreshold;
+        emit TokenAdapterParametersUpdated(weightPerToken);
     }
 
     function _updateWeightPerToken(
@@ -142,13 +125,6 @@ contract ERC20TokenAdapterV1 is
         weightCasted = _getVoteWeightDetails(_voter, _proposalId);
 
         emit VoteRecorded(_voter, _proposalId, weightCasted, bytes(""));
-    }
-
-    function isProposer(
-        address _proposer
-    ) external view override returns (bool) {
-        uint256 rawVotes = token.getVotes(_proposer);
-        return (rawVotes * weightPerToken) >= proposerThreshold;
     }
 
     function getVersion() public pure virtual override returns (uint16) {

--- a/contracts/deployables/strategies/adapters/ERC721TokenAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721TokenAdapterV1.sol
@@ -22,16 +22,12 @@ contract ERC721TokenAdapterV1 is
     IERC721 public token;
     IStrategyBaseV1 public strategy;
     uint256 public weightPerNft;
-    uint256 public proposerThreshold;
 
     mapping(uint32 => mapping(uint256 => bool)) public nftUsedForVote;
 
     uint16 public constant VERSION = 1;
 
-    event TokenAdapterParametersUpdated(
-        uint256 newWeightPerNft,
-        uint256 newProposerThreshold
-    );
+    event TokenAdapterParametersUpdated(uint256 newWeightPerNft);
 
     error InvalidTokenAddress();
     error InvalidStrategyAddress();
@@ -45,8 +41,7 @@ contract ERC721TokenAdapterV1 is
         address _initialOwner,
         address _token,
         address _strategy,
-        uint256 _weightPerNft,
-        uint256 _proposerThreshold
+        uint256 _weightPerNft
     ) external virtual initializer {
         __Ownable_init(_initialOwner);
         __UUPSUpgradeable_init();
@@ -58,9 +53,8 @@ contract ERC721TokenAdapterV1 is
         strategy = IStrategyBaseV1(_strategy);
 
         _updateWeightPerNft(_weightPerNft);
-        _updateProposerThreshold(_proposerThreshold);
 
-        emit TokenAdapterParametersUpdated(weightPerNft, proposerThreshold);
+        emit TokenAdapterParametersUpdated(weightPerNft);
     }
 
     function _authorizeUpgrade(
@@ -71,23 +65,12 @@ contract ERC721TokenAdapterV1 is
         uint256 _newWeightPerNft
     ) external virtual onlyOwner {
         _updateWeightPerNft(_newWeightPerNft);
-        emit TokenAdapterParametersUpdated(weightPerNft, proposerThreshold);
-    }
-
-    function updateProposerThreshold(
-        uint256 _newProposerThreshold
-    ) external onlyOwner {
-        _updateProposerThreshold(_newProposerThreshold);
-        emit TokenAdapterParametersUpdated(weightPerNft, proposerThreshold);
+        emit TokenAdapterParametersUpdated(weightPerNft);
     }
 
     function _updateWeightPerNft(uint256 _newWeightPerNft) internal virtual {
         if (_newWeightPerNft == 0) revert InvalidWeightPerNft();
         weightPerNft = _newWeightPerNft;
-    }
-
-    function _updateProposerThreshold(uint256 _newProposerThreshold) internal {
-        proposerThreshold = _newProposerThreshold;
     }
 
     function _getValidUnvotedTokenIdsAndWeight(
@@ -176,12 +159,6 @@ contract ERC721TokenAdapterV1 is
         weightCasted = totalCalculatedWeight;
 
         emit VoteRecorded(_voter, _proposalId, weightCasted, _adapterVoteData);
-    }
-
-    function isProposer(
-        address _proposer
-    ) external view override returns (bool) {
-        return (token.balanceOf(_proposer) * weightPerNft) >= proposerThreshold;
     }
 
     function getVersion() public pure virtual override returns (uint16) {

--- a/contracts/interfaces/decent/deployables/IProposerAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IProposerAdapterBaseV1.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+interface IProposerAdapterBaseV1 {
+    function isProposer(address _proposer) external view returns (bool);
+}

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -16,6 +16,12 @@ interface IStrategyV1 is IStrategyBaseV1 {
 
     function getTokenAdapterCount() external view returns (uint256);
 
+    function addProposerAdapter(address _adapter) external;
+
+    function removeProposerAdapter(address _adapter) external;
+
+    function getProposerAdapterCount() external view returns (uint256);
+
     function isQuorumMet(uint32 _proposalId) external view returns (bool);
 
     function isBasisMet(uint32 _proposalId) external view returns (bool);

--- a/contracts/interfaces/decent/deployables/ITokenAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/ITokenAdapterBaseV1.sol
@@ -9,8 +9,6 @@ interface ITokenAdapterBaseV1 {
         bytes tokenAdapterVoteData
     );
 
-    function isProposer(address _proposer) external view returns (bool);
-
     function recordVote(
         address _voter,
         uint32 _proposalId,

--- a/contracts/mocks/MockProposerAdapter.sol
+++ b/contracts/mocks/MockProposerAdapter.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.30;
+
+import {IProposerAdapterBaseV1} from "../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
+
+contract MockProposerAdapter is IProposerAdapterBaseV1 {
+    mapping(address => bool) private _isProposer;
+
+    function isProposer(
+        address _proposer
+    ) external view override returns (bool) {
+        return _isProposer[_proposer];
+    }
+
+    // Mock-specific functions for test setup
+    function setProposerStatus(address _proposer, bool status) external {
+        _isProposer[_proposer] = status;
+    }
+}

--- a/contracts/mocks/MockTokenAdapter.sol
+++ b/contracts/mocks/MockTokenAdapter.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.30;
 import {ITokenAdapterBaseV1} from "../interfaces/decent/deployables/ITokenAdapterBaseV1.sol";
 
 contract MockTokenAdapter is ITokenAdapterBaseV1 {
-    mapping(address => bool) public proposerStatusToReturn;
     mapping(address => uint256) public weightsToReturn;
     mapping(address => mapping(uint32 => mapping(bytes32 => uint256)))
         public recordedVotesWeight;
@@ -38,17 +37,7 @@ contract MockTokenAdapter is ITokenAdapterBaseV1 {
         return weightToRecord;
     }
 
-    function isProposer(
-        address _proposer
-    ) external view override returns (bool) {
-        return proposerStatusToReturn[_proposer];
-    }
-
     // mock setters
-
-    function setProposerStatus(address _proposer, bool _isProposer) external {
-        proposerStatusToReturn[_proposer] = _isProposer;
-    }
 
     function setWeight(address _voter, uint256 _weight) external {
         weightsToReturn[_voter] = _weight;

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -10,6 +10,8 @@ import {
   MockLightAccount__factory,
   MockLightAccountFactory,
   MockLightAccountFactory__factory,
+  MockProposerAdapter,
+  MockProposerAdapter__factory,
   MockTokenAdapter,
   MockTokenAdapter__factory,
   StrategyV1,
@@ -32,6 +34,8 @@ describe('StrategyV1', () => {
   let strategy: StrategyV1;
   let mockAdapter1: MockTokenAdapter;
   let mockAdapter2: MockTokenAdapter;
+  let mockProposerAdapter1: MockProposerAdapter;
+  let mockProposerAdapter2: MockProposerAdapter;
   let lightAccountFactoryMock: MockLightAccountFactory;
   let lightAccountFactoryMockAddress: string;
 
@@ -46,7 +50,8 @@ describe('StrategyV1', () => {
     votingPeriod: number,
     quorumThreshold: bigint,
     basisNumerator: bigint,
-    initialAdaptersAddresses: string[], // Changed to addresses for calldata
+    initialTokenAdaptersAddresses: string[],
+    initialProposerAdaptersAddresses: string[],
     lightAccountFactoryAddress: string,
   ): Promise<StrategyV1> {
     // For initialAdapters, StrategyV1's initialize expects ITokenAdapter[]
@@ -63,7 +68,8 @@ describe('StrategyV1', () => {
       votingPeriod,
       quorumThreshold,
       basisNumerator,
-      initialAdaptersAddresses, // Pass addresses directly
+      initialTokenAdaptersAddresses,
+      initialProposerAdaptersAddresses,
       lightAccountFactoryAddress,
     ]);
     const proxy = await new ERC1967Proxy__factory(deployer).deploy(
@@ -89,12 +95,19 @@ describe('StrategyV1', () => {
     mockAdapter2 = await new MockTokenAdapter__factory(deployer).deploy();
     await mockAdapter2.waitForDeployment();
 
+    // Deploy MockProposerAdapters
+    mockProposerAdapter1 = await new MockProposerAdapter__factory(deployer).deploy(undefined);
+    await mockProposerAdapter1.waitForDeployment();
+    mockProposerAdapter2 = await new MockProposerAdapter__factory(deployer).deploy(undefined);
+    await mockProposerAdapter2.waitForDeployment();
+
     strategy = await deployStrategyProxy(
       owner.address,
       azoriusMock.address,
       DEFAULT_VOTING_PERIOD,
       DEFAULT_QUORUM_THRESHOLD,
       DEFAULT_BASIS_NUMERATOR,
+      [],
       [],
       lightAccountFactoryMockAddress,
     );
@@ -105,7 +118,8 @@ describe('StrategyV1', () => {
       const initialOwner = owner.address;
       const azoriusAddress = azoriusMock.address;
       const lightAccountFactoryAddress = lightAccountFactoryMockAddress;
-      const initialAdapters: string[] = [await mockAdapter1.getAddress()];
+      const initialTokenAdapters: string[] = [await mockAdapter1.getAddress()];
+      const initialProposerAdapters: string[] = [await mockProposerAdapter1.getAddress()];
       const votingPeriod = DEFAULT_VOTING_PERIOD + 10;
       const quorumThreshold = DEFAULT_QUORUM_THRESHOLD + 1n;
       const basisNumerator = DEFAULT_BASIS_NUMERATOR + 1n;
@@ -116,7 +130,8 @@ describe('StrategyV1', () => {
         votingPeriod,
         quorumThreshold,
         basisNumerator,
-        initialAdapters,
+        initialTokenAdapters,
+        initialProposerAdapters,
         lightAccountFactoryAddress,
       ]);
       const proxy = await new ERC1967Proxy__factory(deployer).deploy(
@@ -138,6 +153,10 @@ describe('StrategyV1', () => {
       expect(await testStrategy.lightAccountFactory()).to.equal(lightAccountFactoryAddress);
       expect(await testStrategy.getTokenAdapterCount()).to.equal(1);
       expect(await testStrategy.tokenAdapters(0)).to.equal(await mockAdapter1.getAddress());
+      expect(await testStrategy.getProposerAdapterCount()).to.equal(1);
+      expect(await testStrategy.proposerAdapters(0)).to.equal(
+        await mockProposerAdapter1.getAddress(),
+      );
     });
 
     it('should revert if azorius address is zero', async () => {
@@ -148,6 +167,7 @@ describe('StrategyV1', () => {
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
           DEFAULT_BASIS_NUMERATOR,
+          [],
           [],
           lightAccountFactoryMockAddress,
         ),
@@ -163,6 +183,7 @@ describe('StrategyV1', () => {
           DEFAULT_QUORUM_THRESHOLD,
           DEFAULT_BASIS_NUMERATOR,
           [],
+          [],
           lightAccountFactoryMockAddress,
         ),
       ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidVotingPeriod');
@@ -176,6 +197,7 @@ describe('StrategyV1', () => {
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
           1_000_001n,
+          [],
           [],
           lightAccountFactoryMockAddress,
         ),
@@ -191,6 +213,7 @@ describe('StrategyV1', () => {
           DEFAULT_QUORUM_THRESHOLD,
           499_999n,
           [],
+          [],
           lightAccountFactoryMockAddress,
         ),
       ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
@@ -204,6 +227,7 @@ describe('StrategyV1', () => {
         0n, // Zero quorum threshold
         DEFAULT_BASIS_NUMERATOR,
         [],
+        [],
         lightAccountFactoryMockAddress,
       );
       expect(await testStrategy.quorumThreshold()).to.equal(0n);
@@ -216,6 +240,7 @@ describe('StrategyV1', () => {
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         500_000n, // 50% basis numerator
+        [],
         [],
         lightAccountFactoryMockAddress,
       );
@@ -231,6 +256,7 @@ describe('StrategyV1', () => {
           DEFAULT_QUORUM_THRESHOLD,
           1_000_000n, // 100% basis numerator - now invalid
           [],
+          [],
           lightAccountFactoryMockAddress,
         ),
       ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
@@ -244,6 +270,7 @@ describe('StrategyV1', () => {
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         maxValidBasis,
+        [],
         [],
         lightAccountFactoryMockAddress,
       );
@@ -372,6 +399,123 @@ describe('StrategyV1', () => {
     });
   });
 
+  describe('Proposer Adapter Management', () => {
+    // --- addProposerAdapter ---
+    it('should allow owner to add a new proposer adapter', async () => {
+      const adapterAddress = await mockProposerAdapter1.getAddress();
+      await expect(strategy.connect(owner).addProposerAdapter(adapterAddress))
+        .to.emit(strategy, 'ProposerAdapterAdded')
+        .withArgs(adapterAddress, 0);
+      expect(await strategy.proposerAdapters(0)).to.equal(adapterAddress);
+      expect(await strategy.getProposerAdapterCount()).to.equal(1);
+    });
+
+    it('should revert when non-owner tries to add a proposer adapter', async () => {
+      await expect(
+        strategy.connect(nonOwner).addProposerAdapter(await mockProposerAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
+    });
+
+    it('should revert when adding a zero address proposer adapter', async () => {
+      await expect(
+        strategy.connect(owner).addProposerAdapter(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterIsZeroAddress');
+    });
+
+    it('should revert when adding an already existing proposer adapter', async () => {
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
+      await expect(
+        strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterAlreadyExists');
+    });
+
+    it('should allow adding multiple different proposer adapters', async () => {
+      const adapter1Addr = await mockProposerAdapter1.getAddress();
+      const adapter2Addr = await mockProposerAdapter2.getAddress();
+      await strategy.connect(owner).addProposerAdapter(adapter1Addr);
+      await strategy.connect(owner).addProposerAdapter(adapter2Addr);
+      expect(await strategy.getProposerAdapterCount()).to.equal(2);
+      expect(await strategy.proposerAdapters(0)).to.equal(adapter1Addr);
+      expect(await strategy.proposerAdapters(1)).to.equal(adapter2Addr);
+    });
+
+    // --- removeProposerAdapter ---
+    it('should allow owner to remove an existing proposer adapter', async () => {
+      const adapter1Addr = await mockProposerAdapter1.getAddress();
+      const adapter2Addr = await mockProposerAdapter2.getAddress();
+      await strategy.connect(owner).addProposerAdapter(adapter1Addr);
+      await strategy.connect(owner).addProposerAdapter(adapter2Addr);
+
+      await expect(strategy.connect(owner).removeProposerAdapter(adapter1Addr))
+        .to.emit(strategy, 'ProposerAdapterRemoved')
+        .withArgs(adapter1Addr, 0);
+
+      expect(await strategy.getProposerAdapterCount()).to.equal(1);
+      expect(await strategy.proposerAdapters(0)).to.equal(adapter2Addr);
+    });
+
+    it('should allow owner to remove an existing proposer adapter (removing last)', async () => {
+      const adapter1Addr = await mockProposerAdapter1.getAddress();
+      const adapter2Addr = await mockProposerAdapter2.getAddress();
+      await strategy.connect(owner).addProposerAdapter(adapter1Addr);
+      await strategy.connect(owner).addProposerAdapter(adapter2Addr);
+
+      await expect(strategy.connect(owner).removeProposerAdapter(adapter2Addr))
+        .to.emit(strategy, 'ProposerAdapterRemoved')
+        .withArgs(adapter2Addr, 1);
+
+      expect(await strategy.getProposerAdapterCount()).to.equal(1);
+      expect(await strategy.proposerAdapters(0)).to.equal(adapter1Addr);
+    });
+
+    it('should correctly remove the only proposer adapter in the list', async () => {
+      const adapter1Addr = await mockProposerAdapter1.getAddress();
+      await strategy.connect(owner).addProposerAdapter(adapter1Addr);
+
+      await expect(strategy.connect(owner).removeProposerAdapter(adapter1Addr))
+        .to.emit(strategy, 'ProposerAdapterRemoved')
+        .withArgs(adapter1Addr, 0);
+      expect(await strategy.getProposerAdapterCount()).to.equal(0);
+    });
+
+    it('should revert when non-owner tries to remove a proposer adapter', async () => {
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
+      await expect(
+        strategy.connect(nonOwner).removeProposerAdapter(await mockProposerAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
+    });
+
+    it('should revert when removing a zero address proposer adapter', async () => {
+      await expect(
+        strategy.connect(owner).removeProposerAdapter(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterIsZeroAddress');
+    });
+
+    it('should revert when removing a proposer adapter that does not exist', async () => {
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
+      await expect(
+        strategy.connect(owner).removeProposerAdapter(await mockProposerAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterNotFound');
+    });
+
+    it('should revert when removing from an empty list of proposer adapters', async () => {
+      await expect(
+        strategy.connect(owner).removeProposerAdapter(await mockProposerAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterNotFound'); // Error should be ProposerAdapterNotFound
+    });
+
+    // --- getProposerAdapterCount ---
+    it('should return the correct number of proposer adapters', async () => {
+      expect(await strategy.getProposerAdapterCount()).to.equal(0);
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
+      expect(await strategy.getProposerAdapterCount()).to.equal(1);
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
+      expect(await strategy.getProposerAdapterCount()).to.equal(2);
+      await strategy.connect(owner).removeProposerAdapter(await mockProposerAdapter1.getAddress());
+      expect(await strategy.getProposerAdapterCount()).to.equal(1);
+    });
+  });
+
   describe('initializeProposal', () => {
     let defaultProposalId: number;
     let encodedDefaultProposalId: string;
@@ -459,32 +603,32 @@ describe('StrategyV1', () => {
     });
 
     it('should return true if any adapter identifies the address as a proposer', async () => {
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
 
-      // mockAdapter1 says NO, mockAdapter2 says YES
-      await mockAdapter1.connect(owner).setProposerStatus(user1.address, false);
-      await mockAdapter2.connect(owner).setProposerStatus(user1.address, true);
+      // mockProposerAdapter1 says NO, mockProposerAdapter2 says YES
+      await mockProposerAdapter1.connect(owner).setProposerStatus(user1.address, false);
+      await mockProposerAdapter2.connect(owner).setProposerStatus(user1.address, true);
 
       void expect(await strategy.isProposer(user1.address)).to.be.true;
     });
 
     it('should return false if no adapter identifies the address as a proposer', async () => {
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
 
-      await mockAdapter1.connect(owner).setProposerStatus(user1.address, false);
-      await mockAdapter2.connect(owner).setProposerStatus(user1.address, false);
+      await mockProposerAdapter1.connect(owner).setProposerStatus(user1.address, false);
+      await mockProposerAdapter2.connect(owner).setProposerStatus(user1.address, false);
 
       void expect(await strategy.isProposer(user1.address)).to.be.false;
     });
 
     it('should return true if the first adapter identifies the address as a proposer', async () => {
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
+      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
 
-      await mockAdapter1.connect(owner).setProposerStatus(user1.address, true);
-      await mockAdapter2.connect(owner).setProposerStatus(user1.address, false); // Should not be checked
+      await mockProposerAdapter1.connect(owner).setProposerStatus(user1.address, true);
+      await mockProposerAdapter2.connect(owner).setProposerStatus(user1.address, false);
 
       void expect(await strategy.isProposer(user1.address)).to.be.true;
     });

--- a/test/deployables/strategies/adapters/ERC20TokenAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20TokenAdapterV1.test.ts
@@ -26,14 +26,12 @@ async function deployERC20AdapterProxy(
   ownerAddress: string,
   tokenAddress: string,
   strategyAddress: string,
-  proposerThreshold: bigint,
   weightPerToken: bigint,
 ): Promise<{ adapter: ERC20TokenAdapterV1; deployTx: ContractTransactionResponse }> {
   const initData = ERC20TokenAdapterV1__factory.createInterface().encodeFunctionData('initialize', [
     ownerAddress,
     tokenAddress,
     strategyAddress,
-    proposerThreshold,
     weightPerToken,
   ]);
   const proxyContractFactory = new ERC1967Proxy__factory(proxyDeployer);
@@ -53,7 +51,6 @@ describe('ERC20TokenAdapterV1', () => {
   let ownerG: SignerWithAddress;
   let erc20AdapterImplementationAddressG: string;
 
-  const DEFAULT_PROPOSER_THRESHOLD = ethers.parseUnits('100', 18);
   const DEFAULT_WEIGHT_PER_TOKEN = 1n;
 
   async function deployGlobalFixture() {
@@ -117,7 +114,6 @@ describe('ERC20TokenAdapterV1', () => {
   let mockStrategy: MockVotingStrategy;
   let deployer: SignerWithAddress;
   let user1Signer: SignerWithAddress;
-  let user2Signer: SignerWithAddress;
 
   beforeEach(async () => {
     const {
@@ -127,11 +123,9 @@ describe('ERC20TokenAdapterV1', () => {
       mockStrategy: mStrategy,
       deployer: dDeployer,
       user1Signer: vSigner,
-      user2Signer: v2Signer,
     } = await loadFixture(deployMocksAndSignersFixture);
 
     user1Signer = vSigner;
-    user2Signer = v2Signer;
     ownerSigner = oSigner;
     nonOwnerSigner = nSigner;
     mockToken = mToken;
@@ -147,7 +141,6 @@ describe('ERC20TokenAdapterV1', () => {
         ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
-        DEFAULT_PROPOSER_THRESHOLD,
         DEFAULT_WEIGHT_PER_TOKEN,
       );
 
@@ -156,12 +149,11 @@ describe('ERC20TokenAdapterV1', () => {
       // as the event is emitted from the proxy's address due to delegatecall.
       await expect(deployTx.hash)
         .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
-        .withArgs(DEFAULT_PROPOSER_THRESHOLD, DEFAULT_WEIGHT_PER_TOKEN);
+        .withArgs(DEFAULT_WEIGHT_PER_TOKEN);
 
       expect(await erc20Adapter.owner()).to.equal(ownerSigner.address);
       expect(await erc20Adapter.token()).to.equal(await mockToken.getAddress());
       expect(await erc20Adapter.strategy()).to.equal(await mockStrategy.getAddress());
-      expect(await erc20Adapter.proposerThreshold()).to.equal(DEFAULT_PROPOSER_THRESHOLD);
       expect(await erc20Adapter.weightPerToken()).to.equal(DEFAULT_WEIGHT_PER_TOKEN);
     });
 
@@ -178,7 +170,6 @@ describe('ERC20TokenAdapterV1', () => {
           ownerSigner.address,
           ethers.ZeroAddress,
           await mockStrategy.getAddress(),
-          DEFAULT_PROPOSER_THRESHOLD,
           DEFAULT_WEIGHT_PER_TOKEN,
         ),
       ).to.be.revertedWithCustomError(erc20AdapterImplementation, 'InvalidTokenAddress');
@@ -197,7 +188,6 @@ describe('ERC20TokenAdapterV1', () => {
           ownerSigner.address,
           await mockToken.getAddress(),
           ethers.ZeroAddress,
-          DEFAULT_PROPOSER_THRESHOLD,
           DEFAULT_WEIGHT_PER_TOKEN,
         ),
       ).to.be.revertedWithCustomError(erc20AdapterImplementation, 'InvalidStrategyAddress');
@@ -216,7 +206,6 @@ describe('ERC20TokenAdapterV1', () => {
           ownerSigner.address,
           await mockToken.getAddress(),
           await mockStrategy.getAddress(),
-          DEFAULT_PROPOSER_THRESHOLD,
           0n,
         ),
       ).to.be.revertedWithCustomError(erc20AdapterImplementation, 'InvalidWeightPerToken');
@@ -229,18 +218,11 @@ describe('ERC20TokenAdapterV1', () => {
         ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
-        DEFAULT_PROPOSER_THRESHOLD,
         DEFAULT_WEIGHT_PER_TOKEN,
       );
 
       await expect(
-        erc20Adapter.initialize(
-          ownerSigner.address,
-          ethers.ZeroAddress,
-          ethers.ZeroAddress,
-          0n,
-          0n,
-        ),
+        erc20Adapter.initialize(ownerSigner.address, ethers.ZeroAddress, ethers.ZeroAddress, 0n),
       ).to.be.revertedWithCustomError(erc20Adapter, 'InvalidInitialization');
     });
 
@@ -255,7 +237,6 @@ describe('ERC20TokenAdapterV1', () => {
           ownerSigner.address,
           await mockToken.getAddress(),
           await mockStrategy.getAddress(),
-          DEFAULT_PROPOSER_THRESHOLD,
           DEFAULT_WEIGHT_PER_TOKEN,
         ),
       ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
@@ -277,42 +258,9 @@ describe('ERC20TokenAdapterV1', () => {
         currentOwnerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
-        DEFAULT_PROPOSER_THRESHOLD,
         DEFAULT_WEIGHT_PER_TOKEN,
       );
       erc20Adapter = adapter;
-    });
-
-    describe('updateProposerThreshold', () => {
-      const NEW_PROPOSER_THRESHOLD = ethers.parseUnits('200', 18);
-
-      it('should allow owner to update proposer threshold and emit event', async () => {
-        await expect(
-          erc20Adapter.connect(currentOwnerSigner).updateProposerThreshold(NEW_PROPOSER_THRESHOLD),
-        )
-          .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
-          .withArgs(NEW_PROPOSER_THRESHOLD, DEFAULT_WEIGHT_PER_TOKEN);
-
-        expect(await erc20Adapter.proposerThreshold()).to.equal(NEW_PROPOSER_THRESHOLD);
-      });
-
-      it('should not allow non-owner to update proposer threshold', async () => {
-        await expect(
-          erc20Adapter
-            .connect(currentNonOwnerSigner)
-            .updateProposerThreshold(NEW_PROPOSER_THRESHOLD),
-        )
-          .to.be.revertedWithCustomError(erc20Adapter, 'OwnableUnauthorizedAccount')
-          .withArgs(currentNonOwnerSigner.address);
-      });
-
-      it('should allow updating to zero proposer threshold', async () => {
-        await expect(erc20Adapter.connect(currentOwnerSigner).updateProposerThreshold(0n))
-          .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
-          .withArgs(0n, DEFAULT_WEIGHT_PER_TOKEN);
-
-        expect(await erc20Adapter.proposerThreshold()).to.equal(0n);
-      });
     });
 
     describe('updateWeightPerToken', () => {
@@ -323,7 +271,7 @@ describe('ERC20TokenAdapterV1', () => {
           erc20Adapter.connect(currentOwnerSigner).updateWeightPerToken(NEW_WEIGHT_PER_TOKEN),
         )
           .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
-          .withArgs(DEFAULT_PROPOSER_THRESHOLD, NEW_WEIGHT_PER_TOKEN);
+          .withArgs(NEW_WEIGHT_PER_TOKEN);
         expect(await erc20Adapter.weightPerToken()).to.equal(NEW_WEIGHT_PER_TOKEN);
       });
 
@@ -356,7 +304,6 @@ describe('ERC20TokenAdapterV1', () => {
         ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
-        DEFAULT_PROPOSER_THRESHOLD,
         customWeightPerToken || DEFAULT_WEIGHT_PER_TOKEN,
       );
       adapter = deployedAdapter;
@@ -488,7 +435,6 @@ describe('ERC20TokenAdapterV1', () => {
         owner.address,
         await token.getAddress(),
         await strategy.getAddress(),
-        DEFAULT_PROPOSER_THRESHOLD,
         customWeightPerToken || DEFAULT_WEIGHT_PER_TOKEN,
       );
       adapter = deployedAdapter;
@@ -596,96 +542,6 @@ describe('ERC20TokenAdapterV1', () => {
     });
   });
 
-  describe('isProposer', () => {
-    let adapter: ERC20TokenAdapterV1;
-
-    const SUITE_WEIGHT_PER_TOKEN = 2n;
-    const SUITE_RAW_VOTES_THRESHOLD = ethers.parseUnits('100', 18);
-    const SUITE_EFFECTIVE_PROPOSER_THRESHOLD = SUITE_RAW_VOTES_THRESHOLD * SUITE_WEIGHT_PER_TOKEN;
-
-    beforeEach(async () => {
-      const { adapter: deployedAdapter } = await deployERC20AdapterProxy(
-        deployer,
-        erc20AdapterImplementationAddressG,
-        ownerSigner.address,
-        await mockToken.getAddress(),
-        await mockStrategy.getAddress(),
-        SUITE_EFFECTIVE_PROPOSER_THRESHOLD,
-        SUITE_WEIGHT_PER_TOKEN,
-      );
-      adapter = deployedAdapter;
-    });
-
-    it('should return true if user meets proposer threshold (with suite weightPerToken)', async () => {
-      await mockToken.mint(user1Signer.address, SUITE_RAW_VOTES_THRESHOLD);
-      await mockToken.connect(user1Signer).delegate(user1Signer.address);
-      void expect(await adapter.isProposer(user1Signer.address)).to.be.true;
-    });
-
-    it('should return true if user exceeds proposer threshold (with suite weightPerToken)', async () => {
-      const rawVotesExceeding = SUITE_RAW_VOTES_THRESHOLD + ethers.parseUnits('1', 18);
-      await mockToken.mint(user1Signer.address, rawVotesExceeding);
-      await mockToken.connect(user1Signer).delegate(user1Signer.address);
-      void expect(await adapter.isProposer(user1Signer.address)).to.be.true;
-    });
-
-    it('should return false if user is below proposer threshold (with suite weightPerToken)', async () => {
-      const rawVotesBelow = SUITE_RAW_VOTES_THRESHOLD - ethers.parseUnits('1', 18);
-      const currentBal = await mockToken.balanceOf(user2Signer.address);
-      await mockToken.burn(user2Signer.address, currentBal - rawVotesBelow);
-      await mockToken.connect(user2Signer).delegate(user2Signer.address);
-      void expect(await adapter.isProposer(user2Signer.address)).to.be.false;
-    });
-
-    it('should return true if proposer threshold is 0, regardless of balance (with suite weightPerToken > 0)', async () => {
-      const { adapter: adapterWithZeroThreshold } = await deployERC20AdapterProxy(
-        deployer,
-        erc20AdapterImplementationAddressG,
-        ownerSigner.address,
-        await mockToken.getAddress(),
-        await mockStrategy.getAddress(),
-        0n,
-        SUITE_WEIGHT_PER_TOKEN,
-      );
-
-      await mockToken.mint(user1Signer.address, ethers.parseUnits('1', 18));
-      await mockToken.connect(user1Signer).delegate(user1Signer.address);
-      void expect(await adapterWithZeroThreshold.isProposer(user1Signer.address)).to.be.true;
-      const currentBalance = await mockToken.balanceOf(user2Signer.address);
-      await mockToken.burn(user2Signer.address, currentBalance);
-      await mockToken.connect(user2Signer).delegate(user2Signer.address);
-      void expect(await adapterWithZeroThreshold.isProposer(user2Signer.address)).to.be.true;
-    });
-
-    it('should correctly factor in a *different* custom weightPerToken for isProposer', async () => {
-      const customWeightForThisTest = 5n;
-      const rawVotesForCustomTest = ethers.parseUnits('30', 18);
-      const effectiveThresholdForCustomTest = rawVotesForCustomTest * customWeightForThisTest;
-
-      const { adapter: adapterCustomWeight } = await deployERC20AdapterProxy(
-        deployer,
-        erc20AdapterImplementationAddressG,
-        ownerSigner.address,
-        await mockToken.getAddress(),
-        await mockStrategy.getAddress(),
-        effectiveThresholdForCustomTest,
-        customWeightForThisTest,
-      );
-
-      const balProposer = await mockToken.balanceOf(user1Signer.address);
-      await mockToken.burn(user1Signer.address, balProposer - rawVotesForCustomTest);
-      await mockToken.connect(user1Signer).delegate(user1Signer.address);
-
-      void expect(await adapterCustomWeight.isProposer(user1Signer.address)).to.be.true;
-
-      const rawVotesBelowCustom = rawVotesForCustomTest - ethers.parseUnits('1', 18);
-      const balNonProposer = await mockToken.balanceOf(user2Signer.address);
-      await mockToken.burn(user2Signer.address, balNonProposer - rawVotesBelowCustom);
-      await mockToken.connect(user2Signer).delegate(user2Signer.address);
-      void expect(await adapterCustomWeight.isProposer(user2Signer.address)).to.be.false;
-    });
-  });
-
   describe('getVersion()', () => {
     it('should return the correct version', async () => {
       const { adapter: erc20Adapter } = await deployERC20AdapterProxy(
@@ -694,7 +550,6 @@ describe('ERC20TokenAdapterV1', () => {
         ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
-        DEFAULT_PROPOSER_THRESHOLD,
         DEFAULT_WEIGHT_PER_TOKEN,
       );
 
@@ -716,7 +571,6 @@ describe('ERC20TokenAdapterV1', () => {
         ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
-        DEFAULT_PROPOSER_THRESHOLD,
         DEFAULT_WEIGHT_PER_TOKEN,
       );
       erc20Adapter = adapter;
@@ -763,7 +617,6 @@ describe('ERC20TokenAdapterV1', () => {
         ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
-        DEFAULT_PROPOSER_THRESHOLD,
         DEFAULT_WEIGHT_PER_TOKEN,
       );
       erc20AdapterProxy = adapter;

--- a/test/deployables/strategies/adapters/ERC721TokenAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721TokenAdapterV1.test.ts
@@ -26,11 +26,10 @@ async function deployERC721AdapterProxy(
   tokenAddress: string,
   strategyAddress: string,
   weightPerNft: bigint,
-  proposerThreshold: bigint,
 ): Promise<{ adapter: ERC721TokenAdapterV1; deployTx: ContractTransactionResponse }> {
   const initData = ERC721TokenAdapterV1__factory.createInterface().encodeFunctionData(
     'initialize',
-    [initialOwnerAddress, tokenAddress, strategyAddress, weightPerNft, proposerThreshold],
+    [initialOwnerAddress, tokenAddress, strategyAddress, weightPerNft],
   );
   const proxyContractFactory = new ERC1967Proxy__factory(proxyDeployer);
   const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
@@ -54,7 +53,6 @@ describe('ERC721TokenAdapterV1', () => {
 
   // Default Test Params
   const DEFAULT_WEIGHT_PER_NFT = 1n;
-  const DEFAULT_NFT_PROPOSER_THRESHOLD = 2n; // e.g., needs 2 NFTs to be a proposer if weight is 1
 
   async function deployGlobalERC721Fixture() {
     const [deployer] = await ethers.getSigners();
@@ -139,18 +137,16 @@ describe('ERC721TokenAdapterV1', () => {
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
 
       await expect(deployTx)
         .to.emit(erc721Adapter, 'TokenAdapterParametersUpdated')
-        .withArgs(DEFAULT_WEIGHT_PER_NFT, DEFAULT_NFT_PROPOSER_THRESHOLD);
+        .withArgs(DEFAULT_WEIGHT_PER_NFT);
 
       expect(await erc721Adapter.owner()).to.equal(ownerSigner.address);
       expect(await erc721Adapter.token()).to.equal(await mockNft.getAddress());
       expect(await erc721Adapter.strategy()).to.equal(await mockStrategy.getAddress());
       expect(await erc721Adapter.weightPerNft()).to.equal(DEFAULT_WEIGHT_PER_NFT);
-      expect(await erc721Adapter.proposerThreshold()).to.equal(DEFAULT_NFT_PROPOSER_THRESHOLD);
     });
 
     it('should revert if token address is zero', async () => {
@@ -169,7 +165,6 @@ describe('ERC721TokenAdapterV1', () => {
           ethers.ZeroAddress,
           await mockNft.getAddress(),
           DEFAULT_WEIGHT_PER_NFT,
-          DEFAULT_NFT_PROPOSER_THRESHOLD,
         ),
       ).to.be.revertedWithCustomError(erc721AdapterImplementation, 'InvalidTokenAddress');
     });
@@ -190,7 +185,6 @@ describe('ERC721TokenAdapterV1', () => {
           await mockNft.getAddress(),
           ethers.ZeroAddress,
           DEFAULT_WEIGHT_PER_NFT,
-          DEFAULT_NFT_PROPOSER_THRESHOLD,
         ),
       ).to.be.revertedWithCustomError(erc721AdapterImplementation, 'InvalidStrategyAddress');
     });
@@ -213,7 +207,6 @@ describe('ERC721TokenAdapterV1', () => {
           await mockNft.getAddress(),
           await mockStrategy.getAddress(),
           0n, // Invalid weight
-          DEFAULT_NFT_PROPOSER_THRESHOLD,
         ),
       ).to.be.revertedWithCustomError(erc721AdapterImplementation, 'InvalidWeightPerNft');
     });
@@ -231,7 +224,6 @@ describe('ERC721TokenAdapterV1', () => {
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
       await expect(
         erc721Adapter.initialize(
@@ -239,7 +231,6 @@ describe('ERC721TokenAdapterV1', () => {
           await mockNft.getAddress(),
           await mockStrategy.getAddress(),
           DEFAULT_WEIGHT_PER_NFT,
-          DEFAULT_NFT_PROPOSER_THRESHOLD,
         ),
       ).to.be.revertedWithCustomError(erc721Adapter, 'InvalidInitialization');
     });
@@ -260,7 +251,6 @@ describe('ERC721TokenAdapterV1', () => {
           await mockNft.getAddress(),
           await mockStrategy.getAddress(),
           DEFAULT_WEIGHT_PER_NFT,
-          DEFAULT_NFT_PROPOSER_THRESHOLD,
         ),
       ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
     });
@@ -291,7 +281,6 @@ describe('ERC721TokenAdapterV1', () => {
         await mockNft.getAddress(),
         await fixture.mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
       adapter = deployedAdapter;
     });
@@ -374,7 +363,6 @@ describe('ERC721TokenAdapterV1', () => {
         await mockNft.getAddress(),
         await (await loadFixture(deployMocksAndSignersERC721Fixture)).mockStrategy.getAddress(), // Fresh strategy address
         customWeightPerNft,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
 
       const tokenIdsToVoteWith = [user1TokenIds[0], user1TokenIds[1]];
@@ -416,7 +404,6 @@ describe('ERC721TokenAdapterV1', () => {
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
       adapter = deployedAdapter;
     });
@@ -523,7 +510,6 @@ describe('ERC721TokenAdapterV1', () => {
         await localMockNft.getAddress(),
         await localMockStrategy.getAddress(),
         customWeightPerNft,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
 
       const tokenIdsToUseInVote = [localUser1TestTokenIds[0]]; // Use a token minted for localUser1 on localMockNft
@@ -552,108 +538,6 @@ describe('ERC721TokenAdapterV1', () => {
     });
   });
 
-  describe('isProposer', () => {
-    let adapter: ERC721TokenAdapterV1;
-    let mockNft: MockERC721;
-    let user1: SignerWithAddress; // Fixture user1 (has 3 NFTs: 0,1,2)
-    let user2: SignerWithAddress; // Fixture user2 (has 2 NFTs: 3,4)
-    let nonOwnerSigner: SignerWithAddress; // Fixture nonOwner (has 0 NFTs initially)
-    let deployer: SignerWithAddress;
-    let mockStrategy: MockVotingStrategy;
-    let fixtureDeployer: SignerWithAddress;
-
-    const SUITE_WEIGHT_PER_NFT = 2n;
-    const SUITE_RAW_VOTES_THRESHOLD = 2n; // Needs 2 NFTs
-    const SUITE_EFFECTIVE_PROPOSER_THRESHOLD = SUITE_RAW_VOTES_THRESHOLD * SUITE_WEIGHT_PER_NFT; // 2*2=4
-
-    beforeEach(async () => {
-      const fixture = await loadFixture(deployMocksAndSignersERC721Fixture);
-      mockNft = fixture.mockNft;
-      user1 = fixture.user1Signer;
-      user2 = fixture.user2Signer;
-      nonOwnerSigner = fixture.nonOwnerSigner;
-      deployer = fixture.deployer;
-      mockStrategy = fixture.mockStrategy;
-      fixtureDeployer = fixture.deployer;
-
-      const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
-        deployer,
-        erc721AdapterImplementationAddressG,
-        fixtureDeployer.address,
-        await mockNft.getAddress(),
-        await mockStrategy.getAddress(),
-        SUITE_WEIGHT_PER_NFT,
-        SUITE_EFFECTIVE_PROPOSER_THRESHOLD,
-      );
-      adapter = deployedAdapter;
-    });
-
-    it('should return true if user meets proposer threshold (2 NFTs * weight 2 = 4; threshold 4)', async () => {
-      // User2 has 2 NFTs from fixture. (2 * 2) = 4. Threshold is 4. 4 >= 4 is true.
-      void expect(await adapter.isProposer(user2.address)).to.be.true;
-    });
-
-    it('should return true if user exceeds proposer threshold (3 NFTs * weight 2 = 6; threshold 4)', async () => {
-      // User1 has 3 NFTs from fixture. (3 * 2) = 6. Threshold is 4. 6 >= 4 is true.
-      void expect(await adapter.isProposer(user1.address)).to.be.true;
-    });
-
-    it('should return false if user is below proposer threshold (1 NFT * weight 2 = 2; threshold 4)', async () => {
-      // nonOwnerSigner starts with 0 NFTs. Mint 1 to them.
-      await mockNft.mint(nonOwnerSigner.address);
-      // (1 * 2) = 2. Threshold is 4. 2 >= 4 is false.
-      void expect(await adapter.isProposer(nonOwnerSigner.address)).to.be.false;
-    });
-
-    it('should return true if proposer threshold is 0', async () => {
-      const { adapter: zeroThresholdAdapter } = await deployERC721AdapterProxy(
-        deployer,
-        erc721AdapterImplementationAddressG,
-        fixtureDeployer.address,
-        await mockNft.getAddress(),
-        await mockStrategy.getAddress(),
-        SUITE_WEIGHT_PER_NFT,
-        0n, // Zero threshold
-      );
-      // User1 has NFTs (3*2=6 >=0 true)
-      void expect(await zeroThresholdAdapter.isProposer(user1.address)).to.be.true;
-
-      // nonOwnerSigner has 0 NFTs on the mockNft instance initially from fixture
-      const nonOwnerBalance = await mockNft.balanceOf(nonOwnerSigner.address);
-      expect(nonOwnerBalance).to.equal(0n); // Verify assumption from fixture
-
-      const isNonOwnerProposer = await zeroThresholdAdapter.isProposer(nonOwnerSigner.address);
-
-      void expect(isNonOwnerProposer).to.be.true; // (0 * 2) >= 0 is true
-    });
-
-    it('should correctly apply a different custom weightPerNft', async () => {
-      const customWeightPerNft = 5n;
-      const rawNftsNeeded = 2n; // e.g. user needs 2 NFTs
-      const customProposerThreshold = rawNftsNeeded * customWeightPerNft; // So threshold is 10
-
-      const { adapter: customAdapter } = await deployERC721AdapterProxy(
-        deployer,
-        erc721AdapterImplementationAddressG,
-        fixtureDeployer.address,
-        await mockNft.getAddress(),
-        await mockStrategy.getAddress(),
-        customWeightPerNft,
-        customProposerThreshold,
-      );
-      // User2 has 2 NFTs by default from fixture. (2 NFTs * 5 weight) = 10. Threshold = 10. 10 >= 10 is true.
-      void expect(await customAdapter.isProposer(user2.address)).to.be.true;
-
-      // User1 has 3 NFTs by default. (3 NFTs * 5 weight) = 15. Threshold = 10. 15 >= 10 is true.
-      void expect(await customAdapter.isProposer(user1.address)).to.be.true;
-
-      // nonOwnerSigner has 0 NFTs initially. Mint 1.
-      await mockNft.mint(nonOwnerSigner.address);
-      // (1 NFT * 5 weight) = 5. Threshold = 10. 5 >= 10 is false.
-      void expect(await customAdapter.isProposer(nonOwnerSigner.address)).to.be.false;
-    });
-  });
-
   describe('getVersion()', () => {
     it('should return the correct version', async () => {
       const {
@@ -668,7 +552,6 @@ describe('ERC721TokenAdapterV1', () => {
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
       expect(await erc721Adapter.getVersion()).to.equal(1);
     });
@@ -694,7 +577,6 @@ describe('ERC721TokenAdapterV1', () => {
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
       erc721Adapter = adapter;
 
@@ -754,7 +636,6 @@ describe('ERC721TokenAdapterV1', () => {
         mockNftAddress,
         mockStrategyAddress,
         DEFAULT_WEIGHT_PER_NFT,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
       adapter = deployedAdapter;
     });
@@ -765,7 +646,7 @@ describe('ERC721TokenAdapterV1', () => {
       it('should allow owner to update weightPerNft and emit event', async () => {
         await expect(adapter.connect(owner).updateWeightPerNft(NEW_WEIGHT_PER_NFT))
           .to.emit(adapter, 'TokenAdapterParametersUpdated')
-          .withArgs(NEW_WEIGHT_PER_NFT, await adapter.proposerThreshold()); // Current proposerThreshold
+          .withArgs(NEW_WEIGHT_PER_NFT);
         expect(await adapter.weightPerNft()).to.equal(NEW_WEIGHT_PER_NFT);
       });
 
@@ -780,30 +661,6 @@ describe('ERC721TokenAdapterV1', () => {
           adapter,
           'InvalidWeightPerNft',
         );
-      });
-    });
-
-    describe('updateProposerThreshold', () => {
-      const NEW_PROPOSER_THRESHOLD = 10n;
-
-      it('should allow owner to update proposerThreshold and emit event', async () => {
-        await expect(adapter.connect(owner).updateProposerThreshold(NEW_PROPOSER_THRESHOLD))
-          .to.emit(adapter, 'TokenAdapterParametersUpdated')
-          .withArgs(await adapter.weightPerNft(), NEW_PROPOSER_THRESHOLD); // Current weightPerNft
-        expect(await adapter.proposerThreshold()).to.equal(NEW_PROPOSER_THRESHOLD);
-      });
-
-      it('should not allow non-owner to update proposerThreshold', async () => {
-        await expect(adapter.connect(nonOwner).updateProposerThreshold(NEW_PROPOSER_THRESHOLD))
-          .to.be.revertedWithCustomError(adapter, 'OwnableUnauthorizedAccount')
-          .withArgs(nonOwner.address);
-      });
-
-      it('should allow updating proposerThreshold to zero', async () => {
-        await expect(adapter.connect(owner).updateProposerThreshold(0n))
-          .to.emit(adapter, 'TokenAdapterParametersUpdated')
-          .withArgs(await adapter.weightPerNft(), 0n);
-        expect(await adapter.proposerThreshold()).to.equal(0n);
       });
     });
   });
@@ -833,7 +690,6 @@ describe('ERC721TokenAdapterV1', () => {
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
-        DEFAULT_NFT_PROPOSER_THRESHOLD,
       );
       erc721AdapterProxy = adapter;
     });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/276

Fixes [ENG-968](https://linear.app/decent-labs/issue/ENG-968/decouple-proposer-eligibility-into-separate-proposer-adapters-in)

**High-Level Context:**

This Pull Request implements a major architectural enhancement to our `StrategyV1` governance engine by decoupling proposer eligibility logic from the `TokenAdapterV1` contracts. Previously, each token adapter (like `ERC20TokenAdapterV1` and `ERC721TokenAdapterV1`) was responsible for both calculating voting weight *and* determining if an address could submit proposals.

This PR introduces a new, distinct mechanism for proposer checks: `StrategyV1` now manages a separate list of `IProposerAdapterBaseV1` contracts. The `isProposer` check in `StrategyV1` iterates through these dedicated "Proposer Adapters" instead of the "Token Adapters." Consequently, the `isProposer` method and related state (like `proposerThreshold`) have been removed from `ERC20TokenAdapterV1` and `ERC721TokenAdapterV1`.

**Specific Changes in this PR:**

**1. `StrategyV1.sol` Modifications:**
    *   **New State for Proposer Adapters:**
        *   Added `IProposerAdapterBaseV1[] public proposerAdapters;`.
    *   **New Events for Proposer Adapters:**
        *   `ProposerAdapterAdded(address indexed adapter, uint256 index)`
        *   `ProposerAdapterRemoved(address indexed adapter, uint256 index)`
    *   **New Errors for Proposer Adapters:**
        *   `ProposerAdapterIsZeroAddress()`
        *   `ProposerAdapterAlreadyExists()`
        *   `ProposerAdapterNotFound()`
    *   **Updated `initialize` Function:**
        *   Now takes an additional `address[] memory _initialProposerAdapters` parameter.
        *   Iterates through `_initialProposerAdapters` to add them using `_addProposerAdapter`.
    *   **Proposer Adapter Management Functions (Owner-only):**
        *   `addProposerAdapter(address _adapter)`: Adds a new proposer adapter.
        *   `removeProposerAdapter(address _adapter)`: Removes a proposer adapter.
        *   `getProposerAdapterCount()`: Returns the count of configured proposer adapters.
        *   Internal `_addProposerAdapter(address _adapter)`: Handles addition logic with checks.
    *   **Modified `isProposer(address _address)` Logic:**
        *   Now iterates through `proposerAdapters` array.
        *   Calls `isProposer(_address)` on each adapter in `proposerAdapters`.
        *   Returns `true` if any proposer adapter returns `true`.
        *   Returns `false` if `proposerAdapters` is empty or no adapter confirms eligibility.
    *   **Token Adapter Type Simplification:** The `tokenAdapters` array is now `ITokenAdapterBaseV1[]`, as `isProposer` is no longer part of `ITokenAdapterBaseV1`. The `vote` function now casts to `ITokenAdapterBaseV1` when calling `recordVote`.

**2. `ITokenAdapterBaseV1.sol` Interface Modification:**
    *   The `isProposer(address _proposer) external view returns (bool);` function has been **removed** from this interface.
    *   The `VoteRecorded` event parameter `adapterVoteData` has been renamed to `tokenAdapterVoteData` for clarity.


**3. `ITokenAdapterV1.sol` Interface Update:**
    *   No longer needs to implicitly include `isProposer` as it inherits from the modified `ITokenAdapterBaseV1`. It solely defines `weightOf`.

**4. `ERC20TokenAdapterV1.sol` Refactoring:**
    *   Removed `proposerThreshold` state variable and its update function `updateProposerThreshold`.
    *   Removed the `isProposer` function.
    *   The `TokenAdapterParametersUpdated` event no longer includes `newProposerThreshold`.
    *   The `initialize` function no longer takes `_proposerThreshold`.

**5. `ERC721TokenAdapterV1.sol` Refactoring:**
    *   Removed `proposerThreshold` state variable and its update function `updateProposerThreshold`.
    *   Removed the `isProposer` function.
    *   The `TokenAdapterParametersUpdated` event no longer includes `newProposerThreshold`.
    *   The `initialize` function no longer takes `_proposerThreshold`.

**6. New `IProposerAdapterBaseV1.sol` Interface:**
    *   Defines the minimal interface for proposer adapters: `isProposer(address _proposer) external view returns (bool);`.

**7. New `MockProposerAdapter.sol`:**
    *   Implements `IProposerAdapterBaseV1`.
    *   Provides `setProposerStatus` for test configuration.

**8. `MockTokenAdapter.sol` Update:**
    *   Removed `proposerStatusToReturn` mapping and `setProposerStatus` function, as `isProposer` is removed from `ITokenAdapterBaseV1`.

**9. Test Suite Updates (`StrategyV1.test.ts`, `ERC20TokenAdapterV1.test.ts`, `ERC721TokenAdapterV1.test.ts`):**
    *   **`StrategyV1.test.ts`:**
        *   `initialize` calls updated to pass an empty array for `_initialProposerAdapters` by default.
        *   New test section "Proposer Adapter Management" added for `addProposerAdapter`, `removeProposerAdapter`, `getProposerAdapterCount`.
        *   `isProposer` tests completely refactored to use `MockProposerAdapter` instances added to `strategy.proposerAdapters`.
    *   **Adapter Tests:**
        *   Removed tests for `isProposer` and `updateProposerThreshold` from `ERC20TokenAdapterV1.test.ts` and `ERC721TokenAdapterV1.test.ts`.
        *   Updated `initialize` calls in adapter tests to remove the proposer threshold argument.
        *   Adjusted assertions for the `TokenAdapterParametersUpdated` event.

**Impact and Status:**

*   **Clearer Separation of Concerns:** Proposer eligibility is now distinctly managed from token voting weight calculation.
*   **Increased Modularity:** Different, potentially complex, proposer eligibility rules can be implemented as separate `IProposerAdapterBaseV1` contracts without affecting token adapters.
*   **Breaking Change (Internal):** The interfaces for `ITokenAdapterBaseV1` and how `StrategyV1` handles proposer checks are significantly changed.
*   **Compilation Status:** All contracts should compile.
*   **Testing Status:** All tests have been updated to reflect these architectural changes and should pass. This ensures the new proposer adapter mechanism is correctly implemented and integrated within `StrategyV1`.

This refactor paves the way for more sophisticated and independent proposer qualification mechanisms in the future.