### PR TITLE
feat: Enhance contract extensibility with `virtual` keyword

### DIFF
--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -44,7 +44,7 @@ contract DecentPaymasterV1 is
         address _owner,
         address _entryPoint,
         address _lightAccountFactory
-    ) public initializer {
+    ) public virtual initializer {
         __BasePaymasterV1_init(_owner, IEntryPoint(_entryPoint));
         __SmartAccountValidationV1_init(_lightAccountFactory);
     }
@@ -57,7 +57,7 @@ contract DecentPaymasterV1 is
         address target,
         bytes4 selector,
         address validator
-    ) external onlyOwner {
+    ) external virtual override onlyOwner {
         if (validator == address(0)) revert InvalidValidator();
 
         if (
@@ -75,7 +75,7 @@ contract DecentPaymasterV1 is
     function removeFunctionValidator(
         address target,
         bytes4 selector
-    ) external onlyOwner {
+    ) external virtual override onlyOwner {
         _functionValidators[target][selector] = address(0);
         emit FunctionValidatorRemoved(target, selector);
     }
@@ -83,7 +83,7 @@ contract DecentPaymasterV1 is
     function getFunctionValidator(
         address target,
         bytes4 selector
-    ) public view returns (address) {
+    ) public view virtual override returns (address) {
         return _functionValidators[target][selector];
     }
 
@@ -94,6 +94,7 @@ contract DecentPaymasterV1 is
     )
         internal
         view
+        virtual
         override
         returns (bytes memory context, uint256 validationData)
     {
@@ -151,7 +152,12 @@ contract DecentPaymasterV1 is
 
     function transferOwnership(
         address newOwner
-    ) public override(Ownable2StepUpgradeable, OwnableUpgradeable) onlyOwner {
+    )
+        public
+        virtual
+        override(Ownable2StepUpgradeable, OwnableUpgradeable)
+        onlyOwner
+    {
         Ownable2StepUpgradeable.transferOwnership(newOwner);
     }
 }

--- a/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
@@ -56,7 +56,7 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
         address lightAccountOwner,
         address votingContract,
         bytes calldata callData
-    ) external view returns (bool) {
+    ) external view virtual override returns (bool) {
         // confirm here that the calldata selector is correct (`vote(uint32,uint8)`)?
         if (bytes4(callData) != ILinearERC20VotingV1.vote.selector) {
             return false;
@@ -154,7 +154,7 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
         return true;
     }
 
-    function getVersion() public pure override returns (uint16) {
+    function getVersion() public pure virtual override returns (uint16) {
         return VERSION;
     }
 
@@ -163,7 +163,13 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
      */
     function supportsInterface(
         bytes4 interfaceId
-    ) public view override(ERC165, Version, IFunctionValidator) returns (bool) {
+    )
+        public
+        view
+        virtual
+        override(ERC165, Version, IFunctionValidator)
+        returns (bool)
+    {
         return
             interfaceId == type(IFunctionValidator).interfaceId ||
             super.supportsInterface(interfaceId);

--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -55,7 +55,7 @@ contract LinearERC721VotingV1ValidatorV1 is
         address lightAccountOwner,
         address votingContract,
         bytes calldata callData
-    ) external view returns (bool) {
+    ) external view virtual override returns (bool) {
         // Verify function selector matches vote(uint32,uint8,address[],uint256[])
         if (bytes4(callData) != ILinearERC721VotingV1.vote.selector) {
             return false;
@@ -135,7 +135,7 @@ contract LinearERC721VotingV1ValidatorV1 is
         return true;
     }
 
-    function getVersion() public pure override returns (uint16) {
+    function getVersion() public pure virtual override returns (uint16) {
         return VERSION;
     }
 
@@ -144,7 +144,13 @@ contract LinearERC721VotingV1ValidatorV1 is
      */
     function supportsInterface(
         bytes4 interfaceId
-    ) public view override(ERC165, Version, IFunctionValidator) returns (bool) {
+    )
+        public
+        view
+        virtual
+        override(ERC165, Version, IFunctionValidator)
+        returns (bool)
+    {
         return
             interfaceId == type(IFunctionValidator).interfaceId ||
             super.supportsInterface(interfaceId);

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -9,7 +9,9 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 contract DecentAutonomousAdminV1 is IDecentAutonomousAdminV1, Version {
     uint16 private constant VERSION = 1;
 
-    function triggerStartNextTerm(TriggerStartArgs calldata args) public {
+    function triggerStartNextTerm(
+        TriggerStartArgs calldata args
+    ) public virtual override {
         IHatsElectionsEligibility hatsElectionModule = IHatsElectionsEligibility(
                 args.hatsProtocol.getHatEligibilityModule(args.hatId)
             );
@@ -31,7 +33,7 @@ contract DecentAutonomousAdminV1 is IDecentAutonomousAdminV1, Version {
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view override returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IDecentAutonomousAdminV1).interfaceId ||
             super.supportsInterface(interfaceId);

--- a/contracts/deployables/erc20/VotesERC20LockableV1.sol
+++ b/contracts/deployables/erc20/VotesERC20LockableV1.sol
@@ -48,7 +48,7 @@ contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20V1 {
         locked = _locked;
     }
 
-    function lock(bool _locked) external onlyOwner {
+    function lock(bool _locked) external virtual onlyOwner {
         if (_locked == locked) {
             revert CannotSwitchLockState(_locked);
         }
@@ -56,7 +56,10 @@ contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20V1 {
         emit Locked(_locked);
     }
 
-    function whitelist(address account, bool isWhitelisted) external onlyOwner {
+    function whitelist(
+        address account,
+        bool isWhitelisted
+    ) external virtual onlyOwner {
         bool currentlyWhitelisted = whitelisted[account];
         whitelisted[account] = isWhitelisted;
         if (currentlyWhitelisted != isWhitelisted) {
@@ -64,7 +67,7 @@ contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20V1 {
         }
     }
 
-    function mint(address to, uint256 amount) external onlyOwner {
+    function mint(address to, uint256 amount) external virtual onlyOwner {
         _mint(to, amount);
     }
 

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -32,7 +32,7 @@ contract VotesERC20V1 is
         address[] memory allocationAddresses,
         uint256[] memory allocationAmounts,
         address owner
-    ) public initializer {
+    ) public virtual initializer {
         __ERC20_init(name, symbol);
         __ERC20Permit_init(name);
         __ERC20Votes_init();
@@ -52,11 +52,11 @@ contract VotesERC20V1 is
         address newImplementation
     ) internal virtual override onlyOwner {}
 
-    function clock() public view override returns (uint48) {
+    function clock() public view virtual override returns (uint48) {
         return uint48(block.timestamp);
     }
 
-    function CLOCK_MODE() public pure override returns (string memory) {
+    function CLOCK_MODE() public pure virtual override returns (string memory) {
         return "mode=timestamp";
     }
 

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -26,7 +26,7 @@ contract AzoriusFreezeGuardV1 is Version, BaseFreezeGuardV1 {
     function initialize(
         address _owner,
         address _freezeVoting
-    ) public initializer {
+    ) public virtual initializer {
         __BaseFreezeGuardV1_init(_owner);
         freezeVoting = IBaseFreezeVotingV1(_freezeVoting);
 
@@ -45,14 +45,14 @@ contract AzoriusFreezeGuardV1 is Version, BaseFreezeGuardV1 {
         address payable,
         bytes memory,
         address
-    ) external view override(BaseFreezeGuardV1) {
+    ) external view virtual override(BaseFreezeGuardV1) {
         if (freezeVoting.isFrozen()) revert DAOFrozen();
     }
 
     function checkAfterExecution(
         bytes32,
         bool
-    ) external view override(BaseFreezeGuardV1) {}
+    ) external view virtual override(BaseFreezeGuardV1) {}
 
     function getVersion() public view virtual override returns (uint16) {
         return VERSION;

--- a/contracts/deployables/freeze-guard/BaseFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/BaseFreezeGuardV1.sol
@@ -17,7 +17,7 @@ abstract contract BaseFreezeGuardV1 is
         _disableInitializers();
     }
 
-    function __BaseFreezeGuardV1_init(address _owner) public initializer {
+    function __BaseFreezeGuardV1_init(address _owner) internal initializer {
         __Ownable_init(_owner);
         __UUPSUpgradeable_init();
     }

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -55,7 +55,7 @@ contract MultisigFreezeGuardV1 is
         address _owner,
         address _freezeVoting,
         address _childGnosisSafe
-    ) public initializer {
+    ) public virtual initializer {
         __BaseFreezeGuardV1_init(_owner);
         _updateTimelockPeriod(_timelockPeriod);
         _updateExecutionPeriod(_executionPeriod);
@@ -82,7 +82,7 @@ contract MultisigFreezeGuardV1 is
         address payable refundReceiver,
         bytes memory signatures,
         uint256 nonce
-    ) external {
+    ) external virtual {
         bytes32 signaturesHash = keccak256(signatures);
 
         if (transactionTimelocked[signaturesHash] != 0)
@@ -115,11 +115,15 @@ contract MultisigFreezeGuardV1 is
         emit TransactionTimelocked(msg.sender, transactionHash, signatures);
     }
 
-    function updateTimelockPeriod(uint32 _timelockPeriod) external onlyOwner {
+    function updateTimelockPeriod(
+        uint32 _timelockPeriod
+    ) external virtual onlyOwner {
         _updateTimelockPeriod(_timelockPeriod);
     }
 
-    function updateExecutionPeriod(uint32 _executionPeriod) external onlyOwner {
+    function updateExecutionPeriod(
+        uint32 _executionPeriod
+    ) external virtual onlyOwner {
         _updateExecutionPeriod(_executionPeriod);
     }
 
@@ -135,7 +139,7 @@ contract MultisigFreezeGuardV1 is
         address payable,
         bytes memory signatures,
         address
-    ) external view override(BaseFreezeGuardV1) {
+    ) external view virtual override(BaseFreezeGuardV1) {
         bytes32 signaturesHash = keccak256(signatures);
 
         if (transactionTimelocked[signaturesHash] == 0) revert NotTimelocked();
@@ -158,20 +162,20 @@ contract MultisigFreezeGuardV1 is
     function checkAfterExecution(
         bytes32,
         bool
-    ) external view override(BaseFreezeGuardV1) {}
+    ) external view virtual override(BaseFreezeGuardV1) {}
 
     function getTransactionTimelocked(
         bytes32 _signaturesHash
-    ) public view returns (uint48) {
+    ) public view virtual returns (uint48) {
         return transactionTimelocked[_signaturesHash];
     }
 
-    function _updateTimelockPeriod(uint32 _timelockPeriod) internal {
+    function _updateTimelockPeriod(uint32 _timelockPeriod) internal virtual {
         timelockPeriod = _timelockPeriod;
         emit TimelockPeriodUpdated(_timelockPeriod);
     }
 
-    function _updateExecutionPeriod(uint32 _executionPeriod) internal {
+    function _updateExecutionPeriod(uint32 _executionPeriod) internal virtual {
         executionPeriod = _executionPeriod;
         emit ExecutionPeriodUpdated(_executionPeriod);
     }

--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -39,7 +39,7 @@ abstract contract BaseFreezeVotingV1 is
         uint32 _freezeProposalPeriod,
         uint32 _freezePeriod,
         uint256 _freezeVotesThreshold
-    ) public initializer {
+    ) internal initializer {
         __Ownable_init(_owner);
         __UUPSUpgradeable_init();
         _updateFreezeProposalPeriod(_freezeProposalPeriod);
@@ -53,48 +53,50 @@ abstract contract BaseFreezeVotingV1 is
 
     function castFreezeVote() external virtual;
 
-    function isFrozen() external view returns (bool) {
+    function isFrozen() external view virtual returns (bool) {
         return
             freezeProposalVoteCount >= freezeVotesThreshold &&
             block.timestamp < freezeProposalCreated + freezePeriod;
     }
 
-    function unfreeze() external onlyOwner {
+    function unfreeze() external virtual onlyOwner {
         freezeProposalCreated = 0;
         freezeProposalVoteCount = 0;
     }
 
     function updateFreezeVotesThreshold(
         uint256 _freezeVotesThreshold
-    ) external onlyOwner {
+    ) external virtual onlyOwner {
         _updateFreezeVotesThreshold(_freezeVotesThreshold);
     }
 
     function updateFreezeProposalPeriod(
         uint32 _freezeProposalPeriod
-    ) external onlyOwner {
+    ) external virtual onlyOwner {
         _updateFreezeProposalPeriod(_freezeProposalPeriod);
     }
 
-    function updateFreezePeriod(uint32 _freezePeriod) external onlyOwner {
+    function updateFreezePeriod(
+        uint32 _freezePeriod
+    ) external virtual onlyOwner {
         _updateFreezePeriod(_freezePeriod);
     }
 
     function _updateFreezeVotesThreshold(
         uint256 _freezeVotesThreshold
-    ) internal {
+    ) internal virtual {
         freezeVotesThreshold = _freezeVotesThreshold;
         emit FreezeVotesThresholdUpdated(_freezeVotesThreshold);
     }
 
     function _updateFreezeProposalPeriod(
         uint32 _freezeProposalPeriod
-    ) internal {
+    ) internal virtual {
         freezeProposalPeriod = _freezeProposalPeriod;
         emit FreezeProposalPeriodUpdated(_freezeProposalPeriod);
     }
 
-    function _updateFreezePeriod(uint32 _freezePeriod) internal {
+    function _updateFreezePeriod(uint32 _freezePeriod) internal virtual {
         freezePeriod = _freezePeriod;
         emit FreezePeriodUpdated(_freezePeriod);
     }

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -28,7 +28,7 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
         uint32 _freezeProposalPeriod,
         uint32 _freezePeriod,
         address _votesERC20
-    ) public initializer {
+    ) public virtual initializer {
         __BaseFreezeVotingV1_init(
             _owner,
             _freezeProposalPeriod,
@@ -40,7 +40,7 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
         emit ERC20FreezeVotingSetUp(_owner, _votesERC20);
     }
 
-    function castFreezeVote() external override {
+    function castFreezeVote() external virtual override {
         uint256 userVotes;
 
         if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -33,7 +33,7 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
         uint32 _freezeProposalPeriod,
         uint32 _freezePeriod,
         address _strategy
-    ) public initializer {
+    ) public virtual initializer {
         __BaseFreezeVotingV1_init(
             _owner,
             _freezeProposalPeriod,
@@ -45,14 +45,14 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
         emit ERC721FreezeVotingSetUp(_owner, _strategy);
     }
 
-    function castFreezeVote() external pure override {
+    function castFreezeVote() external pure virtual override {
         revert NotSupported();
     }
 
     function castFreezeVote(
         address[] memory _tokenAddresses,
         uint256[] memory _tokenIds
-    ) external {
+    ) external virtual {
         if (_tokenAddresses.length != _tokenIds.length) revert UnequalArrays();
 
         if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
@@ -77,7 +77,7 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
         address[] memory _tokenAddresses,
         uint256[] memory _tokenIds,
         address _voter
-    ) internal returns (uint256) {
+    ) internal virtual returns (uint256) {
         uint256 votes = 0;
 
         for (uint256 i = 0; i < _tokenAddresses.length; i++) {

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -28,7 +28,7 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
         uint32 _freezeProposalPeriod,
         uint32 _freezePeriod,
         address _parentSafe
-    ) public initializer {
+    ) public virtual initializer {
         __BaseFreezeVotingV1_init(
             _owner,
             _freezeProposalPeriod,
@@ -40,7 +40,7 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
         emit MultisigFreezeVotingSetup(_owner, _parentSafe);
     }
 
-    function castFreezeVote() external override {
+    function castFreezeVote() external virtual override {
         if (!parentSafe.isOwner(msg.sender)) revert NotOwner();
 
         if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -391,7 +391,12 @@ contract AzoriusV1 is
 
     function transferOwnership(
         address newOwner
-    ) public override(Ownable2StepUpgradeable, OwnableUpgradeable) onlyOwner {
+    )
+        public
+        virtual
+        override(Ownable2StepUpgradeable, OwnableUpgradeable)
+        onlyOwner
+    {
         Ownable2StepUpgradeable.transferOwnership(newOwner);
     }
 }

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -27,7 +27,7 @@ contract FractalModuleV1 is
         address _owner,
         address _avatar,
         address _target
-    ) public initializer {
+    ) public virtual initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
 
@@ -37,7 +37,9 @@ contract FractalModuleV1 is
         OwnableUpgradeable.transferOwnership(_owner);
     }
 
-    function setUp(bytes memory initializeParams) public override initializer {
+    function setUp(
+        bytes memory initializeParams
+    ) public virtual override initializer {
         (address _owner, address _avatar, address _target) = abi.decode(
             initializeParams,
             (address, address, address)
@@ -49,7 +51,7 @@ contract FractalModuleV1 is
         address newImplementation
     ) internal virtual override onlyOwner {}
 
-    function execTx(bytes memory execTxData) public onlyOwner {
+    function execTx(bytes memory execTxData) public virtual onlyOwner {
         (
             address _target,
             uint256 _value,
@@ -79,7 +81,12 @@ contract FractalModuleV1 is
 
     function transferOwnership(
         address newOwner
-    ) public override(Ownable2StepUpgradeable, OwnableUpgradeable) onlyOwner {
+    )
+        public
+        virtual
+        override(Ownable2StepUpgradeable, OwnableUpgradeable)
+        onlyOwner
+    {
         Ownable2StepUpgradeable.transferOwnership(newOwner);
     }
 }

--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -29,7 +29,7 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
 
     function __ERC4337VoterSupportV1_init(
         address _lightAccountFactory
-    ) internal {
+    ) internal initializer {
         __SmartAccountValidationV1_init(_lightAccountFactory);
     }
 

--- a/contracts/mocks/concretes/deployables/freeze-guard/ConcreteBaseFreezeGuardV1.sol
+++ b/contracts/mocks/concretes/deployables/freeze-guard/ConcreteBaseFreezeGuardV1.sol
@@ -8,6 +8,10 @@ import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
  * A concrete implementation of BaseGuardV1 for testing
  */
 contract ConcreteBaseFreezeGuardV1 is BaseFreezeGuardV1 {
+    function initialize(address _owner) public virtual initializer {
+        __BaseFreezeGuardV1_init(_owner);
+    }
+
     function checkTransaction(
         address,
         uint256,

--- a/test/deployables/freeze-guard/BaseFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/BaseFreezeGuardV1.test.ts
@@ -21,8 +21,8 @@ async function deployConcreteBaseFreezeGuardProxy(
 ): Promise<ConcreteBaseFreezeGuardV1> {
   // Combine selector and encoded params
   const fullInitData =
-    ConcreteBaseFreezeGuardV1__factory.createInterface().getFunction('__BaseFreezeGuardV1_init')
-      .selector + ethers.AbiCoder.defaultAbiCoder().encode(['address'], [owner.address]).slice(2);
+    ConcreteBaseFreezeGuardV1__factory.createInterface().getFunction('initialize').selector +
+    ethers.AbiCoder.defaultAbiCoder().encode(['address'], [owner.address]).slice(2);
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/288

Fixes [ENG-996](https://linear.app/decent-labs/issue/ENG-996/standardize-ownership-to-ownable2step-make-key-contracts-immutable-and)

This commit introduces several changes across the codebase to improve the extensibility and upgradeability of the smart contracts, primarily by leveraging the `virtual` keyword and refining initializer patterns.

**Key Changes:**

*   **Widespread `virtual` Keyword Adoption:** Numerous functions in various contracts including `DecentPaymasterV1`, `LinearERC20VotingV1ValidatorV1`, `LinearERC721VotingV1ValidatorV1`, `DecentAutonomousAdminV1`, `VotesERC20LockableV1`, `VotesERC20V1`, `AzoriusFreezeGuardV1`, `MultisigFreezeGuardV1`, `BaseFreezeVotingV1`, `ERC20FreezeVotingV1`, `ERC721FreezeVotingV1`, `MultisigFreezeVotingV1`, `AzoriusV1`, and `FractalModuleV1` have been marked as `virtual`. This allows these functions to be overridden by inheriting contracts, providing greater flexibility for future customizations and extensions.
*   **Initializer Refactoring for UUPS Compliance:**
    *   The `__BaseFreezeGuardV1_init` function in `BaseFreezeGuardV1.sol` has been changed from `public` to `internal`. A new `public virtual initialize` function has been added to the `ConcreteBaseFreezeGuardV1.sol` mock contract, which now calls this internal initializer. This aligns with OpenZeppelin's recommendations for UUPS proxy patterns, ensuring safer and more robust upgradeability.
    *   The `__BaseFreezeVotingV1_init` function in `BaseFreezeVotingV1.sol` has been changed from `public` to `internal` and marked with the `initializer` modifier. Concrete implementations are expected to provide their own `public virtual initialize` functions.
    *   The `__ERC4337VoterSupportV1_init` function in `ERC4337VoterSupportV1.sol` has been marked with the `initializer` modifier.
*   **Test Updates:** The test file `BaseFreezeGuardV1.test.ts` has been updated to use the new `initialize` function in `ConcreteBaseFreezeGuardV1` for proxy deployment, reflecting the initializer refactoring.

These changes ensure that the contracts are more adaptable for future development, facilitate easier upgrades, and adhere to best practices for smart contract architecture.