### PR TITLE
refactor: Restructure Freeze Voting contracts and interfaces

### DIFF
--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -7,98 +7,136 @@ import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/acces
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 abstract contract BaseFreezeVotingV1 is
+    IBaseFreezeVotingV1,
     UUPSUpgradeable,
     Ownable2StepUpgradeable,
-    IBaseFreezeVotingV1,
     ERC165
 {
-    uint48 public freezeProposalCreated;
-
-    uint32 public freezeProposalPeriod;
-
-    uint32 public freezePeriod;
-
-    uint256 public freezeVotesThreshold;
-
-    uint256 public freezeProposalVoteCount;
-
-    mapping(address => mapping(uint48 => bool)) public userHasFreezeVoted;
-
-    event FreezeVoteCast(address indexed voter, uint256 votesCast);
-    event FreezeProposalCreated(address indexed creator);
-    event FreezeVotesThresholdUpdated(uint256 freezeVotesThreshold);
-    event FreezePeriodUpdated(uint32 freezePeriod);
-    event FreezeProposalPeriodUpdated(uint32 freezeProposalPeriod);
+    uint48 internal _freezeProposalCreated;
+    uint32 internal _freezeProposalPeriod;
+    uint32 internal _freezePeriod;
+    uint256 internal _freezeVotesThreshold;
+    uint256 internal _freezeProposalVoteCount;
+    mapping(address => mapping(uint48 => bool)) internal _userHasFreezeVoted;
 
     constructor() {
         _disableInitializers();
     }
 
     function __BaseFreezeVotingV1_init(
-        address _owner,
-        uint32 _freezeProposalPeriod,
-        uint32 _freezePeriod,
-        uint256 _freezeVotesThreshold
+        address owner_,
+        uint32 freezeProposalPeriod_,
+        uint32 freezePeriod_,
+        uint256 freezeVotesThreshold_
     ) internal initializer {
-        __Ownable_init(_owner);
+        __Ownable_init(owner_);
         __UUPSUpgradeable_init();
-        _updateFreezeProposalPeriod(_freezeProposalPeriod);
-        _updateFreezePeriod(_freezePeriod);
-        _updateFreezeVotesThreshold(_freezeVotesThreshold);
+        _updateFreezeProposalPeriod(freezeProposalPeriod_);
+        _updateFreezePeriod(freezePeriod_);
+        _updateFreezeVotesThreshold(freezeVotesThreshold_);
     }
 
     function _authorizeUpgrade(
         address newImplementation
     ) internal virtual override onlyOwner {}
 
-    function castFreezeVote() external virtual;
-
-    function isFrozen() external view virtual returns (bool) {
-        return
-            freezeProposalVoteCount >= freezeVotesThreshold &&
-            block.timestamp < freezeProposalCreated + freezePeriod;
+    function freezeProposalCreated()
+        external
+        view
+        virtual
+        override
+        returns (uint48)
+    {
+        return _freezeProposalCreated;
     }
 
-    function unfreeze() external virtual onlyOwner {
-        freezeProposalCreated = 0;
-        freezeProposalVoteCount = 0;
+    function freezePeriod() external view virtual override returns (uint32) {
+        return _freezePeriod;
+    }
+
+    function freezeVotesThreshold()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        return _freezeVotesThreshold;
+    }
+
+    function freezeProposalPeriod()
+        external
+        view
+        virtual
+        override
+        returns (uint32)
+    {
+        return _freezeProposalPeriod;
+    }
+
+    function freezeProposalVoteCount()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        return _freezeProposalVoteCount;
+    }
+
+    function userHasFreezeVoted(
+        address user,
+        uint48 proposalId
+    ) external view virtual override returns (bool) {
+        return _userHasFreezeVoted[user][proposalId];
+    }
+
+    function isFrozen() external view virtual override returns (bool) {
+        return
+            _freezeProposalVoteCount >= _freezeVotesThreshold &&
+            block.timestamp < _freezeProposalCreated + _freezePeriod;
+    }
+
+    function unfreeze() external virtual override onlyOwner {
+        _freezeProposalCreated = 0;
+        _freezeProposalVoteCount = 0;
     }
 
     function updateFreezeVotesThreshold(
-        uint256 _freezeVotesThreshold
-    ) external virtual onlyOwner {
-        _updateFreezeVotesThreshold(_freezeVotesThreshold);
+        uint256 freezeVotesThreshold_
+    ) external virtual override onlyOwner {
+        _updateFreezeVotesThreshold(freezeVotesThreshold_);
     }
 
     function updateFreezeProposalPeriod(
-        uint32 _freezeProposalPeriod
-    ) external virtual onlyOwner {
-        _updateFreezeProposalPeriod(_freezeProposalPeriod);
+        uint32 freezeProposalPeriod_
+    ) external virtual override onlyOwner {
+        _updateFreezeProposalPeriod(freezeProposalPeriod_);
     }
 
     function updateFreezePeriod(
-        uint32 _freezePeriod
-    ) external virtual onlyOwner {
-        _updateFreezePeriod(_freezePeriod);
+        uint32 freezePeriod_
+    ) external virtual override onlyOwner {
+        _updateFreezePeriod(freezePeriod_);
     }
 
     function _updateFreezeVotesThreshold(
-        uint256 _freezeVotesThreshold
+        uint256 freezeVotesThreshold_
     ) internal virtual {
-        freezeVotesThreshold = _freezeVotesThreshold;
-        emit FreezeVotesThresholdUpdated(_freezeVotesThreshold);
+        _freezeVotesThreshold = freezeVotesThreshold_;
+        emit FreezeVotesThresholdUpdated(freezeVotesThreshold_);
     }
 
     function _updateFreezeProposalPeriod(
-        uint32 _freezeProposalPeriod
+        uint32 freezeProposalPeriod_
     ) internal virtual {
-        freezeProposalPeriod = _freezeProposalPeriod;
-        emit FreezeProposalPeriodUpdated(_freezeProposalPeriod);
+        _freezeProposalPeriod = freezeProposalPeriod_;
+        emit FreezeProposalPeriodUpdated(freezeProposalPeriod_);
     }
 
-    function _updateFreezePeriod(uint32 _freezePeriod) internal virtual {
-        freezePeriod = _freezePeriod;
-        emit FreezePeriodUpdated(_freezePeriod);
+    function _updateFreezePeriod(uint32 freezePeriod_) internal virtual {
+        _freezePeriod = freezePeriod_;
+        emit FreezePeriodUpdated(freezePeriod_);
     }
 
     function supportsInterface(

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -3,79 +3,79 @@ pragma solidity ^0.8.30;
 
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {Version} from "../Version.sol";
+import {IERC20FreezeVotingV1} from "../../interfaces/decent/deployables/IERC20FreezeVotingV1.sol";
+import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 
-contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
+contract ERC20FreezeVotingV1 is
+    IERC20FreezeVotingV1,
+    BaseFreezeVotingV1,
+    Version
+{
     uint16 private constant VERSION = 1;
 
-    IVotes public votesERC20;
-
-    event ERC20FreezeVotingSetUp(
-        address indexed owner,
-        address indexed votesERC20
-    );
-
-    error NoVotes();
-    error AlreadyVoted();
+    IVotes internal _votesERC20;
 
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address _owner,
-        uint256 _freezeVotesThreshold,
-        uint32 _freezeProposalPeriod,
-        uint32 _freezePeriod,
-        address _votesERC20
-    ) public virtual initializer {
+        address owner_,
+        uint256 freezeVotesThreshold_,
+        uint32 freezeProposalPeriod_,
+        uint32 freezePeriod_,
+        address votesERC20_
+    ) public virtual override initializer {
         __BaseFreezeVotingV1_init(
-            _owner,
-            _freezeProposalPeriod,
-            _freezePeriod,
-            _freezeVotesThreshold
+            owner_,
+            freezeProposalPeriod_,
+            freezePeriod_,
+            freezeVotesThreshold_
         );
-        votesERC20 = IVotes(_votesERC20);
+        _votesERC20 = IVotes(votesERC20_);
+    }
 
-        emit ERC20FreezeVotingSetUp(_owner, _votesERC20);
+    function votesERC20() external view virtual override returns (address) {
+        return address(_votesERC20);
     }
 
     function castFreezeVote() external virtual override {
         uint256 userVotes;
 
-        if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
-            freezeProposalCreated = uint48(block.timestamp);
+        if (block.timestamp > _freezeProposalCreated + _freezeProposalPeriod) {
+            _freezeProposalCreated = uint48(block.timestamp);
 
-            userVotes = votesERC20.getPastVotes(
+            userVotes = _votesERC20.getPastVotes(
                 msg.sender,
-                freezeProposalCreated - 1
+                _freezeProposalCreated - 1
             );
 
             if (userVotes == 0) {
                 revert NoVotes();
             }
 
-            freezeProposalVoteCount = userVotes;
+            _freezeProposalVoteCount = userVotes;
 
             emit FreezeProposalCreated(msg.sender);
         } else {
-            if (userHasFreezeVoted[msg.sender][freezeProposalCreated]) {
+            if (_userHasFreezeVoted[msg.sender][_freezeProposalCreated]) {
                 revert AlreadyVoted();
             }
 
-            userVotes = votesERC20.getPastVotes(
+            userVotes = _votesERC20.getPastVotes(
                 msg.sender,
-                freezeProposalCreated - 1
+                _freezeProposalCreated - 1
             );
 
             if (userVotes == 0) {
                 revert NoVotes();
             }
 
-            freezeProposalVoteCount += userVotes;
+            _freezeProposalVoteCount += userVotes;
         }
 
-        userHasFreezeVoted[msg.sender][freezeProposalCreated] = true;
+        _userHasFreezeVoted[msg.sender][_freezeProposalCreated] = true;
 
         emit FreezeVoteCast(msg.sender, userVotes);
     }
@@ -87,6 +87,8 @@ contract ERC20FreezeVotingV1 is BaseFreezeVotingV1, Version {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override(BaseFreezeVotingV1, Version) returns (bool) {
-        return super.supportsInterface(interfaceId);
+        return
+            interfaceId == type(IERC20FreezeVotingV1).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -2,62 +2,64 @@
 pragma solidity ^0.8.30;
 
 import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
+import {IERC721FreezeVotingV1} from "../../interfaces/decent/deployables/IERC721FreezeVotingV1.sol";
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {Version} from "../Version.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
-contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
+contract ERC721FreezeVotingV1 is
+    IERC721FreezeVotingV1,
+    BaseFreezeVotingV1,
+    Version
+{
     uint16 private constant VERSION = 1;
 
-    IERC721VotingStrategyV1 public strategy;
-
-    mapping(uint256 => mapping(address => mapping(uint256 => bool)))
-        public idHasFreezeVoted;
-
-    event ERC721FreezeVotingSetUp(
-        address indexed owner,
-        address indexed strategy
-    );
-
-    error NoVotes();
-    error NotSupported();
-    error UnequalArrays();
+    IERC721VotingStrategyV1 internal _strategy;
+    mapping(uint48 => mapping(address => mapping(uint256 => bool)))
+        internal _idHasFreezeVoted;
 
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address _owner,
-        uint256 _freezeVotesThreshold,
-        uint32 _freezeProposalPeriod,
-        uint32 _freezePeriod,
-        address _strategy
-    ) public virtual initializer {
+        address owner_,
+        uint256 freezeVotesThreshold_,
+        uint32 freezeProposalPeriod_,
+        uint32 freezePeriod_,
+        address strategy_
+    ) public virtual override initializer {
         __BaseFreezeVotingV1_init(
-            _owner,
-            _freezeProposalPeriod,
-            _freezePeriod,
-            _freezeVotesThreshold
+            owner_,
+            freezeProposalPeriod_,
+            freezePeriod_,
+            freezeVotesThreshold_
         );
-        strategy = IERC721VotingStrategyV1(_strategy);
-
-        emit ERC721FreezeVotingSetUp(_owner, _strategy);
+        _strategy = IERC721VotingStrategyV1(strategy_);
     }
 
-    function castFreezeVote() external pure virtual override {
-        revert NotSupported();
+    function strategy() external view virtual override returns (address) {
+        return address(_strategy);
+    }
+
+    function idHasFreezeVoted(
+        uint48 freezeProposalCreated_,
+        address tokenAddress_,
+        uint256 tokenId_
+    ) external view virtual override returns (bool) {
+        return
+            _idHasFreezeVoted[freezeProposalCreated_][tokenAddress_][tokenId_];
     }
 
     function castFreezeVote(
         address[] memory _tokenAddresses,
         uint256[] memory _tokenIds
-    ) external virtual {
+    ) external virtual override {
         if (_tokenAddresses.length != _tokenIds.length) revert UnequalArrays();
 
-        if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
-            freezeProposalCreated = uint48(block.timestamp);
-            freezeProposalVoteCount = 0;
+        if (block.timestamp > _freezeProposalCreated + _freezeProposalPeriod) {
+            _freezeProposalCreated = uint48(block.timestamp);
+            _freezeProposalVoteCount = 0;
             emit FreezeProposalCreated(msg.sender);
         }
 
@@ -68,7 +70,7 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
         );
         if (userVotes == 0) revert NoVotes();
 
-        freezeProposalVoteCount += userVotes;
+        _freezeProposalVoteCount += userVotes;
 
         emit FreezeVoteCast(msg.sender, userVotes);
     }
@@ -89,14 +91,14 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
             }
 
             if (
-                idHasFreezeVoted[freezeProposalCreated][tokenAddress][tokenId]
+                _idHasFreezeVoted[_freezeProposalCreated][tokenAddress][tokenId]
             ) {
                 continue;
             }
 
-            votes += strategy.getTokenWeight(tokenAddress);
+            votes += _strategy.getTokenWeight(tokenAddress);
 
-            idHasFreezeVoted[freezeProposalCreated][tokenAddress][
+            _idHasFreezeVoted[_freezeProposalCreated][tokenAddress][
                 tokenId
             ] = true;
         }
@@ -111,6 +113,8 @@ contract ERC721FreezeVotingV1 is BaseFreezeVotingV1, Version {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override(BaseFreezeVotingV1, Version) returns (bool) {
-        return super.supportsInterface(interfaceId);
+        return
+            interfaceId == type(IERC721FreezeVotingV1).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -2,59 +2,58 @@
 pragma solidity ^0.8.30;
 
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
+import {IMultisigFreezeVotingV1} from "../../interfaces/decent/deployables/IMultisigFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {Version} from "../Version.sol";
 
-contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
+contract MultisigFreezeVotingV1 is
+    IMultisigFreezeVotingV1,
+    BaseFreezeVotingV1,
+    Version
+{
     uint16 private constant VERSION = 1;
 
-    ISafe public parentSafe;
-
-    event MultisigFreezeVotingSetup(
-        address indexed owner,
-        address indexed parentSafe
-    );
-
-    error NotOwner();
-    error AlreadyVoted();
+    ISafe internal _parentSafe;
 
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address _owner,
-        uint256 _freezeVotesThreshold,
-        uint32 _freezeProposalPeriod,
-        uint32 _freezePeriod,
-        address _parentSafe
-    ) public virtual initializer {
+        address owner_,
+        uint256 freezeVotesThreshold_,
+        uint32 freezeProposalPeriod_,
+        uint32 freezePeriod_,
+        address parentSafe_
+    ) public virtual override initializer {
         __BaseFreezeVotingV1_init(
-            _owner,
-            _freezeProposalPeriod,
-            _freezePeriod,
-            _freezeVotesThreshold
+            owner_,
+            freezeProposalPeriod_,
+            freezePeriod_,
+            freezeVotesThreshold_
         );
-        parentSafe = ISafe(_parentSafe);
+        _parentSafe = ISafe(parentSafe_);
+    }
 
-        emit MultisigFreezeVotingSetup(_owner, _parentSafe);
+    function parentSafe() external view virtual override returns (address) {
+        return address(_parentSafe);
     }
 
     function castFreezeVote() external virtual override {
-        if (!parentSafe.isOwner(msg.sender)) revert NotOwner();
+        if (!_parentSafe.isOwner(msg.sender)) revert NotOwner();
 
-        if (block.timestamp > freezeProposalCreated + freezeProposalPeriod) {
-            freezeProposalCreated = uint48(block.timestamp);
-            freezeProposalVoteCount = 1;
+        if (block.timestamp > _freezeProposalCreated + _freezeProposalPeriod) {
+            _freezeProposalCreated = uint48(block.timestamp);
+            _freezeProposalVoteCount = 1;
             emit FreezeProposalCreated(msg.sender);
         } else {
-            if (userHasFreezeVoted[msg.sender][freezeProposalCreated]) {
+            if (_userHasFreezeVoted[msg.sender][_freezeProposalCreated]) {
                 revert AlreadyVoted();
             }
-            freezeProposalVoteCount++;
+            _freezeProposalVoteCount++;
         }
 
-        userHasFreezeVoted[msg.sender][freezeProposalCreated] = true;
+        _userHasFreezeVoted[msg.sender][_freezeProposalCreated] = true;
         emit FreezeVoteCast(msg.sender, 1);
     }
 
@@ -65,6 +64,8 @@ contract MultisigFreezeVotingV1 is BaseFreezeVotingV1, Version {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override(BaseFreezeVotingV1, Version) returns (bool) {
-        return super.supportsInterface(interfaceId);
+        return
+            interfaceId == type(IMultisigFreezeVotingV1).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
@@ -1,65 +1,35 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
-
-/**
- * A specification for a contract which manages the ability to call for and cast a vote
- * to freeze a subDAO.
- *
- * The participants of this vote are parent token holders or signers. The DAO should be
- * able to operate as normal throughout the freeze voting process, however if the vote
- * passes, further transaction executions on the subDAO should be blocked via a Safe guard
- * module (see [MultisigFreezeGuard](../MultisigFreezeGuard.md) / [AzoriusFreezeGuard](../AzoriusFreezeGuard.md)).
- */
 interface IBaseFreezeVotingV1 {
-    /**
-     * Allows an address to cast a "freeze vote", which is a vote to freeze the DAO
-     * from executing transactions, even if they've already passed via a Proposal.
-     *
-     * If a vote to freeze has not already been initiated, a call to this function will do
-     * so.
-     *
-     * This function should be publicly callable by any DAO token holder or signer.
-     */
-    function castFreezeVote() external;
+    event FreezeVoteCast(address indexed voter, uint256 votesCast);
+    event FreezeProposalCreated(address indexed creator);
+    event FreezeVotesThresholdUpdated(uint256 freezeVotesThreshold);
+    event FreezePeriodUpdated(uint32 freezePeriod);
+    event FreezeProposalPeriodUpdated(uint32 freezeProposalPeriod);
 
-    /**
-     * Unfreezes the DAO.
-     */
+    function freezeProposalCreated() external view returns (uint48);
+
+    function freezePeriod() external view returns (uint32);
+
+    function freezeVotesThreshold() external view returns (uint256);
+
+    function freezeProposalPeriod() external view returns (uint32);
+
+    function freezeProposalVoteCount() external view returns (uint256);
+
+    function userHasFreezeVoted(
+        address user,
+        uint48 proposalId
+    ) external view returns (bool);
+
+    function isFrozen() external view returns (bool);
+
     function unfreeze() external;
 
-    /**
-     * Updates the freeze votes threshold for future freeze votes. This is the number of token
-     * votes necessary to begin a freeze on the subDAO.
-     *
-     * @param _freezeVotesThreshold number of freeze votes required to activate a freeze
-     */
     function updateFreezeVotesThreshold(uint256 _freezeVotesThreshold) external;
 
-    /**
-     * Updates the freeze proposal period for future freeze votes. This is the length of time
-     * (in seconds) that a freeze vote is conducted for.
-     *
-     * @param _freezeProposalPeriod number of seconds a freeze proposal has to succeed
-     */
     function updateFreezeProposalPeriod(uint32 _freezeProposalPeriod) external;
 
-    /**
-     * Updates the freeze period. This is the length of time (in seconds) the subDAO is actually
-     * frozen for if a freeze vote passes.
-     *
-     * This period can be overridden by a call to `unfreeze()`, which would require a passed Proposal
-     * from the parentDAO.
-     *
-     * @param _freezePeriod number of seconds a freeze lasts, from time of freeze proposal creation
-     */
     function updateFreezePeriod(uint32 _freezePeriod) external;
-
-    /**
-     * Returns true if the DAO is currently frozen, false otherwise.
-     *
-     * @return bool whether the DAO is currently frozen
-     */
-    function isFrozen() external view returns (bool);
 }

--- a/contracts/interfaces/decent/deployables/IERC20FreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC20FreezeVotingV1.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IBaseFreezeVotingV1} from "./IBaseFreezeVotingV1.sol";
+
+interface IERC20FreezeVotingV1 is IBaseFreezeVotingV1 {
+    error NoVotes();
+    error AlreadyVoted();
+
+    function initialize(
+        address owner,
+        uint256 freezeVotesThreshold,
+        uint32 freezeProposalPeriod,
+        uint32 freezePeriod,
+        address votesERC20
+    ) external;
+
+    function castFreezeVote() external;
+
+    function votesERC20() external view returns (address);
+}

--- a/contracts/interfaces/decent/deployables/IERC721FreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC721FreezeVotingV1.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IBaseFreezeVotingV1} from "./IBaseFreezeVotingV1.sol";
+
+interface IERC721FreezeVotingV1 is IBaseFreezeVotingV1 {
+    error NoVotes();
+    error UnequalArrays();
+
+    function initialize(
+        address owner,
+        uint256 freezeVotesThreshold,
+        uint32 freezeProposalPeriod,
+        uint32 freezePeriod,
+        address strategy
+    ) external;
+
+    function castFreezeVote(
+        address[] memory tokenAddresses,
+        uint256[] memory tokenIds
+    ) external;
+
+    function strategy() external view returns (address);
+
+    function idHasFreezeVoted(
+        uint48 freezeProposalCreated,
+        address tokenAddress,
+        uint256 tokenId
+    ) external view returns (bool);
+}

--- a/contracts/interfaces/decent/deployables/IMultisigFreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IMultisigFreezeVotingV1.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IBaseFreezeVotingV1} from "./IBaseFreezeVotingV1.sol";
+
+interface IMultisigFreezeVotingV1 is IBaseFreezeVotingV1 {
+    error NotOwner();
+    error AlreadyVoted();
+
+    function initialize(
+        address owner,
+        uint256 freezeVotesThreshold,
+        uint32 freezeProposalPeriod,
+        uint32 freezePeriod,
+        address parentSafe
+    ) external;
+
+    function parentSafe() external view returns (address);
+
+    function castFreezeVote() external;
+}

--- a/contracts/mocks/MockFreezeVoting.sol
+++ b/contracts/mocks/MockFreezeVoting.sol
@@ -26,9 +26,6 @@ contract MockFreezeVoting is IBaseFreezeVotingV1 {
         return _isFrozen;
     }
 
-    /**
-     * @inheritdoc IBaseFreezeVotingV1
-     */
     function castFreezeVote() external {
         // Mock implementation - does nothing except emit an event for testing
         emit FreezeVoteCast(msg.sender);
@@ -45,31 +42,52 @@ contract MockFreezeVoting is IBaseFreezeVotingV1 {
     /**
      * @inheritdoc IBaseFreezeVotingV1
      */
-    function updateFreezeVotesThreshold(uint256 freezeVotesThreshold) external {
-        _freezeVotesThreshold = freezeVotesThreshold;
-        emit FreezeVotesThresholdUpdated(freezeVotesThreshold);
+    function updateFreezeVotesThreshold(
+        uint256 freezeVotesThreshold_
+    ) external override {
+        _freezeVotesThreshold = freezeVotesThreshold_;
+        emit FreezeVotesThresholdUpdated(freezeVotesThreshold_);
     }
 
     /**
      * @inheritdoc IBaseFreezeVotingV1
      */
-    function updateFreezeProposalPeriod(uint32 freezeProposalPeriod) external {
-        _freezeProposalPeriod = freezeProposalPeriod;
-        emit FreezeProposalPeriodUpdated(freezeProposalPeriod);
+    function updateFreezeProposalPeriod(
+        uint32 freezeProposalPeriod_
+    ) external override {
+        _freezeProposalPeriod = freezeProposalPeriod_;
+        emit FreezeProposalPeriodUpdated(freezeProposalPeriod_);
     }
 
     /**
      * @inheritdoc IBaseFreezeVotingV1
      */
-    function updateFreezePeriod(uint32 freezePeriod) external {
-        _freezePeriod = freezePeriod;
-        emit FreezePeriodUpdated(freezePeriod);
+    function updateFreezePeriod(uint32 freezePeriod_) external override {
+        _freezePeriod = freezePeriod_;
+        emit FreezePeriodUpdated(freezePeriod_);
     }
 
     // Mock events for testing
     event FreezeVoteCast(address indexed voter);
     event DAOUnfrozen(address indexed unfreezer);
-    event FreezeVotesThresholdUpdated(uint256 newThreshold);
-    event FreezeProposalPeriodUpdated(uint32 newPeriod);
-    event FreezePeriodUpdated(uint32 newPeriod);
+
+    function freezeProposalCreated() external view override returns (uint48) {}
+
+    function freezePeriod() external view override returns (uint32) {}
+
+    function freezeVotesThreshold() external view override returns (uint256) {}
+
+    function freezeProposalPeriod() external view override returns (uint32) {}
+
+    function freezeProposalVoteCount()
+        external
+        view
+        override
+        returns (uint256)
+    {}
+
+    function userHasFreezeVoted(
+        address user,
+        uint48 proposalId
+    ) external view override returns (bool) {}
 }

--- a/contracts/mocks/concretes/deployables/freeze-voting/ConcreteBaseFreezeVotingV1.sol
+++ b/contracts/mocks/concretes/deployables/freeze-voting/ConcreteBaseFreezeVotingV1.sol
@@ -33,23 +33,23 @@ contract ConcreteBaseFreezeVotingV1 is BaseFreezeVotingV1 {
      *
      * Each call counts as one vote by default, or as many votes as set by setMockVotePower.
      */
-    function castFreezeVote() external override {
+    function castFreezeVote() external {
         // If no freeze proposal exists yet, create one
-        if (freezeProposalCreated == 0) {
-            freezeProposalCreated = uint48(block.timestamp);
-            freezeProposalVoteCount = 0; // Initialize to zero
+        if (_freezeProposalCreated == 0) {
+            _freezeProposalCreated = uint48(block.timestamp);
+            _freezeProposalVoteCount = 0; // Initialize to zero
             emit FreezeProposalCreated(msg.sender);
         }
 
         // Check if proposal period has expired
         require(
-            block.timestamp <= freezeProposalCreated + freezeProposalPeriod,
+            block.timestamp <= _freezeProposalCreated + _freezeProposalPeriod,
             "Freeze proposal period expired"
         );
 
         // Check if the user has already voted on this proposal
         require(
-            !userHasFreezeVoted[msg.sender][freezeProposalCreated],
+            !_userHasFreezeVoted[msg.sender][_freezeProposalCreated],
             "Already voted"
         );
 
@@ -57,8 +57,8 @@ contract ConcreteBaseFreezeVotingV1 is BaseFreezeVotingV1 {
         uint256 _mockVotePower = 1;
 
         // Record the vote
-        userHasFreezeVoted[msg.sender][freezeProposalCreated] = true;
-        freezeProposalVoteCount += _mockVotePower;
+        _userHasFreezeVoted[msg.sender][_freezeProposalCreated] = true;
+        _freezeProposalVoteCount += _mockVotePower;
 
         emit FreezeVoteCast(msg.sender, _mockVotePower);
     }

--- a/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
@@ -6,9 +6,14 @@ import {
   ERC1967Proxy__factory,
   ERC20FreezeVotingV1,
   ERC20FreezeVotingV1__factory,
+  IBaseFreezeVotingV1__factory,
+  IERC165__factory,
+  IERC20FreezeVotingV1__factory,
+  IVersion__factory,
   MockERC20Votes,
   MockERC20Votes__factory,
 } from '../../../typechain-types';
+import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
 // Helper function for deploying ERC20FreezeVotingV1 instances using ERC1967Proxy
@@ -482,6 +487,46 @@ describe('ERC20FreezeVotingV1', () => {
     // Use the shared version test utility
     it('should return the correct version number', async () => {
       expect(await freezeVoting.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', () => {
+    it('should support the IERC20FreezeVotingV1 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IERC20FreezeVotingV1__factory.createInterface(), [
+            IBaseFreezeVotingV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IBaseFreezeVotingV1 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IBaseFreezeVotingV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IERC165 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IERC165__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IVersion interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IVersion__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should not support a random interface', async () => {
+      void expect(await freezeVoting.supportsInterface('0x12345678')).to.be.false;
     });
   });
 

--- a/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
@@ -6,11 +6,16 @@ import {
   ERC1967Proxy__factory,
   ERC721FreezeVotingV1,
   ERC721FreezeVotingV1__factory,
+  IBaseFreezeVotingV1__factory,
+  IERC165__factory,
+  IERC721FreezeVotingV1__factory,
+  IVersion__factory,
   MockERC721,
   MockERC721__factory,
   MockERC721VotingStrategy,
   MockERC721VotingStrategy__factory,
 } from '../../../typechain-types';
+import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
 // Helper function for deploying ERC721FreezeVotingV1 proxy instances using ERC1967Proxy
@@ -183,32 +188,22 @@ describe('ERC721FreezeVotingV1', () => {
   });
 
   describe('Freeze Voting Process', () => {
-    it('should reject casting freeze vote with base method', async () => {
-      await expect(
-        freezeVoting.connect(voter1)['castFreezeVote()'](),
-      ).to.be.revertedWithCustomError(freezeVoting, 'NotSupported');
-    });
-
     it('should reject votes with no NFTs', async () => {
       await expect(
-        freezeVoting.connect(nonVoter)['castFreezeVote(address[],uint256[])']([], []),
+        freezeVoting.connect(nonVoter).castFreezeVote([], []),
       ).to.be.revertedWithCustomError(freezeVoting, 'NoVotes');
     });
 
     it('should reject votes with mismatched token arrays', async () => {
       await expect(
-        freezeVoting
-          .connect(voter1)
-          ['castFreezeVote(address[],uint256[])']([await nftCollection1.getAddress()], []),
+        freezeVoting.connect(voter1).castFreezeVote([await nftCollection1.getAddress()], []),
       ).to.be.revertedWithCustomError(freezeVoting, 'UnequalArrays');
     });
 
     it('should create a freeze proposal when first user votes', async () => {
       // Cast the first vote
       await expect(
-        freezeVoting
-          .connect(voter1)
-          ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds),
+        freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds),
       )
         .to.emit(freezeVoting, 'FreezeProposalCreated')
         .withArgs(voter1.address)
@@ -222,23 +217,17 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should accumulate votes correctly based on token weights', async () => {
       // First vote
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(TOKEN1_WEIGHT);
 
       // Second vote
-      await freezeVoting
-        .connect(voter2)
-        ['castFreezeVote(address[],uint256[])'](voter2TokenAddresses, voter2TokenIds);
+      await freezeVoting.connect(voter2).castFreezeVote(voter2TokenAddresses, voter2TokenIds);
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(TOKEN1_WEIGHT + TOKEN2_WEIGHT);
     });
 
     it('should prevent duplicate votes from the same token', async () => {
       // First vote with voter1's NFT
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
       const initialVoteCount = await freezeVoting.freezeProposalVoteCount();
 
       // Voting again with the same NFT - we need to give a valid additional NFT to avoid NoVotes
@@ -253,9 +242,7 @@ describe('ERC721FreezeVotingV1', () => {
       ];
       const combinedIds = [voter1TokenIds[0], newTokenId];
 
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](combinedAddresses, combinedIds);
+      await freezeVoting.connect(voter1).castFreezeVote(combinedAddresses, combinedIds);
 
       // Only the new token's vote should be counted, so vote count should increase by TOKEN1_WEIGHT
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(
@@ -265,9 +252,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should not count votes from NFTs not owned by voter', async () => {
       // First create a proposal with voter1's NFT to avoid having empty votes
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
       const initialVoteCount = await freezeVoting.freezeProposalVoteCount();
 
       // Mint a new NFT to voter2 to avoid NoVotes when trying to vote
@@ -282,9 +267,7 @@ describe('ERC721FreezeVotingV1', () => {
       const combinedIds = [voter1TokenIds[0], validTokenId];
 
       // Should process transaction but only count voter2's own NFT
-      await freezeVoting
-        .connect(voter2)
-        ['castFreezeVote(address[],uint256[])'](combinedAddresses, combinedIds);
+      await freezeVoting.connect(voter2).castFreezeVote(combinedAddresses, combinedIds);
 
       // Only voter2's NFT vote should be counted, so vote count should increase by TOKEN1_WEIGHT
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(
@@ -294,9 +277,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should accept votes with multiple NFTs', async () => {
       // Voter3 votes with both NFTs
-      await freezeVoting
-        .connect(voter3)
-        ['castFreezeVote(address[],uint256[])'](voter3TokenAddresses, voter3TokenIds);
+      await freezeVoting.connect(voter3).castFreezeVote(voter3TokenAddresses, voter3TokenIds);
 
       // Vote count should be sum of weights (1 + 2 = 3)
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(TOKEN1_WEIGHT + TOKEN2_WEIGHT);
@@ -304,9 +285,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should create a new proposal after proposal period expiry', async () => {
       // First proposal
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
       const firstProposalTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Increase time to pass the freeze proposal period
@@ -314,9 +293,7 @@ describe('ERC721FreezeVotingV1', () => {
 
       // Second vote should create a new proposal
       await expect(
-        freezeVoting
-          .connect(voter2)
-          ['castFreezeVote(address[],uint256[])'](voter2TokenAddresses, voter2TokenIds),
+        freezeVoting.connect(voter2).castFreezeVote(voter2TokenAddresses, voter2TokenIds),
       )
         .to.emit(freezeVoting, 'FreezeProposalCreated')
         .withArgs(voter2.address);
@@ -337,9 +314,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should not be frozen when below threshold', async () => {
       // With threshold of 3, cast only 1 vote (voter1)
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
 
       // Total votes: 1, below threshold of 3
       void expect(await freezeVoting.isFrozen()).to.be.false;
@@ -347,12 +322,8 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should be frozen once threshold is met', async () => {
       // With threshold of 3, cast votes from both voter1 and voter2 (1 + 2 = 3)
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
-      await freezeVoting
-        .connect(voter2)
-        ['castFreezeVote(address[],uint256[])'](voter2TokenAddresses, voter2TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter2).castFreezeVote(voter2TokenAddresses, voter2TokenIds);
 
       // Total votes: 3, equal to threshold of 3
       void expect(await freezeVoting.isFrozen()).to.be.true;
@@ -360,9 +331,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should automatically unfreeze after freeze period', async () => {
       // Cast enough votes to exceed threshold
-      await freezeVoting
-        .connect(voter3)
-        ['castFreezeVote(address[],uint256[])'](voter3TokenAddresses, voter3TokenIds);
+      await freezeVoting.connect(voter3).castFreezeVote(voter3TokenAddresses, voter3TokenIds);
 
       // Should be frozen initially
       void expect(await freezeVoting.isFrozen()).to.be.true;
@@ -376,9 +345,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should allow owner to unfreeze manually', async () => {
       // Cast enough votes to exceed threshold
-      await freezeVoting
-        .connect(voter3)
-        ['castFreezeVote(address[],uint256[])'](voter3TokenAddresses, voter3TokenIds);
+      await freezeVoting.connect(voter3).castFreezeVote(voter3TokenAddresses, voter3TokenIds);
 
       // Should be frozen
       void expect(await freezeVoting.isFrozen()).to.be.true;
@@ -396,9 +363,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should not allow non-owner to unfreeze', async () => {
       // Cast enough votes to exceed threshold
-      await freezeVoting
-        .connect(voter3)
-        ['castFreezeVote(address[],uint256[])'](voter3TokenAddresses, voter3TokenIds);
+      await freezeVoting.connect(voter3).castFreezeVote(voter3TokenAddresses, voter3TokenIds);
 
       // Non-owner tries to unfreeze
       await expect(freezeVoting.connect(voter1).unfreeze()).to.be.revertedWithCustomError(
@@ -412,9 +377,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should track freeze status across multiple proposals', async () => {
       // First proposal: voter3 votes with both NFTs to meet threshold
-      await freezeVoting
-        .connect(voter3)
-        ['castFreezeVote(address[],uint256[])'](voter3TokenAddresses, voter3TokenIds);
+      await freezeVoting.connect(voter3).castFreezeVote(voter3TokenAddresses, voter3TokenIds);
 
       // DAO should be frozen
       void expect(await freezeVoting.isFrozen()).to.be.true;
@@ -426,17 +389,13 @@ describe('ERC721FreezeVotingV1', () => {
       void expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Start a new proposal with not enough votes
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
 
       // DAO should not be frozen with only voter1's vote
       void expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Add voter2's vote to reach threshold
-      await freezeVoting
-        .connect(voter2)
-        ['castFreezeVote(address[],uint256[])'](voter2TokenAddresses, voter2TokenIds);
+      await freezeVoting.connect(voter2).castFreezeVote(voter2TokenAddresses, voter2TokenIds);
 
       // DAO should be frozen again
       void expect(await freezeVoting.isFrozen()).to.be.true;
@@ -494,9 +453,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should affect freeze status when threshold is updated', async () => {
       // Cast votes to meet the threshold of 3
-      await freezeVoting
-        .connect(voter3)
-        ['castFreezeVote(address[],uint256[])'](voter3TokenAddresses, voter3TokenIds);
+      await freezeVoting.connect(voter3).castFreezeVote(voter3TokenAddresses, voter3TokenIds);
 
       // DAO should be frozen
       void expect(await freezeVoting.isFrozen()).to.be.true;
@@ -523,9 +480,7 @@ describe('ERC721FreezeVotingV1', () => {
       ).to.be.false;
 
       // User votes with token
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
 
       // Get the proposal created timestamp
       const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
@@ -542,9 +497,7 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should reset token voting status when unfreeze is called', async () => {
       // User votes with token
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
 
       // Get the created timestamp
       const createdTimestamp = await freezeVoting.freezeProposalCreated();
@@ -565,9 +518,7 @@ describe('ERC721FreezeVotingV1', () => {
       expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
 
       // User should be able to vote again with the same token
-      await freezeVoting
-        .connect(voter1)
-        ['castFreezeVote(address[],uint256[])'](voter1TokenAddresses, voter1TokenIds);
+      await freezeVoting.connect(voter1).castFreezeVote(voter1TokenAddresses, voter1TokenIds);
       const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // The token should be marked as voted for the new proposal
@@ -584,6 +535,46 @@ describe('ERC721FreezeVotingV1', () => {
   describe('Version', () => {
     it('should return the correct version number', async () => {
       expect(await freezeVoting.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', () => {
+    it('should support the IERC721FreezeVotingV1 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IERC721FreezeVotingV1__factory.createInterface(), [
+            IBaseFreezeVotingV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IBaseFreezeVotingV1 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IBaseFreezeVotingV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IERC165 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IERC165__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IVersion interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IVersion__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should not support a random interface', async () => {
+      void expect(await freezeVoting.supportsInterface('0x12345678')).to.be.false;
     });
   });
 

--- a/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
@@ -4,11 +4,16 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IBaseFreezeVotingV1__factory,
+  IERC165__factory,
+  IMultisigFreezeVotingV1__factory,
+  IVersion__factory,
   MockSafe,
   MockSafe__factory,
   MultisigFreezeVotingV1,
   MultisigFreezeVotingV1__factory,
 } from '../../../typechain-types';
+import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
 // Helper function for deploying MultisigFreezeVotingV1 proxy instances using ERC1967Proxy
@@ -482,6 +487,46 @@ describe('MultisigFreezeVotingV1', () => {
   describe('Version', () => {
     it('should return the correct version number', async () => {
       expect(await freezeVoting.getVersion()).to.equal(1);
+    });
+  });
+
+  describe('ERC165', () => {
+    it('should support the IERC721FreezeVotingV1 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IMultisigFreezeVotingV1__factory.createInterface(), [
+            IBaseFreezeVotingV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IBaseFreezeVotingV1 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IBaseFreezeVotingV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IERC165 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IERC165__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IVersion interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IVersion__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should not support a random interface', async () => {
+      void expect(await freezeVoting.supportsInterface('0x12345678')).to.be.false;
     });
   });
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/292

Fixes [ENG-1003](https://linear.app/decent-labs/issue/ENG-1003/refactor-freeze-voting-contracts-with-granular-interfaces-and)

This commit implements a significant refactoring of the Freeze Voting contract system. The primary goals are to:
1.  Align `BaseFreezeVotingV1` more closely with its interface `IBaseFreezeVotingV1` by making state variables internal and providing public getters.
2.  Introduce specific interfaces (`IERC20FreezeVotingV1`, `IERC721FreezeVotingV1`, `IMultisigFreezeVotingV1`) for each concrete freeze voting implementation.
3.  Ensure concrete implementations correctly inherit from and utilize the refactored base contract and their new specific interfaces.
4.  Update tests to reflect these structural changes, especially regarding state access, event emission, and interface support.

**Detailed Changes:**

1.  **Refactoring of `BaseFreezeVotingV1.sol`:**
    *   All public state variables (`freezeProposalCreated`, `freezeProposalPeriod`, `freezePeriod`, `freezeVotesThreshold`, `freezeProposalVoteCount`, `userHasFreezeVoted` mapping) have been made `internal` (prefixed with `_`).
    *   Public `virtual` getter functions have been added for each of these internal state variables, fulfilling the requirements of `IBaseFreezeVotingV1`. These getters are:
        *   `freezeProposalCreated() returns (uint48)`
        *   `freezePeriod() returns (uint32)`
        *   `freezeVotesThreshold() returns (uint256)`
        *   `freezeProposalPeriod() returns (uint32)`
        *   `freezeProposalVoteCount() returns (uint256)`
        *   `userHasFreezeVoted(address user, uint48 proposalId) returns (bool)`
    *   Events (`FreezeVoteCast`, `FreezeProposalCreated`, etc.) are now defined in `IBaseFreezeVotingV1`.
    *   The `__BaseFreezeVotingV1_init` function parameter names have been updated (e.g., `_owner` to `owner_`).
    *   Functions like `isFrozen`, `unfreeze`, `updateFreezeVotesThreshold`, etc., now operate on the internal state variables (e.g., `_freezeProposalVoteCount` instead of `freezeProposalVoteCount`).
    *   The abstract `castFreezeVote()` function declaration has been removed from the base contract as it's now defined in the specific implementation interfaces.

2.  **Updates to `IBaseFreezeVotingV1.sol`:**
    *   Now defines the events previously in `BaseFreezeVotingV1.sol`: `FreezeVoteCast`, `FreezeProposalCreated`, `FreezeVotesThresholdUpdated`, `FreezePeriodUpdated`, `FreezeProposalPeriodUpdated`.
    *   Includes definitions for all the new public getter functions that correspond to the internal state variables in `BaseFreezeVotingV1`.
    *   The `castFreezeVote()` function is no longer declared here, as it's specific to implementations.

3.  **Introduction of Specific Freeze Voting Interfaces:**
    *   `IERC20FreezeVotingV1.sol`: New interface inheriting from `IBaseFreezeVotingV1`. Defines `initialize`, `castFreezeVote`, `votesERC20` (getter), and specific errors (`NoVotes`, `AlreadyVoted`).
    *   `IERC721FreezeVotingV1.sol`: New interface inheriting from `IBaseFreezeVotingV1`. Defines `initialize`, `castFreezeVote(address[],uint256[])`, `strategy` (getter), `idHasFreezeVoted` (getter), and specific errors (`NoVotes`, `UnequalArrays`).
    *   `IMultisigFreezeVotingV1.sol`: New interface inheriting from `IBaseFreezeVotingV1`. Defines `initialize`, `parentSafe` (getter), `castFreezeVote`, and specific errors (`NotOwner`, `AlreadyVoted`).

4.  **Refactoring of `ERC20FreezeVotingV1.sol`:**
    *   Now implements `IERC20FreezeVotingV1` and inherits from `BaseFreezeVotingV1` and `Version`.
    *   The `votesERC20` state variable is now `internal _votesERC20` with a public `virtual override votesERC20() returns (address)` getter.
    *   The `ERC20FreezeVotingSetUp` event has been removed (functionality covered by interface and base events).
    *   Errors `NoVotes` and `AlreadyVoted` are now defined in `IERC20FreezeVotingV1`.
    *   `initialize` and `castFreezeVote` function signatures match the `IERC20FreezeVotingV1` interface.
    *   Logic now uses internal state variables from `BaseFreezeVotingV1` (e.g., `_freezeProposalCreated`).
    *   `supportsInterface` updated to check for `type(IERC20FreezeVotingV1).interfaceId`.

5.  **Refactoring of `ERC721FreezeVotingV1.sol`:**
    *   Now implements `IERC721FreezeVotingV1` and inherits from `BaseFreezeVotingV1` and `Version`.
    *   `strategy` state variable is `internal _strategy` with a public getter.
    *   `idHasFreezeVoted` mapping is `internal _idHasFreezeVoted` with a public getter.
    *   The `ERC721FreezeVotingSetUp` event has been removed.
    *   Errors `NoVotes`, `NotSupported`, `UnequalArrays` are now in `IERC721FreezeVotingV1` (Note: `NotSupported` was removed from concrete contract as `castFreezeVote()` is no longer present).
    *   The `castFreezeVote()` that took no arguments has been removed from the contract, aligning with the interface which only defines the version taking token arrays.
    *   `initialize` and `castFreezeVote(address[],uint256[])` signatures match `IERC721FreezeVotingV1`.
    *   Logic uses internal state variables from `BaseFreezeVotingV1`.
    *   `supportsInterface` updated to check for `type(IERC721FreezeVotingV1).interfaceId`.

6.  **Refactoring of `MultisigFreezeVotingV1.sol`:**
    *   Now implements `IMultisigFreezeVotingV1` and inherits from `BaseFreezeVotingV1` and `Version`.
    *   `parentSafe` state variable is `internal _parentSafe` with a public getter.
    *   The `MultisigFreezeVotingSetup` event has been removed.
    *   Errors `NotOwner` and `AlreadyVoted` are now defined in `IMultisigFreezeVotingV1`.
    *   `initialize` and `castFreezeVote` function signatures match `IMultisigFreezeVotingV1`.
    *   Logic uses internal state variables from `BaseFreezeVotingV1`.
    *   `supportsInterface` updated to check for `type(IMultisigFreezeVotingV1).interfaceId`.

7.  **Updates to Mock Contracts:**
    *   `MockFreezeVoting.sol`: Updated to implement the modified `IBaseFreezeVotingV1` (added empty implementations for new getter functions).
    *   `ConcreteBaseFreezeVotingV1.sol`: Updated to use internal state variables (e.g., `_freezeProposalCreated`) from `BaseFreezeVotingV1`.

8.  **Test Updates:**
    *   Across `ERC20FreezeVotingV1.test.ts`, `ERC721FreezeVotingV1.test.ts`, `MultisigFreezeVotingV1.test.ts`:
        *   Added comprehensive ERC165 `supportsInterface` checks for the new specific interfaces (`IERC20FreezeVotingV1`, `IERC721FreezeVotingV1`, `IMultisigFreezeVotingV1`) and the base `IBaseFreezeVotingV1`.
        *   In `ERC721FreezeVotingV1.test.ts`, calls to `castFreezeVote()` were updated to use the version that takes arguments, as the no-argument version was removed.
        *   Removed assertions for deleted setup events.

This extensive refactoring enhances the modularity, type safety, and clarity of the freeze voting system, making it more maintainable and easier to extend in the future.