### PR TITLE
refactor: Enhance ERC20 token contracts with specific interfaces

### DIFF
--- a/contracts/deployables/erc20/VotesERC20LockableV1.sol
+++ b/contracts/deployables/erc20/VotesERC20LockableV1.sol
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {ILockableV1} from "../../interfaces/decent/deployables/ILockableV1.sol";
-import {IMintableV1} from "../../interfaces/decent/deployables/IMintableV1.sol";
+import {IVotesERC20LockableV1} from "../../interfaces/decent/deployables/IVotesERC20LockableV1.sol";
 import {VotesERC20V1} from "./VotesERC20V1.sol";
 import {Version} from "../Version.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20V1 {
+contract VotesERC20LockableV1 is IVotesERC20LockableV1, VotesERC20V1 {
     uint16 private constant VERSION = 1;
 
-    bool public locked;
-    mapping(address => bool) public whitelisted;
+    bool internal _locked;
+    mapping(address => bool) internal _whitelisted;
 
     constructor() {
         _disableInitializers();
@@ -19,10 +18,10 @@ contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20V1 {
 
     modifier isTransferable(address from) {
         if (
-            locked &&
+            _locked &&
             // overrides while locked
             !(from == owner() || // owner can always transfer
-                whitelisted[from] || // whitelisted addresses can always transfer
+                _whitelisted[from] || // whitelisted addresses can always transfer
                 from == address(0)) // can always mint when locked
         ) {
             revert IsLocked();
@@ -31,43 +30,56 @@ contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20V1 {
     }
 
     function initialize(
-        address _owner,
-        bool _locked,
-        string memory _name,
-        string memory _symbol,
-        address[] memory _allocationAddresses,
-        uint256[] memory _allocationAmounts
-    ) public virtual initializer {
+        address owner_,
+        bool locked_,
+        string memory name_,
+        string memory symbol_,
+        address[] memory allocationAddresses_,
+        uint256[] memory allocationAmounts_
+    ) public virtual override initializer {
         super.initialize(
-            _name,
-            _symbol,
-            _allocationAddresses,
-            _allocationAmounts,
-            _owner
+            name_,
+            symbol_,
+            allocationAddresses_,
+            allocationAmounts_,
+            owner_
         );
-        locked = _locked;
+        _locked = locked_;
     }
 
-    function lock(bool _locked) external virtual onlyOwner {
-        if (_locked == locked) {
-            revert CannotSwitchLockState(_locked);
+    function locked() external view virtual override returns (bool) {
+        return _locked;
+    }
+
+    function whitelisted(
+        address account
+    ) external view virtual override returns (bool) {
+        return _whitelisted[account];
+    }
+
+    function lock(bool locked_) external virtual override onlyOwner {
+        if (locked_ == _locked) {
+            revert CannotSwitchLockState(locked_);
         }
-        locked = _locked;
+        _locked = locked_;
         emit Locked(_locked);
     }
 
     function whitelist(
         address account,
         bool isWhitelisted
-    ) external virtual onlyOwner {
-        bool currentlyWhitelisted = whitelisted[account];
-        whitelisted[account] = isWhitelisted;
+    ) external virtual override onlyOwner {
+        bool currentlyWhitelisted = _whitelisted[account];
+        _whitelisted[account] = isWhitelisted;
         if (currentlyWhitelisted != isWhitelisted) {
             emit Whitelisted(account, isWhitelisted);
         }
     }
 
-    function mint(address to, uint256 amount) external virtual onlyOwner {
+    function mint(
+        address to,
+        uint256 amount
+    ) external virtual override onlyOwner {
         _mint(to, amount);
     }
 
@@ -87,8 +99,7 @@ contract VotesERC20LockableV1 is ILockableV1, IMintableV1, VotesERC20V1 {
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(ILockableV1).interfaceId ||
-            interfaceId == type(IMintableV1).interfaceId ||
+            interfaceId == type(IVotesERC20LockableV1).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {Version} from "../Version.sol";
+import {IVotesERC20V1} from "../../interfaces/decent/deployables/IVotesERC20V1.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
@@ -10,10 +11,12 @@ import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/
 import {NoncesUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/NoncesUpgradeable.sol";
 import {ERC20VotesUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+import {VotesUpgradeable} from "@openzeppelin/contracts-upgradeable/governance/utils/VotesUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 contract VotesERC20V1 is
+    IVotesERC20V1,
     Version,
     ERC20VotesUpgradeable,
     ERC20PermitUpgradeable,
@@ -32,7 +35,7 @@ contract VotesERC20V1 is
         address[] memory allocationAddresses,
         uint256[] memory allocationAmounts,
         address owner
-    ) public virtual initializer {
+    ) public virtual override initializer {
         __ERC20_init(name, symbol);
         __ERC20Permit_init(name);
         __ERC20Votes_init();
@@ -52,11 +55,23 @@ contract VotesERC20V1 is
         address newImplementation
     ) internal virtual override onlyOwner {}
 
-    function clock() public view virtual override returns (uint48) {
+    function clock()
+        public
+        view
+        virtual
+        override(IVotesERC20V1, VotesUpgradeable)
+        returns (uint48)
+    {
         return uint48(block.timestamp);
     }
 
-    function CLOCK_MODE() public pure virtual override returns (string memory) {
+    function CLOCK_MODE()
+        public
+        pure
+        virtual
+        override(IVotesERC20V1, VotesUpgradeable)
+        returns (string memory)
+    {
         return "mode=timestamp";
     }
 

--- a/contracts/interfaces/decent/deployables/IMintableV1.sol
+++ b/contracts/interfaces/decent/deployables/IMintableV1.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.8.30;
-
-interface IMintableV1 {
-    function mint(address to, uint256 amount) external;
-}

--- a/contracts/interfaces/decent/deployables/IVotesERC20LockableV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20LockableV1.sol
@@ -1,12 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-interface ILockableV1 {
+interface IVotesERC20LockableV1 {
     event Locked(bool isLocked);
     event Whitelisted(address indexed account, bool isWhitelisted);
 
     error IsLocked();
     error CannotSwitchLockState(bool newLockState);
+
+    function initialize(
+        address owner_,
+        bool locked_,
+        string memory name_,
+        string memory symbol_,
+        address[] memory allocationAddresses_,
+        uint256[] memory allocationAmounts_
+    ) external;
 
     function lock(bool _locked) external;
 
@@ -15,4 +24,6 @@ interface ILockableV1 {
     function whitelist(address account, bool isWhitelisted) external;
 
     function whitelisted(address account) external view returns (bool);
+
+    function mint(address to, uint256 amount) external;
 }

--- a/contracts/interfaces/decent/deployables/IVotesERC20V1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20V1.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+interface IVotesERC20V1 {
+    function initialize(
+        string memory _name,
+        string memory _symbol,
+        address[] memory _allocationAddresses,
+        uint256[] memory _allocationAmounts,
+        address owner
+    ) external;
+
+    function clock() external view returns (uint48);
+
+    function CLOCK_MODE() external pure returns (string memory);
+}

--- a/test/deployables/erc20/VotesERC20LockableV1.test.ts
+++ b/test/deployables/erc20/VotesERC20LockableV1.test.ts
@@ -6,9 +6,8 @@ import {
   ERC1967Proxy__factory,
   IERC165__factory,
   IERC20__factory,
-  ILockableV1__factory,
-  IMintableV1__factory,
   IVersion__factory,
+  IVotesERC20LockableV1__factory,
   VotesERC20LockableV1,
   VotesERC20LockableV1__factory,
 } from '../../../typechain-types';
@@ -731,8 +730,7 @@ describe('VotesERC20LockableV1', () => {
     let proxy: VotesERC20LockableV1;
     let iVersionInterfaceId: string;
     let iERC165InterfaceId: string;
-    let iLockableV1InterfaceId: string;
-    let iMintableV1InterfaceId: string;
+    let iVotesERC20LockableV1InterfaceId: string;
     let iERC20InterfaceId: string;
 
     beforeEach(async function () {
@@ -754,11 +752,8 @@ describe('VotesERC20LockableV1', () => {
       const IERC165Interface = IERC165__factory.createInterface();
       iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
 
-      const ILockableV1Interface = ILockableV1__factory.createInterface();
-      iLockableV1InterfaceId = calculateInterfaceId(ILockableV1Interface);
-
-      const IMintableV1Interface = IMintableV1__factory.createInterface();
-      iMintableV1InterfaceId = calculateInterfaceId(IMintableV1Interface);
+      const IVotesERC20LockableV1Interface = IVotesERC20LockableV1__factory.createInterface();
+      iVotesERC20LockableV1InterfaceId = calculateInterfaceId(IVotesERC20LockableV1Interface);
 
       const IERC20Interface = IERC20__factory.createInterface();
       iERC20InterfaceId = calculateInterfaceId(IERC20Interface);
@@ -774,13 +769,8 @@ describe('VotesERC20LockableV1', () => {
       void expect(supported).to.be.true;
     });
 
-    it('Should support ILockableV1 interface', async function () {
-      const supported = await proxy.supportsInterface(iLockableV1InterfaceId);
-      void expect(supported).to.be.true;
-    });
-
-    it('Should support IMintableV1 interface', async function () {
-      const supported = await proxy.supportsInterface(iMintableV1InterfaceId);
+    it('Should support IVotesERC20LockableV1 interface', async function () {
+      const supported = await proxy.supportsInterface(iVotesERC20LockableV1InterfaceId);
       void expect(supported).to.be.true;
     });
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/291

Fixes [ENG-999](https://linear.app/decent-labs/issue/ENG-999/refactor-erc20-contracts-with-specific-interfaces-voteserc20lockablev1)

This commit refactors the `VotesERC20LockableV1` and `VotesERC20V1` contracts by introducing more specific interfaces, consolidating existing interface functionalities, and improving overall code structure and clarity.

**Key Changes:**

1.  **Interface Consolidation and Renaming for `VotesERC20LockableV1`:**
    *   The interfaces `ILockableV1.sol` and `IMintableV1.sol` have been consolidated and replaced.
    *   `ILockableV1.sol` has been renamed to `IVotesERC20Lockable.sol`.
    *   The new `IVotesERC20Lockable` interface now includes:
        *   Events: `Locked`, `Whitelisted`
        *   Errors: `IsLocked`, `CannotSwitchLockState`
        *   Functions: `initialize`, `lock`, `locked` (getter), `whitelist`, `whitelisted` (getter), and `mint`.
    *   `IMintableV1.sol` has been deleted, as its `mint` function is now part of `IVotesERC20Lockable`.

2.  **Refactoring of `VotesERC20LockableV1.sol`:**
    *   No longer implements `ILockableV1` and `IMintableV1`.
    *   Now implements the new `IVotesERC20Lockable` interface.
    *   State variables `locked` and `whitelisted` (mapping) are now `internal` (renamed to `_locked` and `_whitelisted` respectively).
    *   Public `virtual` getter functions `locked()` and `whitelisted(address account)` have been added for these state variables, fulfilling the interface requirements.
    *   The `initialize` function signature now matches the `IVotesERC20Lockable` interface (parameter names changed, e.g., `_owner` to `owner_`).
    *   The `isTransferable` modifier now uses the internal `_locked` and `_whitelisted` variables.
    *   `supportsInterface` now checks for `IVotesERC20Lockable.interfaceId` instead of the old interface IDs.

3.  **Introduction of `IVotesERC20V1.sol`:**
    *   A new interface `IVotesERC20V1.sol` has been created specifically for the `VotesERC20V1` contract.
    *   This interface defines:
        *   `initialize` function.
        *   `clock()` function.
        *   `CLOCK_MODE()` function.

4.  **Refactoring of `VotesERC20V1.sol`:**
    *   Now implements the new `IVotesERC20V1` interface.
    *   The `initialize` function signature matches the `IVotesERC20V1` interface (parameter names changed).
    *   The `clock()` and `CLOCK_MODE()` functions now explicitly override both `IVotesERC20V1` and `VotesUpgradeable` (from OpenZeppelin).

5.  **Test Updates for `VotesERC20LockableV1.test.ts`:**
    *   Interface ID calculations and `supportsInterface` tests have been updated to use `IVotesERC20Lockable__factory.createInterface()` instead of the factories for the deleted/renamed interfaces (`ILockableV1__factory`, `IMintableV1__factory`).

These changes lead to a more organized and type-safe structure for the ERC20 token contracts, making their functionalities and exposed APIs clearer through dedicated interfaces. This also improves maintainability and reduces potential naming conflicts or ambiguities.