### PR TITLE
refactor(governance)!: Make StrategyV1 and Adapters Immutable

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -6,8 +6,6 @@ import {IStrategyBaseV1} from "../../interfaces/decent/deployables/IStrategyBase
 import {IVotingAdapterBaseV1} from "../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {IProposerAdapterBaseV1} from "../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {Version} from "../Version.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {ERC4337VoterSupportV1} from "./ERC4337VoterSupportV1.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
@@ -15,8 +13,6 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 contract StrategyV1 is
     Initializable,
     IStrategyV1,
-    OwnableUpgradeable,
-    UUPSUpgradeable,
     ERC165,
     ERC4337VoterSupportV1,
     Version
@@ -49,15 +45,6 @@ contract StrategyV1 is
         ABSTAIN
     }
 
-    event StrategyParametersUpdated(
-        uint32 votingPeriod,
-        uint256 quorumThreshold,
-        uint256 basisNumerator
-    );
-    event VotingAdapterAdded(address indexed adapter, uint256 index);
-    event VotingAdapterRemoved(address indexed adapter, uint256 index);
-    event ProposerAdapterAdded(address indexed adapter, uint256 index);
-    event ProposerAdapterRemoved(address indexed adapter, uint256 index);
     event Voted(
         address indexed voter,
         uint32 indexed proposalId,
@@ -76,11 +63,9 @@ contract StrategyV1 is
     error InvalidBasisNumerator();
     error VotingAdapterIsZeroAddress();
     error VotingAdapterAlreadyExists();
-    error VotingAdapterNotFound();
     error NoVotingAdapters();
     error ProposerAdapterIsZeroAddress();
     error ProposerAdapterAlreadyExists();
-    error ProposerAdapterNotFound();
     error ProposalNotFoundOrNotActive();
     error NoVotingWeight();
     error InvalidVoteType();
@@ -93,104 +78,50 @@ contract StrategyV1 is
     }
 
     function initialize(
-        address _initialOwner,
         address _azorius,
         uint32 _votingPeriod,
         uint256 _quorumThreshold,
         uint256 _basisNumerator,
-        address[] memory _initialVotingAdapters,
-        address[] memory _initialProposerAdapters,
+        address[] memory _votingAdapters,
+        address[] memory _proposerAdapters,
         address _lightAccountFactory
     ) public virtual initializer {
         if (_azorius == address(0)) revert InvalidAzoriusAddress();
 
-        __Ownable_init(_initialOwner);
-        __UUPSUpgradeable_init();
         __ERC4337VoterSupportV1_init(_lightAccountFactory);
 
         azorius = _azorius;
-        _updateVotingPeriod(_votingPeriod);
-        _updateQuorumThreshold(_quorumThreshold);
-        _updateBasisNumerator(_basisNumerator);
 
-        if (_initialVotingAdapters.length > 0) {
-            for (uint256 i = 0; i < _initialVotingAdapters.length; i++) {
-                _addVotingAdapter(_initialVotingAdapters[i]);
+        if (_votingPeriod == 0) revert InvalidVotingPeriod();
+        votingPeriod = _votingPeriod;
+
+        quorumThreshold = _quorumThreshold;
+
+        if (
+            _basisNumerator >= BASIS_DENOMINATOR ||
+            _basisNumerator < BASIS_DENOMINATOR / 2
+        ) revert InvalidBasisNumerator();
+        basisNumerator = _basisNumerator;
+
+        for (uint256 i = 0; i < _votingAdapters.length; i++) {
+            address _adapter = _votingAdapters[i];
+            if (_adapter == address(0)) revert VotingAdapterIsZeroAddress();
+            for (uint256 j = 0; j < votingAdapters.length; j++) {
+                if (address(votingAdapters[j]) == _adapter)
+                    revert VotingAdapterAlreadyExists();
             }
+            votingAdapters.push(IVotingAdapterBaseV1(_adapter));
         }
 
-        if (_initialProposerAdapters.length > 0) {
-            for (uint256 i = 0; i < _initialProposerAdapters.length; i++) {
-                _addProposerAdapter(_initialProposerAdapters[i]);
+        for (uint256 i = 0; i < _proposerAdapters.length; i++) {
+            address _adapter = _proposerAdapters[i];
+            if (_adapter == address(0)) revert ProposerAdapterIsZeroAddress();
+            for (uint256 j = 0; j < proposerAdapters.length; j++) {
+                if (address(proposerAdapters[j]) == _adapter)
+                    revert ProposerAdapterAlreadyExists();
             }
+            proposerAdapters.push(IProposerAdapterBaseV1(_adapter));
         }
-
-        emit StrategyParametersUpdated(
-            votingPeriod,
-            quorumThreshold,
-            basisNumerator
-        );
-    }
-
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {}
-
-    function updateVotingPeriod(
-        uint32 _newVotingPeriod
-    ) external virtual override onlyOwner {
-        _updateVotingPeriod(_newVotingPeriod);
-        emit StrategyParametersUpdated(
-            votingPeriod,
-            quorumThreshold,
-            basisNumerator
-        );
-    }
-
-    function updateQuorumThreshold(
-        uint256 _newQuorumThreshold
-    ) external virtual override onlyOwner {
-        _updateQuorumThreshold(_newQuorumThreshold);
-        emit StrategyParametersUpdated(
-            votingPeriod,
-            quorumThreshold,
-            basisNumerator
-        );
-    }
-
-    function updateBasisNumerator(
-        uint256 _newBasisNumerator
-    ) external virtual override onlyOwner {
-        _updateBasisNumerator(_newBasisNumerator);
-        emit StrategyParametersUpdated(
-            votingPeriod,
-            quorumThreshold,
-            basisNumerator
-        );
-    }
-
-    function addVotingAdapter(
-        address _adapter
-    ) public virtual override onlyOwner {
-        _addVotingAdapter(_adapter);
-    }
-
-    function removeVotingAdapter(
-        address _adapter
-    ) external virtual override onlyOwner {
-        if (_adapter == address(0)) revert VotingAdapterIsZeroAddress();
-        uint256 adapterCount = votingAdapters.length;
-        if (adapterCount == 0) revert VotingAdapterNotFound();
-
-        for (uint256 i = 0; i < adapterCount; i++) {
-            if (address(votingAdapters[i]) == _adapter) {
-                votingAdapters[i] = votingAdapters[adapterCount - 1];
-                votingAdapters.pop();
-                emit VotingAdapterRemoved(address(_adapter), i);
-                return;
-            }
-        }
-        revert VotingAdapterNotFound();
     }
 
     function getVotingAdapterCount()
@@ -201,30 +132,6 @@ contract StrategyV1 is
         returns (uint256)
     {
         return votingAdapters.length;
-    }
-
-    function addProposerAdapter(
-        address _adapter
-    ) public virtual override onlyOwner {
-        _addProposerAdapter(_adapter);
-    }
-
-    function removeProposerAdapter(
-        address _adapter
-    ) external virtual override onlyOwner {
-        if (_adapter == address(0)) revert ProposerAdapterIsZeroAddress();
-        uint256 adapterCount = proposerAdapters.length;
-        if (adapterCount == 0) revert ProposerAdapterNotFound();
-
-        for (uint256 i = 0; i < adapterCount; i++) {
-            if (address(proposerAdapters[i]) == _adapter) {
-                proposerAdapters[i] = proposerAdapters[adapterCount - 1];
-                proposerAdapters.pop();
-                emit ProposerAdapterRemoved(address(_adapter), i);
-                return;
-            }
-        }
-        revert ProposerAdapterNotFound();
     }
 
     function getProposerAdapterCount()
@@ -416,51 +323,6 @@ contract StrategyV1 is
         ];
         if (details.votingEndTimestamp == 0) revert ProposalNotInitialized();
         return details.votingStartBlock;
-    }
-
-    function _updateVotingPeriod(uint32 _newVotingPeriod) internal virtual {
-        if (_newVotingPeriod == 0) revert InvalidVotingPeriod();
-        votingPeriod = _newVotingPeriod;
-    }
-
-    function _updateQuorumThreshold(
-        uint256 _newQuorumThreshold
-    ) internal virtual {
-        quorumThreshold = _newQuorumThreshold;
-    }
-
-    function _updateBasisNumerator(
-        uint256 _newBasisNumerator
-    ) internal virtual {
-        if (
-            _newBasisNumerator >= BASIS_DENOMINATOR ||
-            _newBasisNumerator < BASIS_DENOMINATOR / 2
-        ) revert InvalidBasisNumerator();
-
-        basisNumerator = _newBasisNumerator;
-    }
-
-    function _addVotingAdapter(address _adapter) internal virtual {
-        if (_adapter == address(0)) revert VotingAdapterIsZeroAddress();
-        for (uint256 i = 0; i < votingAdapters.length; i++) {
-            if (address(votingAdapters[i]) == _adapter)
-                revert VotingAdapterAlreadyExists();
-        }
-        votingAdapters.push(IVotingAdapterBaseV1(_adapter));
-        emit VotingAdapterAdded(address(_adapter), votingAdapters.length - 1);
-    }
-
-    function _addProposerAdapter(address _adapter) internal virtual {
-        if (_adapter == address(0)) revert ProposerAdapterIsZeroAddress();
-        for (uint256 i = 0; i < proposerAdapters.length; i++) {
-            if (address(proposerAdapters[i]) == _adapter)
-                revert ProposerAdapterAlreadyExists();
-        }
-        proposerAdapters.push(IProposerAdapterBaseV1(_adapter));
-        emit ProposerAdapterAdded(
-            address(_adapter),
-            proposerAdapters.length - 1
-        );
     }
 
     function getVersion() public view virtual override returns (uint16) {

--- a/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
@@ -9,15 +9,11 @@ import {Version} from "../../Version.sol";
 import {ClockModeLib} from "../../../libs/ClockModeLib.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 contract ERC20VotingAdapterV1 is
     IVotingAdapterV1,
     Initializable,
-    OwnableUpgradeable,
-    UUPSUpgradeable,
     ERC165,
     Version
 {
@@ -31,8 +27,6 @@ contract ERC20VotingAdapterV1 is
 
     uint16 public constant VERSION = 1;
 
-    event VotingAdapterParametersUpdated(uint256 newWeightPerToken);
-
     error InvalidTokenAddress();
     error InvalidStrategyAddress();
     error ProposalNotReadyForSnapshot();
@@ -44,42 +38,19 @@ contract ERC20VotingAdapterV1 is
     }
 
     function initialize(
-        address _initialOwner,
         address _token,
         address _strategy,
         uint256 _weightPerToken
     ) external virtual initializer {
-        __Ownable_init(_initialOwner);
-        __UUPSUpgradeable_init();
-
         if (_token == address(0)) revert InvalidTokenAddress();
         if (_strategy == address(0)) revert InvalidStrategyAddress();
 
-        _updateWeightPerToken(_weightPerToken);
+        if (_weightPerToken == 0) revert InvalidWeightPerToken();
+        weightPerToken = _weightPerToken;
 
         token = IVotes(_token);
         strategy = IStrategyBaseV1(_strategy);
         tokenClockMode = ClockModeLib.getClockMode(_token);
-
-        emit VotingAdapterParametersUpdated(weightPerToken);
-    }
-
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {}
-
-    function updateWeightPerToken(
-        uint256 _newWeightPerToken
-    ) external virtual onlyOwner {
-        _updateWeightPerToken(_newWeightPerToken);
-        emit VotingAdapterParametersUpdated(weightPerToken);
-    }
-
-    function _updateWeightPerToken(
-        uint256 _newWeightPerToken
-    ) internal virtual {
-        if (_newWeightPerToken == 0) revert InvalidWeightPerToken();
-        weightPerToken = _newWeightPerToken;
     }
 
     function _getVoteWeightDetails(

--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -8,14 +8,10 @@ import {Version} from "../../Version.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 contract ERC721VotingAdapterV1 is
     IVotingAdapterV1,
     Initializable,
-    OwnableUpgradeable,
-    UUPSUpgradeable,
     ERC165,
     Version
 {
@@ -27,8 +23,6 @@ contract ERC721VotingAdapterV1 is
 
     uint16 public constant VERSION = 1;
 
-    event VotingAdapterParametersUpdated(uint256 newWeightPerNft);
-
     error InvalidTokenAddress();
     error InvalidStrategyAddress();
     error InvalidWeightPerNft();
@@ -38,39 +32,18 @@ contract ERC721VotingAdapterV1 is
     }
 
     function initialize(
-        address _initialOwner,
         address _token,
         address _strategy,
         uint256 _weightPerNft
     ) external virtual initializer {
-        __Ownable_init(_initialOwner);
-        __UUPSUpgradeable_init();
-
         if (_token == address(0)) revert InvalidTokenAddress();
         if (_strategy == address(0)) revert InvalidStrategyAddress();
 
         token = IERC721(_token);
         strategy = IStrategyBaseV1(_strategy);
 
-        _updateWeightPerNft(_weightPerNft);
-
-        emit VotingAdapterParametersUpdated(weightPerNft);
-    }
-
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {}
-
-    function updateWeightPerNft(
-        uint256 _newWeightPerNft
-    ) external virtual onlyOwner {
-        _updateWeightPerNft(_newWeightPerNft);
-        emit VotingAdapterParametersUpdated(weightPerNft);
-    }
-
-    function _updateWeightPerNft(uint256 _newWeightPerNft) internal virtual {
-        if (_newWeightPerNft == 0) revert InvalidWeightPerNft();
-        weightPerNft = _newWeightPerNft;
+        if (_weightPerNft == 0) revert InvalidWeightPerNft();
+        weightPerNft = _weightPerNft;
     }
 
     function _getValidUnvotedTokenIdsAndWeight(

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -4,21 +4,7 @@ pragma solidity ^0.8.30;
 import {IStrategyBaseV1} from "./IStrategyBaseV1.sol";
 
 interface IStrategyV1 is IStrategyBaseV1 {
-    function updateVotingPeriod(uint32 _newVotingPeriod) external;
-
-    function updateQuorumThreshold(uint256 _newQuorumThreshold) external;
-
-    function updateBasisNumerator(uint256 _newBasisNumerator) external;
-
-    function addVotingAdapter(address _adapter) external;
-
-    function removeVotingAdapter(address _adapter) external;
-
     function getVotingAdapterCount() external view returns (uint256);
-
-    function addProposerAdapter(address _adapter) external;
-
-    function removeProposerAdapter(address _adapter) external;
 
     function getProposerAdapterCount() external view returns (uint256);
 

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -18,12 +18,10 @@ import {
   StrategyV1__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
-import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
 describe('StrategyV1', () => {
   // Signers
   let deployer: SignerWithAddress;
-  let owner: SignerWithAddress;
   let azoriusMock: SignerWithAddress; // To simulate calls from Azorius
   let nonOwner: SignerWithAddress;
   let user1: SignerWithAddress;
@@ -43,32 +41,24 @@ describe('StrategyV1', () => {
   const DEFAULT_VOTING_PERIOD = 100; // Example value
   const DEFAULT_QUORUM_THRESHOLD = 1n;
   const DEFAULT_BASIS_NUMERATOR = 500_001n;
+  let defaultInitialVotingAdapters: string[];
+  let defaultInitialProposerAdapters: string[];
 
   async function deployStrategyProxy(
-    initialOwner: string,
     azoriusAddress: string,
     votingPeriod: number,
     quorumThreshold: bigint,
     basisNumerator: bigint,
-    initialTokenAdaptersAddresses: string[],
+    initialVotingAdaptersAddresses: string[],
     initialProposerAdaptersAddresses: string[],
     lightAccountFactoryAddress: string,
   ): Promise<StrategyV1> {
-    // For initialAdapters, StrategyV1's initialize expects ITokenAdapter[]
-    // This helper will take addresses and we assume they are already deployed mock adapter addresses
-    // If actual ITokenAdapter instances were needed for calldata, the caller would pass them.
-    // However, for encoding, addresses are often what abi.encode expects for an array of interfaces.
-    // Let's clarify this based on how StrategyV1 actually takes it.
-    // StrategyV1 initialize takes ITokenAdapter[] memory _initialTokenAdapters
-    // So, we should pass an array of addresses, which Solidity will interpret as such.
-
     const initializeCalldata = strategyImplementation.interface.encodeFunctionData('initialize', [
-      initialOwner,
       azoriusAddress,
       votingPeriod,
       quorumThreshold,
       basisNumerator,
-      initialTokenAdaptersAddresses,
+      initialVotingAdaptersAddresses,
       initialProposerAdaptersAddresses,
       lightAccountFactoryAddress,
     ]);
@@ -80,7 +70,7 @@ describe('StrategyV1', () => {
   }
 
   beforeEach(async () => {
-    [deployer, owner, azoriusMock, nonOwner, user1, voter2, voter3] = await ethers.getSigners();
+    [deployer, azoriusMock, nonOwner, user1, voter2, voter3] = await ethers.getSigners();
     voter1 = user1; // Alias for clarity in some tests
 
     strategyImplementation = await new StrategyV1__factory(deployer).deploy();
@@ -95,74 +85,67 @@ describe('StrategyV1', () => {
     mockAdapter2 = await new MockVotingAdapter__factory(deployer).deploy();
     await mockAdapter2.waitForDeployment();
 
-    // Deploy MockProposerAdapters
-    mockProposerAdapter1 = await new MockProposerAdapter__factory(deployer).deploy(undefined);
+    mockProposerAdapter1 = await new MockProposerAdapter__factory(deployer).deploy();
     await mockProposerAdapter1.waitForDeployment();
-    mockProposerAdapter2 = await new MockProposerAdapter__factory(deployer).deploy(undefined);
+    mockProposerAdapter2 = await new MockProposerAdapter__factory(deployer).deploy();
     await mockProposerAdapter2.waitForDeployment();
 
+    defaultInitialVotingAdapters = [await mockAdapter1.getAddress()];
+    defaultInitialProposerAdapters = [await mockProposerAdapter1.getAddress()];
+
     strategy = await deployStrategyProxy(
-      owner.address,
       azoriusMock.address,
       DEFAULT_VOTING_PERIOD,
       DEFAULT_QUORUM_THRESHOLD,
       DEFAULT_BASIS_NUMERATOR,
-      [],
-      [],
+      defaultInitialVotingAdapters,
+      defaultInitialProposerAdapters,
       lightAccountFactoryMockAddress,
     );
   });
 
   describe('Initialization', () => {
-    it('should initialize with correct parameters and emit StrategyParametersUpdated for each parameter set', async () => {
-      const initialOwner = owner.address;
+    it('should initialize with correct parameters', async () => {
       const azoriusAddress = azoriusMock.address;
       const lightAccountFactoryAddress = lightAccountFactoryMockAddress;
-      const initialTokenAdapters: string[] = [await mockAdapter1.getAddress()];
-      const initialProposerAdapters: string[] = [await mockProposerAdapter1.getAddress()];
+      const initialVotingAdapters: string[] = [
+        await mockAdapter1.getAddress(),
+        await mockAdapter2.getAddress(),
+      ];
+      const initialProposerAdapters: string[] = [
+        await mockProposerAdapter1.getAddress(),
+        await mockProposerAdapter2.getAddress(),
+      ];
       const votingPeriod = DEFAULT_VOTING_PERIOD + 10;
       const quorumThreshold = DEFAULT_QUORUM_THRESHOLD + 1n;
       const basisNumerator = DEFAULT_BASIS_NUMERATOR + 1n;
 
-      const initializeCalldata = strategyImplementation.interface.encodeFunctionData('initialize', [
-        initialOwner,
+      const testStrategy = await deployStrategyProxy(
         azoriusAddress,
         votingPeriod,
         quorumThreshold,
         basisNumerator,
-        initialTokenAdapters,
+        initialVotingAdapters,
         initialProposerAdapters,
         lightAccountFactoryAddress,
-      ]);
-      const proxy = await new ERC1967Proxy__factory(deployer).deploy(
-        await strategyImplementation.getAddress(),
-        initializeCalldata,
       );
-      const tx = proxy.deploymentTransaction();
-      const testStrategy = StrategyV1__factory.connect(await proxy.getAddress(), deployer);
 
-      await expect(tx)
-        .to.emit(testStrategy, 'StrategyParametersUpdated')
-        .withArgs(votingPeriod, quorumThreshold, basisNumerator);
-
-      expect(await testStrategy.owner()).to.equal(initialOwner);
       expect(await testStrategy.azorius()).to.equal(azoriusAddress);
       expect(await testStrategy.votingPeriod()).to.equal(votingPeriod);
       expect(await testStrategy.quorumThreshold()).to.equal(quorumThreshold);
       expect(await testStrategy.basisNumerator()).to.equal(basisNumerator);
       expect(await testStrategy.lightAccountFactory()).to.equal(lightAccountFactoryAddress);
-      expect(await testStrategy.getVotingAdapterCount()).to.equal(1);
-      expect(await testStrategy.votingAdapters(0)).to.equal(await mockAdapter1.getAddress());
-      expect(await testStrategy.getProposerAdapterCount()).to.equal(1);
-      expect(await testStrategy.proposerAdapters(0)).to.equal(
-        await mockProposerAdapter1.getAddress(),
-      );
+      expect(await testStrategy.getVotingAdapterCount()).to.equal(initialVotingAdapters.length);
+      expect(await testStrategy.votingAdapters(0)).to.equal(initialVotingAdapters[0]);
+      expect(await testStrategy.votingAdapters(1)).to.equal(initialVotingAdapters[1]);
+      expect(await testStrategy.getProposerAdapterCount()).to.equal(initialProposerAdapters.length);
+      expect(await testStrategy.proposerAdapters(0)).to.equal(initialProposerAdapters[0]);
+      expect(await testStrategy.proposerAdapters(1)).to.equal(initialProposerAdapters[1]);
     });
 
     it('should revert if azorius address is zero', async () => {
       await expect(
         deployStrategyProxy(
-          owner.address,
           ethers.ZeroAddress, // Invalid Azorius
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
@@ -177,7 +160,6 @@ describe('StrategyV1', () => {
     it('should revert if voting period is zero during initialization', async () => {
       await expect(
         deployStrategyProxy(
-          owner.address,
           azoriusMock.address,
           0, // Invalid voting period
           DEFAULT_QUORUM_THRESHOLD,
@@ -192,7 +174,6 @@ describe('StrategyV1', () => {
     it('should revert if basis numerator is invalid (too high) during initialization', async () => {
       await expect(
         deployStrategyProxy(
-          owner.address,
           azoriusMock.address,
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
@@ -207,7 +188,6 @@ describe('StrategyV1', () => {
     it('should revert if basis numerator is invalid (too low, <50%) during initialization', async () => {
       await expect(
         deployStrategyProxy(
-          owner.address,
           azoriusMock.address,
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
@@ -221,7 +201,6 @@ describe('StrategyV1', () => {
 
     it('should initialize correctly with zero quorum threshold', async () => {
       const testStrategy = await deployStrategyProxy(
-        owner.address,
         azoriusMock.address,
         DEFAULT_VOTING_PERIOD,
         0n, // Zero quorum threshold
@@ -235,7 +214,6 @@ describe('StrategyV1', () => {
 
     it('should initialize correctly with basis numerator at 50%', async () => {
       const testStrategy = await deployStrategyProxy(
-        owner.address,
         azoriusMock.address,
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
@@ -250,7 +228,6 @@ describe('StrategyV1', () => {
     it('should revert when initializing with basis numerator at 100% (1,000,000)', async () => {
       await expect(
         deployStrategyProxy(
-          owner.address,
           azoriusMock.address,
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
@@ -265,7 +242,6 @@ describe('StrategyV1', () => {
     it('should initialize correctly with basis numerator at new maximum (BASIS_DENOMINATOR - 1)', async () => {
       const maxValidBasis = 1_000_000n - 1n; // BASIS_DENOMINATOR - 1
       const testStrategy = await deployStrategyProxy(
-        owner.address,
         azoriusMock.address,
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
@@ -276,300 +252,171 @@ describe('StrategyV1', () => {
       );
       expect(await testStrategy.basisNumerator()).to.equal(maxValidBasis);
     });
-  });
 
-  describe('Adapter Management', () => {
-    // --- addAdapter ---
-    it('should allow owner to add a new adapter', async () => {
-      const adapterAddress = await mockAdapter1.getAddress();
-      await expect(strategy.connect(owner).addVotingAdapter(adapterAddress))
-        .to.emit(strategy, 'VotingAdapterAdded')
-        .withArgs(adapterAddress, 0);
-      expect(await strategy.votingAdapters(0)).to.equal(adapterAddress);
-      expect(await strategy.getVotingAdapterCount()).to.equal(1);
-    });
-
-    it('should revert when non-owner tries to add an adapter', async () => {
+    it('should revert if a voting adapter address is zero', async () => {
       await expect(
-        strategy.connect(nonOwner).addVotingAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
+        deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          DEFAULT_BASIS_NUMERATOR,
+          [ethers.ZeroAddress],
+          [],
+          lightAccountFactoryMockAddress,
+        ),
+      ).to.be.revertedWithCustomError(strategyImplementation, 'VotingAdapterIsZeroAddress');
     });
 
-    it('should revert when adding a zero address adapter', async () => {
+    it('should revert if a voting adapter address is repeated', async () => {
+      const adapterAddr = await mockAdapter1.getAddress();
       await expect(
-        strategy.connect(owner).addVotingAdapter(ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterIsZeroAddress');
+        deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          DEFAULT_BASIS_NUMERATOR,
+          [adapterAddr, adapterAddr],
+          [],
+          lightAccountFactoryMockAddress,
+        ),
+      ).to.be.revertedWithCustomError(strategyImplementation, 'VotingAdapterAlreadyExists');
     });
 
-    it('should revert when adding an already existing adapter', async () => {
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
+    it('should revert if a proposer adapter address is zero', async () => {
       await expect(
-        strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterAlreadyExists');
+        deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          DEFAULT_BASIS_NUMERATOR,
+          [],
+          [ethers.ZeroAddress],
+          lightAccountFactoryMockAddress,
+        ),
+      ).to.be.revertedWithCustomError(strategyImplementation, 'ProposerAdapterIsZeroAddress');
     });
 
-    it('should allow adding multiple different adapters', async () => {
-      const adapter1Addr = await mockAdapter1.getAddress();
-      const adapter2Addr = await mockAdapter2.getAddress();
-      await strategy.connect(owner).addVotingAdapter(adapter1Addr);
-      await strategy.connect(owner).addVotingAdapter(adapter2Addr);
-      expect(await strategy.getVotingAdapterCount()).to.equal(2);
-      expect(await strategy.votingAdapters(0)).to.equal(adapter1Addr);
-      expect(await strategy.votingAdapters(1)).to.equal(adapter2Addr);
-    });
-
-    // --- removeAdapter ---
-    it('should allow owner to remove an existing adapter', async () => {
-      const adapter1Addr = await mockAdapter1.getAddress();
-      const adapter2Addr = await mockAdapter2.getAddress();
-      await strategy.connect(owner).addVotingAdapter(adapter1Addr);
-      await strategy.connect(owner).addVotingAdapter(adapter2Addr);
-
-      // To correctly test the emitted index, we need to know the exact removal logic
-      // Assuming it swaps with last and pops:
-      // If removing adapter1Addr (at index 0), adapter2Addr (at index 1) moves to 0.
-      // The event should reflect the original index of the removed item.
-      await expect(strategy.connect(owner).removeVotingAdapter(adapter1Addr))
-        .to.emit(strategy, 'VotingAdapterRemoved')
-        .withArgs(adapter1Addr, 0);
-
-      expect(await strategy.getVotingAdapterCount()).to.equal(1);
-      expect(await strategy.votingAdapters(0)).to.equal(adapter2Addr);
-    });
-
-    it('should allow owner to remove an existing adapter (removing last)', async () => {
-      const adapter1Addr = await mockAdapter1.getAddress();
-      const adapter2Addr = await mockAdapter2.getAddress();
-      await strategy.connect(owner).addVotingAdapter(adapter1Addr);
-      await strategy.connect(owner).addVotingAdapter(adapter2Addr);
-
-      await expect(strategy.connect(owner).removeVotingAdapter(adapter2Addr))
-        .to.emit(strategy, 'VotingAdapterRemoved')
-        .withArgs(adapter2Addr, 1);
-
-      expect(await strategy.getVotingAdapterCount()).to.equal(1);
-      expect(await strategy.votingAdapters(0)).to.equal(adapter1Addr);
-    });
-
-    it('should correctly remove the only adapter in the list', async () => {
-      const adapter1Addr = await mockAdapter1.getAddress();
-      await strategy.connect(owner).addVotingAdapter(adapter1Addr);
-
-      await expect(strategy.connect(owner).removeVotingAdapter(adapter1Addr))
-        .to.emit(strategy, 'VotingAdapterRemoved')
-        .withArgs(adapter1Addr, 0);
-      expect(await strategy.getVotingAdapterCount()).to.equal(0);
-    });
-
-    it('should revert when non-owner tries to remove an adapter', async () => {
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
+    it('should revert if a proposer adapter address is repeated', async () => {
+      const adapterAddr = await mockProposerAdapter1.getAddress();
       await expect(
-        strategy.connect(nonOwner).removeVotingAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should revert when removing a zero address adapter', async () => {
-      await expect(
-        strategy.connect(owner).removeVotingAdapter(ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterIsZeroAddress');
-    });
-
-    it('should revert when removing an adapter that does not exist', async () => {
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter2.getAddress()); // Add a different one
-      await expect(
-        strategy.connect(owner).removeVotingAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterNotFound');
-    });
-
-    it('should revert when removing from an empty list of adapters', async () => {
-      await expect(
-        strategy.connect(owner).removeVotingAdapter(await mockAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'VotingAdapterNotFound');
-    });
-
-    // --- getVotingAdapterCount ---
-    it('should return the correct number of adapters', async () => {
-      expect(await strategy.getVotingAdapterCount()).to.equal(0);
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
-      expect(await strategy.getVotingAdapterCount()).to.equal(1);
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter2.getAddress());
-      expect(await strategy.getVotingAdapterCount()).to.equal(2);
-      await strategy.connect(owner).removeVotingAdapter(await mockAdapter1.getAddress());
-      expect(await strategy.getVotingAdapterCount()).to.equal(1);
+        deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          DEFAULT_BASIS_NUMERATOR,
+          [],
+          [adapterAddr, adapterAddr],
+          lightAccountFactoryMockAddress,
+        ),
+      ).to.be.revertedWithCustomError(strategyImplementation, 'ProposerAdapterAlreadyExists');
     });
   });
 
-  describe('Proposer Adapter Management', () => {
-    // --- addProposerAdapter ---
-    it('should allow owner to add a new proposer adapter', async () => {
-      const adapterAddress = await mockProposerAdapter1.getAddress();
-      await expect(strategy.connect(owner).addProposerAdapter(adapterAddress))
-        .to.emit(strategy, 'ProposerAdapterAdded')
-        .withArgs(adapterAddress, 0);
-      expect(await strategy.proposerAdapters(0)).to.equal(adapterAddress);
-      expect(await strategy.getProposerAdapterCount()).to.equal(1);
+  describe('Voting Adapter Counts (Post-Initialization)', () => {
+    it('should return the correct number of voting adapters based on initialization', async () => {
+      expect(await strategy.getVotingAdapterCount()).to.equal(defaultInitialVotingAdapters.length);
+
+      const testStrategy2 = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        [await mockAdapter1.getAddress()], // 1 voting adapter
+        [],
+        lightAccountFactoryMockAddress,
+      );
+      expect(await testStrategy2.getVotingAdapterCount()).to.equal(1);
+
+      const testStrategy0 = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        [], // 0 voting adapters
+        [],
+        lightAccountFactoryMockAddress,
+      );
+      expect(await testStrategy0.getVotingAdapterCount()).to.equal(0);
     });
 
-    it('should revert when non-owner tries to add a proposer adapter', async () => {
-      await expect(
-        strategy.connect(nonOwner).addProposerAdapter(await mockProposerAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
-    });
+    it('should return the correct number of proposer adapters based on initialization', async () => {
+      expect(await strategy.getProposerAdapterCount()).to.equal(
+        defaultInitialProposerAdapters.length,
+      );
 
-    it('should revert when adding a zero address proposer adapter', async () => {
-      await expect(
-        strategy.connect(owner).addProposerAdapter(ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterIsZeroAddress');
-    });
+      const testStrategy2 = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        [],
+        [await mockProposerAdapter1.getAddress()], // 1 proposer adapter
+        lightAccountFactoryMockAddress,
+      );
+      expect(await testStrategy2.getProposerAdapterCount()).to.equal(1);
 
-    it('should revert when adding an already existing proposer adapter', async () => {
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
-      await expect(
-        strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterAlreadyExists');
-    });
-
-    it('should allow adding multiple different proposer adapters', async () => {
-      const adapter1Addr = await mockProposerAdapter1.getAddress();
-      const adapter2Addr = await mockProposerAdapter2.getAddress();
-      await strategy.connect(owner).addProposerAdapter(adapter1Addr);
-      await strategy.connect(owner).addProposerAdapter(adapter2Addr);
-      expect(await strategy.getProposerAdapterCount()).to.equal(2);
-      expect(await strategy.proposerAdapters(0)).to.equal(adapter1Addr);
-      expect(await strategy.proposerAdapters(1)).to.equal(adapter2Addr);
-    });
-
-    // --- removeProposerAdapter ---
-    it('should allow owner to remove an existing proposer adapter', async () => {
-      const adapter1Addr = await mockProposerAdapter1.getAddress();
-      const adapter2Addr = await mockProposerAdapter2.getAddress();
-      await strategy.connect(owner).addProposerAdapter(adapter1Addr);
-      await strategy.connect(owner).addProposerAdapter(adapter2Addr);
-
-      await expect(strategy.connect(owner).removeProposerAdapter(adapter1Addr))
-        .to.emit(strategy, 'ProposerAdapterRemoved')
-        .withArgs(adapter1Addr, 0);
-
-      expect(await strategy.getProposerAdapterCount()).to.equal(1);
-      expect(await strategy.proposerAdapters(0)).to.equal(adapter2Addr);
-    });
-
-    it('should allow owner to remove an existing proposer adapter (removing last)', async () => {
-      const adapter1Addr = await mockProposerAdapter1.getAddress();
-      const adapter2Addr = await mockProposerAdapter2.getAddress();
-      await strategy.connect(owner).addProposerAdapter(adapter1Addr);
-      await strategy.connect(owner).addProposerAdapter(adapter2Addr);
-
-      await expect(strategy.connect(owner).removeProposerAdapter(adapter2Addr))
-        .to.emit(strategy, 'ProposerAdapterRemoved')
-        .withArgs(adapter2Addr, 1);
-
-      expect(await strategy.getProposerAdapterCount()).to.equal(1);
-      expect(await strategy.proposerAdapters(0)).to.equal(adapter1Addr);
-    });
-
-    it('should correctly remove the only proposer adapter in the list', async () => {
-      const adapter1Addr = await mockProposerAdapter1.getAddress();
-      await strategy.connect(owner).addProposerAdapter(adapter1Addr);
-
-      await expect(strategy.connect(owner).removeProposerAdapter(adapter1Addr))
-        .to.emit(strategy, 'ProposerAdapterRemoved')
-        .withArgs(adapter1Addr, 0);
-      expect(await strategy.getProposerAdapterCount()).to.equal(0);
-    });
-
-    it('should revert when non-owner tries to remove a proposer adapter', async () => {
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
-      await expect(
-        strategy.connect(nonOwner).removeProposerAdapter(await mockProposerAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should revert when removing a zero address proposer adapter', async () => {
-      await expect(
-        strategy.connect(owner).removeProposerAdapter(ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterIsZeroAddress');
-    });
-
-    it('should revert when removing a proposer adapter that does not exist', async () => {
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
-      await expect(
-        strategy.connect(owner).removeProposerAdapter(await mockProposerAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterNotFound');
-    });
-
-    it('should revert when removing from an empty list of proposer adapters', async () => {
-      await expect(
-        strategy.connect(owner).removeProposerAdapter(await mockProposerAdapter1.getAddress()),
-      ).to.be.revertedWithCustomError(strategy, 'ProposerAdapterNotFound'); // Error should be ProposerAdapterNotFound
-    });
-
-    // --- getProposerAdapterCount ---
-    it('should return the correct number of proposer adapters', async () => {
-      expect(await strategy.getProposerAdapterCount()).to.equal(0);
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
-      expect(await strategy.getProposerAdapterCount()).to.equal(1);
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
-      expect(await strategy.getProposerAdapterCount()).to.equal(2);
-      await strategy.connect(owner).removeProposerAdapter(await mockProposerAdapter1.getAddress());
-      expect(await strategy.getProposerAdapterCount()).to.equal(1);
+      const testStrategy0 = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        [],
+        [], // 0 proposer adapters
+        lightAccountFactoryMockAddress,
+      );
+      expect(await testStrategy0.getProposerAdapterCount()).to.equal(0);
     });
   });
 
   describe('initializeProposal', () => {
     let defaultProposalId: number;
-    let encodedDefaultProposalId: string;
 
     beforeEach(() => {
       defaultProposalId = 1;
-      encodedDefaultProposalId = ethers.AbiCoder.defaultAbiCoder().encode(
-        ['uint32'],
-        [defaultProposalId],
-      );
     });
 
     it('should revert if called by a non-azorius address', async () => {
-      // Ensure at least one adapter is set so NoAdapters isn't hit first
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
       await expect(
-        strategy
-          .connect(nonOwner)
-          .initializeProposal(encodedDefaultProposalId, [], ethers.ZeroHash),
+        strategy.connect(nonOwner).initializeProposal(defaultProposalId, [], ethers.ZeroHash),
       ).to.be.revertedWithCustomError(strategy, 'InvalidAzoriusAddress');
     });
 
-    it('should revert if no token adapters are configured', async () => {
-      // Strategy is deployed with no adapters by default in the main beforeEach
+    it('should revert if no voting adapters are configured', async () => {
+      const noAdapterStrategy = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        [], // NO voting adapters
+        [],
+        lightAccountFactoryMockAddress,
+      );
       await expect(
-        strategy
+        noAdapterStrategy
           .connect(azoriusMock)
-          .initializeProposal(encodedDefaultProposalId, [], ethers.ZeroHash),
-      ).to.be.revertedWithCustomError(strategy, 'NoVotingAdapters');
+          .initializeProposal(defaultProposalId, [], ethers.ZeroHash),
+      ).to.be.revertedWithCustomError(noAdapterStrategy, 'NoVotingAdapters');
     });
 
     it('should correctly initialize proposal details and emit event', async () => {
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
-
       const blockBefore = await ethers.provider.getBlock('latest');
       if (!blockBefore) throw new Error('Failed to get latest block');
       const timestampBefore = blockBefore.timestamp;
       const blockNumberBefore = blockBefore.number;
 
       await expect(
-        strategy
-          .connect(azoriusMock)
-          .initializeProposal(encodedDefaultProposalId, [], ethers.ZeroHash),
+        strategy.connect(azoriusMock).initializeProposal(defaultProposalId, [], ethers.ZeroHash),
       )
         .to.emit(strategy, 'ProposalInitialized')
         .withArgs(
           defaultProposalId,
-          timestampBefore + 1, // Approximate, depends on block mining time
-          timestampBefore + 1 + DEFAULT_VOTING_PERIOD, // Approximate
+          timestampBefore + 1,
+          timestampBefore + 1 + DEFAULT_VOTING_PERIOD,
           blockNumberBefore + 1,
         );
 
       const proposalDetails = await strategy.proposalVotingDetails(defaultProposalId);
-      expect(proposalDetails.votingStartTimestamp).to.be.closeTo(timestampBefore + 1, 2); // Allow some leeway for block time
+      expect(proposalDetails.votingStartTimestamp).to.be.closeTo(timestampBefore + 1, 2);
       expect(proposalDetails.votingEndTimestamp).to.be.closeTo(
         timestampBefore + 1 + DEFAULT_VOTING_PERIOD,
         2,
@@ -581,14 +428,13 @@ describe('StrategyV1', () => {
     });
 
     it('should reset vote counts for a re-initialized proposal', async () => {
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
       await strategy
         .connect(azoriusMock)
-        .initializeProposal(encodedDefaultProposalId, [], ethers.ZeroHash);
+        .initializeProposal(defaultProposalId, [], ethers.ZeroHash);
 
       await strategy
         .connect(azoriusMock)
-        .initializeProposal(encodedDefaultProposalId, [], ethers.ZeroHash); // Re-initialize
+        .initializeProposal(defaultProposalId, [], ethers.ZeroHash); // Re-initialize
 
       const proposalDetails = await strategy.proposalVotingDetails(defaultProposalId);
       expect(proposalDetails.yesVotes).to.equal(0);
@@ -598,69 +444,78 @@ describe('StrategyV1', () => {
   });
 
   describe('isProposer', () => {
-    it('should return false if no adapters are configured', async () => {
+    it('should return false if no proposer adapters are configured at init', async () => {
+      const noProposerAdapterStrategy = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        defaultInitialVotingAdapters,
+        [], // NO proposer adapters
+        lightAccountFactoryMockAddress,
+      );
+      void expect(await noProposerAdapterStrategy.isProposer(user1.address)).to.be.false;
+    });
+
+    it('should return true if any configured adapter identifies the address as a proposer', async () => {
+      const multiProposerStrategy = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        defaultInitialVotingAdapters,
+        [await mockProposerAdapter1.getAddress(), await mockProposerAdapter2.getAddress()],
+        lightAccountFactoryMockAddress,
+      );
+
+      await mockProposerAdapter1.setProposerStatus(user1.address, false);
+      await mockProposerAdapter2.setProposerStatus(user1.address, true);
+
+      void expect(await multiProposerStrategy.isProposer(user1.address)).to.be.true;
+    });
+
+    it('should return false if no configured adapter identifies the address as a proposer', async () => {
+      await mockProposerAdapter1.setProposerStatus(user1.address, false);
       void expect(await strategy.isProposer(user1.address)).to.be.false;
+
+      const multiProposerStrategy = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        defaultInitialVotingAdapters,
+        [await mockProposerAdapter1.getAddress(), await mockProposerAdapter2.getAddress()],
+        lightAccountFactoryMockAddress,
+      );
+      await mockProposerAdapter1.setProposerStatus(user1.address, false);
+      await mockProposerAdapter2.setProposerStatus(user1.address, false);
+      void expect(await multiProposerStrategy.isProposer(user1.address)).to.be.false;
     });
 
-    it('should return true if any adapter identifies the address as a proposer', async () => {
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
-
-      // mockProposerAdapter1 says NO, mockProposerAdapter2 says YES
-      await mockProposerAdapter1.connect(owner).setProposerStatus(user1.address, false);
-      await mockProposerAdapter2.connect(owner).setProposerStatus(user1.address, true);
-
-      void expect(await strategy.isProposer(user1.address)).to.be.true;
-    });
-
-    it('should return false if no adapter identifies the address as a proposer', async () => {
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
-
-      await mockProposerAdapter1.connect(owner).setProposerStatus(user1.address, false);
-      await mockProposerAdapter2.connect(owner).setProposerStatus(user1.address, false);
-
-      void expect(await strategy.isProposer(user1.address)).to.be.false;
-    });
-
-    it('should return true if the first adapter identifies the address as a proposer', async () => {
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter1.getAddress());
-      await strategy.connect(owner).addProposerAdapter(await mockProposerAdapter2.getAddress());
-
-      await mockProposerAdapter1.connect(owner).setProposerStatus(user1.address, true);
-      await mockProposerAdapter2.connect(owner).setProposerStatus(user1.address, false);
-
+    it('should return true if the first configured adapter identifies the address as a proposer', async () => {
+      await mockProposerAdapter1.setProposerStatus(user1.address, true);
       void expect(await strategy.isProposer(user1.address)).to.be.true;
     });
   });
 
   describe('getVotingTimestamps & getVotingStartBlock', () => {
     let proposalId: number;
-    let encodedProposalId: string;
 
     beforeEach(async () => {
       proposalId = 1;
-      encodedProposalId = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
-      // Ensure at least one adapter is added for initializeProposal to succeed
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
+      await strategy.connect(azoriusMock).initializeProposal(proposalId, [], ethers.ZeroHash);
     });
 
     it('should return correct timestamps and block after proposal initialization', async () => {
-      const blockBefore = await ethers.provider.getBlock('latest');
-      if (!blockBefore) throw new Error('Failed to get latest block');
-      const timestampBefore = blockBefore.timestamp;
-      const blockNumberBefore = blockBefore.number;
-
-      await strategy
-        .connect(azoriusMock)
-        .initializeProposal(encodedProposalId, [], ethers.ZeroHash);
+      const blockBeforeInit = await strategy.proposalVotingDetails(proposalId);
+      const initTimestamp = blockBeforeInit.votingStartTimestamp;
 
       const [startTime, endTime] = await strategy.getVotingTimestamps(proposalId);
       const startBlock = await strategy.getVotingStartBlock(proposalId);
 
-      expect(startTime).to.be.closeTo(timestampBefore + 1, 2);
-      expect(endTime).to.be.closeTo(timestampBefore + 1 + DEFAULT_VOTING_PERIOD, 2);
-      expect(startBlock).to.equal(blockNumberBefore + 1);
+      expect(startTime).to.equal(initTimestamp);
+      expect(endTime).to.equal(initTimestamp + BigInt(DEFAULT_VOTING_PERIOD));
+      expect(startBlock).to.equal(blockBeforeInit.votingStartBlock);
     });
 
     it('getVotingTimestamps should revert if proposal is not initialized', async () => {
@@ -680,33 +535,19 @@ describe('StrategyV1', () => {
 
   describe('vote', () => {
     let proposalId: number;
-    let encodedProposalId: string;
-    let adapter1Data: string; // abi.encode(tokenId[]) for ERC721, or empty for ERC20
+    let adapter1Data: string;
     let adapter2Data: string;
 
     beforeEach(async () => {
       proposalId = 1;
-      encodedProposalId = ethers.AbiCoder.defaultAbiCoder().encode(['uint32'], [proposalId]);
+      await strategy.connect(azoriusMock).initializeProposal(proposalId, [], ethers.ZeroHash);
 
-      // Add at least one adapter for most tests
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
-      // Initialize the proposal by azoriusMock
-      await strategy
-        .connect(azoriusMock)
-        .initializeProposal(encodedProposalId, [], ethers.ZeroHash);
-
-      // Example adapter data (can be customized per test)
-      // For ERC20Adapter, this would typically be ethers.AbiCoder.defaultAbiCoder().encode([], []); (empty)
-      // For ERC721Adapter, ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[101, 102]]);
-      adapter1Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[1]]); // Mocking ERC721 style data
+      adapter1Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[1]]);
       adapter2Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[2]]);
-
-      // Deploy MockLightAccount for ERC4337 tests if not already available globally
-      // For this specific test, we might deploy it inside if needed fresh
     });
 
     it('should revert if _adaptersToUse and _adapterVoteData lengths mismatch', async () => {
-      const adaptersToUse = [mockAdapter1]; // 1 adapter
+      const adaptersToUse = [await mockAdapter1.getAddress()]; // 1 adapter
       const adapterVoteData: string[] = []; // 0 data entries
       await expect(
         strategy.connect(user1).vote(proposalId, 1, adaptersToUse, adapterVoteData),
@@ -716,32 +557,39 @@ describe('StrategyV1', () => {
     it('should revert if proposal is not initialized (votingEndTimestamp is 0)', async () => {
       const uninitializedProposalId = 999;
       await expect(
-        strategy.connect(user1).vote(uninitializedProposalId, 1, [mockAdapter1], [adapter1Data]),
+        strategy
+          .connect(user1)
+          .vote(uninitializedProposalId, 1, [await mockAdapter1.getAddress()], [adapter1Data]),
       ).to.be.revertedWithCustomError(strategy, 'ProposalNotFoundOrNotActive');
     });
 
     it('should revert if voting period has ended', async () => {
-      // Advance time beyond voting period
       const proposalDetails = await strategy.proposalVotingDetails(proposalId);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
       await expect(
-        strategy.connect(user1).vote(proposalId, 1, [mockAdapter1], [adapter1Data]),
+        strategy
+          .connect(user1)
+          .vote(proposalId, 1, [await mockAdapter1.getAddress()], [adapter1Data]),
       ).to.be.revertedWithCustomError(strategy, 'ProposalNotFoundOrNotActive');
     });
 
     it('should revert if total weight cast is zero (e.g., adapter.recordVote returns 0)', async () => {
-      await mockAdapter1.connect(owner).setWeight(user1.address, 0); // Ensure recordVote (via setWeight) returns 0
+      await mockAdapter1.setWeight(user1.address, 0);
       await expect(
-        strategy.connect(user1).vote(proposalId, 1, [mockAdapter1], [adapter1Data]),
+        strategy
+          .connect(user1)
+          .vote(proposalId, 1, [await mockAdapter1.getAddress()], [adapter1Data]),
       ).to.be.revertedWithCustomError(strategy, 'NoVotingWeight');
     });
 
     it('should revert on invalid voteType', async () => {
       const invalidVoteType = 3; // VoteType enum is 0, 1, 2
-      await mockAdapter1.connect(owner).setWeight(user1.address, 10); // Give some weight
+      await mockAdapter1.setWeight(user1.address, 10);
       await expect(
-        strategy.connect(user1).vote(proposalId, invalidVoteType, [mockAdapter1], [adapter1Data]),
+        strategy
+          .connect(user1)
+          .vote(proposalId, invalidVoteType, [await mockAdapter1.getAddress()], [adapter1Data]),
       ).to.be.revertedWithCustomError(strategy, 'InvalidVoteType');
     });
 
@@ -750,11 +598,10 @@ describe('StrategyV1', () => {
       await unconfiguredAdapter.waitForDeployment();
       const unconfiguredAdapterAddress = await unconfiguredAdapter.getAddress();
 
-      // mockAdapter1 is configured from the beforeEach of the parent 'vote' describe block
       await mockAdapter1.setWeight(user1.address, 10);
 
       const adaptersToUse = [await mockAdapter1.getAddress(), unconfiguredAdapterAddress];
-      const adapterDataArray = [adapter1Data, adapter1Data]; // Dummy data for both
+      const adapterDataArray = [adapter1Data, adapter1Data];
 
       await expect(
         strategy.connect(user1).vote(proposalId, 1 /* YES */, adaptersToUse, adapterDataArray),
@@ -763,11 +610,11 @@ describe('StrategyV1', () => {
 
     it('should correctly record a YES vote, update counts, and emit Voted event', async () => {
       const voteWeight = 100;
-      await mockAdapter1.connect(owner).setWeight(user1.address, voteWeight);
+      await mockAdapter1.setWeight(user1.address, voteWeight);
 
       const tx = await strategy
         .connect(user1)
-        .vote(proposalId, 1 /* YES */, [mockAdapter1], [adapter1Data]);
+        .vote(proposalId, 1 /* YES */, [await mockAdapter1.getAddress()], [adapter1Data]);
 
       await expect(tx)
         .to.emit(strategy, 'Voted')
@@ -778,11 +625,8 @@ describe('StrategyV1', () => {
       expect(proposalDetails.noVotes).to.equal(0);
       expect(proposalDetails.abstainVotes).to.equal(0);
 
-      // Verify adapter's recordVote was called (using our mock's state)
       expect(await mockAdapter1.lastVoterForRecordVote()).to.equal(user1.address);
       expect(await mockAdapter1.lastProposalIdForRecordVote()).to.equal(proposalId);
-      // Note: MockVotingAdapter currently doesn't store lastAdapterDataForRecordVote to save gas
-      // but we can check if it was recorded if needed by enhancing the mock.
       expect(
         await mockAdapter1.recordedVotesWeight(
           user1.address,
@@ -794,10 +638,12 @@ describe('StrategyV1', () => {
 
     it('should correctly record a NO vote', async () => {
       const voteWeight = 50;
-      await mockAdapter1.connect(owner).setWeight(user1.address, voteWeight);
+      await mockAdapter1.setWeight(user1.address, voteWeight);
 
       await expect(
-        strategy.connect(user1).vote(proposalId, 0 /* NO */, [mockAdapter1], [adapter1Data]),
+        strategy
+          .connect(user1)
+          .vote(proposalId, 0 /* NO */, [await mockAdapter1.getAddress()], [adapter1Data]),
       )
         .to.emit(strategy, 'Voted')
         .withArgs(user1.address, proposalId, 0 /* NO */, voteWeight);
@@ -810,10 +656,12 @@ describe('StrategyV1', () => {
 
     it('should correctly record an ABSTAIN vote', async () => {
       const voteWeight = 25;
-      await mockAdapter1.connect(owner).setWeight(user1.address, voteWeight);
+      await mockAdapter1.setWeight(user1.address, voteWeight);
 
       await expect(
-        strategy.connect(user1).vote(proposalId, 2 /* ABSTAIN */, [mockAdapter1], [adapter1Data]),
+        strategy
+          .connect(user1)
+          .vote(proposalId, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [adapter1Data]),
       )
         .to.emit(strategy, 'Voted')
         .withArgs(user1.address, proposalId, 2 /* ABSTAIN */, voteWeight);
@@ -825,24 +673,39 @@ describe('StrategyV1', () => {
     });
 
     it('should sum weights if multiple adapters are used in one vote call', async () => {
-      // Add second adapter to the strategy for this test
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter2.getAddress());
+      const multiAdapterStrategy = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        [await mockAdapter1.getAddress(), await mockAdapter2.getAddress()], // Both adapters
+        defaultInitialProposerAdapters,
+        lightAccountFactoryMockAddress,
+      );
+      await multiAdapterStrategy
+        .connect(azoriusMock)
+        .initializeProposal(proposalId, [], ethers.ZeroHash);
 
       const weight1 = 60;
       const weight2 = 40;
-      await mockAdapter1.connect(owner).setWeight(user1.address, weight1);
-      await mockAdapter2.connect(owner).setWeight(user1.address, weight2); // user1 votes with both adapters
+      await mockAdapter1.setWeight(user1.address, weight1);
+      await mockAdapter2.setWeight(user1.address, weight2);
 
-      const adaptersToUse = [mockAdapter1, mockAdapter2];
-      const adapterVoteDataArray = [adapter1Data, adapter2Data]; // Assuming different data for each or just placeholders
+      const adaptersToUseAddresses = [
+        await mockAdapter1.getAddress(),
+        await mockAdapter2.getAddress(),
+      ];
+      const adapterVoteDataArray = [adapter1Data, adapter2Data];
 
       await expect(
-        strategy.connect(user1).vote(proposalId, 1 /* YES */, adaptersToUse, adapterVoteDataArray),
+        multiAdapterStrategy
+          .connect(user1)
+          .vote(proposalId, 1 /* YES */, adaptersToUseAddresses, adapterVoteDataArray),
       )
-        .to.emit(strategy, 'Voted')
+        .to.emit(multiAdapterStrategy, 'Voted')
         .withArgs(user1.address, proposalId, 1 /* YES */, weight1 + weight2);
 
-      const proposalDetails = await strategy.proposalVotingDetails(proposalId);
+      const proposalDetails = await multiAdapterStrategy.proposalVotingDetails(proposalId);
       expect(proposalDetails.yesVotes).to.equal(weight1 + weight2);
     });
 
@@ -850,7 +713,6 @@ describe('StrategyV1', () => {
       const smartAccountOwner = user1;
       const relayer = nonOwner;
 
-      // 1. Deploy MockLightAccount directly, owned by smartAccountOwner
       const mockLightAccountDeployedFactory = new MockLightAccount__factory(deployer);
       const mockSmartAccount = await mockLightAccountDeployedFactory.deploy(
         smartAccountOwner.address,
@@ -858,7 +720,6 @@ describe('StrategyV1', () => {
       await mockSmartAccount.waitForDeployment();
       const mockSmartAccountAddress = await mockSmartAccount.getAddress();
 
-      // 2. IMPORTANT: Configure the lightAccountFactoryMock (used by StrategyV1) to correctly resolve this smart account
       await lightAccountFactoryMock.setAccountAddress(
         smartAccountOwner.address,
         0,
@@ -866,8 +727,7 @@ describe('StrategyV1', () => {
       );
 
       const voteWeight = 77;
-      // Set weight for the smartAccountOwner (user1) in the mock adapter
-      await mockAdapter1.connect(owner).setWeight(smartAccountOwner.address, voteWeight);
+      await mockAdapter1.setWeight(smartAccountOwner.address, voteWeight);
 
       const tx = await mockSmartAccount
         .connect(relayer)
@@ -890,24 +750,40 @@ describe('StrategyV1', () => {
     });
 
     it('should revert if an adapter call to recordVote reverts', async () => {
-      await mockAdapter1.connect(owner).setWeight(user1.address, 10);
-      await mockAdapter1.setShouldRevertOnRecordVote(true); // Configure mock to revert
+      await mockAdapter1.setWeight(user1.address, 10);
+      await mockAdapter1.setShouldRevertOnRecordVote(true);
 
       await expect(
-        strategy.connect(user1).vote(proposalId, 1 /* YES */, [mockAdapter1], [adapter1Data]),
+        strategy
+          .connect(user1)
+          .vote(proposalId, 1 /* YES */, [await mockAdapter1.getAddress()], [adapter1Data]),
       ).to.be.revertedWith('MockVotingAdapter: recordVote forced revert');
     });
 
     it('should revert if any adapter call reverts in a multi-adapter vote (all-or-nothing)', async () => {
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter2.getAddress());
+      const multiAdapterStrategy = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        [await mockAdapter1.getAddress(), await mockAdapter2.getAddress()], // Both adapters
+        defaultInitialProposerAdapters,
+        lightAccountFactoryMockAddress,
+      );
+      await multiAdapterStrategy
+        .connect(azoriusMock)
+        .initializeProposal(proposalId, [], ethers.ZeroHash);
 
-      await mockAdapter1.connect(owner).setWeight(user1.address, 10);
-      await mockAdapter2.connect(owner).setWeight(user1.address, 20);
+      await mockAdapter1.setWeight(user1.address, 10);
+      await mockAdapter2.setWeight(user1.address, 20);
 
-      await mockAdapter1.setShouldRevertOnRecordVote(false); // Adapter 1 should succeed initially
+      await mockAdapter1.setShouldRevertOnRecordVote(false);
       await mockAdapter2.setShouldRevertOnRecordVote(true); // Adapter 2 will revert
 
-      const adaptersToUse = [mockAdapter1, mockAdapter2];
+      const adaptersToUseAddresses = [
+        await mockAdapter1.getAddress(),
+        await mockAdapter2.getAddress(),
+      ];
       const adapterDataForVoter1Adapter1 = ethers.AbiCoder.defaultAbiCoder().encode(
         ['uint256[]'],
         [[777]],
@@ -919,10 +795,12 @@ describe('StrategyV1', () => {
       const adapterVoteDataArray = [adapterDataForVoter1Adapter1, adapterDataForVoter1Adapter2];
 
       await expect(
-        strategy.connect(user1).vote(proposalId, 1 /* YES */, adaptersToUse, adapterVoteDataArray),
+        multiAdapterStrategy
+          .connect(user1)
+          .vote(proposalId, 1 /* YES */, adaptersToUseAddresses, adapterVoteDataArray),
       ).to.be.revertedWith('MockVotingAdapter: recordVote forced revert');
 
-      const proposalDetails = await strategy.proposalVotingDetails(proposalId);
+      const proposalDetails = await multiAdapterStrategy.proposalVotingDetails(proposalId);
       expect(proposalDetails.yesVotes).to.equal(0);
       expect(proposalDetails.noVotes).to.equal(0);
       expect(proposalDetails.abstainVotes).to.equal(0);
@@ -935,12 +813,7 @@ describe('StrategyV1', () => {
 
   describe('isPassed', () => {
     const PROPOSAL_ID = 1;
-    // This beforeEach ensures that for each test in this describe block,
-    // the strategy has an adapter and a proposal is initialized.
     beforeEach(async () => {
-      // Ensure adapter is present on the strategy instance for these specific tests
-      await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
-      // Initialize the proposal fresh for each isPassed test
       await strategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
     });
 
@@ -953,11 +826,10 @@ describe('StrategyV1', () => {
     });
 
     it('should return false if voting period is not over', async () => {
-      // Proposal PROPOSAL_ID is initialized by this describe block's beforeEach.
       await mockAdapter1.setWeight(voter1.address, DEFAULT_QUORUM_THRESHOLD + 10n);
       await strategy
         .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
       void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.false; // Voting not over
     });
 
@@ -965,7 +837,7 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(voter1.address, DEFAULT_QUORUM_THRESHOLD + 10n);
       await strategy
         .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
 
       const proposalDetails = await strategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
@@ -974,47 +846,67 @@ describe('StrategyV1', () => {
     });
 
     it('should return false if quorum is met but basis is not, after voting period', async () => {
-      await strategy.connect(owner).updateQuorumThreshold(50n);
-      await strategy.connect(owner).updateBasisNumerator(500_001n);
+      const specificStrategy = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        50n, // quorumThreshold
+        500_001n, // basisNumerator (yes > no)
+        defaultInitialVotingAdapters,
+        defaultInitialProposerAdapters,
+        lightAccountFactoryMockAddress,
+      );
+      await specificStrategy
+        .connect(azoriusMock)
+        .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
       await mockAdapter1.setWeight(voter1.address, 50n);
       await mockAdapter1.setWeight(voter2.address, 50n);
       await mockAdapter1.setWeight(voter3.address, 10n);
 
-      await strategy
+      await specificStrategy
         .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
-      await strategy
+        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+      await specificStrategy
         .connect(voter2)
-        .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
-      await strategy
+        .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+      await specificStrategy
         .connect(voter3)
-        .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
+        .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
 
-      const proposalDetails = await strategy.proposalVotingDetails(PROPOSAL_ID);
+      const proposalDetails = await specificStrategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
-      void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.false;
+      void expect(await specificStrategy.isPassed(PROPOSAL_ID)).to.be.false;
     });
 
     it('should return false if basis is met but quorum is not, after voting period', async () => {
-      await strategy.connect(owner).updateQuorumThreshold(100n);
-      await strategy.connect(owner).updateBasisNumerator(500_001n);
+      const specificStrategy = await deployStrategyProxy(
+        azoriusMock.address,
+        DEFAULT_VOTING_PERIOD,
+        100n, // quorumThreshold
+        500_001n, // basisNumerator (yes > no)
+        defaultInitialVotingAdapters,
+        defaultInitialProposerAdapters,
+        lightAccountFactoryMockAddress,
+      );
+      await specificStrategy
+        .connect(azoriusMock)
+        .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
-      await mockAdapter1.setWeight(voter1.address, 60n);
-      await mockAdapter1.setWeight(voter2.address, 10n);
+      await mockAdapter1.setWeight(voter1.address, 60n); // YES
+      await mockAdapter1.setWeight(voter2.address, 10n); // NO
 
-      await strategy
+      await specificStrategy
         .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
-      await strategy
+        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+      await specificStrategy
         .connect(voter2)
-        .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+        .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
 
-      const proposalDetails = await strategy.proposalVotingDetails(PROPOSAL_ID);
+      const proposalDetails = await specificStrategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
-      void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.false;
+      void expect(await specificStrategy.isPassed(PROPOSAL_ID)).to.be.false;
     });
   });
 
@@ -1054,127 +946,6 @@ describe('StrategyV1', () => {
     });
   });
 
-  describe('UUPS Upgradeability', () => {
-    // Note: The `strategy` instance used here is the proxy deployed in the main beforeEach.
-    // The owner of this proxy is `owner` (the signer).
-    runUUPSUpgradeabilityTests({
-      getContract: () => strategy,
-      createNewImplementation: async () => {
-        // Deploy a new logic contract using the `owner` signer for consistency,
-        // as owner is typically responsible for upgrades.
-        const newImplementation = await new StrategyV1__factory(owner).deploy();
-        return newImplementation;
-      },
-      owner: () => owner, // The `owner` variable from the test suite
-      nonOwner: () => nonOwner, // The `nonOwner` variable from the test suite
-    });
-  });
-
-  describe('Update Strategy Parameters', () => {
-    describe('updateVotingPeriod', () => {
-      it('should allow owner to update voting period and emit StrategyParametersUpdated event', async () => {
-        const newVotingPeriod = 200;
-        await expect(strategy.connect(owner).updateVotingPeriod(newVotingPeriod))
-          .to.emit(strategy, 'StrategyParametersUpdated')
-          .withArgs(newVotingPeriod, DEFAULT_QUORUM_THRESHOLD, DEFAULT_BASIS_NUMERATOR);
-        expect(await strategy.votingPeriod()).to.equal(newVotingPeriod);
-      });
-
-      it('should revert if non-owner tries to update voting period', async () => {
-        const newVotingPeriod = 200;
-        await expect(
-          strategy.connect(nonOwner).updateVotingPeriod(newVotingPeriod),
-        ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
-      });
-
-      it('should revert if voting period is zero', async () => {
-        await expect(strategy.connect(owner).updateVotingPeriod(0)).to.be.revertedWithCustomError(
-          strategy,
-          'InvalidVotingPeriod',
-        );
-      });
-    });
-
-    describe('updateQuorumThreshold', () => {
-      it('should allow owner to update quorum threshold and emit StrategyParametersUpdated event', async () => {
-        const newQuorumThreshold = 50n;
-        await expect(strategy.connect(owner).updateQuorumThreshold(newQuorumThreshold))
-          .to.emit(strategy, 'StrategyParametersUpdated')
-          .withArgs(DEFAULT_VOTING_PERIOD, newQuorumThreshold, DEFAULT_BASIS_NUMERATOR);
-        expect(await strategy.quorumThreshold()).to.equal(newQuorumThreshold);
-      });
-
-      it('should allow owner to set quorum threshold to zero', async () => {
-        const newQuorumThreshold = 0n;
-        await expect(strategy.connect(owner).updateQuorumThreshold(newQuorumThreshold))
-          .to.emit(strategy, 'StrategyParametersUpdated')
-          .withArgs(DEFAULT_VOTING_PERIOD, newQuorumThreshold, DEFAULT_BASIS_NUMERATOR);
-        expect(await strategy.quorumThreshold()).to.equal(newQuorumThreshold);
-      });
-
-      it('should revert if non-owner tries to update quorum threshold', async () => {
-        const newQuorumThreshold = 50n;
-        await expect(
-          strategy.connect(nonOwner).updateQuorumThreshold(newQuorumThreshold),
-        ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
-      });
-    });
-
-    describe('updateBasisNumerator', () => {
-      it('should allow owner to update basis numerator and emit StrategyParametersUpdated event', async () => {
-        const newBasisNumerator = 600_000n;
-        await expect(strategy.connect(owner).updateBasisNumerator(newBasisNumerator))
-          .to.emit(strategy, 'StrategyParametersUpdated')
-          .withArgs(DEFAULT_VOTING_PERIOD, DEFAULT_QUORUM_THRESHOLD, newBasisNumerator);
-        expect(await strategy.basisNumerator()).to.equal(newBasisNumerator);
-      });
-
-      it('should revert if non-owner tries to update basis numerator', async () => {
-        const newBasisNumerator = 600_000n;
-        await expect(
-          strategy.connect(nonOwner).updateBasisNumerator(newBasisNumerator),
-        ).to.be.revertedWithCustomError(strategy, 'OwnableUnauthorizedAccount');
-      });
-
-      it('should revert if basis numerator is too high (> 1,000,000)', async () => {
-        const invalidBasisNumerator = 1_000_001n;
-        await expect(
-          strategy.connect(owner).updateBasisNumerator(invalidBasisNumerator),
-        ).to.be.revertedWithCustomError(strategy, 'InvalidBasisNumerator');
-      });
-
-      it('should revert if basis numerator is too low (< 500,000)', async () => {
-        const invalidBasisNumerator = 499_999n;
-        await expect(
-          strategy.connect(owner).updateBasisNumerator(invalidBasisNumerator),
-        ).to.be.revertedWithCustomError(strategy, 'InvalidBasisNumerator');
-      });
-
-      it('should allow setting basis numerator to 50% (500,000) and emit StrategyParametersUpdated', async () => {
-        const newBasisNumerator = 500_000n;
-        await expect(strategy.connect(owner).updateBasisNumerator(newBasisNumerator))
-          .to.emit(strategy, 'StrategyParametersUpdated')
-          .withArgs(DEFAULT_VOTING_PERIOD, DEFAULT_QUORUM_THRESHOLD, newBasisNumerator);
-        expect(await strategy.basisNumerator()).to.equal(newBasisNumerator);
-      });
-
-      it('should revert when updating basis numerator to 100% (1,000,000)', async () => {
-        const newBasisNumerator = 1_000_000n;
-        await expect(
-          strategy.connect(owner).updateBasisNumerator(newBasisNumerator),
-        ).to.be.revertedWithCustomError(strategy, 'InvalidBasisNumerator');
-      });
-
-      it('should allow setting basis numerator to new maximum (BASIS_DENOMINATOR - 1) and emit event', async () => {
-        const newMaxBasis = 1_000_000n - 1n;
-        await expect(strategy.connect(owner).updateBasisNumerator(newMaxBasis))
-          .to.emit(strategy, 'StrategyParametersUpdated')
-          .withArgs(DEFAULT_VOTING_PERIOD, DEFAULT_QUORUM_THRESHOLD, newMaxBasis);
-        expect(await strategy.basisNumerator()).to.equal(newMaxBasis);
-      });
-    });
-  });
-
   describe('Version', () => {
     it('should return the correct version', async () => {
       void expect(await strategy.getVersion()).to.equal(1);
@@ -1185,11 +956,6 @@ describe('StrategyV1', () => {
     const PROPOSAL_ID = 1;
 
     beforeEach(async () => {
-      const adapterCount = await strategy.getVotingAdapterCount();
-      if (adapterCount === 0n) {
-        await strategy.connect(owner).addVotingAdapter(await mockAdapter1.getAddress());
-      }
-
       await strategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
     });
 
@@ -1202,63 +968,103 @@ describe('StrategyV1', () => {
       });
 
       it('should return true if quorum is met exactly (yes + abstain == threshold)', async () => {
-        const quorum = 100n;
-        await strategy.connect(owner).updateQuorumThreshold(quorum);
+        const testQuorum = 100n;
+        const qStrategy = await deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          testQuorum,
+          DEFAULT_BASIS_NUMERATOR,
+          defaultInitialVotingAdapters,
+          defaultInitialProposerAdapters,
+          lightAccountFactoryMockAddress,
+        );
+        await qStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 40n);
-        await strategy
+        await qStrategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
-        await strategy
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await qStrategy
           .connect(voter2)
-          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
-        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
+          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return true if quorum is exceeded (yes + abstain > threshold)', async () => {
-        const quorum = 100n;
-        await strategy.connect(owner).updateQuorumThreshold(quorum);
+        const testQuorum = 100n;
+        const qStrategy = await deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          testQuorum,
+          DEFAULT_BASIS_NUMERATOR,
+          defaultInitialVotingAdapters,
+          defaultInitialProposerAdapters,
+          lightAccountFactoryMockAddress,
+        );
+        await qStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 41n); // Exceeds
-        await strategy
+        await qStrategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
-        await strategy
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await qStrategy
           .connect(voter2)
-          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
-        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
+          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if quorum is not met (yes + abstain < threshold)', async () => {
-        const quorum = 100n;
-        await strategy.connect(owner).updateQuorumThreshold(quorum);
+        const testQuorum = 100n;
+        const qStrategy = await deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          testQuorum,
+          DEFAULT_BASIS_NUMERATOR,
+          defaultInitialVotingAdapters,
+          defaultInitialProposerAdapters,
+          lightAccountFactoryMockAddress,
+        );
+        await qStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+
         await mockAdapter1.setWeight(voter1.address, 50n);
         await mockAdapter1.setWeight(voter2.address, 40n); // 90 total, < 100
-        await strategy
+        await qStrategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
-        await strategy
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await qStrategy
           .connect(voter2)
-          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
-        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
+          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+
+        void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return true if quorum threshold is 0, even with no votes contributing to quorum count', async () => {
-        await strategy.connect(owner).updateQuorumThreshold(0n);
+        const qStrategy = await deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          0n /* quorum */,
+          DEFAULT_BASIS_NUMERATOR,
+          defaultInitialVotingAdapters,
+          defaultInitialProposerAdapters,
+          lightAccountFactoryMockAddress,
+        );
+        await qStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+
         await mockAdapter1.setWeight(voter1.address, 10n); // Only NO votes
-        await strategy
+        await qStrategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
-        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
+          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+
+        void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if only NO votes are cast and quorum threshold > 0', async () => {
-        const quorum = 100n;
-        await strategy.connect(owner).updateQuorumThreshold(quorum);
-        await mockAdapter1.setWeight(voter1.address, 150n); // Sufficient weight, but wrong type
+        await mockAdapter1.setWeight(voter1.address, 150n);
         await strategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
         void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
       });
     });
@@ -1272,15 +1078,14 @@ describe('StrategyV1', () => {
       });
 
       it('should return true if basis is met (yes > no for >50% basis)', async () => {
-        // Default basis is 500,001 / 1,000,000 (requires yes > no)
         await mockAdapter1.setWeight(voter1.address, 101n);
         await mockAdapter1.setWeight(voter2.address, 100n);
         await strategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
         await strategy
           .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
         void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.true;
       });
 
@@ -1289,10 +1094,10 @@ describe('StrategyV1', () => {
         await mockAdapter1.setWeight(voter2.address, 100n);
         await strategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
         await strategy
           .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
         void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
@@ -1301,10 +1106,10 @@ describe('StrategyV1', () => {
         await mockAdapter1.setWeight(voter2.address, 100n);
         await strategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
         await strategy
           .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
+          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
         void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
@@ -1312,63 +1117,99 @@ describe('StrategyV1', () => {
         await mockAdapter1.setWeight(voter1.address, 100n);
         await strategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [mockAdapter1], [ethers.ZeroHash]);
+          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
         void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return true if basisNumerator is 500,000 (50%) and yes > no', async () => {
-        await strategy.connect(owner).updateBasisNumerator(500_000n);
+        const bStrategy = await deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          500_000n /* basis */,
+          defaultInitialVotingAdapters,
+          defaultInitialProposerAdapters,
+          lightAccountFactoryMockAddress,
+        );
+        await bStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+
         await mockAdapter1.setWeight(voter1.address, 101n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await strategy
+        await bStrategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
-        await strategy
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await bStrategy
           .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
-        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.true;
+          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if basisNumerator is 500,000 (50%) and yes == no', async () => {
-        await strategy.connect(owner).updateBasisNumerator(500_000n);
+        const bStrategy = await deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          500_000n /* basis */,
+          defaultInitialVotingAdapters,
+          defaultInitialProposerAdapters,
+          lightAccountFactoryMockAddress,
+        );
+        await bStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await strategy
+        await bStrategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
-        await strategy
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await bStrategy
           .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
-        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return true if basisNumerator is max valid (DENOMINATOR - 1) and yes > 0, no == 0', async () => {
         const maxValidBasis = 1_000_000n - 1n;
-        await strategy.connect(owner).updateBasisNumerator(maxValidBasis);
+        const bStrategy = await deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          maxValidBasis,
+          defaultInitialVotingAdapters,
+          defaultInitialProposerAdapters,
+          lightAccountFactoryMockAddress,
+        );
+        await bStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+
         await mockAdapter1.setWeight(voter1.address, 100n);
-        await strategy
+        await bStrategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
-        // (100 * 1M) > (100 * (1M-1)) => 100M > 100M - 100. This is true.
-        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.true;
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if basisNumerator is max valid (DENOMINATOR - 1) and yes > 0, no > 0', async () => {
         const maxValidBasis = 1_000_000n - 1n;
-        await strategy.connect(owner).updateBasisNumerator(maxValidBasis);
+        const bStrategy = await deployStrategyProxy(
+          azoriusMock.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          maxValidBasis,
+          defaultInitialVotingAdapters,
+          defaultInitialProposerAdapters,
+          lightAccountFactoryMockAddress,
+        );
+        await bStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+
         await mockAdapter1.setWeight(voter1.address, 100n);
-        await mockAdapter1.setWeight(voter2.address, 1n); // Add one NO vote
-        await strategy
+        await mockAdapter1.setWeight(voter2.address, 1n);
+        await bStrategy
           .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [mockAdapter1], [ethers.ZeroHash]);
-        await strategy
+          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await bStrategy
           .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [mockAdapter1], [ethers.ZeroHash]);
-        // yes = 100, no = 1, totalYesNo = 101
-        // (100 * 1M) > (101 * (1M-1))
-        // 100_000_000 > 101_000_000 - 101
-        // 100_000_000 > 100_999_899. This is false.
-        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+
+        void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
     });
   });

--- a/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
-import type { ContractTransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
@@ -17,66 +16,55 @@ import {
   MockVotingStrategy__factory,
 } from '../../../../typechain-types';
 import { calculateInterfaceId } from '../../../helpers/utils';
-import { runUUPSUpgradeabilityTests } from '../../../helpers/uupsUpgradeabilityTests';
 
 // Modified helper function to return deployment tx hash
 async function deployERC20AdapterProxy(
   proxyDeployer: SignerWithAddress,
   implementationAddress: string,
-  ownerAddress: string,
   tokenAddress: string,
   strategyAddress: string,
   weightPerToken: bigint,
-): Promise<{ adapter: ERC20VotingAdapterV1; deployTx: ContractTransactionResponse }> {
+): Promise<{ adapter: ERC20VotingAdapterV1 }> {
   const initData = ERC20VotingAdapterV1__factory.createInterface().encodeFunctionData(
     'initialize',
-    [ownerAddress, tokenAddress, strategyAddress, weightPerToken],
+    [tokenAddress, strategyAddress, weightPerToken],
   );
   const proxyContractFactory = new ERC1967Proxy__factory(proxyDeployer);
   const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
   await proxy.waitForDeployment();
 
   const adapter = ERC20VotingAdapterV1__factory.connect(await proxy.getAddress(), proxyDeployer);
-  const deployTx = proxy.deploymentTransaction();
-  if (!deployTx) {
-    throw new Error('Proxy deployment transaction not found');
-  }
-  return { adapter, deployTx };
+  return { adapter };
 }
 
 describe('ERC20VotingAdapterV1', () => {
   let deployerG: SignerWithAddress;
-  let ownerG: SignerWithAddress;
   let erc20AdapterImplementationAddressG: string;
 
   const DEFAULT_WEIGHT_PER_TOKEN = 1n;
 
   async function deployGlobalFixture() {
-    const [deployer, owner, user1, user2, nonOwner] = await ethers.getSigners();
-    const adapterImplFactory = new ERC20VotingAdapterV1__factory(deployer);
-    const deployedAdapterImpl = await adapterImplFactory.deploy();
+    const [deployer, user1, user2] = await ethers.getSigners();
+    const deployedAdapterImpl = await new ERC20VotingAdapterV1__factory(deployer).deploy();
     await deployedAdapterImpl.waitForDeployment();
 
     // Assign to global vars
     deployerG = deployer;
-    ownerG = owner;
     erc20AdapterImplementationAddressG = await deployedAdapterImpl.getAddress();
 
     // Only return what's needed if this fixture is for global one-time setup
     // For deploying fresh mocks per test suite, a different fixture or direct deployment is better.
     return {
       deployer,
-      owner,
       user1,
       user2,
-      nonOwner,
       erc20AdapterImplementationAddress: erc20AdapterImplementationAddressG,
     };
   }
 
   // This specialized fixture is for deploying fresh mocks for specific test suites
   async function deployMocksAndSignersFixture() {
-    const [deployer, owner, user1, user2, nonOwner] = await ethers.getSigners();
+    const [deployer, user1, user2] = await ethers.getSigners();
 
     const deployedMockToken = await new MockERC20Votes__factory(deployer).deploy();
 
@@ -92,10 +80,8 @@ describe('ERC20VotingAdapterV1', () => {
 
     return {
       deployer,
-      ownerSigner: owner,
       user1Signer: user1,
       user2Signer: user2,
-      nonOwnerSigner: nonOwner,
       mockToken: deployedMockToken,
       mockStrategy: deployedMockStrategy,
     };
@@ -106,8 +92,6 @@ describe('ERC20VotingAdapterV1', () => {
     await loadFixture(deployGlobalFixture);
   });
 
-  let ownerSigner: SignerWithAddress;
-  let nonOwnerSigner: SignerWithAddress;
   let mockToken: MockERC20Votes;
   let mockStrategy: MockVotingStrategy;
   let deployer: SignerWithAddress;
@@ -115,8 +99,6 @@ describe('ERC20VotingAdapterV1', () => {
 
   beforeEach(async () => {
     const {
-      ownerSigner: oSigner,
-      nonOwnerSigner: nSigner,
       mockToken: mToken,
       mockStrategy: mStrategy,
       deployer: dDeployer,
@@ -124,8 +106,6 @@ describe('ERC20VotingAdapterV1', () => {
     } = await loadFixture(deployMocksAndSignersFixture);
 
     user1Signer = vSigner;
-    ownerSigner = oSigner;
-    nonOwnerSigner = nSigner;
     mockToken = mToken;
     mockStrategy = mStrategy;
     deployer = dDeployer;
@@ -133,23 +113,14 @@ describe('ERC20VotingAdapterV1', () => {
 
   describe('Initialization', () => {
     it('should initialize correctly with valid parameters and emit event', async () => {
-      const { adapter: erc20Adapter, deployTx } = await deployERC20AdapterProxy(
+      const { adapter: erc20Adapter } = await deployERC20AdapterProxy(
         deployer,
         erc20AdapterImplementationAddressG,
-        ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_TOKEN,
       );
 
-      // Check the event on the deployment transaction hash.
-      // Provide the proxy instance (erc20Adapter) to .to.emit(),
-      // as the event is emitted from the proxy's address due to delegatecall.
-      await expect(deployTx.hash)
-        .to.emit(erc20Adapter, 'VotingAdapterParametersUpdated')
-        .withArgs(DEFAULT_WEIGHT_PER_TOKEN);
-
-      expect(await erc20Adapter.owner()).to.equal(ownerSigner.address);
       expect(await erc20Adapter.token()).to.equal(await mockToken.getAddress());
       expect(await erc20Adapter.strategy()).to.equal(await mockStrategy.getAddress());
       expect(await erc20Adapter.weightPerToken()).to.equal(DEFAULT_WEIGHT_PER_TOKEN);
@@ -165,7 +136,6 @@ describe('ERC20VotingAdapterV1', () => {
         deployERC20AdapterProxy(
           deployer,
           erc20AdapterImplementationAddressG,
-          ownerSigner.address,
           ethers.ZeroAddress,
           await mockStrategy.getAddress(),
           DEFAULT_WEIGHT_PER_TOKEN,
@@ -183,7 +153,6 @@ describe('ERC20VotingAdapterV1', () => {
         deployERC20AdapterProxy(
           deployer,
           erc20AdapterImplementationAddressG,
-          ownerSigner.address,
           await mockToken.getAddress(),
           ethers.ZeroAddress,
           DEFAULT_WEIGHT_PER_TOKEN,
@@ -201,7 +170,6 @@ describe('ERC20VotingAdapterV1', () => {
         deployERC20AdapterProxy(
           deployer,
           erc20AdapterImplementationAddressG,
-          ownerSigner.address,
           await mockToken.getAddress(),
           await mockStrategy.getAddress(),
           0n,
@@ -213,79 +181,29 @@ describe('ERC20VotingAdapterV1', () => {
       const { adapter: erc20Adapter } = await deployERC20AdapterProxy(
         deployer,
         erc20AdapterImplementationAddressG,
-        ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_TOKEN,
       );
 
       await expect(
-        erc20Adapter.initialize(ownerSigner.address, ethers.ZeroAddress, ethers.ZeroAddress, 0n),
+        erc20Adapter.initialize(ethers.ZeroAddress, ethers.ZeroAddress, 0n),
       ).to.be.revertedWithCustomError(erc20Adapter, 'InvalidInitialization');
     });
 
     it('Should have initialization disabled in the implementation contract', async function () {
       const implementationContract = ERC20VotingAdapterV1__factory.connect(
         erc20AdapterImplementationAddressG,
-        ownerG,
+        deployerG,
       );
 
       await expect(
         implementationContract.initialize(
-          ownerSigner.address,
           await mockToken.getAddress(),
           await mockStrategy.getAddress(),
           DEFAULT_WEIGHT_PER_TOKEN,
         ),
       ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
-    });
-  });
-
-  describe('Owner Functions', () => {
-    let erc20Adapter: ERC20VotingAdapterV1;
-    let currentOwnerSigner: SignerWithAddress;
-    let currentNonOwnerSigner: SignerWithAddress;
-
-    beforeEach(async () => {
-      currentOwnerSigner = ownerSigner;
-      currentNonOwnerSigner = nonOwnerSigner;
-
-      const { adapter } = await deployERC20AdapterProxy(
-        deployer,
-        erc20AdapterImplementationAddressG,
-        currentOwnerSigner.address,
-        await mockToken.getAddress(),
-        await mockStrategy.getAddress(),
-        DEFAULT_WEIGHT_PER_TOKEN,
-      );
-      erc20Adapter = adapter;
-    });
-
-    describe('updateWeightPerToken', () => {
-      const NEW_WEIGHT_PER_TOKEN = 2n;
-
-      it('should allow owner to update weight per token and emit event', async () => {
-        await expect(
-          erc20Adapter.connect(currentOwnerSigner).updateWeightPerToken(NEW_WEIGHT_PER_TOKEN),
-        )
-          .to.emit(erc20Adapter, 'VotingAdapterParametersUpdated')
-          .withArgs(NEW_WEIGHT_PER_TOKEN);
-        expect(await erc20Adapter.weightPerToken()).to.equal(NEW_WEIGHT_PER_TOKEN);
-      });
-
-      it('should not allow non-owner to update weight per token', async () => {
-        await expect(
-          erc20Adapter.connect(currentNonOwnerSigner).updateWeightPerToken(NEW_WEIGHT_PER_TOKEN),
-        )
-          .to.be.revertedWithCustomError(erc20Adapter, 'OwnableUnauthorizedAccount')
-          .withArgs(currentNonOwnerSigner.address);
-      });
-
-      it('should revert if new weightPerToken is zero', async () => {
-        await expect(
-          erc20Adapter.connect(currentOwnerSigner).updateWeightPerToken(0n),
-        ).to.be.revertedWithCustomError(erc20Adapter, 'InvalidWeightPerToken');
-      });
     });
   });
 
@@ -299,7 +217,6 @@ describe('ERC20VotingAdapterV1', () => {
       const { adapter: deployedAdapter } = await deployERC20AdapterProxy(
         deployer,
         erc20AdapterImplementationAddressG,
-        ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
         customWeightPerToken || DEFAULT_WEIGHT_PER_TOKEN,
@@ -408,19 +325,16 @@ describe('ERC20VotingAdapterV1', () => {
     let token: MockERC20Votes;
     let strategy: MockVotingStrategy;
     let voter: SignerWithAddress;
-    let owner: SignerWithAddress;
     let currentDeployer: SignerWithAddress;
 
     async function setupAdapterForRecordVote(clockMode: 0 | 1, customWeightPerToken?: bigint) {
       const {
-        ownerSigner: fixtureOwner,
         user1Signer: fixtureVoter,
         deployer: fixDeployer,
         mockToken: fToken,
         mockStrategy: fStrategy,
       } = await loadFixture(deployMocksAndSignersFixture);
 
-      owner = fixtureOwner;
       voter = fixtureVoter;
       token = fToken;
       strategy = fStrategy;
@@ -430,7 +344,6 @@ describe('ERC20VotingAdapterV1', () => {
       const { adapter: deployedAdapter } = await deployERC20AdapterProxy(
         currentDeployer,
         erc20AdapterImplementationAddressG,
-        owner.address,
         await token.getAddress(),
         await strategy.getAddress(),
         customWeightPerToken || DEFAULT_WEIGHT_PER_TOKEN,
@@ -503,9 +416,9 @@ describe('ERC20VotingAdapterV1', () => {
         votingStartTimestamp,
         votingStartTimestamp + 1000,
       );
-      await adapter.recordVote(voter.address, proposalId, mockExtraData);
+      await adapter.connect(voter).recordVote(voter.address, proposalId, mockExtraData);
       await expect(
-        adapter.recordVote(voter.address, proposalId, mockExtraData),
+        adapter.connect(voter).recordVote(voter.address, proposalId, mockExtraData),
       ).to.be.revertedWithCustomError(adapter, 'ERC20AlreadyVoted');
     });
 
@@ -518,7 +431,7 @@ describe('ERC20VotingAdapterV1', () => {
         votingStartTimestamp,
         votingStartTimestamp + 1000,
       );
-      await adapter.recordVote(voter.address, proposalId, mockExtraData);
+      await adapter.connect(voter).recordVote(voter.address, proposalId, mockExtraData);
       const weight = await adapter.weightOf(voter.address, proposalId, mockExtraData);
       expect(weight).to.equal(0);
     });
@@ -527,7 +440,7 @@ describe('ERC20VotingAdapterV1', () => {
       await setupAdapterForRecordVote(0);
       await strategy.setVotingTimestamps(proposalId, 0, 1000);
       await expect(
-        adapter.recordVote(voter.address, proposalId, mockExtraData),
+        adapter.connect(voter).recordVote(voter.address, proposalId, mockExtraData),
       ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
     });
 
@@ -535,7 +448,7 @@ describe('ERC20VotingAdapterV1', () => {
       await setupAdapterForRecordVote(1);
       await strategy.setVotingStartBlock(proposalId, 0);
       await expect(
-        adapter.recordVote(voter.address, proposalId, mockExtraData),
+        adapter.connect(voter).recordVote(voter.address, proposalId, mockExtraData),
       ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
     });
   });
@@ -545,7 +458,6 @@ describe('ERC20VotingAdapterV1', () => {
       const { adapter: erc20Adapter } = await deployERC20AdapterProxy(
         deployer,
         erc20AdapterImplementationAddressG,
-        ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_TOKEN,
@@ -566,7 +478,6 @@ describe('ERC20VotingAdapterV1', () => {
       const { adapter } = await deployERC20AdapterProxy(
         deployer,
         erc20AdapterImplementationAddressG,
-        ownerSigner.address,
         await mockToken.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_TOKEN,
@@ -602,32 +513,6 @@ describe('ERC20VotingAdapterV1', () => {
 
     it('should not support a random interfaceId', async () => {
       void expect(await erc20Adapter.supportsInterface('0x12345678')).to.be.false;
-    });
-  });
-
-  describe('UUPS Upgradeability', () => {
-    let erc20AdapterProxy: ERC20VotingAdapterV1;
-
-    beforeEach(async () => {
-      const { adapter } = await deployERC20AdapterProxy(
-        deployer,
-        erc20AdapterImplementationAddressG,
-        ownerSigner.address,
-        await mockToken.getAddress(),
-        await mockStrategy.getAddress(),
-        DEFAULT_WEIGHT_PER_TOKEN,
-      );
-      erc20AdapterProxy = adapter;
-    });
-
-    runUUPSUpgradeabilityTests({
-      getContract: () => erc20AdapterProxy,
-      createNewImplementation: async () => {
-        const newImplementation = await new ERC20VotingAdapterV1__factory(deployer).deploy();
-        return newImplementation;
-      },
-      owner: () => ownerSigner,
-      nonOwner: () => nonOwnerSigner,
     });
   });
 });

--- a/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
-import type { ContractTransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
@@ -17,19 +16,17 @@ import {
   MockVotingStrategy__factory,
 } from '../../../../typechain-types';
 import { calculateInterfaceId } from '../../../helpers/utils';
-import { runUUPSUpgradeabilityTests } from '../../../helpers/uupsUpgradeabilityTests';
 
 async function deployERC721AdapterProxy(
   proxyDeployer: SignerWithAddress,
   implementationAddress: string,
-  initialOwnerAddress: string,
   tokenAddress: string,
   strategyAddress: string,
   weightPerNft: bigint,
-): Promise<{ adapter: ERC721VotingAdapterV1; deployTx: ContractTransactionResponse }> {
+): Promise<{ adapter: ERC721VotingAdapterV1 }> {
   const initData = ERC721VotingAdapterV1__factory.createInterface().encodeFunctionData(
     'initialize',
-    [initialOwnerAddress, tokenAddress, strategyAddress, weightPerNft],
+    [tokenAddress, strategyAddress, weightPerNft],
   );
   const proxyContractFactory = new ERC1967Proxy__factory(proxyDeployer);
   const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
@@ -39,11 +36,8 @@ async function deployERC721AdapterProxy(
     await proxy.getAddress(),
     proxyDeployer,
   );
-  const deployTxObj = proxy.deploymentTransaction();
-  if (!deployTxObj) {
-    throw new Error('Proxy deployment transaction not found for ERC721AdapterV1');
-  }
-  return { adapter: adapterInstance, deployTx: deployTxObj };
+
+  return { adapter: adapterInstance };
 }
 
 describe('ERC721VotingAdapterV1', () => {
@@ -65,7 +59,7 @@ describe('ERC721VotingAdapterV1', () => {
   }
 
   async function deployMocksAndSignersERC721Fixture() {
-    const [deployer, owner, user1, user2, nonOwnerAccount] = await ethers.getSigners();
+    const [deployer, user1, user2] = await ethers.getSigners();
 
     const mockNftFactory = new MockERC721__factory(deployer);
     const mockNft = await mockNftFactory.deploy();
@@ -106,10 +100,8 @@ describe('ERC721VotingAdapterV1', () => {
 
     return {
       deployer,
-      ownerSigner: owner,
       user1Signer: user1,
       user2Signer: user2,
-      nonOwnerSigner: nonOwnerAccount,
       mockNft,
       mockStrategy,
       user1TokenIds,
@@ -122,28 +114,21 @@ describe('ERC721VotingAdapterV1', () => {
   });
 
   describe('Initialization', () => {
-    it('should initialize correctly, set owner, and emit VotingAdapterParametersUpdated event', async () => {
+    it('should initialize correctly', async () => {
       const {
-        ownerSigner,
         mockNft,
         mockStrategy,
         deployer: fixtureDeployer,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
 
-      const { adapter: erc721Adapter, deployTx } = await deployERC721AdapterProxy(
+      const { adapter: erc721Adapter } = await deployERC721AdapterProxy(
         fixtureDeployer,
         erc721AdapterImplementationAddressG,
-        ownerSigner.address,
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
 
-      await expect(deployTx)
-        .to.emit(erc721Adapter, 'VotingAdapterParametersUpdated')
-        .withArgs(DEFAULT_WEIGHT_PER_NFT);
-
-      expect(await erc721Adapter.owner()).to.equal(ownerSigner.address);
       expect(await erc721Adapter.token()).to.equal(await mockNft.getAddress());
       expect(await erc721Adapter.strategy()).to.equal(await mockStrategy.getAddress());
       expect(await erc721Adapter.weightPerNft()).to.equal(DEFAULT_WEIGHT_PER_NFT);
@@ -161,7 +146,6 @@ describe('ERC721VotingAdapterV1', () => {
         deployERC721AdapterProxy(
           fixtureDeployer,
           erc721AdapterImplementationAddressG,
-          fixtureDeployer.address,
           ethers.ZeroAddress,
           await mockNft.getAddress(),
           DEFAULT_WEIGHT_PER_NFT,
@@ -181,7 +165,6 @@ describe('ERC721VotingAdapterV1', () => {
         deployERC721AdapterProxy(
           fixtureDeployer,
           erc721AdapterImplementationAddressG,
-          fixtureDeployer.address,
           await mockNft.getAddress(),
           ethers.ZeroAddress,
           DEFAULT_WEIGHT_PER_NFT,
@@ -203,7 +186,6 @@ describe('ERC721VotingAdapterV1', () => {
         deployERC721AdapterProxy(
           fixtureDeployer,
           erc721AdapterImplementationAddressG,
-          fixtureDeployer.address,
           await mockNft.getAddress(),
           await mockStrategy.getAddress(),
           0n, // Invalid weight
@@ -220,14 +202,12 @@ describe('ERC721VotingAdapterV1', () => {
       const { adapter: erc721Adapter } = await deployERC721AdapterProxy(
         fixtureDeployer,
         erc721AdapterImplementationAddressG,
-        fixtureDeployer.address,
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
       await expect(
         erc721Adapter.initialize(
-          fixtureDeployer.address,
           await mockNft.getAddress(),
           await mockStrategy.getAddress(),
           DEFAULT_WEIGHT_PER_NFT,
@@ -247,7 +227,6 @@ describe('ERC721VotingAdapterV1', () => {
       );
       await expect(
         implementationContract.initialize(
-          fixtureDeployer.address,
           await mockNft.getAddress(),
           await mockStrategy.getAddress(),
           DEFAULT_WEIGHT_PER_NFT,
@@ -277,7 +256,6 @@ describe('ERC721VotingAdapterV1', () => {
       const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
         deployer,
         erc721AdapterImplementationAddressG,
-        deployer.address,
         await mockNft.getAddress(),
         await fixture.mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
@@ -359,7 +337,6 @@ describe('ERC721VotingAdapterV1', () => {
       const { adapter: customAdapter } = await deployERC721AdapterProxy(
         deployer, // from beforeEach
         erc721AdapterImplementationAddressG,
-        deployer.address,
         await mockNft.getAddress(),
         await (await loadFixture(deployMocksAndSignersERC721Fixture)).mockStrategy.getAddress(), // Fresh strategy address
         customWeightPerNft,
@@ -382,7 +359,6 @@ describe('ERC721VotingAdapterV1', () => {
     let user1TokenIds: bigint[];
     let user2TokenIds: bigint[];
     let deployer: SignerWithAddress;
-    let owner: SignerWithAddress;
     let mockStrategy: MockVotingStrategy;
 
     const proposalId = 1;
@@ -394,13 +370,11 @@ describe('ERC721VotingAdapterV1', () => {
       user1TokenIds = fixture.user1TokenIds;
       user2TokenIds = fixture.user2TokenIds;
       deployer = fixture.deployer;
-      owner = fixture.ownerSigner;
       mockStrategy = fixture.mockStrategy;
 
       const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
         deployer,
         erc721AdapterImplementationAddressG,
-        owner.address,
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
@@ -489,7 +463,6 @@ describe('ERC721VotingAdapterV1', () => {
       const {
         mockNft: localMockNft,
         mockStrategy: localMockStrategy,
-        ownerSigner: localOwner,
         user1Signer: localUser1,
         deployer: localDeployer,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
@@ -506,7 +479,6 @@ describe('ERC721VotingAdapterV1', () => {
       const { adapter: customAdapter } = await deployERC721AdapterProxy(
         localDeployer,
         erc721AdapterImplementationAddressG,
-        localOwner.address,
         await localMockNft.getAddress(),
         await localMockStrategy.getAddress(),
         customWeightPerNft,
@@ -548,7 +520,6 @@ describe('ERC721VotingAdapterV1', () => {
       const { adapter: erc721Adapter } = await deployERC721AdapterProxy(
         fixtureDeployer,
         erc721AdapterImplementationAddressG,
-        fixtureDeployer.address,
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
@@ -573,7 +544,6 @@ describe('ERC721VotingAdapterV1', () => {
       const { adapter } = await deployERC721AdapterProxy(
         fixtureDeployer,
         erc721AdapterImplementationAddressG,
-        fixtureDeployer.address,
         await mockNft.getAddress(),
         await mockStrategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
@@ -611,101 +581,6 @@ describe('ERC721VotingAdapterV1', () => {
 
     it('should not support a random interfaceId', async () => {
       void expect(await erc721Adapter.supportsInterface('0x12345678')).to.be.false;
-    });
-  });
-
-  describe('Owner Functions', () => {
-    let adapter: ERC721VotingAdapterV1;
-    let owner: SignerWithAddress;
-    let nonOwner: SignerWithAddress;
-    let deployer: SignerWithAddress; // This will be the fixture.deployer
-    let mockNftAddress: string;
-    let mockStrategyAddress: string;
-
-    beforeEach(async () => {
-      const fixture = await loadFixture(deployMocksAndSignersERC721Fixture);
-      owner = fixture.ownerSigner; // This is the intended owner for the adapter
-      nonOwner = fixture.nonOwnerSigner;
-      deployer = fixture.deployer; // This is the signer used to deploy the proxy
-      mockNftAddress = await fixture.mockNft.getAddress();
-      mockStrategyAddress = await fixture.mockStrategy.getAddress();
-
-      const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
-        deployer, // The fixture.deployer can deploy the proxy
-        erc721AdapterImplementationAddressG,
-        owner.address, // The fixture.ownerSigner becomes the owner of the adapter
-        mockNftAddress,
-        mockStrategyAddress,
-        DEFAULT_WEIGHT_PER_NFT,
-      );
-      adapter = deployedAdapter;
-    });
-
-    describe('updateWeightPerNft', () => {
-      const NEW_WEIGHT_PER_NFT = 5n;
-
-      it('should allow owner to update weightPerNft and emit event', async () => {
-        await expect(adapter.connect(owner).updateWeightPerNft(NEW_WEIGHT_PER_NFT))
-          .to.emit(adapter, 'VotingAdapterParametersUpdated')
-          .withArgs(NEW_WEIGHT_PER_NFT);
-        expect(await adapter.weightPerNft()).to.equal(NEW_WEIGHT_PER_NFT);
-      });
-
-      it('should not allow non-owner to update weightPerNft', async () => {
-        await expect(adapter.connect(nonOwner).updateWeightPerNft(NEW_WEIGHT_PER_NFT))
-          .to.be.revertedWithCustomError(adapter, 'OwnableUnauthorizedAccount')
-          .withArgs(nonOwner.address);
-      });
-
-      it('should revert if new weightPerNft is zero', async () => {
-        await expect(adapter.connect(owner).updateWeightPerNft(0n)).to.be.revertedWithCustomError(
-          adapter,
-          'InvalidWeightPerNft',
-        );
-      });
-    });
-  });
-
-  describe('UUPS Upgradeability', () => {
-    let erc721AdapterProxy: ERC721VotingAdapterV1;
-    let fixtureOwner: SignerWithAddress;
-    let fixtureNonOwner: SignerWithAddress;
-    let fixtureDeployer: SignerWithAddress;
-
-    beforeEach(async () => {
-      const {
-        ownerSigner,
-        nonOwnerSigner,
-        deployer: testDeployer,
-        mockNft,
-        mockStrategy,
-      } = await loadFixture(deployMocksAndSignersERC721Fixture);
-      fixtureOwner = ownerSigner;
-      fixtureNonOwner = nonOwnerSigner;
-      fixtureDeployer = testDeployer;
-
-      const { adapter } = await deployERC721AdapterProxy(
-        fixtureDeployer,
-        erc721AdapterImplementationAddressG,
-        fixtureOwner.address,
-        await mockNft.getAddress(),
-        await mockStrategy.getAddress(),
-        DEFAULT_WEIGHT_PER_NFT,
-      );
-      erc721AdapterProxy = adapter;
-    });
-
-    runUUPSUpgradeabilityTests({
-      getContract: () => erc721AdapterProxy,
-      createNewImplementation: async () => {
-        const newImplementation = await new ERC721VotingAdapterV1__factory(
-          fixtureDeployer,
-        ).deploy();
-        await newImplementation.waitForDeployment();
-        return newImplementation;
-      },
-      owner: () => fixtureOwner,
-      nonOwner: () => fixtureNonOwner,
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/280

Fixes [ENG-975](https://linear.app/decent-labs/issue/ENG-975/make-strategyv1-and-voting-adapters-immutable-remove-ownable-and-uups)

**High-Level Context:**

This Pull Request implements a significant design shift for our `StrategyV1` governance engine and its associated Token Adapters (`ERC20VotingAdapterV1`, `ERC721VotingAdapterV1`). To enhance the predictability and trustlessness of a deployed governance strategy, we are removing Ownable-related functionalities and UUPS upgradeability from these contracts. Once initialized, the core parameters and logic of `StrategyV1` and its adapters will be immutable.

This change prioritizes the invariant nature of a proposal's voting conditions from the moment of its creation through its resolution.

**Specific Changes in this PR:**

1.  **`StrategyV1.sol` Modifications:**
    *   **Removed Inheritance:** `OwnableUpgradeable` and `UUPSUpgradeable` are no longer inherited.
    *   **Removed Owner-Only Functions:**
        *   `updateVotingPeriod`
        *   `updateQuorumThreshold`
        *   `updateBasisNumerator`
        *   `addVotingAdapter`
        *   `removeVotingAdapter`
        *   `addProposerAdapter`
        *   `removeProposerAdapter`
        *   `_authorizeUpgrade`
    *   **Simplified `initialize` Function:**
        *   Removed `_initialOwner` parameter.
        *   No longer calls `__Ownable_init()` or `__UUPSUpgradeable_init()`.
        *   Voting parameters (`_votingPeriod`, `_quorumThreshold`, `_basisNumerator`) and adapter lists (`_initialVotingAdapters`, `_initialProposerAdapters`) are now set once at initialization and are immutable thereafter.
        *   Validation logic for these parameters (e.g., `_votingPeriod > 0`, basis numerator range, adapter zero address checks, duplicate adapter checks) is now performed directly within `initialize`.
    *   **Removed Events:** `StrategyParametersUpdated`, `VotingAdapterAdded`, `VotingAdapterRemoved`, `ProposerAdapterAdded`, `ProposerAdapterRemoved` are removed.

2.  **`ERC20VotingAdapterV1.sol` Modifications:**
    *   **Removed Inheritance:** `OwnableUpgradeable` and `UUPSUpgradeable` are no longer inherited.
    *   **Removed Owner-Only Functions:**
        *   `updateProposerThreshold` (this was already removed in a prior step if following the sequence, but good to confirm removal from ownable pattern)
        *   `updateWeightPerToken`
        *   `_authorizeUpgrade`
    *   **Simplified `initialize` Function:**
        *   Removed `_initialOwner` parameter.
        *   No longer calls `__Ownable_init()` or `__UUPSUpgradeable_init()`.
        *   `weightPerToken` is now set once at initialization and is immutable. `proposerThreshold` was already removed.
    *   **Removed Event:** `VotingAdapterParametersUpdated` is removed.

3.  **`ERC721VotingAdapterV1.sol` Modifications:**
    *   **Removed Inheritance:** `OwnableUpgradeable` and `UUPSUpgradeable` are no longer inherited.
    *   **Removed Owner-Only Functions:**
        *   `updateWeightPerNft`
        *   `updateProposerThreshold` (already removed)
        *   `_authorizeUpgrade`
    *   **Simplified `initialize` Function:**
        *   Removed `_initialOwner` parameter.
        *   No longer calls `__Ownable_init()` or `__UUPSUpgradeable_init()`.
        *   `weightPerNft` is now set once at initialization and is immutable.
    *   **Removed Event:** `VotingAdapterParametersUpdated` is removed.

4.  **Interface `IStrategyV1.sol` Updates:**
    *   Removed function declarations for: `updateVotingPeriod`, `updateQuorumThreshold`, `updateBasisNumerator`, `addVotingAdapter`, `removeVotingAdapter`, `addProposerAdapter`, `removeProposerAdapter`.

5.  **Test Suite Updates (`StrategyV1.test.ts`, `ERC20VotingAdapterV1.test.ts`, `ERC721VotingAdapterV1.test.ts`):**
    *   Removed tests related to Ownable functions (e.g., checking non-owner reverts, successful updates by owner).
    *   Removed tests for UUPS upgradeability for these contracts.
    *   Updated deployment helpers (`deployStrategyProxy`, `deployERC20AdapterProxy`, `deployERC721AdapterProxy`) to remove the `initialOwner` parameter from `initialize` calls.
    *   Ensured initialization tests correctly validate parameters set at construction time and handle reverts for invalid initial parameters (e.g., zero voting period, invalid basis).

**Impact and Status:**

*   **Immutability:** `StrategyV1` and its adapters, once deployed and initialized, will have fixed parameters and logic. This means that the rules governing proposals (voting duration, quorum, basis, and the set of active adapters) cannot be changed for that specific strategy instance.
*   **Predictability & Trust:** This change enhances the predictability for DAO members, as the conditions for proposal success are locked in at the time of the strategy's deployment.
*   **Upgrade Path:** Upgrading a strategy or its parameters would now require deploying a new `StrategyV1` (or adapter) instance and having `AzoriusV1` (which remains upgradeable and ownable) point to the new strategy contract via its `updateStrategy` function.
*   **Compilation Status:** All contracts should compile.
*   **Testing Status:** All tests related to ownership and upgradeability for these specific contracts have been removed. Remaining tests have been updated to reflect the immutable nature of the contracts and should pass.

This architectural decision prioritizes the immutability of voting rules for a deployed strategy instance, ensuring that once a proposal is live, its success criteria cannot be altered mid-stream by administrative actions on the strategy contract itself.