### PR TITLE
refactor(governance): Rename TokenAdapters to VotingAdapters for Clarity

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IStrategyBaseV1} from "../../interfaces/decent/deployables/IStrategyBaseV1.sol";
-import {ITokenAdapterBaseV1} from "../../interfaces/decent/deployables/ITokenAdapterBaseV1.sol";
+import {IVotingAdapterBaseV1} from "../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {IProposerAdapterBaseV1} from "../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {Version} from "../Version.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -40,7 +40,7 @@ contract StrategyV1 is
     }
     mapping(uint32 => ProposalVotingDetails) public proposalVotingDetails;
 
-    ITokenAdapterBaseV1[] public tokenAdapters;
+    IVotingAdapterBaseV1[] public votingAdapters;
     IProposerAdapterBaseV1[] public proposerAdapters;
 
     enum VoteType {
@@ -54,8 +54,8 @@ contract StrategyV1 is
         uint256 quorumThreshold,
         uint256 basisNumerator
     );
-    event TokenAdapterAdded(address indexed adapter, uint256 index);
-    event TokenAdapterRemoved(address indexed adapter, uint256 index);
+    event VotingAdapterAdded(address indexed adapter, uint256 index);
+    event VotingAdapterRemoved(address indexed adapter, uint256 index);
     event ProposerAdapterAdded(address indexed adapter, uint256 index);
     event ProposerAdapterRemoved(address indexed adapter, uint256 index);
     event Voted(
@@ -74,10 +74,10 @@ contract StrategyV1 is
     error InvalidAzoriusAddress();
     error InvalidVotingPeriod();
     error InvalidBasisNumerator();
-    error TokenAdapterIsZeroAddress();
-    error TokenAdapterAlreadyExists();
-    error TokenAdapterNotFound();
-    error NoTokenAdapters();
+    error VotingAdapterIsZeroAddress();
+    error VotingAdapterAlreadyExists();
+    error VotingAdapterNotFound();
+    error NoVotingAdapters();
     error ProposerAdapterIsZeroAddress();
     error ProposerAdapterAlreadyExists();
     error ProposerAdapterNotFound();
@@ -86,7 +86,7 @@ contract StrategyV1 is
     error InvalidVoteType();
     error ProposalNotInitialized();
     error MismatchedInputs();
-    error InvalidAdapterProvidedInVote();
+    error InvalidVotingAdapter();
 
     constructor() {
         _disableInitializers();
@@ -98,7 +98,7 @@ contract StrategyV1 is
         uint32 _votingPeriod,
         uint256 _quorumThreshold,
         uint256 _basisNumerator,
-        address[] memory _initialTokenAdapters,
+        address[] memory _initialVotingAdapters,
         address[] memory _initialProposerAdapters,
         address _lightAccountFactory
     ) public virtual initializer {
@@ -113,9 +113,9 @@ contract StrategyV1 is
         _updateQuorumThreshold(_quorumThreshold);
         _updateBasisNumerator(_basisNumerator);
 
-        if (_initialTokenAdapters.length > 0) {
-            for (uint256 i = 0; i < _initialTokenAdapters.length; i++) {
-                _addTokenAdapter(_initialTokenAdapters[i]);
+        if (_initialVotingAdapters.length > 0) {
+            for (uint256 i = 0; i < _initialVotingAdapters.length; i++) {
+                _addVotingAdapter(_initialVotingAdapters[i]);
             }
         }
 
@@ -169,38 +169,38 @@ contract StrategyV1 is
         );
     }
 
-    function addTokenAdapter(
+    function addVotingAdapter(
         address _adapter
     ) public virtual override onlyOwner {
-        _addTokenAdapter(_adapter);
+        _addVotingAdapter(_adapter);
     }
 
-    function removeTokenAdapter(
+    function removeVotingAdapter(
         address _adapter
     ) external virtual override onlyOwner {
-        if (_adapter == address(0)) revert TokenAdapterIsZeroAddress();
-        uint256 adapterCount = tokenAdapters.length;
-        if (adapterCount == 0) revert TokenAdapterNotFound();
+        if (_adapter == address(0)) revert VotingAdapterIsZeroAddress();
+        uint256 adapterCount = votingAdapters.length;
+        if (adapterCount == 0) revert VotingAdapterNotFound();
 
         for (uint256 i = 0; i < adapterCount; i++) {
-            if (address(tokenAdapters[i]) == _adapter) {
-                tokenAdapters[i] = tokenAdapters[adapterCount - 1];
-                tokenAdapters.pop();
-                emit TokenAdapterRemoved(address(_adapter), i);
+            if (address(votingAdapters[i]) == _adapter) {
+                votingAdapters[i] = votingAdapters[adapterCount - 1];
+                votingAdapters.pop();
+                emit VotingAdapterRemoved(address(_adapter), i);
                 return;
             }
         }
-        revert TokenAdapterNotFound();
+        revert VotingAdapterNotFound();
     }
 
-    function getTokenAdapterCount()
+    function getVotingAdapterCount()
         external
         view
         virtual
         override
         returns (uint256)
     {
-        return tokenAdapters.length;
+        return votingAdapters.length;
     }
 
     function addProposerAdapter(
@@ -243,7 +243,7 @@ contract StrategyV1 is
         bytes memory
     ) external virtual override {
         if (msg.sender != azorius) revert InvalidAzoriusAddress();
-        if (tokenAdapters.length == 0) revert NoTokenAdapters();
+        if (votingAdapters.length == 0) revert NoVotingAdapters();
 
         ProposalVotingDetails storage proposal = proposalVotingDetails[
             proposalId
@@ -266,10 +266,10 @@ contract StrategyV1 is
     function vote(
         uint32 _proposalId,
         uint8 _voteType,
-        address[] calldata _tokenAdaptersToUse,
-        bytes[] calldata _tokenAdapterVoteData
+        address[] calldata _votingAdaptersToUse,
+        bytes[] calldata _votingAdapterVoteData
     ) external virtual override {
-        if (_tokenAdaptersToUse.length != _tokenAdapterVoteData.length)
+        if (_votingAdaptersToUse.length != _votingAdapterVoteData.length)
             revert MismatchedInputs();
 
         address resolvedVoter = voter(msg.sender);
@@ -285,16 +285,16 @@ contract StrategyV1 is
         }
 
         uint256 totalWeightForThisVoteTransaction = 0;
-        uint256 numConfiguredAdapters = tokenAdapters.length;
+        uint256 numConfiguredAdapters = votingAdapters.length;
 
-        for (uint256 i = 0; i < _tokenAdaptersToUse.length; i++) {
+        for (uint256 i = 0; i < _votingAdaptersToUse.length; i++) {
             bool isValidAndConfiguredAdapter = false;
             uint256 configuredAdapterIndex = 0;
 
             for (uint256 j = 0; j < numConfiguredAdapters; j++) {
                 if (
-                    tokenAdapters[j] ==
-                    ITokenAdapterBaseV1(_tokenAdaptersToUse[i])
+                    votingAdapters[j] ==
+                    IVotingAdapterBaseV1(_votingAdaptersToUse[i])
                 ) {
                     isValidAndConfiguredAdapter = true;
                     configuredAdapterIndex = j;
@@ -303,12 +303,12 @@ contract StrategyV1 is
             }
 
             if (!isValidAndConfiguredAdapter) {
-                revert InvalidAdapterProvidedInVote();
+                revert InvalidVotingAdapter();
             }
 
-            totalWeightForThisVoteTransaction += tokenAdapters[
+            totalWeightForThisVoteTransaction += votingAdapters[
                 configuredAdapterIndex
-            ].recordVote(resolvedVoter, _proposalId, _tokenAdapterVoteData[i]);
+            ].recordVote(resolvedVoter, _proposalId, _votingAdapterVoteData[i]);
         }
 
         if (totalWeightForThisVoteTransaction == 0) revert NoVotingWeight();
@@ -440,14 +440,14 @@ contract StrategyV1 is
         basisNumerator = _newBasisNumerator;
     }
 
-    function _addTokenAdapter(address _adapter) internal virtual {
-        if (_adapter == address(0)) revert TokenAdapterIsZeroAddress();
-        for (uint256 i = 0; i < tokenAdapters.length; i++) {
-            if (address(tokenAdapters[i]) == _adapter)
-                revert TokenAdapterAlreadyExists();
+    function _addVotingAdapter(address _adapter) internal virtual {
+        if (_adapter == address(0)) revert VotingAdapterIsZeroAddress();
+        for (uint256 i = 0; i < votingAdapters.length; i++) {
+            if (address(votingAdapters[i]) == _adapter)
+                revert VotingAdapterAlreadyExists();
         }
-        tokenAdapters.push(ITokenAdapterBaseV1(_adapter));
-        emit TokenAdapterAdded(address(_adapter), tokenAdapters.length - 1);
+        votingAdapters.push(IVotingAdapterBaseV1(_adapter));
+        emit VotingAdapterAdded(address(_adapter), votingAdapters.length - 1);
     }
 
     function _addProposerAdapter(address _adapter) internal virtual {

--- a/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {ITokenAdapterV1} from "../../../interfaces/decent/deployables/ITokenAdapterV1.sol";
-import {ITokenAdapterBaseV1} from "../../../interfaces/decent/deployables/ITokenAdapterBaseV1.sol";
+import {IVotingAdapterV1} from "../../../interfaces/decent/deployables/IVotingAdapterV1.sol";
+import {IVotingAdapterBaseV1} from "../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {IStrategyBaseV1} from "../../../interfaces/decent/deployables/IStrategyBaseV1.sol";
 import {ClockMode} from "../../../interfaces/decent/ClockMode.sol";
 import {Version} from "../../Version.sol";
@@ -13,8 +13,8 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-contract ERC20TokenAdapterV1 is
-    ITokenAdapterV1,
+contract ERC20VotingAdapterV1 is
+    IVotingAdapterV1,
     Initializable,
     OwnableUpgradeable,
     UUPSUpgradeable,
@@ -31,7 +31,7 @@ contract ERC20TokenAdapterV1 is
 
     uint16 public constant VERSION = 1;
 
-    event TokenAdapterParametersUpdated(uint256 newWeightPerToken);
+    event VotingAdapterParametersUpdated(uint256 newWeightPerToken);
 
     error InvalidTokenAddress();
     error InvalidStrategyAddress();
@@ -61,7 +61,7 @@ contract ERC20TokenAdapterV1 is
         strategy = IStrategyBaseV1(_strategy);
         tokenClockMode = ClockModeLib.getClockMode(_token);
 
-        emit TokenAdapterParametersUpdated(weightPerToken);
+        emit VotingAdapterParametersUpdated(weightPerToken);
     }
 
     function _authorizeUpgrade(
@@ -72,7 +72,7 @@ contract ERC20TokenAdapterV1 is
         uint256 _newWeightPerToken
     ) external virtual onlyOwner {
         _updateWeightPerToken(_newWeightPerToken);
-        emit TokenAdapterParametersUpdated(weightPerToken);
+        emit VotingAdapterParametersUpdated(weightPerToken);
     }
 
     function _updateWeightPerToken(
@@ -135,8 +135,8 @@ contract ERC20TokenAdapterV1 is
         bytes4 interfaceId
     ) public view virtual override(ERC165, Version) returns (bool) {
         return
-            interfaceId == type(ITokenAdapterV1).interfaceId ||
-            interfaceId == type(ITokenAdapterBaseV1).interfaceId ||
+            interfaceId == type(IVotingAdapterV1).interfaceId ||
+            interfaceId == type(IVotingAdapterBaseV1).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {ITokenAdapterV1} from "../../../interfaces/decent/deployables/ITokenAdapterV1.sol";
-import {ITokenAdapterBaseV1} from "../../../interfaces/decent/deployables/ITokenAdapterBaseV1.sol";
+import {IVotingAdapterV1} from "../../../interfaces/decent/deployables/IVotingAdapterV1.sol";
+import {IVotingAdapterBaseV1} from "../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {IStrategyBaseV1} from "../../../interfaces/decent/deployables/IStrategyBaseV1.sol";
 import {Version} from "../../Version.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -11,8 +11,8 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-contract ERC721TokenAdapterV1 is
-    ITokenAdapterV1,
+contract ERC721VotingAdapterV1 is
+    IVotingAdapterV1,
     Initializable,
     OwnableUpgradeable,
     UUPSUpgradeable,
@@ -27,7 +27,7 @@ contract ERC721TokenAdapterV1 is
 
     uint16 public constant VERSION = 1;
 
-    event TokenAdapterParametersUpdated(uint256 newWeightPerNft);
+    event VotingAdapterParametersUpdated(uint256 newWeightPerNft);
 
     error InvalidTokenAddress();
     error InvalidStrategyAddress();
@@ -54,7 +54,7 @@ contract ERC721TokenAdapterV1 is
 
         _updateWeightPerNft(_weightPerNft);
 
-        emit TokenAdapterParametersUpdated(weightPerNft);
+        emit VotingAdapterParametersUpdated(weightPerNft);
     }
 
     function _authorizeUpgrade(
@@ -65,7 +65,7 @@ contract ERC721TokenAdapterV1 is
         uint256 _newWeightPerNft
     ) external virtual onlyOwner {
         _updateWeightPerNft(_newWeightPerNft);
-        emit TokenAdapterParametersUpdated(weightPerNft);
+        emit VotingAdapterParametersUpdated(weightPerNft);
     }
 
     function _updateWeightPerNft(uint256 _newWeightPerNft) internal virtual {
@@ -169,8 +169,8 @@ contract ERC721TokenAdapterV1 is
         bytes4 interfaceId
     ) public view virtual override(ERC165, Version) returns (bool) {
         return
-            interfaceId == type(ITokenAdapterV1).interfaceId ||
-            interfaceId == type(ITokenAdapterBaseV1).interfaceId ||
+            interfaceId == type(IVotingAdapterV1).interfaceId ||
+            interfaceId == type(IVotingAdapterBaseV1).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -10,11 +10,11 @@ interface IStrategyV1 is IStrategyBaseV1 {
 
     function updateBasisNumerator(uint256 _newBasisNumerator) external;
 
-    function addTokenAdapter(address _adapter) external;
+    function addVotingAdapter(address _adapter) external;
 
-    function removeTokenAdapter(address _adapter) external;
+    function removeVotingAdapter(address _adapter) external;
 
-    function getTokenAdapterCount() external view returns (uint256);
+    function getVotingAdapterCount() external view returns (uint256);
 
     function addProposerAdapter(address _adapter) external;
 
@@ -29,7 +29,7 @@ interface IStrategyV1 is IStrategyBaseV1 {
     function vote(
         uint32 _proposalId,
         uint8 _voteType,
-        address[] calldata _tokenAdaptersToUse,
-        bytes[] calldata _tokenAdapterVoteData
+        address[] calldata _votingAdaptersToUse,
+        bytes[] calldata _votingAdapterVoteData
     ) external;
 }

--- a/contracts/interfaces/decent/deployables/IVotingAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotingAdapterBaseV1.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-interface ITokenAdapterBaseV1 {
+interface IVotingAdapterBaseV1 {
     event VoteRecorded(
         address indexed voter,
         uint32 indexed proposalId,
         uint256 weightCasted,
-        bytes tokenAdapterVoteData
+        bytes votingAdapterVoteData
     );
 
     function recordVote(
         address _voter,
         uint32 _proposalId,
-        bytes calldata _tokenAdapterVoteData
+        bytes calldata _votingAdapterVoteData
     ) external returns (uint256 weightCasted);
 }

--- a/contracts/interfaces/decent/deployables/IVotingAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotingAdapterV1.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {ITokenAdapterBaseV1} from "./ITokenAdapterBaseV1.sol";
+import {IVotingAdapterBaseV1} from "./IVotingAdapterBaseV1.sol";
 
-interface ITokenAdapterV1 is ITokenAdapterBaseV1 {
+interface IVotingAdapterV1 is IVotingAdapterBaseV1 {
     function weightOf(
         address _voter,
         uint32 _proposalId,
-        bytes calldata _tokenAdapterVoteData
+        bytes calldata _votingAdapterVoteData
     ) external view returns (uint256 weight);
 }

--- a/contracts/mocks/MockVotingAdapter.sol
+++ b/contracts/mocks/MockVotingAdapter.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {ITokenAdapterBaseV1} from "../interfaces/decent/deployables/ITokenAdapterBaseV1.sol";
+import {IVotingAdapterBaseV1} from "../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 
-contract MockTokenAdapter is ITokenAdapterBaseV1 {
+contract MockVotingAdapter is IVotingAdapterBaseV1 {
     mapping(address => uint256) public weightsToReturn;
     mapping(address => mapping(uint32 => mapping(bytes32 => uint256)))
         public recordedVotesWeight;
@@ -19,7 +19,7 @@ contract MockTokenAdapter is ITokenAdapterBaseV1 {
         bytes calldata _adapterVoteData
     ) external override returns (uint256 weightCasted) {
         if (shouldRevertRecordVote) {
-            revert("MockTokenAdapter: recordVote forced revert");
+            revert("MockVotingAdapter: recordVote forced revert");
         }
 
         lastVoterForRecordVote = _voter;

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -12,8 +12,8 @@ import {
   MockLightAccountFactory__factory,
   MockProposerAdapter,
   MockProposerAdapter__factory,
-  MockTokenAdapter,
-  MockTokenAdapter__factory,
+  MockVotingAdapter,
+  MockVotingAdapter__factory,
   StrategyV1,
   StrategyV1__factory,
 } from '../../../typechain-types';
@@ -32,8 +32,8 @@ describe('StrategyV1', () => {
   // Contract Instances
   let strategyImplementation: StrategyV1;
   let strategy: StrategyV1;
-  let mockAdapter1: MockTokenAdapter;
-  let mockAdapter2: MockTokenAdapter;
+  let mockAdapter1: MockVotingAdapter;
+  let mockAdapter2: MockVotingAdapter;
   let mockProposerAdapter1: MockProposerAdapter;
   let mockProposerAdapter2: MockProposerAdapter;
   let lightAccountFactoryMock: MockLightAccountFactory;
@@ -90,9 +90,9 @@ describe('StrategyV1', () => {
     await lightAccountFactoryMock.waitForDeployment();
     lightAccountFactoryMockAddress = lightAccountFactoryMock.target as string;
 
-    mockAdapter1 = await new MockTokenAdapter__factory(deployer).deploy();
+    mockAdapter1 = await new MockVotingAdapter__factory(deployer).deploy();
     await mockAdapter1.waitForDeployment();
-    mockAdapter2 = await new MockTokenAdapter__factory(deployer).deploy();
+    mockAdapter2 = await new MockVotingAdapter__factory(deployer).deploy();
     await mockAdapter2.waitForDeployment();
 
     // Deploy MockProposerAdapters
@@ -151,8 +151,8 @@ describe('StrategyV1', () => {
       expect(await testStrategy.quorumThreshold()).to.equal(quorumThreshold);
       expect(await testStrategy.basisNumerator()).to.equal(basisNumerator);
       expect(await testStrategy.lightAccountFactory()).to.equal(lightAccountFactoryAddress);
-      expect(await testStrategy.getTokenAdapterCount()).to.equal(1);
-      expect(await testStrategy.tokenAdapters(0)).to.equal(await mockAdapter1.getAddress());
+      expect(await testStrategy.getVotingAdapterCount()).to.equal(1);
+      expect(await testStrategy.votingAdapters(0)).to.equal(await mockAdapter1.getAddress());
       expect(await testStrategy.getProposerAdapterCount()).to.equal(1);
       expect(await testStrategy.proposerAdapters(0)).to.equal(
         await mockProposerAdapter1.getAddress(),
@@ -282,120 +282,120 @@ describe('StrategyV1', () => {
     // --- addAdapter ---
     it('should allow owner to add a new adapter', async () => {
       const adapterAddress = await mockAdapter1.getAddress();
-      await expect(strategy.connect(owner).addTokenAdapter(adapterAddress))
-        .to.emit(strategy, 'TokenAdapterAdded')
+      await expect(strategy.connect(owner).addVotingAdapter(adapterAddress))
+        .to.emit(strategy, 'VotingAdapterAdded')
         .withArgs(adapterAddress, 0);
-      expect(await strategy.tokenAdapters(0)).to.equal(adapterAddress);
-      expect(await strategy.getTokenAdapterCount()).to.equal(1);
+      expect(await strategy.votingAdapters(0)).to.equal(adapterAddress);
+      expect(await strategy.getVotingAdapterCount()).to.equal(1);
     });
 
     it('should revert when non-owner tries to add an adapter', async () => {
       await expect(
-        strategy.connect(nonOwner).addTokenAdapter(await mockAdapter1.getAddress()),
+        strategy.connect(nonOwner).addVotingAdapter(await mockAdapter1.getAddress()),
       ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
     });
 
     it('should revert when adding a zero address adapter', async () => {
       await expect(
-        strategy.connect(owner).addTokenAdapter(ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterIsZeroAddress');
+        strategy.connect(owner).addVotingAdapter(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterIsZeroAddress');
     });
 
     it('should revert when adding an already existing adapter', async () => {
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
       await expect(
-        strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterAlreadyExists');
+        strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterAlreadyExists');
     });
 
     it('should allow adding multiple different adapters', async () => {
       const adapter1Addr = await mockAdapter1.getAddress();
       const adapter2Addr = await mockAdapter2.getAddress();
-      await strategy.connect(owner).addTokenAdapter(adapter1Addr);
-      await strategy.connect(owner).addTokenAdapter(adapter2Addr);
-      expect(await strategy.getTokenAdapterCount()).to.equal(2);
-      expect(await strategy.tokenAdapters(0)).to.equal(adapter1Addr);
-      expect(await strategy.tokenAdapters(1)).to.equal(adapter2Addr);
+      await strategy.connect(owner).addVotingAdapter(adapter1Addr);
+      await strategy.connect(owner).addVotingAdapter(adapter2Addr);
+      expect(await strategy.getVotingAdapterCount()).to.equal(2);
+      expect(await strategy.votingAdapters(0)).to.equal(adapter1Addr);
+      expect(await strategy.votingAdapters(1)).to.equal(adapter2Addr);
     });
 
     // --- removeAdapter ---
     it('should allow owner to remove an existing adapter', async () => {
       const adapter1Addr = await mockAdapter1.getAddress();
       const adapter2Addr = await mockAdapter2.getAddress();
-      await strategy.connect(owner).addTokenAdapter(adapter1Addr);
-      await strategy.connect(owner).addTokenAdapter(adapter2Addr);
+      await strategy.connect(owner).addVotingAdapter(adapter1Addr);
+      await strategy.connect(owner).addVotingAdapter(adapter2Addr);
 
       // To correctly test the emitted index, we need to know the exact removal logic
       // Assuming it swaps with last and pops:
       // If removing adapter1Addr (at index 0), adapter2Addr (at index 1) moves to 0.
       // The event should reflect the original index of the removed item.
-      await expect(strategy.connect(owner).removeTokenAdapter(adapter1Addr))
-        .to.emit(strategy, 'TokenAdapterRemoved')
+      await expect(strategy.connect(owner).removeVotingAdapter(adapter1Addr))
+        .to.emit(strategy, 'VotingAdapterRemoved')
         .withArgs(adapter1Addr, 0);
 
-      expect(await strategy.getTokenAdapterCount()).to.equal(1);
-      expect(await strategy.tokenAdapters(0)).to.equal(adapter2Addr);
+      expect(await strategy.getVotingAdapterCount()).to.equal(1);
+      expect(await strategy.votingAdapters(0)).to.equal(adapter2Addr);
     });
 
     it('should allow owner to remove an existing adapter (removing last)', async () => {
       const adapter1Addr = await mockAdapter1.getAddress();
       const adapter2Addr = await mockAdapter2.getAddress();
-      await strategy.connect(owner).addTokenAdapter(adapter1Addr);
-      await strategy.connect(owner).addTokenAdapter(adapter2Addr);
+      await strategy.connect(owner).addVotingAdapter(adapter1Addr);
+      await strategy.connect(owner).addVotingAdapter(adapter2Addr);
 
-      await expect(strategy.connect(owner).removeTokenAdapter(adapter2Addr))
-        .to.emit(strategy, 'TokenAdapterRemoved')
+      await expect(strategy.connect(owner).removeVotingAdapter(adapter2Addr))
+        .to.emit(strategy, 'VotingAdapterRemoved')
         .withArgs(adapter2Addr, 1);
 
-      expect(await strategy.getTokenAdapterCount()).to.equal(1);
-      expect(await strategy.tokenAdapters(0)).to.equal(adapter1Addr);
+      expect(await strategy.getVotingAdapterCount()).to.equal(1);
+      expect(await strategy.votingAdapters(0)).to.equal(adapter1Addr);
     });
 
     it('should correctly remove the only adapter in the list', async () => {
       const adapter1Addr = await mockAdapter1.getAddress();
-      await strategy.connect(owner).addTokenAdapter(adapter1Addr);
+      await strategy.connect(owner).addVotingAdapter(adapter1Addr);
 
-      await expect(strategy.connect(owner).removeTokenAdapter(adapter1Addr))
-        .to.emit(strategy, 'TokenAdapterRemoved')
+      await expect(strategy.connect(owner).removeVotingAdapter(adapter1Addr))
+        .to.emit(strategy, 'VotingAdapterRemoved')
         .withArgs(adapter1Addr, 0);
-      expect(await strategy.getTokenAdapterCount()).to.equal(0);
+      expect(await strategy.getVotingAdapterCount()).to.equal(0);
     });
 
     it('should revert when non-owner tries to remove an adapter', async () => {
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
       await expect(
-        strategy.connect(nonOwner).removeTokenAdapter(await mockAdapter1.getAddress()),
+        strategy.connect(nonOwner).removeVotingAdapter(await mockAdapter1.getAddress()),
       ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
     });
 
     it('should revert when removing a zero address adapter', async () => {
       await expect(
-        strategy.connect(owner).removeTokenAdapter(ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterIsZeroAddress');
+        strategy.connect(owner).removeVotingAdapter(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterIsZeroAddress');
     });
 
     it('should revert when removing an adapter that does not exist', async () => {
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress()); // Add a different one
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter2.getAddress()); // Add a different one
       await expect(
-        strategy.connect(owner).removeTokenAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterNotFound');
+        strategy.connect(owner).removeVotingAdapter(await mockAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterNotFound');
     });
 
     it('should revert when removing from an empty list of adapters', async () => {
       await expect(
-        strategy.connect(owner).removeTokenAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'TokenAdapterNotFound');
+        strategy.connect(owner).removeVotingAdapter(await mockAdapter1.getAddress()),
+      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterNotFound');
     });
 
-    // --- getTokenAdapterCount ---
+    // --- getVotingAdapterCount ---
     it('should return the correct number of adapters', async () => {
-      expect(await strategy.getTokenAdapterCount()).to.equal(0);
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
-      expect(await strategy.getTokenAdapterCount()).to.equal(1);
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
-      expect(await strategy.getTokenAdapterCount()).to.equal(2);
-      await strategy.connect(owner).removeTokenAdapter(await mockAdapter1.getAddress());
-      expect(await strategy.getTokenAdapterCount()).to.equal(1);
+      expect(await strategy.getVotingAdapterCount()).to.equal(0);
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
+      expect(await strategy.getVotingAdapterCount()).to.equal(1);
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter2.getAddress());
+      expect(await strategy.getVotingAdapterCount()).to.equal(2);
+      await strategy.connect(owner).removeVotingAdapter(await mockAdapter1.getAddress());
+      expect(await strategy.getVotingAdapterCount()).to.equal(1);
     });
   });
 
@@ -530,7 +530,7 @@ describe('StrategyV1', () => {
 
     it('should revert if called by a non-azorius address', async () => {
       // Ensure at least one adapter is set so NoAdapters isn't hit first
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
       await expect(
         strategy
           .connect(nonOwner)
@@ -544,11 +544,11 @@ describe('StrategyV1', () => {
         strategy
           .connect(azoriusMock)
           .initializeProposal(encodedDefaultProposalId, [], ethers.ZeroHash),
-      ).to.be.revertedWithCustomError(strategy, 'NoTokenAdapters');
+      ).to.be.revertedWithCustomError(strategy, 'NoVotingAdapters');
     });
 
     it('should correctly initialize proposal details and emit event', async () => {
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
 
       const blockBefore = await ethers.provider.getBlock('latest');
       if (!blockBefore) throw new Error('Failed to get latest block');
@@ -581,7 +581,7 @@ describe('StrategyV1', () => {
     });
 
     it('should reset vote counts for a re-initialized proposal', async () => {
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
       await strategy
         .connect(azoriusMock)
         .initializeProposal(encodedDefaultProposalId, [], ethers.ZeroHash);
@@ -642,7 +642,7 @@ describe('StrategyV1', () => {
       proposalId = 1;
       encodedProposalId = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
       // Ensure at least one adapter is added for initializeProposal to succeed
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
     });
 
     it('should return correct timestamps and block after proposal initialization', async () => {
@@ -689,7 +689,7 @@ describe('StrategyV1', () => {
       encodedProposalId = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
 
       // Add at least one adapter for most tests
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
       // Initialize the proposal by azoriusMock
       await strategy
         .connect(azoriusMock)
@@ -745,8 +745,8 @@ describe('StrategyV1', () => {
       ).to.be.revertedWithCustomError(strategy, 'InvalidVoteType');
     });
 
-    it('should revert with InvalidAdapterProvidedInVote if an adapter in _adaptersToUse is not configured in the strategy', async () => {
-      const unconfiguredAdapter = await new MockTokenAdapter__factory(deployer).deploy();
+    it('should revert with InvalidVotingAdapter if an adapter in _adaptersToUse is not configured in the strategy', async () => {
+      const unconfiguredAdapter = await new MockVotingAdapter__factory(deployer).deploy();
       await unconfiguredAdapter.waitForDeployment();
       const unconfiguredAdapterAddress = await unconfiguredAdapter.getAddress();
 
@@ -758,7 +758,7 @@ describe('StrategyV1', () => {
 
       await expect(
         strategy.connect(user1).vote(proposalId, 1 /* YES */, adaptersToUse, adapterDataArray),
-      ).to.be.revertedWithCustomError(strategy, 'InvalidAdapterProvidedInVote');
+      ).to.be.revertedWithCustomError(strategy, 'InvalidVotingAdapter');
     });
 
     it('should correctly record a YES vote, update counts, and emit Voted event', async () => {
@@ -781,7 +781,7 @@ describe('StrategyV1', () => {
       // Verify adapter's recordVote was called (using our mock's state)
       expect(await mockAdapter1.lastVoterForRecordVote()).to.equal(user1.address);
       expect(await mockAdapter1.lastProposalIdForRecordVote()).to.equal(proposalId);
-      // Note: MockTokenAdapter currently doesn't store lastAdapterDataForRecordVote to save gas
+      // Note: MockVotingAdapter currently doesn't store lastAdapterDataForRecordVote to save gas
       // but we can check if it was recorded if needed by enhancing the mock.
       expect(
         await mockAdapter1.recordedVotesWeight(
@@ -826,7 +826,7 @@ describe('StrategyV1', () => {
 
     it('should sum weights if multiple adapters are used in one vote call', async () => {
       // Add second adapter to the strategy for this test
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter2.getAddress());
 
       const weight1 = 60;
       const weight2 = 40;
@@ -895,11 +895,11 @@ describe('StrategyV1', () => {
 
       await expect(
         strategy.connect(user1).vote(proposalId, 1 /* YES */, [mockAdapter1], [adapter1Data]),
-      ).to.be.revertedWith('MockTokenAdapter: recordVote forced revert');
+      ).to.be.revertedWith('MockVotingAdapter: recordVote forced revert');
     });
 
     it('should revert if any adapter call reverts in a multi-adapter vote (all-or-nothing)', async () => {
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter2.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter2.getAddress());
 
       await mockAdapter1.connect(owner).setWeight(user1.address, 10);
       await mockAdapter2.connect(owner).setWeight(user1.address, 20);
@@ -920,7 +920,7 @@ describe('StrategyV1', () => {
 
       await expect(
         strategy.connect(user1).vote(proposalId, 1 /* YES */, adaptersToUse, adapterVoteDataArray),
-      ).to.be.revertedWith('MockTokenAdapter: recordVote forced revert');
+      ).to.be.revertedWith('MockVotingAdapter: recordVote forced revert');
 
       const proposalDetails = await strategy.proposalVotingDetails(proposalId);
       expect(proposalDetails.yesVotes).to.equal(0);
@@ -939,7 +939,7 @@ describe('StrategyV1', () => {
     // the strategy has an adapter and a proposal is initialized.
     beforeEach(async () => {
       // Ensure adapter is present on the strategy instance for these specific tests
-      await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
       // Initialize the proposal fresh for each isPassed test
       await strategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
     });
@@ -1185,9 +1185,9 @@ describe('StrategyV1', () => {
     const PROPOSAL_ID = 1;
 
     beforeEach(async () => {
-      const adapterCount = await strategy.getTokenAdapterCount();
+      const adapterCount = await strategy.getVotingAdapterCount();
       if (adapterCount === 0n) {
-        await strategy.connect(owner).addTokenAdapter(await mockAdapter1.getAddress());
+        await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
       }
 
       await strategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);

--- a/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
@@ -5,12 +5,12 @@ import type { ContractTransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  ERC20TokenAdapterV1,
-  ERC20TokenAdapterV1__factory,
+  ERC20VotingAdapterV1,
+  ERC20VotingAdapterV1__factory,
   IERC165__factory,
-  ITokenAdapterBaseV1__factory,
-  ITokenAdapterV1__factory,
   IVersion__factory,
+  IVotingAdapterBaseV1__factory,
+  IVotingAdapterV1__factory,
   MockERC20Votes,
   MockERC20Votes__factory,
   MockVotingStrategy,
@@ -27,18 +27,16 @@ async function deployERC20AdapterProxy(
   tokenAddress: string,
   strategyAddress: string,
   weightPerToken: bigint,
-): Promise<{ adapter: ERC20TokenAdapterV1; deployTx: ContractTransactionResponse }> {
-  const initData = ERC20TokenAdapterV1__factory.createInterface().encodeFunctionData('initialize', [
-    ownerAddress,
-    tokenAddress,
-    strategyAddress,
-    weightPerToken,
-  ]);
+): Promise<{ adapter: ERC20VotingAdapterV1; deployTx: ContractTransactionResponse }> {
+  const initData = ERC20VotingAdapterV1__factory.createInterface().encodeFunctionData(
+    'initialize',
+    [ownerAddress, tokenAddress, strategyAddress, weightPerToken],
+  );
   const proxyContractFactory = new ERC1967Proxy__factory(proxyDeployer);
   const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
   await proxy.waitForDeployment();
 
-  const adapter = ERC20TokenAdapterV1__factory.connect(await proxy.getAddress(), proxyDeployer);
+  const adapter = ERC20VotingAdapterV1__factory.connect(await proxy.getAddress(), proxyDeployer);
   const deployTx = proxy.deploymentTransaction();
   if (!deployTx) {
     throw new Error('Proxy deployment transaction not found');
@@ -46,7 +44,7 @@ async function deployERC20AdapterProxy(
   return { adapter, deployTx };
 }
 
-describe('ERC20TokenAdapterV1', () => {
+describe('ERC20VotingAdapterV1', () => {
   let deployerG: SignerWithAddress;
   let ownerG: SignerWithAddress;
   let erc20AdapterImplementationAddressG: string;
@@ -55,7 +53,7 @@ describe('ERC20TokenAdapterV1', () => {
 
   async function deployGlobalFixture() {
     const [deployer, owner, user1, user2, nonOwner] = await ethers.getSigners();
-    const adapterImplFactory = new ERC20TokenAdapterV1__factory(deployer);
+    const adapterImplFactory = new ERC20VotingAdapterV1__factory(deployer);
     const deployedAdapterImpl = await adapterImplFactory.deploy();
     await deployedAdapterImpl.waitForDeployment();
 
@@ -148,7 +146,7 @@ describe('ERC20TokenAdapterV1', () => {
       // Provide the proxy instance (erc20Adapter) to .to.emit(),
       // as the event is emitted from the proxy's address due to delegatecall.
       await expect(deployTx.hash)
-        .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
+        .to.emit(erc20Adapter, 'VotingAdapterParametersUpdated')
         .withArgs(DEFAULT_WEIGHT_PER_TOKEN);
 
       expect(await erc20Adapter.owner()).to.equal(ownerSigner.address);
@@ -158,7 +156,7 @@ describe('ERC20TokenAdapterV1', () => {
     });
 
     it('should revert if token address is zero', async () => {
-      const erc20AdapterImplementation = ERC20TokenAdapterV1__factory.connect(
+      const erc20AdapterImplementation = ERC20VotingAdapterV1__factory.connect(
         erc20AdapterImplementationAddressG,
         deployerG,
       );
@@ -176,7 +174,7 @@ describe('ERC20TokenAdapterV1', () => {
     });
 
     it('should revert if strategy address is zero', async () => {
-      const erc20AdapterImplementation = ERC20TokenAdapterV1__factory.connect(
+      const erc20AdapterImplementation = ERC20VotingAdapterV1__factory.connect(
         erc20AdapterImplementationAddressG,
         deployerG,
       );
@@ -194,7 +192,7 @@ describe('ERC20TokenAdapterV1', () => {
     });
 
     it('should revert if weightPerToken is zero', async () => {
-      const erc20AdapterImplementation = ERC20TokenAdapterV1__factory.connect(
+      const erc20AdapterImplementation = ERC20VotingAdapterV1__factory.connect(
         erc20AdapterImplementationAddressG,
         deployerG,
       );
@@ -227,7 +225,7 @@ describe('ERC20TokenAdapterV1', () => {
     });
 
     it('Should have initialization disabled in the implementation contract', async function () {
-      const implementationContract = ERC20TokenAdapterV1__factory.connect(
+      const implementationContract = ERC20VotingAdapterV1__factory.connect(
         erc20AdapterImplementationAddressG,
         ownerG,
       );
@@ -244,7 +242,7 @@ describe('ERC20TokenAdapterV1', () => {
   });
 
   describe('Owner Functions', () => {
-    let erc20Adapter: ERC20TokenAdapterV1;
+    let erc20Adapter: ERC20VotingAdapterV1;
     let currentOwnerSigner: SignerWithAddress;
     let currentNonOwnerSigner: SignerWithAddress;
 
@@ -270,7 +268,7 @@ describe('ERC20TokenAdapterV1', () => {
         await expect(
           erc20Adapter.connect(currentOwnerSigner).updateWeightPerToken(NEW_WEIGHT_PER_TOKEN),
         )
-          .to.emit(erc20Adapter, 'TokenAdapterParametersUpdated')
+          .to.emit(erc20Adapter, 'VotingAdapterParametersUpdated')
           .withArgs(NEW_WEIGHT_PER_TOKEN);
         expect(await erc20Adapter.weightPerToken()).to.equal(NEW_WEIGHT_PER_TOKEN);
       });
@@ -294,7 +292,7 @@ describe('ERC20TokenAdapterV1', () => {
   describe('weightOf', () => {
     const proposalId = 1;
     const mockExtraData = ethers.ZeroHash;
-    let adapter: ERC20TokenAdapterV1;
+    let adapter: ERC20VotingAdapterV1;
 
     async function setupAdapterForWeightOf(clockMode: 0 | 1, customWeightPerToken?: bigint) {
       await mockToken.setClockMode(clockMode);
@@ -406,7 +404,7 @@ describe('ERC20TokenAdapterV1', () => {
     const mockExtraData = ethers.ZeroHash;
     const expectedEventAdapterVoteData = '0x';
 
-    let adapter: ERC20TokenAdapterV1;
+    let adapter: ERC20VotingAdapterV1;
     let token: MockERC20Votes;
     let strategy: MockVotingStrategy;
     let voter: SignerWithAddress;
@@ -558,9 +556,9 @@ describe('ERC20TokenAdapterV1', () => {
   });
 
   describe('ERC165 supportsInterface', () => {
-    let erc20Adapter: ERC20TokenAdapterV1;
-    let iTokenAdapterV1InterfaceId: string;
-    let iTokenAdapterBaseV1InterfaceId: string;
+    let erc20Adapter: ERC20VotingAdapterV1;
+    let iVotingAdapterV1InterfaceId: string;
+    let iVotingAdapterBaseV1InterfaceId: string;
     let iVersionInterfaceId: string;
     let iERC165InterfaceId: string;
 
@@ -575,23 +573,23 @@ describe('ERC20TokenAdapterV1', () => {
       );
       erc20Adapter = adapter;
 
-      iTokenAdapterV1InterfaceId = calculateInterfaceId(
-        ITokenAdapterV1__factory.createInterface(),
-        [ITokenAdapterBaseV1__factory.createInterface()],
+      iVotingAdapterV1InterfaceId = calculateInterfaceId(
+        IVotingAdapterV1__factory.createInterface(),
+        [IVotingAdapterBaseV1__factory.createInterface()],
       );
-      iTokenAdapterBaseV1InterfaceId = calculateInterfaceId(
-        ITokenAdapterBaseV1__factory.createInterface(),
+      iVotingAdapterBaseV1InterfaceId = calculateInterfaceId(
+        IVotingAdapterBaseV1__factory.createInterface(),
       );
       iVersionInterfaceId = calculateInterfaceId(IVersion__factory.createInterface());
       iERC165InterfaceId = calculateInterfaceId(IERC165__factory.createInterface());
     });
 
-    it('should support ITokenAdapterV1', async () => {
-      void expect(await erc20Adapter.supportsInterface(iTokenAdapterV1InterfaceId)).to.be.true;
+    it('should support IVotingAdapterV1', async () => {
+      void expect(await erc20Adapter.supportsInterface(iVotingAdapterV1InterfaceId)).to.be.true;
     });
 
-    it('should support ITokenAdapterBaseV1', async () => {
-      void expect(await erc20Adapter.supportsInterface(iTokenAdapterBaseV1InterfaceId)).to.be.true;
+    it('should support IVotingAdapterBaseV1', async () => {
+      void expect(await erc20Adapter.supportsInterface(iVotingAdapterBaseV1InterfaceId)).to.be.true;
     });
 
     it('should support IVersion', async () => {
@@ -608,7 +606,7 @@ describe('ERC20TokenAdapterV1', () => {
   });
 
   describe('UUPS Upgradeability', () => {
-    let erc20AdapterProxy: ERC20TokenAdapterV1;
+    let erc20AdapterProxy: ERC20VotingAdapterV1;
 
     beforeEach(async () => {
       const { adapter } = await deployERC20AdapterProxy(
@@ -625,7 +623,7 @@ describe('ERC20TokenAdapterV1', () => {
     runUUPSUpgradeabilityTests({
       getContract: () => erc20AdapterProxy,
       createNewImplementation: async () => {
-        const newImplementation = await new ERC20TokenAdapterV1__factory(deployer).deploy();
+        const newImplementation = await new ERC20VotingAdapterV1__factory(deployer).deploy();
         return newImplementation;
       },
       owner: () => ownerSigner,

--- a/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
@@ -5,12 +5,12 @@ import type { ContractTransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  ERC721TokenAdapterV1,
-  ERC721TokenAdapterV1__factory,
+  ERC721VotingAdapterV1,
+  ERC721VotingAdapterV1__factory,
   IERC165__factory,
-  ITokenAdapterBaseV1__factory,
-  ITokenAdapterV1__factory,
   IVersion__factory,
+  IVotingAdapterBaseV1__factory,
+  IVotingAdapterV1__factory,
   MockERC721,
   MockERC721__factory,
   MockVotingStrategy,
@@ -26,8 +26,8 @@ async function deployERC721AdapterProxy(
   tokenAddress: string,
   strategyAddress: string,
   weightPerNft: bigint,
-): Promise<{ adapter: ERC721TokenAdapterV1; deployTx: ContractTransactionResponse }> {
-  const initData = ERC721TokenAdapterV1__factory.createInterface().encodeFunctionData(
+): Promise<{ adapter: ERC721VotingAdapterV1; deployTx: ContractTransactionResponse }> {
+  const initData = ERC721VotingAdapterV1__factory.createInterface().encodeFunctionData(
     'initialize',
     [initialOwnerAddress, tokenAddress, strategyAddress, weightPerNft],
   );
@@ -35,7 +35,7 @@ async function deployERC721AdapterProxy(
   const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
   await proxy.waitForDeployment();
 
-  const adapterInstance = ERC721TokenAdapterV1__factory.connect(
+  const adapterInstance = ERC721VotingAdapterV1__factory.connect(
     await proxy.getAddress(),
     proxyDeployer,
   );
@@ -46,7 +46,7 @@ async function deployERC721AdapterProxy(
   return { adapter: adapterInstance, deployTx: deployTxObj };
 }
 
-describe('ERC721TokenAdapterV1', () => {
+describe('ERC721VotingAdapterV1', () => {
   // Globally scoped (from first fixture load in `before`)
   let erc721AdapterImplementationAddressG: string;
   let deployerG: SignerWithAddress;
@@ -56,7 +56,7 @@ describe('ERC721TokenAdapterV1', () => {
 
   async function deployGlobalERC721Fixture() {
     const [deployer] = await ethers.getSigners();
-    const adapterImplFactory = new ERC721TokenAdapterV1__factory(deployer);
+    const adapterImplFactory = new ERC721VotingAdapterV1__factory(deployer);
     const deployedAdapterImpl = await adapterImplFactory.deploy();
     await deployedAdapterImpl.waitForDeployment();
     erc721AdapterImplementationAddressG = await deployedAdapterImpl.getAddress();
@@ -122,7 +122,7 @@ describe('ERC721TokenAdapterV1', () => {
   });
 
   describe('Initialization', () => {
-    it('should initialize correctly, set owner, and emit TokenAdapterParametersUpdated event', async () => {
+    it('should initialize correctly, set owner, and emit VotingAdapterParametersUpdated event', async () => {
       const {
         ownerSigner,
         mockNft,
@@ -140,7 +140,7 @@ describe('ERC721TokenAdapterV1', () => {
       );
 
       await expect(deployTx)
-        .to.emit(erc721Adapter, 'TokenAdapterParametersUpdated')
+        .to.emit(erc721Adapter, 'VotingAdapterParametersUpdated')
         .withArgs(DEFAULT_WEIGHT_PER_NFT);
 
       expect(await erc721Adapter.owner()).to.equal(ownerSigner.address);
@@ -153,7 +153,7 @@ describe('ERC721TokenAdapterV1', () => {
       const { mockNft, deployer: fixtureDeployer } = await loadFixture(
         deployMocksAndSignersERC721Fixture,
       );
-      const erc721AdapterImplementation = ERC721TokenAdapterV1__factory.connect(
+      const erc721AdapterImplementation = ERC721VotingAdapterV1__factory.connect(
         erc721AdapterImplementationAddressG,
         deployerG,
       );
@@ -173,7 +173,7 @@ describe('ERC721TokenAdapterV1', () => {
       const { mockNft, deployer: fixtureDeployer } = await loadFixture(
         deployMocksAndSignersERC721Fixture,
       );
-      const erc721AdapterImplementation = ERC721TokenAdapterV1__factory.connect(
+      const erc721AdapterImplementation = ERC721VotingAdapterV1__factory.connect(
         erc721AdapterImplementationAddressG,
         deployerG,
       );
@@ -195,7 +195,7 @@ describe('ERC721TokenAdapterV1', () => {
         mockStrategy,
         deployer: fixtureDeployer,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
-      const erc721AdapterImplementation = ERC721TokenAdapterV1__factory.connect(
+      const erc721AdapterImplementation = ERC721VotingAdapterV1__factory.connect(
         erc721AdapterImplementationAddressG,
         deployerG,
       );
@@ -241,7 +241,7 @@ describe('ERC721TokenAdapterV1', () => {
         mockStrategy,
         deployer: fixtureDeployer,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
-      const implementationContract = ERC721TokenAdapterV1__factory.connect(
+      const implementationContract = ERC721VotingAdapterV1__factory.connect(
         erc721AdapterImplementationAddressG,
         fixtureDeployer,
       );
@@ -257,7 +257,7 @@ describe('ERC721TokenAdapterV1', () => {
   });
 
   describe('weightOf', () => {
-    let adapter: ERC721TokenAdapterV1;
+    let adapter: ERC721VotingAdapterV1;
     let mockNft: MockERC721; // Explicitly type mockNft here
     let user1: SignerWithAddress;
     let user1TokenIds: bigint[];
@@ -376,7 +376,7 @@ describe('ERC721TokenAdapterV1', () => {
   });
 
   describe('recordVote', () => {
-    let adapter: ERC721TokenAdapterV1;
+    let adapter: ERC721VotingAdapterV1;
     let mockNft: MockERC721;
     let user1: SignerWithAddress;
     let user1TokenIds: bigint[];
@@ -558,9 +558,9 @@ describe('ERC721TokenAdapterV1', () => {
   });
 
   describe('ERC165 supportsInterface', () => {
-    let erc721Adapter: ERC721TokenAdapterV1;
-    let iTokenAdapterV1InterfaceId: string;
-    let iTokenAdapterBaseV1InterfaceId: string;
+    let erc721Adapter: ERC721VotingAdapterV1;
+    let iVotingAdapterV1InterfaceId: string;
+    let iVotingAdapterBaseV1InterfaceId: string;
     let iVersionInterfaceId: string;
     let iERC165InterfaceId: string;
 
@@ -581,23 +581,24 @@ describe('ERC721TokenAdapterV1', () => {
       erc721Adapter = adapter;
 
       // Calculate interface IDs
-      iTokenAdapterV1InterfaceId = calculateInterfaceId(
-        ITokenAdapterV1__factory.createInterface(),
-        [ITokenAdapterBaseV1__factory.createInterface()],
+      iVotingAdapterV1InterfaceId = calculateInterfaceId(
+        IVotingAdapterV1__factory.createInterface(),
+        [IVotingAdapterBaseV1__factory.createInterface()],
       );
-      iTokenAdapterBaseV1InterfaceId = calculateInterfaceId(
-        ITokenAdapterBaseV1__factory.createInterface(),
+      iVotingAdapterBaseV1InterfaceId = calculateInterfaceId(
+        IVotingAdapterBaseV1__factory.createInterface(),
       );
       iVersionInterfaceId = calculateInterfaceId(IVersion__factory.createInterface());
       iERC165InterfaceId = calculateInterfaceId(IERC165__factory.createInterface());
     });
 
-    it('should support ITokenAdapterV1', async () => {
-      void expect(await erc721Adapter.supportsInterface(iTokenAdapterV1InterfaceId)).to.be.true;
+    it('should support IVotingAdapterV1', async () => {
+      void expect(await erc721Adapter.supportsInterface(iVotingAdapterV1InterfaceId)).to.be.true;
     });
 
-    it('should support ITokenAdapterBaseV1', async () => {
-      void expect(await erc721Adapter.supportsInterface(iTokenAdapterBaseV1InterfaceId)).to.be.true;
+    it('should support IVotingAdapterBaseV1', async () => {
+      void expect(await erc721Adapter.supportsInterface(iVotingAdapterBaseV1InterfaceId)).to.be
+        .true;
     });
 
     it('should support IVersion', async () => {
@@ -614,7 +615,7 @@ describe('ERC721TokenAdapterV1', () => {
   });
 
   describe('Owner Functions', () => {
-    let adapter: ERC721TokenAdapterV1;
+    let adapter: ERC721VotingAdapterV1;
     let owner: SignerWithAddress;
     let nonOwner: SignerWithAddress;
     let deployer: SignerWithAddress; // This will be the fixture.deployer
@@ -645,7 +646,7 @@ describe('ERC721TokenAdapterV1', () => {
 
       it('should allow owner to update weightPerNft and emit event', async () => {
         await expect(adapter.connect(owner).updateWeightPerNft(NEW_WEIGHT_PER_NFT))
-          .to.emit(adapter, 'TokenAdapterParametersUpdated')
+          .to.emit(adapter, 'VotingAdapterParametersUpdated')
           .withArgs(NEW_WEIGHT_PER_NFT);
         expect(await adapter.weightPerNft()).to.equal(NEW_WEIGHT_PER_NFT);
       });
@@ -666,7 +667,7 @@ describe('ERC721TokenAdapterV1', () => {
   });
 
   describe('UUPS Upgradeability', () => {
-    let erc721AdapterProxy: ERC721TokenAdapterV1;
+    let erc721AdapterProxy: ERC721VotingAdapterV1;
     let fixtureOwner: SignerWithAddress;
     let fixtureNonOwner: SignerWithAddress;
     let fixtureDeployer: SignerWithAddress;
@@ -697,7 +698,9 @@ describe('ERC721TokenAdapterV1', () => {
     runUUPSUpgradeabilityTests({
       getContract: () => erc721AdapterProxy,
       createNewImplementation: async () => {
-        const newImplementation = await new ERC721TokenAdapterV1__factory(fixtureDeployer).deploy();
+        const newImplementation = await new ERC721VotingAdapterV1__factory(
+          fixtureDeployer,
+        ).deploy();
         await newImplementation.waitForDeployment();
         return newImplementation;
       },


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/277

Fixes [ENG-972](https://linear.app/decent-labs/issue/ENG-972/refactor-rename-tokenadapter-to-votingadapter-for-clarity)

**High-Level Context:**

This Pull Request continues the refinement of our new modular `StrategyV1` governance system. To more clearly distinguish between adapters responsible for voting weight/mechanics and the recently introduced adapters responsible for proposer eligibility, this PR renames "TokenAdapter" constructs to "VotingAdapter" where appropriate. This affects contract names, interface names, event names, error names, and variable names.

**Specific Changes in this PR:**

1.  **Contract Renaming:**
    *   `ERC20TokenAdapterV1.sol` is renamed to `ERC20VotingAdapterV1.sol`.
    *   `ERC721TokenAdapterV1.sol` is renamed to `ERC721VotingAdapterV1.sol`.
    *   All import paths and contract name references (e.g., in `StrategyV1.sol` and test files) are updated.

2.  **Interface Renaming:**
    *   `ITokenAdapterBaseV1.sol` is renamed to `IVotingAdapterBaseV1.sol`.
    *   `ITokenAdapterV1.sol` is renamed to `IVotingAdapterV1.sol`.
    *   The inheritance structure (`IVotingAdapterV1 is IVotingAdapterBaseV1`) is maintained.
    *   All contracts implementing or referencing these interfaces are updated.

3.  **`StrategyV1.sol` Updates:**
    *   **State Variable:** `ITokenAdapterBaseV1[] public tokenAdapters;` is renamed to `IVotingAdapterBaseV1[] public votingAdapters;`.
    *   **Events:**
        *   `TokenAdapterAdded` event is now `VotingAdapterAdded`.
        *   `TokenAdapterRemoved` event is now `VotingAdapterRemoved`.
    *   **Errors:**
        *   `TokenAdapterIsZeroAddress` is now `VotingAdapterIsZeroAddress`.
        *   `TokenAdapterAlreadyExists` is now `VotingAdapterAlreadyExists`.
        *   `TokenAdapterNotFound` is now `VotingAdapterNotFound`.
        *   `NoTokenAdapters` is now `NoVotingAdapters`.
        *   `InvalidAdapterProvidedInVote` is now `InvalidVotingAdapter`.
    *   **Functions:**
        *   `addTokenAdapter` is now `addVotingAdapter`.
        *   `removeTokenAdapter` is now `removeVotingAdapter`.
        *   `getTokenAdapterCount` is now `getVotingAdapterCount`.
        *   Internal helper `_addTokenAdapter` is now `_addVotingAdapter`.
    *   **`vote` Function Parameters:**
        *   `_tokenAdaptersToUse` is renamed to `_votingAdaptersToUse`.
        *   `_tokenAdapterVoteData` is renamed to `_votingAdapterVoteData`.
    *   The internal logic now refers to `votingAdapters` array.

4.  **Voting Adapter Contract Updates (`ERC20VotingAdapterV1.sol`, `ERC721VotingAdapterV1.sol`):**
    *   The event `TokenAdapterParametersUpdated` is renamed to `VotingAdapterParametersUpdated`.
    *   Interfaces implemented are updated (e.g., `ITokenAdapterV1` to `IVotingAdapterV1`).

5.  **`ITokenAdapterBaseV1.sol` (now `IVotingAdapterBaseV1.sol`) Event Parameter Renaming:**
    *   In the `VoteRecorded` event, the parameter `tokenAdapterVoteData` is renamed to `votingAdapterVoteData`.

6.  **Mock Contract Updates:**
    *   `MockTokenAdapter.sol` is renamed to `MockVotingAdapter.sol`.
    *   Its internal logic and references are updated if necessary (though the main change is the filename and what it implements).

7.  **Test File Renaming and Updates:**
    *   `test/.../ERC20TokenAdapterV1.test.ts` renamed to `ERC20VotingAdapterV1.test.ts`.
    *   `test/.../ERC721TokenAdapterV1.test.ts` renamed to `ERC721VotingAdapterV1.test.ts`.
    *   All factory imports, type references, and function calls (e.g., `strategy.addVotingAdapter`) within test files are updated to reflect the new names.

**Impact and Status:**

*   **Improved Clarity:** This renaming provides a clearer semantic distinction between adapters dealing with voting mechanics (`VotingAdapter`) and those dealing with proposer eligibility (`ProposerAdapter`).
*   **Consistency:** Enforces a more consistent naming scheme across the new strategy system.
*   **No Functional Change:** This is primarily a find-and-replace refactoring for names and should not alter the underlying logic or behavior of the contracts.
*   **Compilation Status:** All contracts should compile successfully with these changes.
*   **Testing Status:** All tests have been updated to use the new names and should continue to pass, confirming that the renaming was applied correctly and did not introduce regressions.

This change helps to make the roles of different adapter types within the `StrategyV1` ecosystem more immediately understandable.