### PR TITLE
refactor: Introduce new proposer adapter interfaces and update existing contracts for consistency

### DIFF
--- a/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+import {IERC20ProposerAdapterV1} from "../../../interfaces/decent/deployables/IERC20ProposerAdapterV1.sol";
 import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
 import {IProposerAdapterBaseV1} from "../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
@@ -9,42 +10,48 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {Version} from "../../Version.sol";
 
 contract ERC20ProposerAdapterV1 is
-    IProposerAdapterV1,
+    IERC20ProposerAdapterV1,
     Initializable,
     ERC165,
     Version
 {
-    IVotes public token;
-    uint256 public proposerThreshold;
-    uint256 public weightPerToken;
+    IVotes internal _token;
+    uint256 internal _proposerThreshold;
 
     uint16 public constant VERSION = 1;
-
-    error InvalidTokenAddress();
-    error InvalidWeightPerToken();
 
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address _token,
-        uint256 _proposerThreshold,
-        uint256 _weightPerToken
-    ) external virtual initializer {
-        if (_token == address(0)) revert InvalidTokenAddress();
-        if (_weightPerToken == 0) revert InvalidWeightPerToken();
+        address token_,
+        uint256 proposerThreshold_
+    ) external virtual override initializer {
+        if (token_ == address(0)) revert InvalidTokenAddress();
 
-        token = IVotes(_token);
-        proposerThreshold = _proposerThreshold;
-        weightPerToken = _weightPerToken;
+        _token = IVotes(token_);
+        _proposerThreshold = proposerThreshold_;
+    }
+
+    function token() external view virtual override returns (address) {
+        return address(_token);
+    }
+
+    function proposerThreshold()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        return _proposerThreshold;
     }
 
     function isProposer(
         address _proposer
     ) external view virtual override returns (bool) {
-        return
-            (token.getVotes(_proposer) * weightPerToken) >= proposerThreshold;
+        return _token.getVotes(_proposer) >= _proposerThreshold;
     }
 
     function getVersion() public pure virtual override returns (uint16) {
@@ -55,6 +62,7 @@ contract ERC20ProposerAdapterV1 is
         bytes4 interfaceId
     ) public view virtual override(ERC165, Version) returns (bool) {
         return
+            interfaceId == type(IERC20ProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterBaseV1).interfaceId ||
             super.supportsInterface(interfaceId);

--- a/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+import {IERC721ProposerAdapterV1} from "../../../interfaces/decent/deployables/IERC721ProposerAdapterV1.sol";
 import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
 import {IProposerAdapterBaseV1} from "../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -9,41 +10,48 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {Version} from "../../Version.sol";
 
 contract ERC721ProposerAdapterV1 is
-    IProposerAdapterV1,
+    IERC721ProposerAdapterV1,
     Initializable,
     ERC165,
     Version
 {
-    IERC721 public token;
-    uint256 public proposerThreshold;
-    uint256 public weightPerNft;
+    IERC721 internal _token;
+    uint256 internal _proposerThreshold;
 
     uint16 public constant VERSION = 1;
-
-    error InvalidTokenAddress();
-    error InvalidWeightPerNft();
 
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address _token,
-        uint256 _proposerThreshold,
-        uint256 _weightPerNft
-    ) external virtual initializer {
-        if (_token == address(0)) revert InvalidTokenAddress();
-        if (_weightPerNft == 0) revert InvalidWeightPerNft();
+        address token_,
+        uint256 proposerThreshold_
+    ) external virtual override initializer {
+        if (token_ == address(0)) revert InvalidTokenAddress();
 
-        token = IERC721(_token);
-        proposerThreshold = _proposerThreshold;
-        weightPerNft = _weightPerNft;
+        _token = IERC721(token_);
+        _proposerThreshold = proposerThreshold_;
+    }
+
+    function token() external view virtual override returns (address) {
+        return address(_token);
+    }
+
+    function proposerThreshold()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        return _proposerThreshold;
     }
 
     function isProposer(
         address _proposer
     ) external view virtual override returns (bool) {
-        return (token.balanceOf(_proposer) * weightPerNft) >= proposerThreshold;
+        return _token.balanceOf(_proposer) >= _proposerThreshold;
     }
 
     function getVersion() public pure virtual override returns (uint16) {
@@ -54,6 +62,7 @@ contract ERC721ProposerAdapterV1 is
         bytes4 interfaceId
     ) public view virtual override(ERC165, Version) returns (bool) {
         return
+            interfaceId == type(IERC721ProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterBaseV1).interfaceId ||
             super.supportsInterface(interfaceId);

--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+import {IHatsProposerAdapterV1} from "../../../interfaces/decent/deployables/IHatsProposerAdapterV1.sol";
 import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
 import {IProposerAdapterBaseV1} from "../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {IHats} from "../../../interfaces/hats/IHats.sol";
@@ -9,56 +10,57 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {Version} from "../../Version.sol";
 
 contract HatsProposerAdapterV1 is
-    IProposerAdapterV1,
+    IHatsProposerAdapterV1,
     Initializable,
     ERC165,
     Version
 {
-    IHats public hatsContract;
-    uint256[] private whitelistedHatIds;
+    IHats internal _hatsContract;
+    uint256[] internal _whitelistedHatIds;
 
     uint16 public constant VERSION = 1;
-
-    error MissingHatsContract();
-    error NoHatsWhitelisted();
-    error HatAlreadyWhitelisted();
 
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address _hatsContractAddress,
-        uint256[] memory _whitelistedHats
-    ) public virtual initializer {
-        if (_hatsContractAddress == address(0)) revert MissingHatsContract();
-        hatsContract = IHats(_hatsContractAddress);
+        address hatsContract_,
+        uint256[] memory whitelistedHatIds_
+    ) public virtual override initializer {
+        if (hatsContract_ == address(0)) revert MissingHatsContract();
+        _hatsContract = IHats(hatsContract_);
 
-        if (_whitelistedHats.length == 0) revert NoHatsWhitelisted();
-        for (uint256 i = 0; i < _whitelistedHats.length; i++) {
-            uint256 _hatId = _whitelistedHats[i];
-            for (uint256 j = 0; j < whitelistedHatIds.length; j++) {
-                if (whitelistedHatIds[j] == _hatId)
+        if (whitelistedHatIds_.length == 0) revert NoHatsWhitelisted();
+        for (uint256 i = 0; i < whitelistedHatIds_.length; i++) {
+            uint256 _hatId = whitelistedHatIds_[i];
+            for (uint256 j = 0; j < _whitelistedHatIds.length; j++) {
+                if (_whitelistedHatIds[j] == _hatId)
                     revert HatAlreadyWhitelisted();
             }
-            whitelistedHatIds.push(_hatId);
+            _whitelistedHatIds.push(_hatId);
         }
     }
 
-    function getWhitelistedHatIds()
+    function hatsContract() external view virtual override returns (address) {
+        return address(_hatsContract);
+    }
+
+    function whitelistedHatIds()
         public
         view
         virtual
+        override
         returns (uint256[] memory)
     {
-        return whitelistedHatIds;
+        return _whitelistedHatIds;
     }
 
     function isProposer(
         address _proposer
     ) public view virtual override returns (bool) {
-        for (uint256 i = 0; i < whitelistedHatIds.length; i++) {
-            if (hatsContract.isWearerOfHat(_proposer, whitelistedHatIds[i])) {
+        for (uint256 i = 0; i < _whitelistedHatIds.length; i++) {
+            if (_hatsContract.isWearerOfHat(_proposer, _whitelistedHatIds[i])) {
                 return true;
             }
         }
@@ -73,6 +75,7 @@ contract HatsProposerAdapterV1 is
         bytes4 interfaceId
     ) public view virtual override(ERC165, Version) returns (bool) {
         return
+            interfaceId == type(IHatsProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterBaseV1).interfaceId ||
             super.supportsInterface(interfaceId);

--- a/contracts/interfaces/decent/deployables/IERC20ProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC20ProposerAdapterV1.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
+
+interface IERC20ProposerAdapterV1 is IProposerAdapterV1 {
+    error InvalidTokenAddress();
+
+    function initialize(address token, uint256 proposerThreshold) external;
+
+    function token() external view returns (address);
+
+    function proposerThreshold() external view returns (uint256);
+}

--- a/contracts/interfaces/decent/deployables/IERC721ProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC721ProposerAdapterV1.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
+
+interface IERC721ProposerAdapterV1 is IProposerAdapterV1 {
+    error InvalidTokenAddress();
+
+    function initialize(address token, uint256 proposerThreshold) external;
+
+    function token() external view returns (address);
+
+    function proposerThreshold() external view returns (uint256);
+}

--- a/contracts/interfaces/decent/deployables/IHatsProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IHatsProposerAdapterV1.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
+
+interface IHatsProposerAdapterV1 is IProposerAdapterV1 {
+    error MissingHatsContract();
+    error NoHatsWhitelisted();
+    error HatAlreadyWhitelisted();
+
+    function initialize(
+        address hatsContractAddress,
+        uint256[] memory whitelistedHats
+    ) external;
+
+    function hatsContract() external view returns (address);
+
+    function whitelistedHatIds() external view returns (uint256[] memory);
+}

--- a/test/deployables/strategies/adapters/ERC20ProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20ProposerAdapterV1.test.ts
@@ -6,6 +6,7 @@ import {
   ERC20ProposerAdapterV1,
   ERC20ProposerAdapterV1__factory,
   IERC165__factory,
+  IERC20ProposerAdapterV1__factory,
   IProposerAdapterBaseV1__factory,
   IProposerAdapterV1__factory,
   IVersion__factory,
@@ -19,13 +20,11 @@ async function deployERC20ProposerAdapterProxy(
   implementationAddress: string,
   tokenAddress: string,
   proposerThreshold: bigint,
-  weightPerToken: bigint,
 ): Promise<ERC20ProposerAdapterV1> {
   const adapterInterface = ERC20ProposerAdapterV1__factory.createInterface();
   const initializeCalldata = adapterInterface.encodeFunctionData('initialize', [
     tokenAddress,
     proposerThreshold,
-    weightPerToken,
   ]);
   const proxyFactory = new ERC1967Proxy__factory(deployer);
   const proxy = await proxyFactory.deploy(implementationAddress, initializeCalldata);
@@ -42,7 +41,6 @@ describe('ERC20ProposerAdapterV1', () => {
   let mockToken: MockERC20Votes;
 
   const DEFAULT_PROPOSER_THRESHOLD = ethers.parseUnits('100', 18);
-  const DEFAULT_WEIGHT_PER_TOKEN = 1n;
 
   beforeEach(async () => {
     [deployer, user1] = await ethers.getSigners();
@@ -62,7 +60,6 @@ describe('ERC20ProposerAdapterV1', () => {
       await adapterImplementation.getAddress(),
       await mockToken.getAddress(),
       DEFAULT_PROPOSER_THRESHOLD,
-      DEFAULT_WEIGHT_PER_TOKEN,
     );
   });
 
@@ -70,7 +67,6 @@ describe('ERC20ProposerAdapterV1', () => {
     it('should initialize correctly with valid parameters', async () => {
       expect(await adapter.token()).to.equal(await mockToken.getAddress());
       expect(await adapter.proposerThreshold()).to.equal(DEFAULT_PROPOSER_THRESHOLD);
-      expect(await adapter.weightPerToken()).to.equal(DEFAULT_WEIGHT_PER_TOKEN);
     });
 
     it('should revert if token address is zero during proxy initialization', async () => {
@@ -80,21 +76,8 @@ describe('ERC20ProposerAdapterV1', () => {
           await adapterImplementation.getAddress(),
           ethers.ZeroAddress,
           DEFAULT_PROPOSER_THRESHOLD,
-          DEFAULT_WEIGHT_PER_TOKEN,
         ),
       ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidTokenAddress');
-    });
-
-    it('should revert if weightPerToken is zero during proxy initialization', async () => {
-      await expect(
-        deployERC20ProposerAdapterProxy(
-          deployer,
-          await adapterImplementation.getAddress(),
-          await mockToken.getAddress(),
-          DEFAULT_PROPOSER_THRESHOLD,
-          0n,
-        ),
-      ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidWeightPerToken');
     });
 
     it('should allow proposerThreshold to be zero during proxy initialization', async () => {
@@ -103,57 +86,44 @@ describe('ERC20ProposerAdapterV1', () => {
         await adapterImplementation.getAddress(),
         await mockToken.getAddress(),
         0n,
-        DEFAULT_WEIGHT_PER_TOKEN,
       );
       expect(await localAdapter.proposerThreshold()).to.equal(0n);
     });
 
     it('should prevent reinitialization on proxied adapter', async () => {
       await expect(
-        adapter.initialize(
-          await mockToken.getAddress(),
-          DEFAULT_PROPOSER_THRESHOLD,
-          DEFAULT_WEIGHT_PER_TOKEN,
-        ),
+        adapter.initialize(await mockToken.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
       ).to.be.revertedWithCustomError(adapter, 'InvalidInitialization');
     });
 
     it('Implementation contract should remain uninitialized', async () => {
       await expect(
-        adapterImplementation.initialize(
-          await mockToken.getAddress(),
-          DEFAULT_PROPOSER_THRESHOLD,
-          DEFAULT_WEIGHT_PER_TOKEN,
-        ),
+        adapterImplementation.initialize(await mockToken.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
       ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidInitialization');
     });
   });
 
   describe('isProposer', () => {
     it('should return true if user meets the proposer threshold', async () => {
-      const userVotes = DEFAULT_PROPOSER_THRESHOLD / DEFAULT_WEIGHT_PER_TOKEN;
-      await mockToken.connect(deployer).mint(user1.address, userVotes);
+      await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
       await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await adapter.isProposer(user1.address);
       void expect(canPropose).to.be.true;
     });
 
     it('should return true if user exceeds the proposer threshold', async () => {
-      const userVotes = DEFAULT_PROPOSER_THRESHOLD / DEFAULT_WEIGHT_PER_TOKEN + 1n;
-      await mockToken.connect(deployer).mint(user1.address, userVotes);
+      await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
       await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await adapter.isProposer(user1.address);
       void expect(canPropose).to.be.true;
     });
 
     it('should return false if user is below the proposer threshold', async () => {
-      if (DEFAULT_PROPOSER_THRESHOLD > 0n) {
-        const userVotes = DEFAULT_PROPOSER_THRESHOLD / DEFAULT_WEIGHT_PER_TOKEN - 1n;
-        if (userVotes > 0) {
-          await mockToken.connect(deployer).mint(user1.address, userVotes);
-        }
-        await mockToken.connect(user1).delegate(user1.address);
-      }
+      const userVotes = DEFAULT_PROPOSER_THRESHOLD - 1n;
+      await mockToken.connect(deployer).mint(user1.address, userVotes);
+
+      await mockToken.connect(user1).delegate(user1.address);
+
       const canPropose = await adapter.isProposer(user1.address);
       void expect(canPropose).to.be.false;
     });
@@ -170,7 +140,6 @@ describe('ERC20ProposerAdapterV1', () => {
         await adapterImplementation.getAddress(),
         await mockToken.getAddress(),
         0n,
-        DEFAULT_WEIGHT_PER_TOKEN,
       );
       await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await localAdapter.isProposer(user1.address);
@@ -184,29 +153,50 @@ describe('ERC20ProposerAdapterV1', () => {
     });
   });
 
-  describe('supportsInterface', () => {
-    it('should support IProposerAdapterV1, IProposerAdapterBaseV1, IVersion and IERC165', async () => {
-      const iProposerAdapterV1Interface = IProposerAdapterV1__factory.createInterface();
-      const iProposerAdapterBaseV1Interface = IProposerAdapterBaseV1__factory.createInterface();
-      const iVersionInterface = IVersion__factory.createInterface();
-      const iERC165Interface = IERC165__factory.createInterface();
+  describe('ERC165 supportsInterface', () => {
+    it('should support IERC20ProposerAdapterV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IERC20ProposerAdapterV1__factory.createInterface(), [
+            IProposerAdapterV1__factory.createInterface(),
+            IProposerAdapterBaseV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
+    });
 
-      const iProposerAdapterV1Id = calculateInterfaceId(iProposerAdapterV1Interface, [
-        iProposerAdapterBaseV1Interface,
-      ]);
-      const iProposerAdapterBaseV1Id = calculateInterfaceId(iProposerAdapterBaseV1Interface);
-      const iVersionId = calculateInterfaceId(iVersionInterface);
-      const iERC165Id = calculateInterfaceId(iERC165Interface);
+    it('should support IProposerAdapterV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IProposerAdapterV1__factory.createInterface(), [
+            IProposerAdapterBaseV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
+    });
 
-      void expect(await adapter.supportsInterface(iProposerAdapterV1Id)).to.be.true;
-      void expect(await adapter.supportsInterface(iProposerAdapterBaseV1Id)).to.be.true;
-      void expect(await adapter.supportsInterface(iVersionId)).to.be.true;
-      void expect(await adapter.supportsInterface(iERC165Id)).to.be.true;
+    it('should support IProposerAdapterBaseV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IProposerAdapterBaseV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support IVersion', async () => {
+      void expect(
+        await adapter.supportsInterface(calculateInterfaceId(IVersion__factory.createInterface())),
+      ).to.be.true;
+    });
+
+    it('should support IERC165', async () => {
+      void expect(
+        await adapter.supportsInterface(calculateInterfaceId(IERC165__factory.createInterface())),
+      ).to.be.true;
     });
 
     it('should not support a random interfaceId', async () => {
-      const randomInterfaceId = '0x12345678';
-      void expect(await adapter.supportsInterface(randomInterfaceId)).to.be.false;
+      void expect(await adapter.supportsInterface('0x12345678')).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/adapters/ERC721ProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721ProposerAdapterV1.test.ts
@@ -6,6 +6,7 @@ import {
   ERC721ProposerAdapterV1,
   ERC721ProposerAdapterV1__factory,
   IERC165__factory,
+  IERC721ProposerAdapterV1__factory,
   IProposerAdapterBaseV1__factory,
   IProposerAdapterV1__factory,
   IVersion__factory,
@@ -19,13 +20,11 @@ async function deployERC721ProposerAdapterProxy(
   implementationAddress: string,
   tokenAddress: string,
   proposerThreshold: bigint,
-  weightPerNft: bigint,
 ): Promise<ERC721ProposerAdapterV1> {
   const adapterInterface = ERC721ProposerAdapterV1__factory.createInterface();
   const initializeCalldata = adapterInterface.encodeFunctionData('initialize', [
     tokenAddress,
     proposerThreshold,
-    weightPerNft,
   ]);
   const proxyFactory = new ERC1967Proxy__factory(deployer);
   const proxy = await proxyFactory.deploy(implementationAddress, initializeCalldata);
@@ -42,7 +41,6 @@ describe('ERC721ProposerAdapterV1', () => {
   let mockNft: MockERC721;
 
   const DEFAULT_PROPOSER_THRESHOLD = 5n;
-  const DEFAULT_WEIGHT_PER_NFT = 1n;
 
   beforeEach(async () => {
     [deployer, user1] = await ethers.getSigners();
@@ -62,7 +60,6 @@ describe('ERC721ProposerAdapterV1', () => {
       await adapterImplementation.getAddress(),
       await mockNft.getAddress(),
       DEFAULT_PROPOSER_THRESHOLD,
-      DEFAULT_WEIGHT_PER_NFT,
     );
   });
 
@@ -70,7 +67,6 @@ describe('ERC721ProposerAdapterV1', () => {
     it('should initialize correctly with valid parameters', async () => {
       expect(await adapter.token()).to.equal(await mockNft.getAddress());
       expect(await adapter.proposerThreshold()).to.equal(DEFAULT_PROPOSER_THRESHOLD);
-      expect(await adapter.weightPerNft()).to.equal(DEFAULT_WEIGHT_PER_NFT);
     });
 
     it('should revert if token address is zero during proxy initialization', async () => {
@@ -80,21 +76,8 @@ describe('ERC721ProposerAdapterV1', () => {
           await adapterImplementation.getAddress(),
           ethers.ZeroAddress,
           DEFAULT_PROPOSER_THRESHOLD,
-          DEFAULT_WEIGHT_PER_NFT,
         ),
       ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidTokenAddress');
-    });
-
-    it('should revert if weightPerNft is zero during proxy initialization', async () => {
-      await expect(
-        deployERC721ProposerAdapterProxy(
-          deployer,
-          await adapterImplementation.getAddress(),
-          await mockNft.getAddress(),
-          DEFAULT_PROPOSER_THRESHOLD,
-          0n,
-        ),
-      ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidWeightPerNft');
     });
 
     it('should allow proposerThreshold to be zero during proxy initialization', async () => {
@@ -103,28 +86,19 @@ describe('ERC721ProposerAdapterV1', () => {
         await adapterImplementation.getAddress(),
         await mockNft.getAddress(),
         0n,
-        DEFAULT_WEIGHT_PER_NFT,
       );
       expect(await localAdapter.proposerThreshold()).to.equal(0n);
     });
 
     it('should prevent reinitialization on proxied adapter', async () => {
       await expect(
-        adapter.initialize(
-          await mockNft.getAddress(),
-          DEFAULT_PROPOSER_THRESHOLD,
-          DEFAULT_WEIGHT_PER_NFT,
-        ),
+        adapter.initialize(await mockNft.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
       ).to.be.revertedWithCustomError(adapter, 'InvalidInitialization');
     });
 
     it('Implementation contract should remain uninitialized', async () => {
       await expect(
-        adapterImplementation.initialize(
-          await mockNft.getAddress(),
-          DEFAULT_PROPOSER_THRESHOLD,
-          DEFAULT_WEIGHT_PER_NFT,
-        ),
+        adapterImplementation.initialize(await mockNft.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
       ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidInitialization');
     });
   });
@@ -165,7 +139,6 @@ describe('ERC721ProposerAdapterV1', () => {
         await adapterImplementation.getAddress(),
         await mockNft.getAddress(),
         0n,
-        DEFAULT_WEIGHT_PER_NFT,
       );
       const canPropose = await localAdapter.isProposer(user1.address);
       void expect(canPropose).to.be.true;
@@ -178,29 +151,50 @@ describe('ERC721ProposerAdapterV1', () => {
     });
   });
 
-  describe('supportsInterface', () => {
-    it('should support IProposerAdapterV1, IProposerAdapterBaseV1, IVersion and IERC165', async () => {
-      const iProposerAdapterV1Interface = IProposerAdapterV1__factory.createInterface();
-      const iProposerAdapterBaseV1Interface = IProposerAdapterBaseV1__factory.createInterface();
-      const iVersionInterface = IVersion__factory.createInterface();
-      const iERC165Interface = IERC165__factory.createInterface();
+  describe('ERC165 supportsInterface', () => {
+    it('should support IERC721ProposerAdapterV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IERC721ProposerAdapterV1__factory.createInterface(), [
+            IProposerAdapterV1__factory.createInterface(),
+            IProposerAdapterBaseV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
+    });
 
-      const iProposerAdapterV1Id = calculateInterfaceId(iProposerAdapterV1Interface, [
-        iProposerAdapterBaseV1Interface,
-      ]);
-      const iProposerAdapterBaseV1Id = calculateInterfaceId(iProposerAdapterBaseV1Interface);
-      const iVersionId = calculateInterfaceId(iVersionInterface);
-      const iERC165Id = calculateInterfaceId(iERC165Interface);
+    it('should support IProposerAdapterV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IProposerAdapterV1__factory.createInterface(), [
+            IProposerAdapterBaseV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
+    });
 
-      void expect(await adapter.supportsInterface(iProposerAdapterV1Id)).to.be.true;
-      void expect(await adapter.supportsInterface(iProposerAdapterBaseV1Id)).to.be.true;
-      void expect(await adapter.supportsInterface(iVersionId)).to.be.true;
-      void expect(await adapter.supportsInterface(iERC165Id)).to.be.true;
+    it('should support IProposerAdapterBaseV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IProposerAdapterBaseV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support IVersion', async () => {
+      void expect(
+        await adapter.supportsInterface(calculateInterfaceId(IVersion__factory.createInterface())),
+      ).to.be.true;
+    });
+
+    it('should support IERC165', async () => {
+      void expect(
+        await adapter.supportsInterface(calculateInterfaceId(IERC165__factory.createInterface())),
+      ).to.be.true;
     });
 
     it('should not support a random interfaceId', async () => {
-      const randomInterfaceId = '0x12345678';
-      void expect(await adapter.supportsInterface(randomInterfaceId)).to.be.false;
+      void expect(await adapter.supportsInterface('0x12345678')).to.be.false;
     });
   });
 });

--- a/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
@@ -6,6 +6,7 @@ import {
   HatsProposerAdapterV1,
   HatsProposerAdapterV1__factory,
   IERC165__factory,
+  IHatsProposerAdapterV1__factory,
   IProposerAdapterBaseV1__factory,
   IProposerAdapterV1__factory,
   IVersion__factory,
@@ -67,7 +68,7 @@ describe('HatsProposerAdapterV1', () => {
   describe('Initialization (via Proxy)', () => {
     it('should initialize correctly with valid parameters', async () => {
       expect(await adapter.hatsContract()).to.equal(await mockHats.getAddress());
-      const whitelistedHats = await adapter.getWhitelistedHatIds();
+      const whitelistedHats = await adapter.whitelistedHatIds();
       expect(whitelistedHats).to.deep.equal([HAT_ID_1]);
     });
 
@@ -147,27 +148,50 @@ describe('HatsProposerAdapterV1', () => {
     });
   });
 
-  describe('supportsInterface', () => {
-    it('should support IProposerAdapterV1, IProposerAdapterBaseV1, IVersion and IERC165', async () => {
-      const iProposerAdapterV1Interface = IProposerAdapterV1__factory.createInterface();
-      const iProposerAdapterBaseV1Interface = IProposerAdapterBaseV1__factory.createInterface();
-      const iVersionInterface = IVersion__factory.createInterface();
-      const iERC165Interface = IERC165__factory.createInterface();
+  describe('ERC165 supportsInterface', () => {
+    it('should support IHatsProposerAdapterV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IHatsProposerAdapterV1__factory.createInterface(), [
+            IProposerAdapterV1__factory.createInterface(),
+            IProposerAdapterBaseV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
+    });
 
-      const iProposerAdapterV1Id = calculateInterfaceId(iProposerAdapterV1Interface);
-      const iProposerAdapterBaseV1Id = calculateInterfaceId(iProposerAdapterBaseV1Interface);
-      const iVersionId = calculateInterfaceId(iVersionInterface);
-      const iERC165Id = calculateInterfaceId(iERC165Interface);
+    it('should support IProposerAdapterV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IProposerAdapterV1__factory.createInterface(), [
+            IProposerAdapterBaseV1__factory.createInterface(),
+          ]),
+        ),
+      ).to.be.true;
+    });
 
-      void expect(await adapter.supportsInterface(iProposerAdapterV1Id)).to.be.true;
-      void expect(await adapter.supportsInterface(iProposerAdapterBaseV1Id)).to.be.true;
-      void expect(await adapter.supportsInterface(iVersionId)).to.be.true;
-      void expect(await adapter.supportsInterface(iERC165Id)).to.be.true;
+    it('should support IProposerAdapterBaseV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IProposerAdapterBaseV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support IVersion', async () => {
+      void expect(
+        await adapter.supportsInterface(calculateInterfaceId(IVersion__factory.createInterface())),
+      ).to.be.true;
+    });
+
+    it('should support IERC165', async () => {
+      void expect(
+        await adapter.supportsInterface(calculateInterfaceId(IERC165__factory.createInterface())),
+      ).to.be.true;
     });
 
     it('should not support a random interfaceId', async () => {
-      const randomInterfaceId = '0x12345678';
-      void expect(await adapter.supportsInterface(randomInterfaceId)).to.be.false;
+      void expect(await adapter.supportsInterface('0x12345678')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/301

This commit introduces three new interfaces: `IERC20ProposerAdapterV1`, `IERC721ProposerAdapterV1`, and `IHatsProposerAdapterV1`, enhancing the structure and clarity of the proposer adapter contracts. Key changes include:

1. **Interface Definitions:**
   - Created `IERC20ProposerAdapterV1` and `IERC721ProposerAdapterV1` to define specific functions and errors for ERC20 and ERC721 proposer adapters, respectively.
   - Introduced `IHatsProposerAdapterV1` for hats-based proposer logic.

2. **Contract Modifications:**
   - Updated `ERC20ProposerAdapterV1`, `ERC721ProposerAdapterV1`, and `HatsProposerAdapterV1` to implement their respective new interfaces, ensuring consistency in function signatures and error handling.
   - Changed state variable visibility from public to internal in all three adapter contracts to enhance encapsulation.

3. **Error Handling:**
   - Retained existing error definitions and added new ones in the interfaces for better clarity and consistency in error handling.

These changes improve the maintainability and clarity of the proposer adapter contracts while ensuring they adhere to the defined interface structure.