### PR TITLE
feat(governance): Implement `HatsProposerAdapterV1`

### DIFF
--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
+import {IProposerAdapterBaseV1} from "../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
+import {IHats} from "../../../interfaces/hats/IHats.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {Version} from "../../Version.sol";
+
+contract HatsProposerAdapterV1 is
+    IProposerAdapterV1,
+    Initializable,
+    ERC165,
+    Version
+{
+    IHats public hatsContract;
+    uint256[] private whitelistedHatIds;
+
+    uint16 public constant VERSION = 1;
+
+    error MissingHatsContract();
+    error NoHatsWhitelisted();
+    error HatAlreadyWhitelisted();
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address _hatsContractAddress,
+        uint256[] memory _whitelistedHats
+    ) public virtual initializer {
+        if (_hatsContractAddress == address(0)) revert MissingHatsContract();
+        hatsContract = IHats(_hatsContractAddress);
+
+        if (_whitelistedHats.length == 0) revert NoHatsWhitelisted();
+        for (uint256 i = 0; i < _whitelistedHats.length; i++) {
+            uint256 _hatId = _whitelistedHats[i];
+            for (uint256 j = 0; j < whitelistedHatIds.length; j++) {
+                if (whitelistedHatIds[j] == _hatId)
+                    revert HatAlreadyWhitelisted();
+            }
+            whitelistedHatIds.push(_hatId);
+        }
+    }
+
+    function getWhitelistedHatIds()
+        public
+        view
+        virtual
+        returns (uint256[] memory)
+    {
+        return whitelistedHatIds;
+    }
+
+    function isProposer(
+        address _proposer
+    ) public view virtual override returns (bool) {
+        for (uint256 i = 0; i < whitelistedHatIds.length; i++) {
+            if (hatsContract.isWearerOfHat(_proposer, whitelistedHatIds[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function getVersion() public pure virtual override returns (uint16) {
+        return VERSION;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165, Version) returns (bool) {
+        return
+            interfaceId == type(IProposerAdapterV1).interfaceId ||
+            interfaceId == type(IProposerAdapterBaseV1).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
@@ -1,0 +1,173 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ERC1967Proxy__factory,
+  HatsProposerAdapterV1,
+  HatsProposerAdapterV1__factory,
+  IERC165__factory,
+  IProposerAdapterBaseV1__factory,
+  IProposerAdapterV1__factory,
+  IVersion__factory,
+  MockHats,
+  MockHats__factory,
+} from '../../../../typechain-types';
+import { calculateInterfaceId } from '../../../helpers/utils';
+
+async function deployHatsProposerAdapterProxy(
+  deployer: SignerWithAddress,
+  implementationAddress: string,
+  hatsContractAddress: string,
+  initialWhitelistedHats: bigint[],
+): Promise<HatsProposerAdapterV1> {
+  const adapterInterface = HatsProposerAdapterV1__factory.createInterface();
+  const initializeCalldata = adapterInterface.encodeFunctionData('initialize', [
+    hatsContractAddress,
+    initialWhitelistedHats,
+  ]);
+  const proxyFactory = new ERC1967Proxy__factory(deployer);
+  const proxy = await proxyFactory.deploy(implementationAddress, initializeCalldata);
+  await proxy.waitForDeployment();
+  return HatsProposerAdapterV1__factory.connect(await proxy.getAddress(), deployer);
+}
+
+describe('HatsProposerAdapterV1', () => {
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+
+  let adapterImplementation: HatsProposerAdapterV1;
+  let adapter: HatsProposerAdapterV1;
+  let mockHats: MockHats;
+
+  const HAT_ID_1 = 111n;
+  const HAT_ID_2 = 222n;
+
+  beforeEach(async () => {
+    [deployer, user1] = await ethers.getSigners();
+
+    const mockHatsFactory = new MockHats__factory(deployer);
+    mockHats = await mockHatsFactory.deploy();
+    await mockHats.waitForDeployment();
+
+    if (!adapterImplementation) {
+      const adapterFactory = new HatsProposerAdapterV1__factory(deployer);
+      adapterImplementation = await adapterFactory.deploy();
+      await adapterImplementation.waitForDeployment();
+    }
+
+    // Deploy with a default whitelisted hat for most tests
+    adapter = await deployHatsProposerAdapterProxy(
+      deployer,
+      await adapterImplementation.getAddress(),
+      await mockHats.getAddress(),
+      [HAT_ID_1],
+    );
+  });
+
+  describe('Initialization (via Proxy)', () => {
+    it('should initialize correctly with valid parameters', async () => {
+      expect(await adapter.hatsContract()).to.equal(await mockHats.getAddress());
+      const whitelistedHats = await adapter.getWhitelistedHatIds();
+      expect(whitelistedHats).to.deep.equal([HAT_ID_1]);
+    });
+
+    it('should revert if hats contract address is zero', async () => {
+      await expect(
+        deployHatsProposerAdapterProxy(
+          deployer,
+          await adapterImplementation.getAddress(),
+          ethers.ZeroAddress,
+          [HAT_ID_1],
+        ),
+      ).to.be.revertedWithCustomError(adapterImplementation, 'MissingHatsContract');
+    });
+
+    it('should revert if initialWhitelistedHats is empty', async () => {
+      await expect(
+        deployHatsProposerAdapterProxy(
+          deployer,
+          await adapterImplementation.getAddress(),
+          await mockHats.getAddress(),
+          [],
+        ),
+      ).to.be.revertedWithCustomError(adapterImplementation, 'NoHatsWhitelisted');
+    });
+
+    it('should prevent reinitialization on proxied adapter', async () => {
+      await expect(
+        adapter.initialize(await mockHats.getAddress(), [HAT_ID_1]),
+      ).to.be.revertedWithCustomError(adapter, 'InvalidInitialization');
+    });
+
+    it('Implementation contract should remain uninitialized', async () => {
+      await expect(
+        adapterImplementation.initialize(await mockHats.getAddress(), [HAT_ID_1]),
+      ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidInitialization');
+    });
+  });
+
+  describe('isProposer', () => {
+    // Adapter is initialized with HAT_ID_1 in beforeEach
+
+    it('should return true if user wears a whitelisted hat', async () => {
+      await mockHats.setWearerStatus(user1.address, HAT_ID_1, true);
+      const canPropose = await adapter.isProposer(user1.address);
+      void expect(canPropose).to.be.true;
+    });
+
+    it('should return false if user does not wear any whitelisted hat', async () => {
+      await mockHats.setWearerStatus(user1.address, HAT_ID_1, false);
+      await mockHats.setWearerStatus(user1.address, HAT_ID_2, true); // Wears a non-whitelisted hat
+      const canPropose = await adapter.isProposer(user1.address);
+      void expect(canPropose).to.be.false;
+    });
+
+    it('should return false if user wears no hats', async () => {
+      const canPropose = await adapter.isProposer(user1.address);
+      void expect(canPropose).to.be.false;
+    });
+
+    it('should work with multiple whitelisted hats', async () => {
+      const localAdapter = await deployHatsProposerAdapterProxy(
+        deployer,
+        await adapterImplementation.getAddress(),
+        await mockHats.getAddress(),
+        [HAT_ID_1, HAT_ID_2],
+      );
+      await mockHats.setWearerStatus(user1.address, HAT_ID_1, false);
+      await mockHats.setWearerStatus(user1.address, HAT_ID_2, true); // Wears the second whitelisted hat
+      const canPropose = await localAdapter.isProposer(user1.address);
+      void expect(canPropose).to.be.true;
+    });
+  });
+
+  describe('getVersion', () => {
+    it('should return the correct version', async () => {
+      expect(await adapter.getVersion()).to.equal(1n);
+    });
+  });
+
+  describe('supportsInterface', () => {
+    it('should support IProposerAdapterV1, IProposerAdapterBaseV1, IVersion and IERC165', async () => {
+      const iProposerAdapterV1Interface = IProposerAdapterV1__factory.createInterface();
+      const iProposerAdapterBaseV1Interface = IProposerAdapterBaseV1__factory.createInterface();
+      const iVersionInterface = IVersion__factory.createInterface();
+      const iERC165Interface = IERC165__factory.createInterface();
+
+      const iProposerAdapterV1Id = calculateInterfaceId(iProposerAdapterV1Interface);
+      const iProposerAdapterBaseV1Id = calculateInterfaceId(iProposerAdapterBaseV1Interface);
+      const iVersionId = calculateInterfaceId(iVersionInterface);
+      const iERC165Id = calculateInterfaceId(iERC165Interface);
+
+      void expect(await adapter.supportsInterface(iProposerAdapterV1Id)).to.be.true;
+      void expect(await adapter.supportsInterface(iProposerAdapterBaseV1Id)).to.be.true;
+      void expect(await adapter.supportsInterface(iVersionId)).to.be.true;
+      void expect(await adapter.supportsInterface(iERC165Id)).to.be.true;
+    });
+
+    it('should not support a random interfaceId', async () => {
+      const randomInterfaceId = '0x12345678';
+      void expect(await adapter.supportsInterface(randomInterfaceId)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/284

Fixes [ENG-978](https://linear.app/decent-labs/issue/ENG-978/implement-hatsproposeradapterv1-for-strategyv1)

**High-Level Context:**

This Pull Request introduces `HatsProposerAdapterV1.sol`, a new concrete implementation of the `IProposerAdapterV1` interface. This adapter integrates with the Hats Protocol, enabling the `StrategyV1` governance engine to determine proposer eligibility based on whether an address is a "wearer" of one or more specified Hat IDs. This adds a powerful and flexible dimension to how proposal creation rights can be configured within DAOs using our system.

**Specific Changes in this PR:**

1.  **`HatsProposerAdapterV1.sol` (New Contract):**
    *   **Core Functionality:** An adapter to determine proposer eligibility based on an address wearing specific Hats Protocol IDs.
    *   **Interfaces Implemented:** `IProposerAdapterV1`, `Initializable`, `ERC165`, `Version`. (Note: This adapter is immutable after initialization, not Ownable or UUPSUpgradeable).
    *   **State Variables:**
        *   `hatsContract`: Stores the `IHats` contract instance.
        *   `whitelistedHatIds`: An array `uint256[] private` storing the Hat IDs that grant proposer rights.
    *   **Errors:** `MissingHatsContract`, `NoHatsWhitelisted`, `HatAlreadyWhitelisted`.
    *   **Constructor:** Calls `_disableInitializers()`.
    *   **`initialize(address _hatsContractAddress, uint256[] memory _whitelistedHats)`:**
        *   Sets the Hats Protocol contract address and the initial list of whitelisted Hat IDs.
        *   Validates `_hatsContractAddress` is not a zero address (reverts `MissingHatsContract`).
        *   Validates `_whitelistedHats` is not empty (reverts `NoHatsWhitelisted`).
        *   Validates that there are no duplicate Hat IDs in `_whitelistedHats` during initialization (reverts `HatAlreadyWhitelisted`).
    *   **`getWhitelistedHatIds()` (View Function):**
        *   Returns the array of `whitelistedHatIds`.
    *   **`IProposerAdapterBaseV1` Implementation:**
        *   `isProposer(address _proposer)`: Iterates through `whitelistedHatIds` and calls `hatsContract.isWearerOfHat(_proposer, hatId)`. Returns `true` if the address wears any of the whitelisted hats, `false` otherwise.
    *   **Version & ERC165:** Implements `getVersion()` and `supportsInterface()` (for `IProposerAdapterV1`, `IProposerAdapterBaseV1`, and `ERC165`).

2.  **Test Suite `HatsProposerAdapterV1.test.ts` (New File):**
    *   Comprehensive unit tests for `HatsProposerAdapterV1`.
    *   Covers:
        *   Correct initialization via a proxy with valid parameters.
        *   Reverts on invalid initialization parameters (zero Hats contract address, empty whitelisted hats list, duplicate hat IDs in initial list).
        *   Prevention of re-initialization.
        *   `isProposer` logic:
            *   Returns `true` if a user wears one of the whitelisted hats.
            *   Returns `false` if a user does not wear any whitelisted hat (even if they wear other hats).
            *   Returns `false` if a user wears no hats at all.
            *   Correctly handles multiple whitelisted hats.
        *   `getWhitelistedHatIds()` returns the correct list.
        *   `getVersion()` functionality.
        *   ERC165 `supportsInterface()` for relevant interfaces.

**Impact and Status:**

*   This PR adds a new, specialized Proposer Adapter, enhancing `StrategyV1`'s flexibility in defining who can create proposals.
*   The adapter's configuration (Hats contract and whitelisted Hat IDs) is immutable after initialization.
*   **Compilation Status:** All new and modified contracts should compile successfully.
*   **Testing Status:** The new `HatsProposerAdapterV1.test.ts` suite validates the functionality of this adapter. The overall project test suite should remain in its current state. This PR itself should not introduce new failures outside its specific scope.