### PR TITLE
refactor: Standardize AzoriusV1 and FractalModuleV1 contracts and interfaces

### DIFF
--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -43,91 +43,58 @@ contract AzoriusV1 is
     bytes32 public constant TRANSACTION_TYPEHASH =
         0x72e9670a7ee00f5fbf1049b8c38e3f22fab7e9b85029e85cf9412f17fdd5c2ad;
 
-    uint32 public totalProposalCount;
-
-    uint32 public timelockPeriod;
-
-    uint32 public executionPeriod;
-
-    mapping(uint256 => Proposal) internal proposals;
-
-    IStrategyBaseV1 public strategy;
-
-    event AzoriusSetUp(
-        address indexed creator,
-        address indexed owner,
-        address indexed avatar,
-        address target
-    );
-    event ProposalCreated(
-        address strategy,
-        uint256 proposalId,
-        address proposer,
-        Transaction[] transactions,
-        string metadata
-    );
-    event ProposalExecuted(uint32 proposalId, bytes32[] txHashes);
-    event TimelockPeriodUpdated(uint32 timelockPeriod);
-    event ExecutionPeriodUpdated(uint32 executionPeriod);
-    event StrategyUpdated(address strategy);
-
-    error InvalidStrategy();
-    error InvalidProposal();
-    error InvalidProposer();
-    error ProposalNotExecutable();
-    error InvalidTxHash();
-    error TxFailed();
-    error InvalidTxs();
-    error InvalidArrayLengths();
+    uint32 internal _totalProposalCount;
+    uint32 internal _timelockPeriod;
+    uint32 internal _executionPeriod;
+    mapping(uint256 => Proposal) internal _proposals;
+    IStrategyBaseV1 internal _strategy;
 
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address _owner,
-        address _avatar,
-        address _target,
-        address _strategy,
-        uint32 _timelockPeriod,
-        uint32 _executionPeriod
-    ) public virtual initializer {
+        address owner_,
+        address avatar_,
+        address target_,
+        address strategy_,
+        uint32 timelockPeriod_,
+        uint32 executionPeriod_
+    ) public virtual override initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
 
-        setAvatar(_avatar);
-        setTarget(_target);
+        setAvatar(avatar_);
+        setTarget(target_);
 
-        _updateStrategy(_strategy);
-        _updateTimelockPeriod(_timelockPeriod);
-        _updateExecutionPeriod(_executionPeriod);
+        _updateStrategy(strategy_);
+        _updateTimelockPeriod(timelockPeriod_);
+        _updateExecutionPeriod(executionPeriod_);
 
-        OwnableUpgradeable.transferOwnership(_owner);
-
-        emit AzoriusSetUp(msg.sender, _owner, _avatar, _target);
+        OwnableUpgradeable.transferOwnership(owner_);
     }
 
     function setUp(
         bytes memory initializeParams
     ) public virtual override initializer {
         (
-            address _owner,
-            address _avatar,
-            address _target,
-            address _strategy,
-            uint32 _timelockPeriod,
-            uint32 _executionPeriod
+            address owner_,
+            address avatar_,
+            address target_,
+            address strategy_,
+            uint32 timelockPeriod_,
+            uint32 executionPeriod_
         ) = abi.decode(
                 initializeParams,
                 (address, address, address, address, uint32, uint32)
             );
         initialize(
-            _owner,
-            _avatar,
-            _target,
-            _strategy,
-            _timelockPeriod,
-            _executionPeriod
+            owner_,
+            avatar_,
+            target_,
+            strategy_,
+            timelockPeriod_,
+            executionPeriod_
         );
     }
 
@@ -135,22 +102,50 @@ contract AzoriusV1 is
         address newImplementation
     ) internal virtual override onlyOwner {}
 
+    function totalProposalCount()
+        external
+        view
+        virtual
+        override
+        returns (uint32)
+    {
+        return _totalProposalCount;
+    }
+
+    function timelockPeriod() external view virtual override returns (uint32) {
+        return _timelockPeriod;
+    }
+
+    function executionPeriod() external view virtual override returns (uint32) {
+        return _executionPeriod;
+    }
+
+    function proposals(
+        uint32 _proposalId
+    ) external view virtual override returns (Proposal memory) {
+        return _proposals[_proposalId];
+    }
+
+    function strategy() external view virtual override returns (address) {
+        return address(_strategy);
+    }
+
     function updateTimelockPeriod(
-        uint32 _timelockPeriod
+        uint32 timelockPeriod_
     ) external virtual override onlyOwner {
-        _updateTimelockPeriod(_timelockPeriod);
+        _updateTimelockPeriod(timelockPeriod_);
     }
 
     function updateExecutionPeriod(
-        uint32 _executionPeriod
+        uint32 executionPeriod_
     ) external virtual override onlyOwner {
-        _updateExecutionPeriod(_executionPeriod);
+        _updateExecutionPeriod(executionPeriod_);
     }
 
     function updateStrategy(
-        address _strategy
+        address strategy_
     ) external virtual override onlyOwner {
-        _updateStrategy(_strategy);
+        _updateStrategy(strategy_);
     }
 
     function submitProposal(
@@ -158,7 +153,7 @@ contract AzoriusV1 is
         string calldata _metadata,
         bytes memory _data
     ) external virtual override {
-        if (!strategy.isProposer(msg.sender)) revert InvalidProposer();
+        if (!_strategy.isProposer(msg.sender)) revert InvalidProposer();
 
         bytes32[] memory txHashes = new bytes32[](_transactions.length);
         uint256 transactionsLength = _transactions.length;
@@ -174,22 +169,22 @@ contract AzoriusV1 is
             }
         }
 
-        proposals[totalProposalCount].strategy = address(strategy);
-        proposals[totalProposalCount].txHashes = txHashes;
-        proposals[totalProposalCount].timelockPeriod = timelockPeriod;
-        proposals[totalProposalCount].executionPeriod = executionPeriod;
+        _proposals[_totalProposalCount].strategy = address(_strategy);
+        _proposals[_totalProposalCount].txHashes = txHashes;
+        _proposals[_totalProposalCount].timelockPeriod = _timelockPeriod;
+        _proposals[_totalProposalCount].executionPeriod = _executionPeriod;
 
-        strategy.initializeProposal(totalProposalCount, txHashes, _data);
+        _strategy.initializeProposal(_totalProposalCount, txHashes, _data);
 
         emit ProposalCreated(
-            address(strategy),
-            totalProposalCount,
+            address(_strategy),
+            _totalProposalCount,
             msg.sender,
             _transactions,
             _metadata
         );
 
-        totalProposalCount++;
+        _totalProposalCount++;
     }
 
     function executeProposal(
@@ -206,8 +201,8 @@ contract AzoriusV1 is
             _targets.length != _operations.length
         ) revert InvalidArrayLengths();
         if (
-            proposals[_proposalId].executionCounter + _targets.length >
-            proposals[_proposalId].txHashes.length
+            _proposals[_proposalId].executionCounter + _targets.length >
+            _proposals[_proposalId].txHashes.length
         ) revert InvalidTxs();
         uint256 targetsLength = _targets.length;
         bytes32[] memory txHashes = new bytes32[](targetsLength);
@@ -230,13 +225,13 @@ contract AzoriusV1 is
         uint32 _proposalId,
         uint32 _txIndex
     ) external view virtual override returns (bytes32) {
-        return proposals[_proposalId].txHashes[_txIndex];
+        return _proposals[_proposalId].txHashes[_txIndex];
     }
 
     function getProposalTxHashes(
         uint32 _proposalId
     ) external view virtual override returns (bytes32[] memory) {
-        return proposals[_proposalId].txHashes;
+        return _proposals[_proposalId].txHashes;
     }
 
     function getProposal(
@@ -247,35 +242,35 @@ contract AzoriusV1 is
         virtual
         override
         returns (
-            address _strategy,
-            bytes32[] memory _txHashes,
-            uint32 _timelockPeriod,
-            uint32 _executionPeriod,
-            uint32 _executionCounter
+            address strategy_,
+            bytes32[] memory txHashes_,
+            uint32 timelockPeriod_,
+            uint32 executionPeriod_,
+            uint32 executionCounter_
         )
     {
-        Proposal memory _proposal = proposals[_proposalId];
-        _strategy = _proposal.strategy;
-        _txHashes = _proposal.txHashes;
-        _timelockPeriod = _proposal.timelockPeriod;
-        _executionPeriod = _proposal.executionPeriod;
-        _executionCounter = _proposal.executionCounter;
+        Proposal memory _proposal = _proposals[_proposalId];
+        strategy_ = _proposal.strategy;
+        txHashes_ = _proposal.txHashes;
+        timelockPeriod_ = _proposal.timelockPeriod;
+        executionPeriod_ = _proposal.executionPeriod;
+        executionCounter_ = _proposal.executionCounter;
     }
 
     function proposalState(
         uint32 _proposalId
     ) public view virtual override returns (ProposalState) {
-        if (_proposalId >= totalProposalCount) revert InvalidProposal();
-        Proposal memory _proposal = proposals[_proposalId];
-        IStrategyBaseV1 _strategy = IStrategyBaseV1(_proposal.strategy);
+        if (_proposalId >= _totalProposalCount) revert InvalidProposal();
+        Proposal memory _proposal = _proposals[_proposalId];
+        IStrategyBaseV1 strategy_ = IStrategyBaseV1(_proposal.strategy);
 
-        (, uint48 votingEndTimestamp) = _strategy.getVotingTimestamps(
+        (, uint48 votingEndTimestamp) = strategy_.getVotingTimestamps(
             _proposalId
         );
 
         if (block.timestamp <= votingEndTimestamp) {
             return ProposalState.ACTIVE;
-        } else if (!_strategy.isPassed(_proposalId)) {
+        } else if (!strategy_.isPassed(_proposalId)) {
             return ProposalState.FAILED;
         } else if (_proposal.executionCounter == _proposal.txHashes.length) {
             return ProposalState.EXECUTED;
@@ -345,30 +340,30 @@ contract AzoriusV1 is
             revert ProposalNotExecutable();
         txHash = getTxHash(_target, _value, _data, _operation);
         if (
-            proposals[_proposalId].txHashes[
-                proposals[_proposalId].executionCounter
+            _proposals[_proposalId].txHashes[
+                _proposals[_proposalId].executionCounter
             ] != txHash
         ) revert InvalidTxHash();
 
-        proposals[_proposalId].executionCounter++;
+        _proposals[_proposalId].executionCounter++;
 
         if (!exec(_target, _value, _data, _operation)) revert TxFailed();
     }
 
-    function _updateTimelockPeriod(uint32 _timelockPeriod) internal virtual {
-        timelockPeriod = _timelockPeriod;
-        emit TimelockPeriodUpdated(_timelockPeriod);
+    function _updateTimelockPeriod(uint32 timelockPeriod_) internal virtual {
+        _timelockPeriod = timelockPeriod_;
+        emit TimelockPeriodUpdated(timelockPeriod_);
     }
 
-    function _updateExecutionPeriod(uint32 _executionPeriod) internal virtual {
-        executionPeriod = _executionPeriod;
-        emit ExecutionPeriodUpdated(_executionPeriod);
+    function _updateExecutionPeriod(uint32 executionPeriod_) internal virtual {
+        _executionPeriod = executionPeriod_;
+        emit ExecutionPeriodUpdated(executionPeriod_);
     }
 
-    function _updateStrategy(address _strategy) internal virtual {
-        if (_strategy == address(0)) revert InvalidStrategy();
-        strategy = IStrategyBaseV1(_strategy);
-        emit StrategyUpdated(_strategy);
+    function _updateStrategy(address strategy_) internal virtual {
+        if (strategy_ == address(0)) revert InvalidStrategy();
+        _strategy = IStrategyBaseV1(strategy_);
+        emit StrategyUpdated(strategy_);
     }
 
     function getVersion() public view virtual override returns (uint16) {

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -17,24 +17,22 @@ contract FractalModuleV1 is
 {
     uint16 private constant VERSION = 1;
 
-    error TxFailed();
-
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address _owner,
-        address _avatar,
-        address _target
-    ) public virtual initializer {
+        address owner_,
+        address avatar_,
+        address target_
+    ) public virtual override initializer {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
 
-        setAvatar(_avatar);
-        setTarget(_target);
+        setAvatar(avatar_);
+        setTarget(target_);
 
-        OwnableUpgradeable.transferOwnership(_owner);
+        OwnableUpgradeable.transferOwnership(owner_);
     }
 
     function setUp(
@@ -51,13 +49,12 @@ contract FractalModuleV1 is
         address newImplementation
     ) internal virtual override onlyOwner {}
 
-    function execTx(bytes memory execTxData) public virtual onlyOwner {
-        (
-            address _target,
-            uint256 _value,
-            bytes memory _data,
-            Enum.Operation _operation
-        ) = abi.decode(execTxData, (address, uint256, bytes, Enum.Operation));
+    function execTx(
+        address _target,
+        uint256 _value,
+        bytes memory _data,
+        Enum.Operation _operation
+    ) public virtual override onlyOwner {
         if (!exec(_target, _value, _data, _operation)) revert TxFailed();
     }
 

--- a/contracts/interfaces/decent/deployables/IAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IAzoriusV1.sol
@@ -4,6 +4,27 @@ pragma solidity ^0.8.30;
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 interface IAzoriusV1 {
+    event ProposalCreated(
+        address strategy,
+        uint256 proposalId,
+        address proposer,
+        Transaction[] transactions,
+        string metadata
+    );
+    event ProposalExecuted(uint32 proposalId, bytes32[] txHashes);
+    event TimelockPeriodUpdated(uint32 timelockPeriod);
+    event ExecutionPeriodUpdated(uint32 executionPeriod);
+    event StrategyUpdated(address strategy);
+
+    error InvalidStrategy();
+    error InvalidProposal();
+    error InvalidProposer();
+    error ProposalNotExecutable();
+    error InvalidTxHash();
+    error TxFailed();
+    error InvalidTxs();
+    error InvalidArrayLengths();
+
     struct Transaction {
         address to;
         uint256 value;
@@ -27,6 +48,27 @@ interface IAzoriusV1 {
         EXPIRED,
         FAILED
     }
+
+    function initialize(
+        address owner,
+        address avatar,
+        address target,
+        address strategy,
+        uint32 timelockPeriod,
+        uint32 executionPeriod
+    ) external;
+
+    function totalProposalCount() external view returns (uint32);
+
+    function timelockPeriod() external view returns (uint32);
+
+    function executionPeriod() external view returns (uint32);
+
+    function proposals(
+        uint32 _proposalId
+    ) external view returns (Proposal memory);
+
+    function strategy() external view returns (address);
 
     function updateTimelockPeriod(uint32 _timelockPeriod) external;
 

--- a/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
+++ b/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
@@ -2,8 +2,16 @@
 pragma solidity ^0.8.30;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 interface IFractalModuleV1 {
-    function execTx(bytes memory execTxData) external;
+    error TxFailed();
+
+    function initialize(address owner, address avatar, address target) external;
+
+    function execTx(
+        address _target,
+        uint256 _value,
+        bytes memory _data,
+        Enum.Operation _operation
+    ) external;
 }

--- a/test/deployables/modules/FractalModuleV1.test.ts
+++ b/test/deployables/modules/FractalModuleV1.test.ts
@@ -245,72 +245,62 @@ describe('FractalModuleV1', () => {
     });
 
     describe('Authorization', () => {
-      let txData: string;
+      let target: string;
+      let value: bigint;
+      let data: string;
+      let operation: number;
 
       beforeEach(async () => {
         await mockToken.mint(await avatar.getAddress(), 1000); // Mint tokens for these tests
-        txData = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'uint256', 'bytes', 'uint8'],
-          [
-            await mockToken.getAddress(),
-            0,
-            mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
-            0, // Call operation
-          ],
-        );
+
+        target = await mockToken.getAddress();
+        value = 0n;
+        data = mockToken.interface.encodeFunctionData('transfer', [user.address, 100]);
+        operation = 0;
       });
 
       it('should allow owner to execute transactions', async () => {
         await mockToken.mint(await avatar.getAddress(), 1000);
-        await fractalModule.execTx(txData);
+        await fractalModule.execTx(target, value, data, operation);
         expect(await mockToken.balanceOf(user.address)).to.equal(100);
       });
 
       it('should revert with OwnableUnauthorizedAccount for non-owner', async () => {
-        await expect(fractalModule.connect(user).execTx(txData)).to.be.revertedWithCustomError(
-          fractalModule,
-          'OwnableUnauthorizedAccount',
-        );
+        await expect(
+          fractalModule.connect(user).execTx(target, value, data, operation),
+        ).to.be.revertedWithCustomError(fractalModule, 'OwnableUnauthorizedAccount');
       });
     });
 
     describe('Transaction Success/Failure', () => {
-      let txData: string;
+      let target: string;
+      let value: bigint;
+      let data: string;
+      let operation: number;
 
       beforeEach(async () => {
-        txData = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'uint256', 'bytes', 'uint8'],
-          [
-            await mockToken.getAddress(),
-            0,
-            mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
-            0, // Call operation
-          ],
-        );
+        target = await mockToken.getAddress();
+        value = 0n;
+        data = mockToken.interface.encodeFunctionData('transfer', [user.address, 100]);
+        operation = 0;
       });
 
       it('should execute successful transactions', async () => {
         await mockToken.mint(await avatar.getAddress(), 1000);
-        await fractalModule.execTx(txData);
+        await fractalModule.execTx(target, value, data, operation);
         expect(await mockToken.balanceOf(user.address)).to.equal(100);
       });
 
       it('should revert with TxFailed on failed transactions', async () => {
         // No tokens minted to avatar, so transfer should fail
-        const failingTxData = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'uint256', 'bytes', 'uint8'],
-          [
-            await mockToken.getAddress(),
-            0,
-            mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
-            0,
-          ],
-        );
+        target = await mockToken.getAddress();
+        value = 0n;
+        data = mockToken.interface.encodeFunctionData('transfer', [user.address, 100]);
+        operation = 0;
 
-        await expect(fractalModule.execTx(failingTxData)).to.be.revertedWithCustomError(
-          fractalModule,
-          'TxFailed',
-        );
+        await expect(
+          fractalModule.execTx(target, value, data, operation),
+        ).to.be.revertedWithCustomError(fractalModule, 'TxFailed');
       });
     });
 
@@ -322,35 +312,25 @@ describe('FractalModuleV1', () => {
           value: ethers.parseEther('1.0'),
         });
 
-        const txData = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'uint256', 'bytes', 'uint8'],
-          [
-            user.address,
-            ethers.parseEther('0.5'),
-            '0x', // empty data
-            0, // Call operation
-          ],
-        );
+        const target = user.address;
+        const value = ethers.parseEther('0.5');
+        const data = '0x';
+        const operation = 0;
 
         const initialBalance = await ethers.provider.getBalance(user.address);
-        await fractalModule.execTx(txData);
+        await fractalModule.execTx(target, value, data, operation);
         const finalBalance = await ethers.provider.getBalance(user.address);
 
         expect(finalBalance - initialBalance).to.equal(ethers.parseEther('0.5'));
       });
 
       it('should handle transactions with empty data', async () => {
-        const txData = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'uint256', 'bytes', 'uint8'],
-          [
-            user.address,
-            0,
-            '0x', // empty data
-            0, // Call operation
-          ],
-        );
+        const target = user.address;
+        const value = 0n;
+        const data = '0x';
+        const operation = 0;
 
-        await fractalModule.execTx(txData);
+        await fractalModule.execTx(target, value, data, operation);
       });
 
       it('should handle transactions with both value and data', async () => {
@@ -362,32 +342,22 @@ describe('FractalModuleV1', () => {
         await mockToken.mint(await avatar.getAddress(), 1000);
 
         // First send ETH to user
-        const ethTxData = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'uint256', 'bytes', 'uint8'],
-          [
-            user.address,
-            ethers.parseEther('0.5'),
-            '0x',
-            0, // Call operation
-          ],
-        );
+        const ethTxTarget = user.address;
+        const ethTxValue = ethers.parseEther('0.5');
+        const ethTxData = '0x';
+        const ethTxOperation = 0;
 
         // Then do token transfer
-        const tokenTxData = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'uint256', 'bytes', 'uint8'],
-          [
-            await mockToken.getAddress(),
-            0,
-            mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
-            0, // Call operation
-          ],
-        );
+        const tokenTxTarget = await mockToken.getAddress();
+        const tokenTxValue = 0n;
+        const tokenTxData = mockToken.interface.encodeFunctionData('transfer', [user.address, 100]);
+        const tokenTxOperation = 0;
 
         const initialEthBalance = await ethers.provider.getBalance(user.address);
 
         // Execute both transactions
-        await fractalModule.execTx(ethTxData);
-        await fractalModule.execTx(tokenTxData);
+        await fractalModule.execTx(ethTxTarget, ethTxValue, ethTxData, ethTxOperation);
+        await fractalModule.execTx(tokenTxTarget, tokenTxValue, tokenTxData, tokenTxOperation);
 
         const finalEthBalance = await ethers.provider.getBalance(user.address);
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/293

Fixes [ENG-1004](https://linear.app/decent-labs/issue/ENG-1004/refactor-azoriusv1-and-fractalmodulev1-for-interface-alignment-and)

This commit refactors the `AzoriusV1` and `FractalModuleV1` contracts, along with their respective interfaces (`IAzoriusV1` and `IFractalModuleV1`). The changes aim to improve code structure, clarity, and consistency by:
- Making state variables internal and providing public, interface-defined getter functions.
- Moving event definitions and custom error definitions from concrete contracts to their interfaces.
- Refining function signatures for better explicitness and consistency (e.g., parameter naming, `execTx` in `FractalModuleV1`).

**Key Changes:**

**1. `AzoriusV1.sol` and `IAzoriusV1.sol`:**
    *   **State Management:**
        *   Public state variables in `AzoriusV1` (`totalProposalCount`, `timelockPeriod`, `executionPeriod`, `proposals` mapping, `strategy`) have been changed to `internal` (prefixed with `_`).
        *   Public `virtual override` getter functions for these internal variables (`totalProposalCount()`, `timelockPeriod()`, `executionPeriod()`, `proposals(uint32)`, `strategy()`) have been added to `AzoriusV1` and are now defined in the `IAzoriusV1` interface.
    *   **Interface Definitions (`IAzoriusV1.sol`):**
        *   Events (`ProposalCreated`, `ProposalExecuted`, `TimelockPeriodUpdated`, `ExecutionPeriodUpdated`, `StrategyUpdated`) have been moved from `AzoriusV1` to `IAzoriusV1`.
        *   Custom errors (`InvalidStrategy`, `InvalidProposal`, `InvalidProposer`, etc.) have been moved from `AzoriusV1` to `IAzoriusV1`.
        *   The `initialize` function signature is now defined in the interface.
    *   **Contract Logic (`AzoriusV1.sol`):**
        *   The `initialize` and `setUp` function parameter names have been updated for consistency (e.g., `_owner` to `owner_`).
        *   The `AzoriusSetUp` event emission has been removed (covered by standard UUPS/Ownable events or implied by successful initialization).
        *   Internal functions (`_updateTimelockPeriod`, `_updateExecutionPeriod`, `_updateStrategy`) now use the consistent parameter naming (e.g., `timelockPeriod_`).
        *   The contract logic now consistently uses its internal state variables (e.g., `_proposals`, `_strategy`).

**2. `FractalModuleV1.sol` and `IFractalModuleV1.sol`:**
    *   **`execTx` Refactoring:**
        *   The `execTx` function in `FractalModuleV1` no longer takes a single `bytes memory execTxData` argument. Instead, it now explicitly accepts `address _target, uint256 _value, bytes memory _data, Enum.Operation _operation` as parameters.
        *   The `IFractalModuleV1` interface has been updated to reflect this new `execTx` signature.
    *   **Interface Definitions (`IFractalModuleV1.sol`):**
        *   The `TxFailed` custom error has been moved from `FractalModuleV1` to `IFractalModuleV1`.
        *   The `initialize` function signature is now defined in the interface.
    *   **Contract Logic (`FractalModuleV1.sol`):**
        *   The `initialize` function parameter names have been updated for consistency (e.g., `_owner` to `owner_`).

**3. Test Updates (`FractalModuleV1.test.ts`):**
    *   Tests for `FractalModuleV1` have been updated to accommodate the new `execTx` function signature, passing arguments directly instead of as ABI-encoded bytes.

These changes contribute to a more robust, maintainable, and standardized codebase, aligning with best practices for upgradeable smart contracts and improving the clarity of their public APIs through well-defined interfaces.