### PR TITLE
refactor(Ownership)!: Standardize to Ownable2Step

### DIFF
--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -10,17 +10,19 @@ import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint
 import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 contract DecentPaymasterV1 is
     IDecentPaymasterV1,
     Version,
     BasePaymasterV1,
     SmartAccountValidationV1,
+    Ownable2StepUpgradeable,
     UUPSUpgradeable
 {
     uint16 private constant VERSION = 1;
 
-    // Mapping: contract address => function selector => validator contract
     mapping(address => mapping(bytes4 => address)) private _functionValidators;
 
     event FunctionValidatorSet(
@@ -38,13 +40,6 @@ contract DecentPaymasterV1 is
         _disableInitializers();
     }
 
-    /**
-     * Initialize function for the proxy deployment. This standardizes the initialization
-     * to better work with ProxyFactory.
-     *
-     * @param _owner Address that will own the proxy and be able to upgrade it
-     * @param _entryPoint The EntryPoint address this paymaster will work with
-     */
     function initialize(
         address _owner,
         address _entryPoint,
@@ -54,24 +49,10 @@ contract DecentPaymasterV1 is
         __SmartAccountValidationV1_init(_lightAccountFactory);
     }
 
-    /**
-     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
-     * Called by {upgradeTo} and {upgradeToAndCall}.
-     *
-     * Reverts if the sender is not the owner of the contract.
-     */
     function _authorizeUpgrade(
         address newImplementation
-    ) internal virtual override onlyOwner {
-        // Authorization is handled by the onlyOwner modifier
-    }
+    ) internal virtual override onlyOwner {}
 
-    /**
-     * Set validator for a specific function
-     * @param target The target contract address
-     * @param selector Function selector to validate
-     * @param validator Address of the validator contract
-     */
     function setFunctionValidator(
         address target,
         bytes4 selector,
@@ -79,7 +60,6 @@ contract DecentPaymasterV1 is
     ) external onlyOwner {
         if (validator == address(0)) revert InvalidValidator();
 
-        // Verify the validator implements IFunctionValidator interface
         if (
             !IFunctionValidator(validator).supportsInterface(
                 type(IFunctionValidator).interfaceId
@@ -92,11 +72,6 @@ contract DecentPaymasterV1 is
         emit FunctionValidatorSet(target, selector, validator);
     }
 
-    /**
-     * Remove validator for a specific function
-     * @param target The target contract address
-     * @param selector Function selector to remove validation for
-     */
     function removeFunctionValidator(
         address target,
         bytes4 selector
@@ -105,12 +80,6 @@ contract DecentPaymasterV1 is
         emit FunctionValidatorRemoved(target, selector);
     }
 
-    /*
-     * Get a function's validator
-     * @param target The contract address
-     * @param selector The function selector to check
-     * @return address The validator address, or zero if no validator is set
-     */
     function getFunctionValidator(
         address target,
         bytes4 selector
@@ -118,7 +87,6 @@ contract DecentPaymasterV1 is
         return _functionValidators[target][selector];
     }
 
-    /// @inheritdoc BasePaymasterV1
     function _validatePaymasterUserOp(
         PackedUserOperation calldata userOp,
         bytes32,
@@ -162,7 +130,6 @@ contract DecentPaymasterV1 is
         return (abi.encode(), 0);
     }
 
-    /// @inheritdoc Version
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;
     }
@@ -174,5 +141,17 @@ contract DecentPaymasterV1 is
             interfaceId == type(IDecentPaymasterV1).interfaceId ||
             interfaceId == type(IPaymaster).interfaceId ||
             super.supportsInterface(interfaceId);
+    }
+
+    function _transferOwnership(
+        address newOwner
+    ) internal virtual override(Ownable2StepUpgradeable, OwnableUpgradeable) {
+        Ownable2StepUpgradeable._transferOwnership(newOwner);
+    }
+
+    function transferOwnership(
+        address newOwner
+    ) public override(Ownable2StepUpgradeable, OwnableUpgradeable) onlyOwner {
+        Ownable2StepUpgradeable.transferOwnership(newOwner);
     }
 }

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -5,47 +5,10 @@ import {IHatsElectionsEligibility} from "../../interfaces/hats/modules/IHatsElec
 import {IDecentAutonomousAdminV1} from "../../interfaces/decent/deployables/IDecentAutonomousAdminV1.sol";
 import {Version} from "../Version.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
-contract DecentAutonomousAdminV1 is
-    IDecentAutonomousAdminV1,
-    Version,
-    UUPSUpgradeable,
-    OwnableUpgradeable
-{
+contract DecentAutonomousAdminV1 is IDecentAutonomousAdminV1, Version {
     uint16 private constant VERSION = 1;
 
-    constructor() {
-        _disableInitializers();
-    }
-
-    /**
-     * Initialize function for the proxy deployment. This standardizes the initialization
-     * to better work with ProxyFactory.
-     *
-     * @param _owner Address that will own the proxy and be able to upgrade it
-     */
-    function initialize(address _owner) public initializer {
-        __Ownable_init(_owner);
-        __UUPSUpgradeable_init();
-    }
-
-    /**
-     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
-     * Called by {upgradeTo} and {upgradeToAndCall}.
-     *
-     * Reverts if the sender is not the owner of the contract.
-     */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {
-        // Authorization is handled by the onlyOwner modifier
-    }
-
-    // //////////////////////////////////////////////////////////////
-    //                         Public Functions
-    // //////////////////////////////////////////////////////////////
     function triggerStartNextTerm(TriggerStartArgs calldata args) public {
         IHatsElectionsEligibility hatsElectionModule = IHatsElectionsEligibility(
                 args.hatsProtocol.getHatEligibilityModule(args.hatId)
@@ -62,7 +25,6 @@ contract DecentAutonomousAdminV1 is
         }
     }
 
-    /// @inheritdoc Version
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;
     }

--- a/contracts/deployables/erc20/VotesERC20LockableV1.sol
+++ b/contracts/deployables/erc20/VotesERC20LockableV1.sol
@@ -45,20 +45,7 @@ contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20V1 {
             _allocationAmounts,
             _owner
         );
-        _transferOwnership(_owner);
         locked = _locked;
-    }
-
-    /**
-     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
-     * Called by {upgradeTo} and {upgradeToAndCall}.
-     *
-     * Reverts if the sender is not the owner of the contract.
-     */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {
-        // Authorization is handled by the onlyOwner modifier
     }
 
     function lock(bool _locked) external onlyOwner {

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -11,18 +11,14 @@ import {NoncesUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Nonce
 import {ERC20VotesUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
-/**
- * An implementation of the OpenZeppelin `IVotes` voting token standard.
- * Implements the UUPS proxy pattern for upgradeability.
- */
 contract VotesERC20V1 is
     Version,
     ERC20VotesUpgradeable,
     ERC20PermitUpgradeable,
     UUPSUpgradeable,
-    OwnableUpgradeable
+    Ownable2StepUpgradeable
 {
     uint16 private constant VERSION = 1;
 
@@ -30,15 +26,6 @@ contract VotesERC20V1 is
         _disableInitializers();
     }
 
-    /**
-     * Initialize function, will be triggered when a new proxy instance is deployed.
-     *
-     * @param name Token name
-     * @param symbol Token symbol
-     * @param allocationAddresses Addresses of initial allocations
-     * @param allocationAmounts Amounts of initial allocations
-     * @param owner Address that will own the proxy and be able to upgrade it
-     */
     function initialize(
         string memory name,
         string memory symbol,
@@ -61,24 +48,16 @@ contract VotesERC20V1 is
         }
     }
 
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal virtual override onlyOwner {}
+
     function clock() public view override returns (uint48) {
         return uint48(block.timestamp);
     }
 
     function CLOCK_MODE() public pure override returns (string memory) {
         return "mode=timestamp";
-    }
-
-    /**
-     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
-     * Called by {upgradeTo} and {upgradeToAndCall}.
-     *
-     * Reverts if the sender is not the owner of the contract.
-     */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {
-        // Authorization is handled by the onlyOwner modifier
     }
 
     function _update(
@@ -101,7 +80,6 @@ contract VotesERC20V1 is
         return super.nonces(owner);
     }
 
-    /// @inheritdoc Version
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;
     }

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -6,19 +6,9 @@ import {Version} from "../Version.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
-/**
- * A Safe Transaction Guard contract that prevents an [Azorius](./azorius/Azorius.md)
- * subDAO from executing transactions if it has been frozen by its parentDAO.
- *
- * See https://docs.safe.global/learn/safe-core/safe-core-protocol/guards.
- */
 contract AzoriusFreezeGuardV1 is Version, BaseFreezeGuardV1 {
     uint16 private constant VERSION = 1;
 
-    /**
-     * A reference to the freeze voting contract, which manages the freeze
-     * voting process and maintains the frozen / unfrozen state of the DAO.
-     */
     IBaseFreezeVotingV1 public freezeVoting;
 
     event AzoriusFreezeGuardSetUp(
@@ -33,42 +23,16 @@ contract AzoriusFreezeGuardV1 is Version, BaseFreezeGuardV1 {
         _disableInitializers();
     }
 
-    /**
-     * Initialize function for the proxy deployment. This standardizes the initialization
-     * to better work with ProxyFactory.
-     *
-     * @param _owner Address that will own the proxy and be able to upgrade it
-     * @param _freezeVoting Address of the freeze voting contract
-     */
     function initialize(
         address _owner,
         address _freezeVoting
     ) public initializer {
-        super.initialize(_owner);
+        __BaseFreezeGuardV1_init(_owner);
         freezeVoting = IBaseFreezeVotingV1(_freezeVoting);
 
         emit AzoriusFreezeGuardSetUp(msg.sender, _owner, _freezeVoting);
     }
 
-    /**
-     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
-     * Called by {upgradeTo} and {upgradeToAndCall}.
-     *
-     * Reverts if the sender is not the owner of the contract.
-     */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {
-        // Authorization is handled by the onlyOwner modifier
-    }
-
-    /**
-     * This function is called by the Safe to check if the transaction
-     * is able to be executed and reverts if the guard conditions are
-     * not met.
-     *
-     * In our implementation, this reverts if the DAO is frozen.
-     */
     function checkTransaction(
         address,
         uint256,
@@ -82,23 +46,14 @@ contract AzoriusFreezeGuardV1 is Version, BaseFreezeGuardV1 {
         bytes memory,
         address
     ) external view override(BaseFreezeGuardV1) {
-        // if the DAO is currently frozen, revert
-        // see BaseFreezeVoting for freeze voting details
         if (freezeVoting.isFrozen()) revert DAOFrozen();
     }
 
-    /**
-     * A callback performed after a transaction is executed on the Safe. This is a required
-     * function of the `BaseGuard` and `IGuard` interfaces that we do not make use of.
-     */
     function checkAfterExecution(
         bytes32,
         bool
-    ) external view override(BaseFreezeGuardV1) {
-        // not implementated
-    }
+    ) external view override(BaseFreezeGuardV1) {}
 
-    /// @inheritdoc Version
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;
     }

--- a/contracts/deployables/freeze-guard/BaseFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/BaseFreezeGuardV1.sol
@@ -5,52 +5,27 @@ import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 abstract contract BaseFreezeGuardV1 is
     IGuard,
     ERC165,
-    OwnableUpgradeable,
+    Ownable2StepUpgradeable,
     UUPSUpgradeable
 {
     constructor() {
         _disableInitializers();
     }
 
-    /**
-     * Initialize function for the proxy deployment. This standardizes the initialization
-     * to better work with ProxyFactory.
-     *
-     * @param _owner Address that will own the proxy and be able to upgrade it
-     */
-    function initialize(address _owner) public initializer {
+    function __BaseFreezeGuardV1_init(address _owner) public initializer {
         __Ownable_init(_owner);
         __UUPSUpgradeable_init();
     }
 
-    /**
-     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract.
-     * Called by {upgradeTo} and {upgradeToAndCall}.
-     *
-     * Reverts if the sender is not the owner of the contract.
-     */
     function _authorizeUpgrade(
         address newImplementation
-    ) internal virtual override onlyOwner {
-        // Authorization is handled by the onlyOwner modifier
-    }
+    ) internal virtual override onlyOwner {}
 
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override returns (bool) {
-        return
-            interfaceId == type(IGuard).interfaceId ||
-            super.supportsInterface(interfaceId);
-    }
-
-    /// @dev Module transactions only use the first four parameters: to, value, data, and operation.
-    /// Module.sol hardcodes the remaining parameters as 0 since they are not used for module transactions.
-    /// @notice This interface is used to maintain compatibilty with Gnosis Safe transaction guards.
     function checkTransaction(
         address to,
         uint256 value,
@@ -66,4 +41,12 @@ abstract contract BaseFreezeGuardV1 is
     ) external virtual;
 
     function checkAfterExecution(bytes32 txHash, bool success) external virtual;
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IGuard).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -7,12 +7,7 @@ import {IMultisigFreezeGuardV1} from "../../interfaces/decent/deployables/IMulti
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
-/**
- * Implementation of [IMultisigFreezeGuard](./interfaces/IMultisigFreezeGuard.md).
- */
 contract MultisigFreezeGuardV1 is
     IMultisigFreezeGuardV1,
     Version,
@@ -20,22 +15,14 @@ contract MultisigFreezeGuardV1 is
 {
     uint16 private constant VERSION = 1;
 
-    /** Timelock period (in seconds). */
     uint32 public timelockPeriod;
 
-    /** Execution period (in seconds). */
     uint32 public executionPeriod;
 
-    /**
-     * Reference to the [IBaseFreezeVoting](./interfaces/IBaseFreezeVoting.md)
-     * implementation that determines whether the Safe is frozen.
-     */
     IBaseFreezeVotingV1 public freezeVoting;
 
-    /** Reference to the Safe that can be frozen. */
     ISafe public childGnosisSafe;
 
-    /** Mapping of signatures hash to the timestamp during which it was timelocked. */
     mapping(bytes32 => uint48) internal transactionTimelocked;
 
     event MultisigFreezeGuardSetup(
@@ -62,15 +49,6 @@ contract MultisigFreezeGuardV1 is
         _disableInitializers();
     }
 
-    /**
-     * Initialize function, will be triggered when a new instance is deployed.
-     *
-     * @param _timelockPeriod The timelock period in blocks
-     * @param _executionPeriod The execution period in blocks
-     * @param _owner The owner of the contract
-     * @param _freezeVoting The address of the freeze voting contract
-     * @param _childGnosisSafe The address of the child Gnosis Safe
-     */
     function initialize(
         uint32 _timelockPeriod,
         uint32 _executionPeriod,
@@ -78,7 +56,7 @@ contract MultisigFreezeGuardV1 is
         address _freezeVoting,
         address _childGnosisSafe
     ) public initializer {
-        super.initialize(_owner);
+        __BaseFreezeGuardV1_init(_owner);
         _updateTimelockPeriod(_timelockPeriod);
         _updateExecutionPeriod(_executionPeriod);
         freezeVoting = IBaseFreezeVotingV1(_freezeVoting);
@@ -92,15 +70,6 @@ contract MultisigFreezeGuardV1 is
         );
     }
 
-    /**
-     * @dev Function that authorizes an upgrade. Only the owner can upgrade the implementation.
-     * @param newImplementation The address of the new implementation
-     */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {}
-
-    /** @inheritdoc IMultisigFreezeGuardV1*/
     function timelockTransaction(
         address to,
         uint256 value,
@@ -135,7 +104,6 @@ contract MultisigFreezeGuardV1 is
 
         bytes32 transactionHash = keccak256(transactionHashData);
 
-        // if signatures are not valid, this will revert
         childGnosisSafe.checkSignatures(
             transactionHash,
             transactionHashData,
@@ -147,20 +115,14 @@ contract MultisigFreezeGuardV1 is
         emit TransactionTimelocked(msg.sender, transactionHash, signatures);
     }
 
-    /** @inheritdoc IMultisigFreezeGuardV1*/
     function updateTimelockPeriod(uint32 _timelockPeriod) external onlyOwner {
         _updateTimelockPeriod(_timelockPeriod);
     }
 
-    /** @inheritdoc IMultisigFreezeGuardV1*/
     function updateExecutionPeriod(uint32 _executionPeriod) external onlyOwner {
         _updateExecutionPeriod(_executionPeriod);
     }
 
-    /**
-     * Called by the Safe to check if the transaction is able to be executed and reverts
-     * if the guard conditions are not met.
-     */
     function checkTransaction(
         address,
         uint256,
@@ -193,37 +155,27 @@ contract MultisigFreezeGuardV1 is
         if (freezeVoting.isFrozen()) revert DAOFrozen();
     }
 
-    /**
-     * A callback performed after a transaction is executed on the Safe. This is a required
-     * function of the `BaseGuard` and `IGuard` interfaces that we do not make use of.
-     */
     function checkAfterExecution(
         bytes32,
         bool
-    ) external view override(BaseFreezeGuardV1) {
-        // not implementated
-    }
+    ) external view override(BaseFreezeGuardV1) {}
 
-    /** @inheritdoc IMultisigFreezeGuardV1*/
     function getTransactionTimelocked(
         bytes32 _signaturesHash
     ) public view returns (uint48) {
         return transactionTimelocked[_signaturesHash];
     }
 
-    /** Internal implementation of `updateTimelockPeriod` */
     function _updateTimelockPeriod(uint32 _timelockPeriod) internal {
         timelockPeriod = _timelockPeriod;
         emit TimelockPeriodUpdated(_timelockPeriod);
     }
 
-    /** Internal implementation of `updateExecutionPeriod` */
     function _updateExecutionPeriod(uint32 _executionPeriod) internal {
         executionPeriod = _executionPeriod;
         emit ExecutionPeriodUpdated(_executionPeriod);
     }
 
-    /// @inheritdoc Version
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;
     }

--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -3,51 +3,25 @@ pragma solidity ^0.8.30;
 
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-/**
- * The base abstract contract which holds the state of a vote to freeze a childDAO.
- *
- * The freeze feature gives a way for parentDAOs to have a limited measure of control
- * over their created subDAOs.
- *
- * Normally a subDAO operates independently, and can vote on or sign transactions,
- * however should the parent disagree with a decision made by the subDAO, any parent
- * token holder can initiate a vote to "freeze" it, making executing transactions impossible
- * for the time denoted by `freezePeriod`.
- *
- * This requires a number of votes equal to `freezeVotesThreshold`, within the `freezeProposalPeriod`
- * to be successful.
- *
- * Following a successful freeze vote, the childDAO will be unable to execute transactions, due to
- * a Safe Transaction Guard, until the `freezePeriod` has elapsed.
- */
 abstract contract BaseFreezeVotingV1 is
     UUPSUpgradeable,
-    OwnableUpgradeable,
+    Ownable2StepUpgradeable,
     IBaseFreezeVotingV1,
     ERC165
 {
-    /** Timestamp the freeze proposal was created at. */
     uint48 public freezeProposalCreated;
 
-    /** Number of seconds a freeze proposal has to succeed. */
     uint32 public freezeProposalPeriod;
 
-    /** Number of seconds a freeze lasts, from time of freeze proposal creation. */
     uint32 public freezePeriod;
 
-    /** Number of freeze votes required to activate a freeze. */
     uint256 public freezeVotesThreshold;
 
-    /** Number of accrued freeze votes. */
     uint256 public freezeProposalVoteCount;
 
-    /**
-     * Mapping of address to the timestamp the freeze vote was started to
-     * whether the address has voted yet on the freeze proposal.
-     */
     mapping(address => mapping(uint48 => bool)) public userHasFreezeVoted;
 
     event FreezeVoteCast(address indexed voter, uint256 votesCast);
@@ -60,77 +34,52 @@ abstract contract BaseFreezeVotingV1 is
         _disableInitializers();
     }
 
-    /**
-     * @dev Function that authorizes an upgrade. Only the owner can upgrade the implementation.
-     * @param newImplementation The address of the new implementation
-     */
+    function __BaseFreezeVotingV1_init(
+        address _owner,
+        uint32 _freezeProposalPeriod,
+        uint32 _freezePeriod,
+        uint256 _freezeVotesThreshold
+    ) public initializer {
+        __Ownable_init(_owner);
+        __UUPSUpgradeable_init();
+        _updateFreezeProposalPeriod(_freezeProposalPeriod);
+        _updateFreezePeriod(_freezePeriod);
+        _updateFreezeVotesThreshold(_freezeVotesThreshold);
+    }
+
     function _authorizeUpgrade(
         address newImplementation
     ) internal virtual override onlyOwner {}
 
-    /**
-     * Casts a positive vote to freeze the subDAO. This function is intended to be called
-     * by the individual token holders themselves directly, and will allot their token
-     * holdings a "yes" votes towards freezing.
-     *
-     * Additionally, if a vote to freeze is not already running, calling this will initiate
-     * a new vote to freeze it.
-     */
     function castFreezeVote() external virtual;
 
-    /**
-     * Returns true if the DAO is currently frozen, false otherwise.
-     *
-     * @return bool whether the DAO is currently frozen
-     */
     function isFrozen() external view returns (bool) {
         return
             freezeProposalVoteCount >= freezeVotesThreshold &&
             block.timestamp < freezeProposalCreated + freezePeriod;
     }
 
-    /**
-     * Unfreezes the DAO, only callable by the owner (parentDAO).
-     */
     function unfreeze() external onlyOwner {
         freezeProposalCreated = 0;
         freezeProposalVoteCount = 0;
     }
 
-    /**
-     * Updates the freeze votes threshold, the number of votes required to enact a freeze.
-     *
-     * @param _freezeVotesThreshold number of freeze votes required to activate a freeze
-     */
     function updateFreezeVotesThreshold(
         uint256 _freezeVotesThreshold
     ) external onlyOwner {
         _updateFreezeVotesThreshold(_freezeVotesThreshold);
     }
 
-    /**
-     * Updates the freeze proposal period, the time that parent token holders have to cast votes
-     * after a freeze vote has been initiated.
-     *
-     * @param _freezeProposalPeriod number of blocks a freeze vote has to succeed to enact a freeze
-     */
     function updateFreezeProposalPeriod(
         uint32 _freezeProposalPeriod
     ) external onlyOwner {
         _updateFreezeProposalPeriod(_freezeProposalPeriod);
     }
 
-    /**
-     * Updates the freeze period, the time the DAO will be unable to execute transactions for,
-     * should a freeze vote pass.
-     *
-     * @param _freezePeriod number of blocks a freeze lasts, from time of freeze proposal creation
-     */
     function updateFreezePeriod(uint32 _freezePeriod) external onlyOwner {
         _updateFreezePeriod(_freezePeriod);
     }
 
-    /** Internal implementation of `updateFreezeVotesThreshold`. */
     function _updateFreezeVotesThreshold(
         uint256 _freezeVotesThreshold
     ) internal {
@@ -138,7 +87,6 @@ abstract contract BaseFreezeVotingV1 is
         emit FreezeVotesThresholdUpdated(_freezeVotesThreshold);
     }
 
-    /** Internal implementation of `updateFreezeProposalPeriod`. */
     function _updateFreezeProposalPeriod(
         uint32 _freezeProposalPeriod
     ) internal {
@@ -146,7 +94,6 @@ abstract contract BaseFreezeVotingV1 is
         emit FreezeProposalPeriodUpdated(_freezeProposalPeriod);
     }
 
-    /** Internal implementation of `updateFreezePeriod`. */
     function _updateFreezePeriod(uint32 _freezePeriod) internal {
         freezePeriod = _freezePeriod;
         emit FreezePeriodUpdated(_freezePeriod);

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -5,14 +5,9 @@ import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {Version} from "../Version.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 
-/**
- * A [BaseFreezeVoting](./BaseFreezeVoting.md) implementation which handles
- * freezes on ERC20 based token voting DAOs.
- */
 contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
     uint16 private constant VERSION = 1;
 
-    /** A reference to the ERC20 voting token of the subDAO. */
     IVotes public votesERC20;
 
     event ERC20FreezeVotingSetUp(
@@ -27,15 +22,6 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
         _disableInitializers();
     }
 
-    /**
-     * Initialize function, will be triggered when a new instance is deployed.
-     *
-     * @param _owner The owner of the contract
-     * @param _freezeVotesThreshold The number of votes required to activate a freeze
-     * @param _freezeProposalPeriod The number of seconds a freeze proposal has to succeed
-     * @param _freezePeriod The number of seconds a freeze lasts
-     * @param _votesERC20 The ERC20 voting token contract address
-     */
     function initialize(
         address _owner,
         uint256 _freezeVotesThreshold,
@@ -43,31 +29,21 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
         uint32 _freezePeriod,
         address _votesERC20
     ) public initializer {
-        __Ownable_init(_owner);
-        __UUPSUpgradeable_init();
-        _updateFreezeVotesThreshold(_freezeVotesThreshold);
-        _updateFreezeProposalPeriod(_freezeProposalPeriod);
-        _updateFreezePeriod(_freezePeriod);
+        __BaseFreezeVotingV1_init(
+            _owner,
+            _freezeProposalPeriod,
+            _freezePeriod,
+            _freezeVotesThreshold
+        );
         votesERC20 = IVotes(_votesERC20);
 
         emit ERC20FreezeVotingSetUp(_owner, _votesERC20);
     }
 
-    /**
-     * @dev Function that authorizes an upgrade. Only the owner can upgrade the implementation.
-     * @param newImplementation The address of the new implementation
-     */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {}
-
-    /** @inheritdoc BaseFreezeVotingV1*/
     function castFreezeVote() external override {
         uint256 userVotes;
 
         if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
-            // create a new freeze proposal and set total votes to msg.sender's vote count
-
             freezeProposalCreated = uint48(block.timestamp);
 
             userVotes = votesERC20.getPastVotes(
@@ -75,23 +51,26 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
                 freezeProposalCreated - 1
             );
 
-            if (userVotes == 0) revert NoVotes();
+            if (userVotes == 0) {
+                revert NoVotes();
+            }
 
             freezeProposalVoteCount = userVotes;
 
             emit FreezeProposalCreated(msg.sender);
         } else {
-            // there is an existing freeze proposal, count user's votes toward it
-
-            if (userHasFreezeVoted[msg.sender][freezeProposalCreated])
+            if (userHasFreezeVoted[msg.sender][freezeProposalCreated]) {
                 revert AlreadyVoted();
+            }
 
             userVotes = votesERC20.getPastVotes(
                 msg.sender,
                 freezeProposalCreated - 1
             );
 
-            if (userVotes == 0) revert NoVotes();
+            if (userVotes == 0) {
+                revert NoVotes();
+            }
 
             freezeProposalVoteCount += userVotes;
         }
@@ -101,7 +80,6 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
         emit FreezeVoteCast(msg.sender, userVotes);
     }
 
-    /// Implementation for the version
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;
     }

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -6,20 +6,11 @@ import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {Version} from "../Version.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
-/**
- * A [BaseFreezeVoting](./BaseFreezeVoting.md) implementation which handles
- * freezes on ERC721 based token voting DAOs.
- */
 contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
     uint16 private constant VERSION = 1;
 
-    /** A reference to the voting strategy of the parent DAO. */
     IERC721VotingStrategyV1 public strategy;
 
-    /**
-     * Mapping of block the freeze vote was started on, to the token address, to token id,
-     * to whether that token has been used to vote already.
-     */
     mapping(uint256 => mapping(address => mapping(uint256 => bool)))
         public idHasFreezeVoted;
 
@@ -36,15 +27,6 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
         _disableInitializers();
     }
 
-    /**
-     * Initialize function, will be triggered when a new instance is deployed.
-     *
-     * @param _owner The owner of the contract
-     * @param _freezeVotesThreshold The number of votes required to activate a freeze
-     * @param _freezeProposalPeriod The number of seconds a freeze proposal has to succeed
-     * @param _freezePeriod The number of seconds a freeze lasts
-     * @param _strategy The address of the voting strategy
-     */
     function initialize(
         address _owner,
         uint256 _freezeVotesThreshold,
@@ -52,25 +34,17 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
         uint32 _freezePeriod,
         address _strategy
     ) public initializer {
-        __Ownable_init(_owner);
-        __UUPSUpgradeable_init();
-        _updateFreezeVotesThreshold(_freezeVotesThreshold);
-        _updateFreezeProposalPeriod(_freezeProposalPeriod);
-        _updateFreezePeriod(_freezePeriod);
+        __BaseFreezeVotingV1_init(
+            _owner,
+            _freezeProposalPeriod,
+            _freezePeriod,
+            _freezeVotesThreshold
+        );
         strategy = IERC721VotingStrategyV1(_strategy);
 
         emit ERC721FreezeVotingSetUp(_owner, _strategy);
     }
 
-    /**
-     * @dev Function that authorizes an upgrade. Only the owner can upgrade the implementation.
-     * @param newImplementation The address of the new implementation
-     */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {}
-
-    /** @inheritdoc BaseFreezeVotingV1*/
     function castFreezeVote() external pure override {
         revert NotSupported();
     }
@@ -82,7 +56,6 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
         if (_tokenAddresses.length != _tokenIds.length) revert UnequalArrays();
 
         if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
-            // create a new freeze proposal
             freezeProposalCreated = uint48(block.timestamp);
             freezeProposalVoteCount = 0;
             emit FreezeProposalCreated(msg.sender);
@@ -111,10 +84,15 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
             address tokenAddress = _tokenAddresses[i];
             uint256 tokenId = _tokenIds[i];
 
-            if (_voter != IERC721(tokenAddress).ownerOf(tokenId)) continue;
-
-            if (idHasFreezeVoted[freezeProposalCreated][tokenAddress][tokenId])
+            if (_voter != IERC721(tokenAddress).ownerOf(tokenId)) {
                 continue;
+            }
+
+            if (
+                idHasFreezeVoted[freezeProposalCreated][tokenAddress][tokenId]
+            ) {
+                continue;
+            }
 
             votes += strategy.getTokenWeight(tokenAddress);
 
@@ -126,7 +104,6 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
         return votes;
     }
 
-    /// Implementation for the version
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;
     }

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -5,9 +5,6 @@ import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {Version} from "../Version.sol";
 
-/**
- * A BaseFreezeVoting implementation which handles freezes on multi-sig (Safe) based DAOs.
- */
 contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
     uint16 private constant VERSION = 1;
 
@@ -25,15 +22,6 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
         _disableInitializers();
     }
 
-    /**
-     * Initialize function, will be triggered when a new instance is deployed.
-     *
-     * @param _owner The owner of the contract
-     * @param _freezeVotesThreshold The number of votes required to activate a freeze
-     * @param _freezeProposalPeriod The number of seconds a freeze proposal has to succeed
-     * @param _freezePeriod The number of seconds a freeze lasts
-     * @param _parentSafe The address of the parent Safe contract
-     */
     function initialize(
         address _owner,
         uint256 _freezeVotesThreshold,
@@ -41,51 +29,35 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
         uint32 _freezePeriod,
         address _parentSafe
     ) public initializer {
-        __Ownable_init(_owner);
-        __UUPSUpgradeable_init();
-        _updateFreezeVotesThreshold(_freezeVotesThreshold);
-        _updateFreezeProposalPeriod(_freezeProposalPeriod);
-        _updateFreezePeriod(_freezePeriod);
+        __BaseFreezeVotingV1_init(
+            _owner,
+            _freezeProposalPeriod,
+            _freezePeriod,
+            _freezeVotesThreshold
+        );
         parentSafe = ISafe(_parentSafe);
 
         emit MultisigFreezeVotingSetup(_owner, _parentSafe);
     }
 
-    /**
-     * @dev Function that authorizes an upgrade. Only the owner can upgrade the implementation.
-     * @param newImplementation The address of the new implementation
-     */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {}
-
-    /** @inheritdoc BaseFreezeVotingV1*/
     function castFreezeVote() external override {
         if (!parentSafe.isOwner(msg.sender)) revert NotOwner();
 
         if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
-            // create a new freeze proposal and count the caller's vote
-
             freezeProposalCreated = uint48(block.timestamp);
-
             freezeProposalVoteCount = 1;
-
             emit FreezeProposalCreated(msg.sender);
         } else {
-            // there is an existing freeze proposal, count the caller's vote
-
-            if (userHasFreezeVoted[msg.sender][freezeProposalCreated])
+            if (userHasFreezeVoted[msg.sender][freezeProposalCreated]) {
                 revert AlreadyVoted();
-
+            }
             freezeProposalVoteCount++;
         }
 
         userHasFreezeVoted[msg.sender][freezeProposalCreated] = true;
-
         emit FreezeVoteCast(msg.sender, 1);
     }
 
-    /// Implementation for the version
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;
     }

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -6,8 +6,16 @@ import {IStrategyBaseV1} from "../../interfaces/decent/deployables/IStrategyBase
 import {IAzoriusV1, Enum} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
-contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
+contract AzoriusV1 is
+    IAzoriusV1,
+    GuardableModule,
+    Ownable2StepUpgradeable,
+    Version,
+    UUPSUpgradeable
+{
     uint16 private constant VERSION = 1;
     /**
      * ```
@@ -94,7 +102,7 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         _updateTimelockPeriod(_timelockPeriod);
         _updateExecutionPeriod(_executionPeriod);
 
-        transferOwnership(_owner);
+        OwnableUpgradeable.transferOwnership(_owner);
 
         emit AzoriusSetUp(msg.sender, _owner, _avatar, _target);
     }
@@ -373,5 +381,17 @@ contract AzoriusV1 is IAzoriusV1, GuardableModule, Version, UUPSUpgradeable {
         return
             interfaceId == type(IAzoriusV1).interfaceId ||
             super.supportsInterface(interfaceId);
+    }
+
+    function _transferOwnership(
+        address newOwner
+    ) internal virtual override(Ownable2StepUpgradeable, OwnableUpgradeable) {
+        Ownable2StepUpgradeable._transferOwnership(newOwner);
+    }
+
+    function transferOwnership(
+        address newOwner
+    ) public override(Ownable2StepUpgradeable, OwnableUpgradeable) onlyOwner {
+        Ownable2StepUpgradeable.transferOwnership(newOwner);
     }
 }

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -5,10 +5,13 @@ import {Version} from "../Version.sol";
 import {IFractalModuleV1} from "../../interfaces/decent/deployables/IFractalModuleV1.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 contract FractalModuleV1 is
     IFractalModuleV1,
     GuardableModule,
+    Ownable2StepUpgradeable,
     Version,
     UUPSUpgradeable
 {
@@ -25,16 +28,13 @@ contract FractalModuleV1 is
         address _avatar,
         address _target
     ) public initializer {
-        // Initializer owner with the msg.sender first,
-        // needed for setting the avatar and target, which are ownable functions
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
 
         setAvatar(_avatar);
         setTarget(_target);
 
-        // Transfer ownership to the provided owner
-        transferOwnership(_owner);
+        OwnableUpgradeable.transferOwnership(_owner);
     }
 
     function setUp(bytes memory initializeParams) public override initializer {
@@ -69,5 +69,17 @@ contract FractalModuleV1 is
         return
             interfaceId == type(IFractalModuleV1).interfaceId ||
             super.supportsInterface(interfaceId);
+    }
+
+    function _transferOwnership(
+        address newOwner
+    ) internal virtual override(Ownable2StepUpgradeable, OwnableUpgradeable) {
+        Ownable2StepUpgradeable._transferOwnership(newOwner);
+    }
+
+    function transferOwnership(
+        address newOwner
+    ) public override(Ownable2StepUpgradeable, OwnableUpgradeable) onlyOwner {
+        Ownable2StepUpgradeable.transferOwnership(newOwner);
     }
 }

--- a/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
+++ b/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
@@ -10,31 +10,22 @@ import {
   IVersion__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
-import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
 // Helper function for deploying DecentAutonomousAdminV1 instances using ERC1967Proxy
 async function deployDecentAutonomousAdminProxy(
   proxyDeployer: SignerWithAddress,
   implementation: string,
-  owner: SignerWithAddress,
 ): Promise<DecentAutonomousAdminV1> {
-  // Create initialization data with function selector
-  const fullInitData =
-    DecentAutonomousAdminV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder().encode(['address'], [owner.address]).slice(2);
-
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, '0x');
 
   // Return a contract instance connected to the proxy
-  return DecentAutonomousAdminV1__factory.connect(await proxy.getAddress(), owner);
+  return DecentAutonomousAdminV1__factory.connect(await proxy.getAddress(), proxyDeployer);
 }
 
 describe('DecentAutonomousAdminV1', function () {
   // Signer accounts
   let proxyDeployer: SignerWithAddress;
-  let owner: SignerWithAddress;
-  let nonOwner: SignerWithAddress;
 
   // Contract instances
   let decentAutonomousAdmin: DecentAutonomousAdminV1;
@@ -42,7 +33,7 @@ describe('DecentAutonomousAdminV1', function () {
 
   beforeEach(async function () {
     // Get signers
-    [proxyDeployer, owner, nonOwner] = await ethers.getSigners();
+    [proxyDeployer] = await ethers.getSigners();
 
     // Deploy DecentAutonomousAdminV1 implementation
     masterCopy = await (
@@ -50,37 +41,7 @@ describe('DecentAutonomousAdminV1', function () {
     ).getAddress();
 
     // Deploy DecentAutonomousAdminV1 via proxy
-    decentAutonomousAdmin = await deployDecentAutonomousAdminProxy(
-      proxyDeployer,
-      masterCopy,
-      owner,
-    );
-  });
-
-  describe('Initialization', function () {
-    it('Should set the owner correctly', async function () {
-      expect(await decentAutonomousAdmin.owner()).to.equal(owner.address);
-    });
-
-    it('Should not allow reinitialization', async function () {
-      await expect(
-        decentAutonomousAdmin.initialize(nonOwner.address),
-      ).to.be.revertedWithCustomError(decentAutonomousAdmin, 'InvalidInitialization');
-    });
-  });
-
-  describe('Ownership', function () {
-    it('Should allow owner to call owner-only functions', async function () {
-      // The transfer ownership function is an example of an owner-only function
-      await decentAutonomousAdmin.connect(owner).transferOwnership(nonOwner.address);
-      expect(await decentAutonomousAdmin.owner()).to.equal(nonOwner.address);
-    });
-
-    it('Should prevent non-owners from calling owner-only functions', async function () {
-      await expect(
-        decentAutonomousAdmin.connect(nonOwner).transferOwnership(nonOwner.address),
-      ).to.be.revertedWithCustomError(decentAutonomousAdmin, 'OwnableUnauthorizedAccount');
-    });
+    decentAutonomousAdmin = await deployDecentAutonomousAdminProxy(proxyDeployer, masterCopy);
   });
 
   describe('ERC165', function () {
@@ -129,18 +90,6 @@ describe('DecentAutonomousAdminV1', function () {
   describe('Version', () => {
     it('should return the correct version number', async () => {
       expect(await decentAutonomousAdmin.getVersion()).to.equal(1);
-    });
-  });
-
-  describe('UUPS Upgradeability', function () {
-    runUUPSUpgradeabilityTests({
-      getContract: () => decentAutonomousAdmin,
-      createNewImplementation: async () => {
-        const newImplementation = await new DecentAutonomousAdminV1__factory(owner).deploy();
-        return newImplementation;
-      },
-      owner: () => owner,
-      nonOwner: () => nonOwner,
     });
   });
 });

--- a/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
@@ -22,8 +22,7 @@ async function deployAzoriusFreezeGuardProxy(
 ): Promise<AzoriusFreezeGuardV1> {
   // Create initialization data with function selector
   const fullInitData =
-    AzoriusFreezeGuardV1__factory.createInterface().getFunction('initialize(address,address)')
-      .selector +
+    AzoriusFreezeGuardV1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(['address', 'address'], [owner.address, freezeVoting])
       .slice(2);
@@ -106,7 +105,7 @@ describe('AzoriusFreezeGuardV1', () => {
       );
 
       await expect(
-        azoriusFreezeGuard['initialize(address,address)'](user.address, ethers.ZeroAddress),
+        azoriusFreezeGuard.initialize(user.address, ethers.ZeroAddress),
       ).to.be.revertedWithCustomError(azoriusFreezeGuard, 'InvalidInitialization');
     });
 
@@ -117,7 +116,7 @@ describe('AzoriusFreezeGuardV1', () => {
       );
 
       await expect(
-        implementationContract['initialize(address,address)'](owner.address, ethers.ZeroAddress),
+        implementationContract.initialize(owner.address, ethers.ZeroAddress),
       ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
     });
   });
@@ -135,6 +134,7 @@ describe('AzoriusFreezeGuardV1', () => {
     it('Should allow owner to call owner-only functions', async function () {
       // The transfer ownership function is an example of an owner-only function
       await azoriusFreezeGuard.connect(owner).transferOwnership(user.address);
+      await azoriusFreezeGuard.connect(user).acceptOwnership();
       expect(await azoriusFreezeGuard.owner()).to.equal(user.address);
     });
 

--- a/test/deployables/freeze-guard/BaseFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/BaseFreezeGuardV1.test.ts
@@ -21,8 +21,8 @@ async function deployConcreteBaseFreezeGuardProxy(
 ): Promise<ConcreteBaseFreezeGuardV1> {
   // Combine selector and encoded params
   const fullInitData =
-    ConcreteBaseFreezeGuardV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder().encode(['address'], [owner.address]).slice(2);
+    ConcreteBaseFreezeGuardV1__factory.createInterface().getFunction('__BaseFreezeGuardV1_init')
+      .selector + ethers.AbiCoder.defaultAbiCoder().encode(['address'], [owner.address]).slice(2);
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/286

Fixes [ENG-992](https://linear.app/decent-labs/issue/ENG-992/standardize-ownership-to-ownable2step-and-make-core-strategy)

**High-Level Context:**

This Pull Request implements two key architectural decisions across our contract suite:
1.  **Standardization of Ownership:** All contracts that remain Ownable are being transitioned to use OpenZeppelin's `Ownable2StepUpgradeable` pattern. This enhances security by requiring a two-step process for ownership transfers.
2.  **Selective Immutability:** Several contracts, where post-deployment changes to core logic or parameters are deemed undesirable or unnecessary, are being made immutable by removing Ownable and UUPSUpgradeable functionality. Their parameters will be set once at initialization.

These changes aim to bolster security for ownable contracts and increase the predictability and trustlessness of contracts intended to be fixed after deployment.

**Specific Changes in this PR:**

**I. Contracts Transitioned to `Ownable2StepUpgradeable` (and remain UUPSUpgradeable):**

*   **`DecentPaymasterV1.sol`:**
    *   Now inherits `Ownable2StepUpgradeable` (it already inherited `OwnableUpgradeable` via `BasePaymasterV1`).
    *   Overrides `_transferOwnership` and `transferOwnership` to use `Ownable2StepUpgradeable._transferOwnership`.
*   **`VotesERC20V1.sol`:**
    *   Inheritance changed from `OwnableUpgradeable` to `Ownable2StepUpgradeable`.
    *   Overrides `_transferOwnership` (which would have been inherited from `OwnableUpgradeable`) to use `Ownable2StepUpgradeable._transferOwnership`.
    *   The `transferOwnership` function is updated to use the 2-step pattern.
    *   `_authorizeUpgrade` remains `onlyOwner`.
*   **`BaseFreezeGuardV1.sol`:**
    *   Inheritance changed from `OwnableUpgradeable` to `Ownable2StepUpgradeable`.
    *   (Implicitly, `AzoriusFreezeGuardV1` and `MultisigFreezeGuardV1` which inherit from it now use 2-step ownership for upgrades and owner functions).
    *   The `initialize` function is renamed to `__BaseFreezeGuardV1_init` to follow the internal initializer pattern.
*   **`BaseFreezeVotingV1.sol`:**
    *   Inheritance changed from `OwnableUpgradeable` to `Ownable2StepUpgradeable`.
    *   The `initialize` function is renamed to `__BaseFreezeVotingV1_init`.
*   **`AzoriusV1.sol`:**
    *   Now inherits `Ownable2StepUpgradeable`.
    *   Overrides `_transferOwnership` and `transferOwnership`.
    *   `initialize` function now calls `OwnableUpgradeable.transferOwnership(_owner)` at the end, effectively setting the initial owner directly (this might be a point to ensure it aligns with the 2-step intent for the *initial* owner or if `msg.sender` should be the first owner).
*   **`FractalModuleV1.sol`:**
    *   Now inherits `Ownable2StepUpgradeable`.
    *   Overrides `_transferOwnership` and `transferOwnership`.
    *   `initialize` function behavior regarding initial ownership transfer is similar to `AzoriusV1`.

**II. Contracts Made Immutable (Ownable & UUPS Upgradeability Removed):**

*   **`DecentAutonomousAdminV1.sol`:**
    *   No longer inherits `UUPSUpgradeable` or `OwnableUpgradeable`.
    *   `initialize` function no longer takes an `_owner` and does not call `__Ownable_init` or `__UUPSUpgradeable_init`.
    *   `_authorizeUpgrade` function removed.
    *   The contract is now non-upgradeable and has no owner once deployed.
*   **`ERC20VotingAdapterV1.sol` (now `ERC20TokenAdapterV1.sol` in diff, but likely `ERC20VotingAdapterV1.sol` based on previous context):**
    *   No longer inherits `OwnableUpgradeable` or `UUPSUpgradeable`.
    *   Removed `_initialOwner` from `initialize` and calls to `__Ownable_init`, `__UUPSUpgradeable_init`.
    *   Removed owner-only functions (`updateWeightPerToken`) and `_authorizeUpgrade`.
    *   Parameters set in `initialize` are now immutable.
*   **`ERC721VotingAdapterV1.sol` (now `ERC721TokenAdapterV1.sol` in diff, but likely `ERC721VotingAdapterV1.sol`):**
    *   No longer inherits `OwnableUpgradeable` or `UUPSUpgradeable`.
    *   Removed `_initialOwner` from `initialize` and calls to `__Ownable_init`, `__UUPSUpgradeable_init`.
    *   Removed owner-only functions (`updateWeightPerNft`) and `_authorizeUpgrade`.
    *   Parameters set in `initialize` are now immutable.
*   **`StrategyV1.sol`:**
    *   No longer inherits `OwnableUpgradeable` or `UUPSUpgradeable`.
    *   Removed `_initialOwner` from `initialize` and related calls.
    *   Removed all owner-only functions (`updateVotingPeriod`, `updateQuorumThreshold`, `updateBasisNumerator`, `addVotingAdapter`, `removeVotingAdapter`, `addProposerAdapter`, `removeProposerAdapter`, `_authorizeUpgrade`).
    *   Parameters and adapter lists set in `initialize` are now immutable. Validation for these is performed within `initialize`.
    *   Removed related events (`StrategyParametersUpdated`, `VotingAdapterAdded/Removed`, `ProposerAdapterAdded/Removed`).

**III. General Cleanup:**

*   Removed redundant `virtual` keywords from functions that are no longer overridden or intended to be overridden in these now-immutable contracts.
*   Removed NatSpec comments referring to owner-only restrictions or upgradeability for the contracts that were made immutable.

**IV. Test Suite Updates:**

*   **`AzoriusFreezeGuardV1.test.ts`:** `deployAzoriusFreezeGuardProxy` updated to reflect `BaseFreezeGuardV1`'s `__BaseFreezeGuardV1_init`. Ownership tests now need to account for the 2-step transfer (e.g., `acceptOwnership`).
*   **`BaseFreezeGuardV1.test.ts`:** `deployConcreteBaseFreezeGuardProxy` updated.
*   **`DecentAutonomousAdminV1.test.ts`:**
    *   Deployment helper updated (no owner in `initialize`).
    *   Removed tests for `initialize` setting owner, reinitialization, ownership transfers, and UUPS upgradeability, as these features are removed.
*   **(Implied but not in diff):** Tests for `DecentPaymasterV1`, `VotesERC20V1`, `BaseFreezeVotingV1`, `AzoriusV1`, `FractalModuleV1` will need updates to correctly test the new two-step ownership transfer process.
*   **(Implied but not in diff):** Tests for `StrategyV1`, `ERC20VotingAdapterV1`, `ERC721VotingAdapterV1` need owner-only function tests and upgradeability tests removed. Initialization tests need to verify parameters are set and validated correctly at deployment.

**Impact and Status:**

*   **Enhanced Security for Ownable Contracts:** The move to `Ownable2StepUpgradeable` for contracts that retain ownership provides an extra layer of security against accidental or malicious immediate ownership transfers.
*   **Increased Predictability for Immutable Contracts:** Contracts like `StrategyV1`, its adapters, and `DecentAutonomousAdminV1` now have their core logic and parameters fixed upon deployment, providing greater certainty for users and integrators.
*   **Breaking Changes:** This is a significant breaking change for the initialization and administration of the affected contracts.
*   **Compilation Status:** All contracts should compile.
*   **Testing Status:** The provided diff updates some tests. However, a **thorough review and update of the entire test suite is critical.** Tests for ownership transfer must be adapted to the 2-step process. Tests for contracts made immutable must have their Ownable/UUPS sections removed and initialization tests potentially revised. It's likely many tests will fail until fully updated.