### PR TITLE
refactor: Enhance ERC165 and interface consistency in AA and Strategy contracts

### DIFF
--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -126,7 +126,13 @@ contract DecentPaymasterV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override returns (bool) {
+    )
+        public
+        view
+        virtual
+        override(SmartAccountValidationV1, Version)
+        returns (bool)
+    {
         return
             interfaceId == type(IDecentPaymasterV1).interfaceId ||
             interfaceId == type(IPaymaster).interfaceId ||

--- a/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
+++ b/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
@@ -6,9 +6,11 @@ import {ILightAccountFactory} from "../../interfaces/light-account/ILightAccount
 import {ISmartAccountValidationV1} from "../../interfaces/decent/deployables/ISmartAccountValidationV1.sol";
 import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 abstract contract SmartAccountValidationV1 is
     ISmartAccountValidationV1,
+    ERC165,
     Initializable
 {
     ILightAccountFactory internal _lightAccountFactory;
@@ -109,5 +111,13 @@ abstract contract SmartAccountValidationV1 is
         }
 
         return (lightAccountOwner, target, bytes4(innerCallData));
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(ISmartAccountValidationV1).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -1,27 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+import {IERC4337VoterSupportV1} from "../../interfaces/decent/deployables/IERC4337VoterSupportV1.sol";
 import {SmartAccountValidationV1} from "../account-abstraction/SmartAccountValidationV1.sol";
 
-/**
- * Functionality to support ERC4337 (Account Abstraction) by properly identifying the voter
- * when a contract account is used to interact with the voting system.
- */
-abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
-    /**
-     * @dev Tracks whether a proposal's voting period has been marked as ended.
-     * This flag is set to true when the first vote attempt occurs after the voting end timestamp,
-     * triggering a VotingPeriodEnded event. Used to allow an at-most-once vote to not revert
-     * after the voting period has ended, and to give bundlers the ability to determine
-     * if a proposal voting period has ended without using the banned NUMBER opcode.
-     */
+abstract contract ERC4337VoterSupportV1 is
+    IERC4337VoterSupportV1,
+    SmartAccountValidationV1
+{
     mapping(uint32 => bool) internal _votingPeriodEnded;
-
-    event VotingPeriodEnded(
-        uint32 indexed proposalId,
-        uint48 votingEndTimestamp,
-        uint48 currentTimestamp
-    );
 
     constructor() {
         _disableInitializers();
@@ -33,12 +20,9 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
         __SmartAccountValidationV1_init(_lightAccountFactory);
     }
 
-    /**
-     * Returns the address of the voter which owns the voting weight
-     * @param _msgSender address of the sender. It can be the wallet address, or the smart account address with EOA as owner
-     * @return address of the voter
-     */
-    function voter(address _msgSender) public view virtual returns (address) {
+    function voter(
+        address _msgSender
+    ) public view virtual override returns (address) {
         (bool isValid, address lightAccountOwner) = validateSmartAccount(
             _msgSender
         );
@@ -49,17 +33,17 @@ abstract contract ERC4337VoterSupportV1 is SmartAccountValidationV1 {
         return lightAccountOwner;
     }
 
-    /**
-     * @dev Tracks whether a proposal's voting period has been officially marked as ended.
-     * This flag is set to true when the first vote attempt occurs after the voting end timestamp,
-     * triggering a VotingPeriodEnded event. Used to ensure the event is emitted exactly once
-     * per proposal, and only if a vote has been attempted after the voting end timestamp.
-     * @param _proposalId The ID of the proposal to check.
-     * @return True if the voting period has ended and a vote has been attempted after the voting end timestamp, false otherwise.
-     */
     function votingPeriodEnded(
         uint32 _proposalId
-    ) external view virtual returns (bool) {
+    ) external view virtual override returns (bool) {
         return _votingPeriodEnded[_proposalId];
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IERC4337VoterSupportV1).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -13,7 +13,6 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 contract StrategyV1 is
     Initializable,
     IStrategyV1,
-    ERC165,
     ERC4337VoterSupportV1,
     Version
 {
@@ -331,7 +330,13 @@ contract StrategyV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165, Version) returns (bool) {
+    )
+        public
+        view
+        virtual
+        override(Version, ERC4337VoterSupportV1)
+        returns (bool)
+    {
         return
             interfaceId == type(IStrategyV1).interfaceId ||
             interfaceId == type(IStrategyBaseV1).interfaceId ||

--- a/contracts/interfaces/decent/deployables/IERC4337VoterSupportV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC4337VoterSupportV1.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+interface IERC4337VoterSupportV1 {
+    event VotingPeriodEnded(
+        uint32 indexed proposalId,
+        uint48 votingEndTimestamp,
+        uint48 currentTimestamp
+    );
+
+    function voter(address _msgSender) external view returns (address);
+
+    function votingPeriodEnded(uint32 _proposalId) external view returns (bool);
+}

--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -8,6 +8,7 @@ import {
   IDecentPaymasterV1__factory,
   IERC165__factory,
   IPaymaster__factory,
+  ISmartAccountValidationV1__factory,
   IVersion__factory,
   MockEntryPoint,
   MockEntryPoint__factory,
@@ -365,48 +366,44 @@ describe('DecentPaymasterV1', function () {
   });
 
   describe('ERC165', function () {
-    // Interface IDs
-    let iPaymasterInterfaceId: string;
-    let iDecentPaymasterInterfaceId: string;
-    let iVersionInterfaceId: string;
-    let iERC165InterfaceId: string;
-
-    beforeEach(async function () {
-      // Calculate IPaymaster interface ID
-      const IPaymasterInterface = IPaymaster__factory.createInterface();
-      iPaymasterInterfaceId = calculateInterfaceId(IPaymasterInterface);
-
-      // Calculate IDecentPaymaster interface ID
-      const IDecentPaymasterInterface = IDecentPaymasterV1__factory.createInterface();
-      iDecentPaymasterInterfaceId = calculateInterfaceId(IDecentPaymasterInterface);
-
-      // Calculate IVersion interface ID
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
-
-      // Calculate IERC165 interface ID
-      const IERC165Interface = IERC165__factory.createInterface();
-      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
-    });
-
     it('Should support IERC165 interface', async function () {
-      const supported = await decentPaymaster.supportsInterface(iERC165InterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await decentPaymaster.supportsInterface(
+          calculateInterfaceId(IERC165__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IPaymaster interface', async function () {
-      const supported = await decentPaymaster.supportsInterface(iPaymasterInterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await decentPaymaster.supportsInterface(
+          calculateInterfaceId(IPaymaster__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IDecentPaymaster interface', async function () {
-      const supported = await decentPaymaster.supportsInterface(iDecentPaymasterInterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await decentPaymaster.supportsInterface(
+          calculateInterfaceId(IDecentPaymasterV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IVersion interface', async function () {
-      const supported = await decentPaymaster.supportsInterface(iVersionInterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await decentPaymaster.supportsInterface(
+          calculateInterfaceId(IVersion__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('Should support ISmartAccountValidationV1 interface', async function () {
+      void expect(
+        await decentPaymaster.supportsInterface(
+          calculateInterfaceId(ISmartAccountValidationV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should not support random interface', async function () {

--- a/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
+++ b/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
@@ -5,6 +5,8 @@ import {
   ConcreteSmartAccountValidation,
   ConcreteSmartAccountValidation__factory,
   ERC1967Proxy__factory,
+  IERC165__factory,
+  ISmartAccountValidationV1__factory,
   MockGaslessTarget,
   MockGaslessTarget__factory,
   MockInvalidLightAccount,
@@ -14,6 +16,7 @@ import {
   MockLightAccountFactory,
   MockLightAccountFactory__factory,
 } from '../../../typechain-types';
+import { calculateInterfaceId } from '../../helpers/utils';
 
 interface PackedUserOperation {
   sender: string;
@@ -260,6 +263,24 @@ describe('SmartAccountValidationV1', function () {
       await expect(
         concreteSmartAccountValidation.validateUserOpPublic(userOp),
       ).to.be.revertedWithCustomError(concreteSmartAccountValidation, 'InvalidInnerCallDataLength');
+    });
+  });
+
+  describe('ERC165 Supports Interface', () => {
+    it('Should support IERC165 interface', async () => {
+      void expect(
+        await concreteSmartAccountValidation.supportsInterface(
+          calculateInterfaceId(IERC165__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('Should support ISmartAccountValidationV1 interface', async () => {
+      void expect(
+        await concreteSmartAccountValidation.supportsInterface(
+          calculateInterfaceId(ISmartAccountValidationV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
   });
 });

--- a/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
+++ b/test/deployables/strategies/ERC4337VoterSupportV1.test.ts
@@ -5,11 +5,15 @@ import {
   ConcreteERC4337VoterSupportV1,
   ConcreteERC4337VoterSupportV1__factory,
   ERC1967Proxy__factory,
+  IERC165__factory,
+  IERC4337VoterSupportV1__factory,
+  ISmartAccountValidationV1__factory,
   MockLightAccount,
   MockLightAccount__factory,
   MockLightAccountFactory,
   MockLightAccountFactory__factory,
 } from '../../../typechain-types';
+import { calculateInterfaceId } from '../../helpers/utils';
 
 async function deployConcreteERC4337VoterSupport(
   deployer: SignerWithAddress,
@@ -154,6 +158,32 @@ describe('ERC4337VoterSupportV1', () => {
         .connect(owner)
         .votingPeriodEnded(proposalId);
       void expect(ownerResult).to.be.true;
+    });
+  });
+
+  describe('ERC165 Supports Interface', () => {
+    it('Should support IERC165 interface', async () => {
+      void expect(
+        await concreteERC4337VoterSupport.supportsInterface(
+          calculateInterfaceId(IERC165__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('Should support IERC4337VoterSupportV1 interface', async () => {
+      void expect(
+        await concreteERC4337VoterSupport.supportsInterface(
+          calculateInterfaceId(IERC4337VoterSupportV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('Should support ISmartAccountValidationV1 interface', async () => {
+      void expect(
+        await concreteERC4337VoterSupport.supportsInterface(
+          calculateInterfaceId(ISmartAccountValidationV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
   });
 });

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -7,6 +7,7 @@ import {
   IERC165__factory,
   IStrategyBaseV1__factory,
   IStrategyV1__factory,
+  IVersion__factory,
   MockLightAccount__factory,
   MockLightAccountFactory,
   MockLightAccountFactory__factory,
@@ -911,33 +912,34 @@ describe('StrategyV1', () => {
   });
 
   describe('ERC165 Supports Interface', () => {
-    let iStrategyBaseV1InterfaceId: string;
-    let iStrategyV1InterfaceId: string;
-    let iERC165InterfaceId: string;
-
-    beforeEach(async () => {
-      const IStrategyBaseV1Interface = IStrategyBaseV1__factory.createInterface();
-      iStrategyBaseV1InterfaceId = calculateInterfaceId(IStrategyBaseV1Interface);
-
-      const IStrategyV1Interface = IStrategyV1__factory.createInterface();
-      iStrategyV1InterfaceId = calculateInterfaceId(IStrategyV1Interface, [
-        IStrategyBaseV1Interface,
-      ]);
-
-      const IERC165Interface = IERC165__factory.createInterface();
-      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
-    });
-
     it('Should support IStrategyBaseV1 interface', async () => {
-      void expect(await strategy.supportsInterface(iStrategyBaseV1InterfaceId)).to.be.true;
+      void expect(
+        await strategy.supportsInterface(
+          calculateInterfaceId(IStrategyBaseV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IStrategyV1 interface', async () => {
-      void expect(await strategy.supportsInterface(iStrategyV1InterfaceId)).to.be.true;
+      void expect(
+        await strategy.supportsInterface(
+          calculateInterfaceId(IStrategyV1__factory.createInterface(), [
+            IStrategyBaseV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IERC165 interface', async () => {
-      void expect(await strategy.supportsInterface(iERC165InterfaceId)).to.be.true;
+      void expect(
+        await strategy.supportsInterface(calculateInterfaceId(IERC165__factory.createInterface())),
+      ).to.be.true;
+    });
+
+    it('Should support IVersion interface', async () => {
+      void expect(
+        await strategy.supportsInterface(calculateInterfaceId(IVersion__factory.createInterface())),
+      ).to.be.true;
     });
 
     it('Should not support a random interface', async () => {


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/297

Fixes [ENG-1007](https://linear.app/decent-labs/issue/ENG-1007/implement-erc165-and-refine-interfaces-in-aa-and-strategy-contracts)

This commit refactors Account Abstraction components (`DecentPaymasterV1`, `SmartAccountValidationV1`, `ERC4337VoterSupportV1`) and the `StrategyV1` contract to improve ERC165 compliance, interface alignment, and overall structural consistency.

**Key Changes:**

1.  **`SmartAccountValidationV1.sol` Enhancements:**
    *   Now directly inherits from OpenZeppelin's `ERC165` contract.
    *   Implements the `supportsInterface` function, correctly reporting support for `ISmartAccountValidationV1` and `IERC165`.

2.  **Introduction of `IERC4337VoterSupportV1.sol`:**
    *   A new interface, `IERC4337VoterSupportV1`, has been created.
    *   It defines the `VotingPeriodEnded` event.
    *   It declares the `voter(address)` and `votingPeriodEnded(uint32)` functions.

3.  **`ERC4337VoterSupportV1.sol` Refactoring:**
    *   Now implements the new `IERC4337VoterSupportV1` interface.
    *   The `VotingPeriodEnded` event has been moved to the `IERC4337VoterSupportV1` interface.
    *   The `voter()` and `votingPeriodEnded()` functions now correctly `override` their definitions from the new interface.
    *   Implements `supportsInterface`, reporting support for `IERC4337VoterSupportV1` and leveraging `super.supportsInterface()` which chains up to `SmartAccountValidationV1` (and thus `ERC165`).

4.  **`DecentPaymasterV1.sol` Updates:**
    *   The `supportsInterface` function now explicitly overrides `(SmartAccountValidationV1, Version)`, reflecting its inheritance and ensuring correct interface reporting. It will now correctly report support for `ISmartAccountValidationV1` due to inheritance from `SmartAccountValidationV1`.

5.  **`StrategyV1.sol` Adjustments:**
    *   Removed direct inheritance from `ERC165` as it's now implicitly inherited via `ERC4337VoterSupportV1` -> `SmartAccountValidationV1` -> `ERC165`.
    *   The `supportsInterface` function now explicitly overrides `(Version, ERC4337VoterSupportV1)`.

6.  **Test Suite Updates:**
    *   **`DecentPaymasterV1.test.ts`**:
        *   Interface ID calculations in tests are now more direct.
        *   Added a test to verify support for the `ISmartAccountValidationV1` interface.
    *   **`SmartAccountValidationV1.test.ts`**:
        *   Added ERC165 tests to verify support for `IERC165` and `ISmartAccountValidationV1`.
    *   **`ERC4337VoterSupportV1.test.ts`**:
        *   Added ERC165 tests to verify support for `IERC165`, `IERC4337VoterSupportV1`, and `ISmartAccountValidationV1`.
    *   **`StrategyV1.test.ts`**:
        *   Interface ID calculations in tests are now more direct.
        *   Added a test to verify support for the `IVersion` interface. Existing tests are implicitly updated due to inheritance changes.

These changes ensure robust ERC165 compliance across the affected contracts, provide clearer API definitions through dedicated interfaces, and improve the overall maintainability and correctness of the codebase.