### PR TITLE
refactor: Enhance Account Abstraction contracts with interface alignment

### DIFF
--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -23,30 +23,19 @@ contract DecentPaymasterV1 is
 {
     uint16 private constant VERSION = 1;
 
-    mapping(address => mapping(bytes4 => address)) private _functionValidators;
-
-    event FunctionValidatorSet(
-        address target,
-        bytes4 selector,
-        address validator
-    );
-    event FunctionValidatorRemoved(address target, bytes4 selector);
-
-    error NoValidatorSet(address target, bytes4 selector);
-    error ValidationFailed(address target, bytes4 selector);
-    error InvalidValidator();
+    mapping(address => mapping(bytes4 => address)) internal _functionValidators;
 
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address _owner,
-        address _entryPoint,
-        address _lightAccountFactory
-    ) public virtual initializer {
-        __BasePaymasterV1_init(_owner, IEntryPoint(_entryPoint));
-        __SmartAccountValidationV1_init(_lightAccountFactory);
+        address owner_,
+        address entryPoint_,
+        address lightAccountFactory_
+    ) public virtual override initializer {
+        __BasePaymasterV1_init(owner_, IEntryPoint(entryPoint_));
+        __SmartAccountValidationV1_init(lightAccountFactory_);
     }
 
     function _authorizeUpgrade(

--- a/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
+++ b/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
@@ -3,25 +3,34 @@ pragma solidity ^0.8.30;
 
 import {ILightAccount} from "../../interfaces/light-account/ILightAccount.sol";
 import {ILightAccountFactory} from "../../interfaces/light-account/ILightAccountFactory.sol";
+import {ISmartAccountValidationV1} from "../../interfaces/decent/deployables/ISmartAccountValidationV1.sol";
 import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-abstract contract SmartAccountValidationV1 is Initializable {
-    ILightAccountFactory public lightAccountFactory;
-
-    error InvalidSmartAccount();
-    error InvalidUserOpCallDataLength();
-    error InvalidCallData();
-    error InvalidInnerCallDataLength();
+abstract contract SmartAccountValidationV1 is
+    ISmartAccountValidationV1,
+    Initializable
+{
+    ILightAccountFactory internal _lightAccountFactory;
 
     constructor() {
         _disableInitializers();
     }
 
     function __SmartAccountValidationV1_init(
-        address _lightAccountFactory
+        address lightAccountFactory_
     ) internal initializer {
-        lightAccountFactory = ILightAccountFactory(_lightAccountFactory);
+        _lightAccountFactory = ILightAccountFactory(lightAccountFactory_);
+    }
+
+    function lightAccountFactory()
+        external
+        view
+        virtual
+        override
+        returns (address)
+    {
+        return address(_lightAccountFactory);
     }
 
     function validateSmartAccount(
@@ -42,7 +51,7 @@ abstract contract SmartAccountValidationV1 is Initializable {
             address lightAccountOwner
         ) {
             // Regenerate the expected light account address
-            address lightAccountAddress = lightAccountFactory.getAddress(
+            address lightAccountAddress = _lightAccountFactory.getAddress(
                 lightAccountOwner,
                 0 // we assume that Decent App is only creating one account per user
             );

--- a/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
@@ -37,20 +37,9 @@ interface IERC20Votes {
     ) external view returns (Checkpoint208 memory);
 }
 
-/**
- * @title LinearERC20VotingV1ValidatorV1
- * @dev Validates vote operations for LinearERC20VotingV1 to ensure they will succeed
- */
 contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
     uint16 public constant VERSION = 1;
 
-    /**
-     * @dev Validates if a vote operation will succeed
-     * @param lightAccountOwner The account attempting to vote
-     * @param votingContract The address of the voting contract
-     * @param callData The encoded vote function call
-     * @return isValid True if the vote operation will succeed
-     */
     function validateOperation(
         address,
         address lightAccountOwner,
@@ -158,9 +147,6 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
         return VERSION;
     }
 
-    /**
-     * @dev ERC165 interface support
-     */
     function supportsInterface(
         bytes4 interfaceId
     )

--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -43,13 +43,6 @@ contract LinearERC721VotingV1ValidatorV1 is
 {
     uint16 public constant VERSION = 1;
 
-    /**
-     * @dev Validates if a vote operation will succeed
-     * @param lightAccountOwner The account attempting to vote
-     * @param votingContract The address of the voting contract
-     * @param callData The encoded vote function call
-     * @return isValid True if the vote operation will succeed
-     */
     function validateOperation(
         address,
         address lightAccountOwner,
@@ -139,9 +132,6 @@ contract LinearERC721VotingV1ValidatorV1 is
         return VERSION;
     }
 
-    /**
-     * @dev ERC165 interface support
-     */
     function supportsInterface(
         bytes4 interfaceId
     )

--- a/contracts/interfaces/decent/deployables/IDecentPaymasterV1.sol
+++ b/contracts/interfaces/decent/deployables/IDecentPaymasterV1.sol
@@ -2,6 +2,23 @@
 pragma solidity ^0.8.30;
 
 interface IDecentPaymasterV1 {
+    event FunctionValidatorSet(
+        address target,
+        bytes4 selector,
+        address validator
+    );
+    event FunctionValidatorRemoved(address target, bytes4 selector);
+
+    error NoValidatorSet(address target, bytes4 selector);
+    error ValidationFailed(address target, bytes4 selector);
+    error InvalidValidator();
+
+    function initialize(
+        address _owner,
+        address _entryPoint,
+        address _lightAccountFactory
+    ) external;
+
     function setFunctionValidator(
         address contractAddress,
         bytes4 selector,

--- a/contracts/interfaces/decent/deployables/ISmartAccountValidationV1.sol
+++ b/contracts/interfaces/decent/deployables/ISmartAccountValidationV1.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+interface ISmartAccountValidationV1 {
+    error InvalidSmartAccount();
+    error InvalidUserOpCallDataLength();
+    error InvalidCallData();
+    error InvalidInnerCallDataLength();
+
+    function lightAccountFactory() external view returns (address);
+}


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/294

Fixes [ENG-1005](https://linear.app/decent-labs/issue/ENG-1005/refactor-account-abstraction-contracts-for-interface-alignment-and)

This commit refactors several contracts within the Account Abstraction system, including `DecentPaymasterV1` and `SmartAccountValidationV1`, along with their interfaces and related validator contracts. The primary goals are to improve structure, clarity, and consistency by:
- Aligning concrete contracts more strictly with their interfaces.
- Internalizing state variables and providing public, interface-defined getter functions.
- Migrating event and custom error definitions from concrete contracts to their respective interfaces.
- Standardizing parameter naming in initialization functions.
- Performing minor NatSpec cleanup in validator contracts.

**Key Changes:**

**1. `DecentPaymasterV1.sol` and `IDecentPaymasterV1.sol`:**
    *   **State Management (`DecentPaymasterV1.sol`):**
        *   The `_functionValidators` mapping has been changed from `private` to `internal`. (Note: A public getter for this mapping, if intended for the interface, would typically be added to `IDecentPaymasterV1` and implemented in `DecentPaymasterV1` if direct mapping access is required by external contracts through the interface).
    *   **Interface Definitions (`IDecentPaymasterV1.sol`):**
        *   Events (`FunctionValidatorSet`, `FunctionValidatorRemoved`) have been moved from `DecentPaymasterV1` to `IDecentPaymasterV1`.
        *   Custom errors (`NoValidatorSet`, `ValidationFailed`, `InvalidValidator`) have been moved from `DecentPaymasterV1` to `IDecentPaymasterV1`.
        *   The `initialize` function signature is now defined in the interface.
    *   **Contract Logic (`DecentPaymasterV1.sol`):**
        *   The `initialize` function now `override`s the definition from `IDecentPaymasterV1`.
        *   Parameter names in `initialize` have been updated for consistency (e.g., `_owner` to `owner_`).

**2. `SmartAccountValidationV1.sol` (and implicitly `ISmartAccountValidationV1.sol`):**
    *   **Interface Implementation:**
        *   `SmartAccountValidationV1` now implements `ISmartAccountValidationV1` (a new interface, inferred from `override` usage).
    *   **State Management:**
        *   The `lightAccountFactory` public state variable has been changed to `internal _lightAccountFactory`.
        *   A public `virtual override lightAccountFactory() returns (address)` getter function has been added to `SmartAccountValidationV1` and would be defined in `ISmartAccountValidationV1`.
    *   **Interface Definitions (assumed for `ISmartAccountValidationV1.sol`):**
        *   Custom errors (`InvalidSmartAccount`, `InvalidUserOpCallDataLength`, `InvalidCallData`, `InvalidInnerCallDataLength`) are assumed to have been moved from `SmartAccountValidationV1` to `ISmartAccountValidationV1`.
        *   The `initialize` (or `__SmartAccountValidationV1_init` if it were public in the interface) function signature would be defined in the interface.
    *   **Contract Logic (`SmartAccountValidationV1.sol`):**
        *   The `__SmartAccountValidationV1_init` function parameter name has been updated (`_lightAccountFactory` to `lightAccountFactory_`).
        *   The `validateSmartAccount` function now uses the internal `_lightAccountFactory`.

**3. Validator Contracts (`LinearERC20VotingV1ValidatorV1.sol`, `LinearERC721VotingV1ValidatorV1.sol`):**
    *   **NatSpec Cleanup:** Removed some `@title` and `@dev` NatSpec comments for conciseness.

These refactorings improve the modularity and maintainability of the Account Abstraction contracts by clearly defining their public APIs through interfaces and standardizing internal implementations.