### PR TITLE
refactor(FractalModuleV1)!: Remove Controller Functionality, Rely on Ownable

### DIFF
--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -6,15 +6,6 @@ import {IFractalModuleV1} from "../../interfaces/decent/deployables/IFractalModu
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-/**
- * Implementation of [IFractalModule](./interfaces/IFractalModule.md).
- *
- * A Safe module contract that allows for a "parent-child" DAO relationship.
- *
- * Adding the module allows for a designated set of addresses to execute
- * transactions on the Safe, which in our implementation is the set of parent
- * DAOs.
- */
 contract FractalModuleV1 is
     IFractalModuleV1,
     GuardableModule,
@@ -23,97 +14,42 @@ contract FractalModuleV1 is
 {
     uint16 private constant VERSION = 1;
 
-    /** Mapping of whether an address is a controller (typically a parentDAO). */
-    mapping(address => bool) public controllers;
-
-    event ControllersAdded(address[] controllers);
-    event ControllersRemoved(address[] controllers);
-
-    error Unauthorized();
     error TxFailed();
-
-    /** Allows only authorized controllers to execute transactions on the Safe. */
-    modifier onlyAuthorized() {
-        if (owner() != msg.sender && !controllers[msg.sender])
-            revert Unauthorized();
-        _;
-    }
 
     constructor() {
         _disableInitializers();
     }
 
-    /**
-     * Initialize function for the UUPS pattern.
-     *
-     * @param _owner Address that will own the contract
-     * @param _avatar Address of the avatar (e.g., the Safe)
-     * @param _target Address that avatar calls are directed to
-     * @param _controllers Array of controller addresses to enable
-     */
     function initialize(
         address _owner,
         address _avatar,
-        address _target,
-        address[] memory _controllers
+        address _target
     ) public initializer {
         // Initializer owner with the msg.sender first,
         // needed for setting the avatar and target, which are ownable functions
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
 
-        // Setup module parameters
         setAvatar(_avatar);
         setTarget(_target);
-        addControllers(_controllers);
 
         // Transfer ownership to the provided owner
         transferOwnership(_owner);
     }
 
-    /**
-     * Initialize function, will be triggered when a new instance is deployed.
-     *
-     * @param initializeParams encoded initialization parameters: `address _owner`,
-     * `address _avatar`, `address _target`, `address[] memory _controllers`
-     */
     function setUp(bytes memory initializeParams) public override initializer {
-        (
-            address _owner, // controlling DAO
-            address _avatar,
-            address _target,
-            address[] memory _controllers // authorized controllers
-        ) = abi.decode(
-                initializeParams,
-                (address, address, address, address[])
-            );
-        initialize(_owner, _avatar, _target, _controllers);
+        (address _owner, address _avatar, address _target) = abi.decode(
+            initializeParams,
+            (address, address, address)
+        );
+        initialize(_owner, _avatar, _target);
     }
 
-    /**
-     * @dev Function that authorizes an upgrade to a new implementation.
-     * @param newImplementation The address of the new implementation
-     */
     function _authorizeUpgrade(
         address newImplementation
     ) internal virtual override onlyOwner {}
 
-    /** @inheritdoc IFractalModuleV1*/
-    function removeControllers(
-        address[] memory _controllers
-    ) external onlyOwner {
-        uint256 controllersLength = _controllers.length;
-        for (uint256 i; i < controllersLength; ) {
-            controllers[_controllers[i]] = false;
-            unchecked {
-                ++i;
-            }
-        }
-        emit ControllersRemoved(_controllers);
-    }
-
-    /** @inheritdoc IFractalModuleV1*/
-    function execTx(bytes memory execTxData) public onlyAuthorized {
+    function execTx(bytes memory execTxData) public onlyOwner {
         (
             address _target,
             uint256 _value,
@@ -123,26 +59,10 @@ contract FractalModuleV1 is
         if (!exec(_target, _value, _data, _operation)) revert TxFailed();
     }
 
-    /** @inheritdoc IFractalModuleV1*/
-    function addControllers(address[] memory _controllers) public onlyOwner {
-        uint256 controllersLength = _controllers.length;
-        for (uint256 i; i < controllersLength; ) {
-            controllers[_controllers[i]] = true;
-            unchecked {
-                ++i;
-            }
-        }
-        emit ControllersAdded(_controllers);
-    }
-
-    /// Implementation for the version
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;
     }
 
-    /**
-     * Implementation of ERC165 for this contract.
-     */
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {

--- a/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
+++ b/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
@@ -4,34 +4,6 @@ pragma solidity ^0.8.30;
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-/**
- * A specification for a Safe module contract that allows for a "parent-child"
- * DAO relationship.
- *
- * Adding the module should allow for a designated set of addresses to execute
- * transactions on the Safe, which in our implementation is the set of parent
- * DAOs.
- */
 interface IFractalModuleV1 {
-    /**
-     * Allows an authorized address to execute arbitrary transactions on the Safe.
-     *
-     * @param execTxData data of the transaction to execute
-     */
     function execTx(bytes memory execTxData) external;
-
-    /**
-     * Adds `_controllers` to the list of controllers, which are allowed
-     * to execute transactions on the Safe.
-     *
-     * @param _controllers addresses to add to the contoller list
-     */
-    function addControllers(address[] memory _controllers) external;
-
-    /**
-     * Removes `_controllers` from the list of controllers.
-     *
-     * @param _controllers addresses to remove from the controller list
-     */
-    function removeControllers(address[] memory _controllers) external;
 }

--- a/test/deployables/modules/FractalModuleV1.test.ts
+++ b/test/deployables/modules/FractalModuleV1.test.ts
@@ -24,16 +24,12 @@ async function deployFractalModuleProxy(
   owner: SignerWithAddress,
   avatar: string,
   target: string,
-  controllers: string[],
 ): Promise<FractalModuleV1> {
   // Combine selector and encoded params
   const fullInitData =
     FractalModuleV1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
-      .encode(
-        ['address', 'address', 'address', 'address[]'],
-        [owner.address, avatar, target, controllers],
-      )
+      .encode(['address', 'address', 'address'], [owner.address, avatar, target])
       .slice(2);
 
   // Deploy the proxy with the implementation
@@ -50,13 +46,12 @@ async function deployFractalModuleProxyWithSetUp(
   owner: SignerWithAddress,
   avatar: string,
   target: string,
-  controllers: string[],
 ): Promise<FractalModuleV1> {
   // Create the call to setUp with the encoded parameters
   const fullInitData = FractalModuleV1__factory.createInterface().encodeFunctionData('setUp', [
     ethers.AbiCoder.defaultAbiCoder().encode(
-      ['address', 'address', 'address', 'address[]'],
-      [owner.address, avatar, target, controllers],
+      ['address', 'address', 'address'],
+      [owner.address, avatar, target],
     ),
   ]);
 
@@ -72,7 +67,6 @@ describe('FractalModuleV1', () => {
   let proxyDeployer: SignerWithAddress;
   let owner: SignerWithAddress;
   let nonOwner: SignerWithAddress;
-  let controller: SignerWithAddress;
   let user: SignerWithAddress;
 
   // mocks and mastercopies
@@ -81,7 +75,7 @@ describe('FractalModuleV1', () => {
 
   beforeEach(async () => {
     // Get signers
-    [proxyDeployer, owner, nonOwner, controller, user] = await ethers.getSigners();
+    [proxyDeployer, owner, nonOwner, user] = await ethers.getSigners();
 
     // Deploy implementation contract
     const implementation = await new FractalModuleV1__factory(proxyDeployer).deploy();
@@ -105,7 +99,6 @@ describe('FractalModuleV1', () => {
           owner,
           await avatar.getAddress(),
           await avatar.getAddress(),
-          [],
         );
 
         expect(await fractalModule.owner()).to.equal(owner.address);
@@ -120,7 +113,6 @@ describe('FractalModuleV1', () => {
           owner,
           await avatar.getAddress(),
           await avatar.getAddress(),
-          [],
         );
 
         expect(await fractalModule.avatar()).to.equal(await avatar.getAddress());
@@ -134,7 +126,6 @@ describe('FractalModuleV1', () => {
           owner,
           await avatar.getAddress(),
           user.address, // Different from avatar
-          [],
         );
 
         expect(await fractalModule.avatar()).to.equal(await avatar.getAddress());
@@ -148,7 +139,6 @@ describe('FractalModuleV1', () => {
           owner,
           ethers.ZeroAddress,
           await avatar.getAddress(),
-          [],
         );
 
         expect(await fractalModule.avatar()).to.equal(ethers.ZeroAddress);
@@ -162,7 +152,6 @@ describe('FractalModuleV1', () => {
           owner,
           await avatar.getAddress(),
           ethers.ZeroAddress,
-          [],
         );
 
         expect(await fractalModule.avatar()).to.equal(await avatar.getAddress());
@@ -176,89 +165,10 @@ describe('FractalModuleV1', () => {
           owner,
           ethers.ZeroAddress,
           ethers.ZeroAddress,
-          [],
         );
 
         expect(await fractalModule.avatar()).to.equal(ethers.ZeroAddress);
         expect(await fractalModule.getFunction('target')()).to.equal(ethers.ZeroAddress);
-      });
-    });
-
-    describe('Controllers parameter', () => {
-      describe('No controllers', () => {
-        it('should initialize with no controllers', async () => {
-          fractalModule = await deployFractalModuleProxy(
-            proxyDeployer,
-            masterCopy,
-            owner,
-            await avatar.getAddress(),
-            await avatar.getAddress(),
-            [], // empty controllers array
-          );
-
-          void expect(await fractalModule.controllers(owner.address)).to.be.false;
-          void expect(await fractalModule.controllers(controller.address)).to.be.false;
-          void expect(await fractalModule.controllers(user.address)).to.be.false;
-        });
-      });
-
-      describe('Single controller', () => {
-        it('should initialize with single controller', async () => {
-          fractalModule = await deployFractalModuleProxy(
-            proxyDeployer,
-            masterCopy,
-            owner,
-            await avatar.getAddress(),
-            await avatar.getAddress(),
-            [controller.address],
-          );
-
-          void expect(await fractalModule.controllers(controller.address)).to.be.true;
-          void expect(await fractalModule.controllers(owner.address)).to.be.false;
-          void expect(await fractalModule.controllers(user.address)).to.be.false;
-        });
-      });
-
-      describe('Multiple controllers', () => {
-        it('should initialize with multiple controllers', async () => {
-          const controllers = [controller.address, user.address];
-          fractalModule = await deployFractalModuleProxy(
-            proxyDeployer,
-            masterCopy,
-            owner,
-            await avatar.getAddress(),
-            await avatar.getAddress(),
-            controllers,
-          );
-
-          void expect(await fractalModule.controllers(controller.address)).to.be.true;
-          void expect(await fractalModule.controllers(user.address)).to.be.true;
-          void expect(await fractalModule.controllers(owner.address)).to.be.false;
-        });
-
-        it('should not allow duplicate controllers', async () => {
-          const controllers = [controller.address, controller.address];
-
-          // The second controller.address will overwrite the first one's mapping,
-          // but both will emit events. This is expected behavior from the contract.
-          fractalModule = await deployFractalModuleProxy(
-            proxyDeployer,
-            masterCopy,
-            owner,
-            await avatar.getAddress(),
-            await avatar.getAddress(),
-            controllers,
-          );
-
-          // Verify the controller is still enabled (only once)
-          void expect(await fractalModule.controllers(controller.address)).to.be.true;
-
-          // Verify that a ControllersAdded event was emitted with both addresses
-          const filter = fractalModule.filters.ControllersAdded;
-          const events = await fractalModule.queryFilter(filter);
-          expect(events.length).to.equal(1);
-          expect(events[0].args[0]).to.deep.equal(controllers);
-        });
       });
     });
 
@@ -270,14 +180,12 @@ describe('FractalModuleV1', () => {
           owner,
           await avatar.getAddress(),
           await avatar.getAddress(),
-          [controller.address],
         );
 
         // Verify initialization was successful
         expect(await fractalModule.owner()).to.equal(owner.address);
         expect(await fractalModule.avatar()).to.equal(await avatar.getAddress());
         expect(await fractalModule.getFunction('target')()).to.equal(await avatar.getAddress());
-        void expect(await fractalModule.controllers(controller.address)).to.be.true;
       });
 
       it('should not allow setUp to be called again after initialization', async () => {
@@ -287,18 +195,12 @@ describe('FractalModuleV1', () => {
           owner,
           await avatar.getAddress(),
           await avatar.getAddress(),
-          [controller.address],
         );
 
         // Encode parameters correctly for setUp
         const innerParams = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'address', 'address', 'address[]'],
-          [
-            owner.address,
-            await avatar.getAddress(),
-            await avatar.getAddress(),
-            [controller.address],
-          ],
+          ['address', 'address', 'address'],
+          [owner.address, await avatar.getAddress(), await avatar.getAddress()],
         );
 
         // Attempt to call setUp again - should revert
@@ -317,128 +219,11 @@ describe('FractalModuleV1', () => {
           owner,
           await avatar.getAddress(),
           await avatar.getAddress(),
-          [],
         );
 
         await expect(
-          fractalModule.initialize(owner.address, ethers.ZeroAddress, ethers.ZeroAddress, []),
+          fractalModule.initialize(owner.address, ethers.ZeroAddress, ethers.ZeroAddress),
         ).to.be.revertedWithCustomError(fractalModule, 'InvalidInitialization');
-      });
-    });
-  });
-
-  describe('Controller Management', () => {
-    let fractalModule: FractalModuleV1;
-    let avatar: MockAvatar;
-
-    beforeEach(async () => {
-      avatar = await new MockAvatar__factory(proxyDeployer).deploy();
-      fractalModule = await deployFractalModuleProxy(
-        proxyDeployer,
-        masterCopy,
-        owner,
-        await avatar.getAddress(),
-        await avatar.getAddress(),
-        [],
-      );
-    });
-
-    describe('Adding controllers', () => {
-      describe('Via owner', () => {
-        it('should allow owner to add single controller', async () => {
-          await fractalModule.addControllers([controller.address]);
-          void expect(await fractalModule.controllers(controller.address)).to.be.true;
-        });
-
-        it('should allow owner to add multiple controllers', async () => {
-          const controllers = [controller.address, user.address];
-          await fractalModule.addControllers(controllers);
-
-          void expect(await fractalModule.controllers(controller.address)).to.be.true;
-          void expect(await fractalModule.controllers(user.address)).to.be.true;
-        });
-
-        it('should emit ControllersAdded event', async () => {
-          const controllers = [controller.address, user.address];
-          await expect(fractalModule.addControllers(controllers))
-            .to.emit(fractalModule, 'ControllersAdded')
-            .withArgs(controllers);
-        });
-
-        it('should properly update controllers mapping', async () => {
-          // Check initial state
-          void expect(await fractalModule.controllers(controller.address)).to.be.false;
-          void expect(await fractalModule.controllers(user.address)).to.be.false;
-
-          // Add controllers
-          const controllers = [controller.address, user.address];
-          await fractalModule.addControllers(controllers);
-
-          // Verify mapping is updated
-          void expect(await fractalModule.controllers(controller.address)).to.be.true;
-          void expect(await fractalModule.controllers(user.address)).to.be.true;
-          void expect(await fractalModule.controllers(owner.address)).to.be.false; // Owner not added as controller
-        });
-      });
-
-      describe('Via non-owner', () => {
-        it('should not allow non-owner to add controllers', async () => {
-          await expect(
-            fractalModule.connect(user).addControllers([controller.address]),
-          ).to.be.revertedWithCustomError(fractalModule, 'OwnableUnauthorizedAccount');
-        });
-      });
-    });
-
-    describe('Removing controllers', () => {
-      describe('Via owner', () => {
-        beforeEach(async () => {
-          // Add controllers for testing removal
-          await fractalModule.addControllers([controller.address, user.address]);
-        });
-
-        it('should allow owner to remove single controller', async () => {
-          await fractalModule.removeControllers([controller.address]);
-          void expect(await fractalModule.controllers(controller.address)).to.be.false;
-          void expect(await fractalModule.controllers(user.address)).to.be.true; // Other controller still enabled
-        });
-
-        it('should allow owner to remove multiple controllers', async () => {
-          const controllers = [controller.address, user.address];
-          await fractalModule.removeControllers(controllers);
-
-          void expect(await fractalModule.controllers(controller.address)).to.be.false;
-          void expect(await fractalModule.controllers(user.address)).to.be.false;
-        });
-
-        it('should emit ControllersRemoved event', async () => {
-          const controllers = [controller.address, user.address];
-          await expect(fractalModule.removeControllers(controllers))
-            .to.emit(fractalModule, 'ControllersRemoved')
-            .withArgs(controllers);
-        });
-
-        it('should properly update controllers mapping', async () => {
-          // Verify initial state
-          void expect(await fractalModule.controllers(controller.address)).to.be.true;
-          void expect(await fractalModule.controllers(user.address)).to.be.true;
-
-          // Remove controllers
-          const controllers = [controller.address, user.address];
-          await fractalModule.removeControllers(controllers);
-
-          // Verify mapping is updated
-          void expect(await fractalModule.controllers(controller.address)).to.be.false;
-          void expect(await fractalModule.controllers(user.address)).to.be.false;
-        });
-      });
-
-      describe('Via non-owner', () => {
-        it('should not allow non-owner to remove controllers', async () => {
-          await expect(
-            fractalModule.connect(user).removeControllers([controller.address]),
-          ).to.be.revertedWithCustomError(fractalModule, 'OwnableUnauthorizedAccount');
-        });
       });
     });
   });
@@ -455,7 +240,6 @@ describe('FractalModuleV1', () => {
         owner,
         await avatar.getAddress(),
         await avatar.getAddress(),
-        [controller.address],
       );
       await avatar.enableModule(await fractalModule.getAddress());
     });
@@ -482,16 +266,10 @@ describe('FractalModuleV1', () => {
         expect(await mockToken.balanceOf(user.address)).to.equal(100);
       });
 
-      it('should allow controller to execute transactions', async () => {
-        await mockToken.mint(await avatar.getAddress(), 1000);
-        await fractalModule.connect(controller).execTx(txData);
-        expect(await mockToken.balanceOf(user.address)).to.equal(100);
-      });
-
-      it('should revert with Unauthorized for non-owner/non-controller', async () => {
+      it('should revert with OwnableUnauthorizedAccount for non-owner', async () => {
         await expect(fractalModule.connect(user).execTx(txData)).to.be.revertedWithCustomError(
           fractalModule,
-          'Unauthorized',
+          'OwnableUnauthorizedAccount',
         );
       });
     });
@@ -630,7 +408,6 @@ describe('FractalModuleV1', () => {
         owner,
         ethers.ZeroAddress,
         ethers.ZeroAddress,
-        [],
       );
     });
 
@@ -654,7 +431,6 @@ describe('FractalModuleV1', () => {
         owner,
         ethers.ZeroAddress,
         ethers.ZeroAddress,
-        [],
       );
 
       // Dynamically calculate interface IDs
@@ -701,7 +477,6 @@ describe('FractalModuleV1', () => {
         owner,
         ethers.ZeroAddress,
         ethers.ZeroAddress,
-        [],
       );
     });
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/285

Fixes [ENG-980](https://linear.app/decent-labs/issue/ENG-980/refactor-fractalmodulev1-to-remove-controller-functionality)

**High-Level Context:**

This Pull Request simplifies the `FractalModuleV1` by removing the "controllers" feature. The original design allowed a list of designated controller addresses (in addition to the owner) to execute transactions through the module. This functionality was found to be largely unused in practice and added unnecessary complexity.

This refactoring streamlines the module's authorization model to rely solely on the standard OpenZeppelin `Ownable2StepUpgradeable` pattern. Only the owner of the `FractalModuleV1` instance will now be authorized to execute transactions via `execTx`.

**Specific Changes in this PR:**

1.  **State Variable Removal:**
    *   The `mapping(address => bool) public controllers;` state variable has been removed.

2.  **Event Removal:**
    *   The `ControllersAdded(address[] controllers)` and `ControllersRemoved(address[] controllers)` events have been removed.

3.  **Error Removal:**
    *   The `Unauthorized()` error, previously used by the `onlyAuthorized` modifier, has been removed.

4.  **Modifier Removal:**
    *   The `onlyAuthorized` modifier, which checked if `msg.sender` was the owner or a registered controller, has been removed.

5.  **Function Modification:**
    *   `initialize(address _owner, address _avatar, address _target, address[] memory _controllers)`:
        *   The `_controllers` parameter has been removed.
        *   The call to `addControllers(_controllers)` has been removed.
    *   `setUp(bytes memory initializeParams)`:
        *   The `abi.decode` no longer expects or decodes `address[] memory _controllers`.
        *   The `_controllers` argument is removed from the call to `initialize`.
    *   `execTx(bytes memory execTxData)`:
        *   The `onlyAuthorized` modifier has been replaced with `onlyOwner`. Now, only the owner of the `FractalModuleV1` can call this function.

6.  **Function Removal:**
    *   `addControllers(address[] memory _controllers)` has been removed.
    *   `removeControllers(address[] memory _controllers)` has been removed.

7.  **Interface `IFractalModuleV1.sol` Simplification:**
    *   Removed declarations for `addControllers` and `removeControllers`.
    *   Updated NatSpec/comments to remove references to controllers.

8.  **Test Suite (`FractalModuleV1.test.ts`) Updates:**
    *   Deployment helpers (`deployFractalModuleProxy`, `deployFractalModuleProxyWithSetUp`) updated to remove the `controllers` parameter.
    *   Removed all tests related to adding, removing, and checking controller status.
    *   Tests for `execTx` updated:
        *   Removed tests for execution by a controller.
        *   The test for execution by a non-authorized party now checks for `OwnableUnauthorizedAccount` (from `onlyOwner`) instead of the custom `Unauthorized` error.

**Impact and Status:**

*   **Breaking Change:** This is a breaking change to the `FractalModuleV1` interface and initialization, as the controller-related functions and parameters are removed.
*   **Simplified Authorization:** The module now has a simpler, purely Ownable-based authorization model for its `execTx` function.
*   **Reduced Complexity:** The contract code and its external interface are significantly simplified.
*   **Compilation Status:** All contracts should compile successfully.
*   **Testing Status:** All tests have been updated to reflect the removal of controller functionality and the shift to `onlyOwner` for `execTx`. The test suite should pass.

This change streamlines `FractalModuleV1` by removing an underutilized feature, making the contract easier to understand, audit, and maintain.