### PR TITLE
refactor: Rename getVersion() to version() across multiple contracts and interfaces

### DIFF
--- a/contracts/deployables/Version.sol
+++ b/contracts/deployables/Version.sol
@@ -9,14 +9,14 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  * @dev Abstract contract providing standardized contract identification
  *
  * Inheriting contracts MUST implement:
- * - getVersion()
+ * - version()
  */
 abstract contract Version is IVersion, ERC165 {
     /**
      * @dev Returns the version number of this contract implementation
      * Inheriting contracts MUST override this function.
      */
-    function getVersion() public view virtual returns (uint16);
+    function version() public view virtual returns (uint16);
 
     function supportsInterface(
         bytes4 interfaceId

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -120,7 +120,7 @@ contract DecentPaymasterV1 is
         return (abi.encode(), 0);
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
@@ -143,7 +143,7 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
         return true;
     }
 
-    function getVersion() public pure virtual override returns (uint16) {
+    function version() public pure virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -128,7 +128,7 @@ contract LinearERC721VotingV1ValidatorV1 is
         return true;
     }
 
-    function getVersion() public pure virtual override returns (uint16) {
+    function version() public pure virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -27,7 +27,7 @@ contract DecentAutonomousAdminV1 is IDecentAutonomousAdminV1, Version {
         }
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/erc20/VotesERC20LockableV1.sol
+++ b/contracts/deployables/erc20/VotesERC20LockableV1.sol
@@ -92,7 +92,7 @@ contract VotesERC20LockableV1 is IVotesERC20LockableV1, VotesERC20V1 {
         super._update(from, to, amount);
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -93,7 +93,7 @@ contract VotesERC20StakedV1 is
         emit MinimumStakingPeriodUpdated(newMinimumStakingPeriod);
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -95,7 +95,7 @@ contract VotesERC20V1 is
         return super.nonces(owner);
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -64,7 +64,7 @@ contract AzoriusFreezeGuardV1 is
         bool
     ) external view virtual override {}
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -182,7 +182,7 @@ contract MultisigFreezeGuardV1 is
         emit ExecutionPeriodUpdated(executionPeriod_);
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -80,7 +80,7 @@ contract ERC20FreezeVotingV1 is
         emit FreezeVoteCast(msg.sender, userVotes);
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -106,7 +106,7 @@ contract ERC721FreezeVotingV1 is
         return votes;
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -57,7 +57,7 @@ contract MultisigFreezeVotingV1 is
         emit FreezeVoteCast(msg.sender, 1);
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -366,7 +366,7 @@ contract AzoriusV1 is
         emit StrategyUpdated(strategy_);
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -58,7 +58,7 @@ contract FractalModuleV1 is
         if (!exec(_target, _value, _data, _operation)) revert TxFailed();
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -310,7 +310,7 @@ contract StrategyV1 is
         return details.votingStartBlock;
     }
 
-    function getVersion() public view virtual override returns (uint16) {
+    function version() public view virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
@@ -54,7 +54,7 @@ contract ERC20ProposerAdapterV1 is
         return _token.getVotes(_proposer) >= _proposerThreshold;
     }
 
-    function getVersion() public pure virtual override returns (uint16) {
+    function version() public pure virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
@@ -103,7 +103,7 @@ contract ERC20VotingAdapterV1 is
         emit VoteRecorded(_voter, _proposalId, weightCasted, bytes(""));
     }
 
-    function getVersion() public pure virtual override returns (uint16) {
+    function version() public pure virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
@@ -54,7 +54,7 @@ contract ERC721ProposerAdapterV1 is
         return _token.balanceOf(_proposer) >= _proposerThreshold;
     }
 
-    function getVersion() public pure virtual override returns (uint16) {
+    function version() public pure virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -139,7 +139,7 @@ contract ERC721VotingAdapterV1 is
         emit VoteRecorded(_voter, _proposalId, weightCasted, _adapterVoteData);
     }
 
-    function getVersion() public pure virtual override returns (uint16) {
+    function version() public pure virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -67,7 +67,7 @@ contract HatsProposerAdapterV1 is
         return false;
     }
 
-    function getVersion() public pure virtual override returns (uint16) {
+    function version() public pure virtual override returns (uint16) {
         return VERSION;
     }
 

--- a/contracts/interfaces/decent/deployables/IVersion.sol
+++ b/contracts/interfaces/decent/deployables/IVersion.sol
@@ -2,5 +2,5 @@
 pragma solidity ^0.8.30;
 
 interface IVersion {
-    function getVersion() external view returns (uint16);
+    function version() external view returns (uint16);
 }

--- a/contracts/mocks/concretes/deployables/ConcreteVersion.sol
+++ b/contracts/mocks/concretes/deployables/ConcreteVersion.sol
@@ -10,13 +10,7 @@ contract ConcreteVersion is Version {
         _version = newVersion;
     }
 
-    function getVersion()
-        public
-        view
-        virtual
-        override(Version)
-        returns (uint16)
-    {
+    function version() public view virtual override(Version) returns (uint16) {
         return _version;
     }
 }

--- a/test/deployables/Version.test.ts
+++ b/test/deployables/Version.test.ts
@@ -29,7 +29,7 @@ describe('Version', () => {
 
       await concreteVersion.setVersion(version);
 
-      expect(await concreteVersion.getVersion()).to.equal(version);
+      expect(await concreteVersion.version()).to.equal(version);
     });
 
     it('should update version when setter is called', async () => {
@@ -37,10 +37,10 @@ describe('Version', () => {
       const newVersion = 2;
 
       await concreteVersion.setVersion(oldVersion);
-      expect(await concreteVersion.getVersion()).to.equal(oldVersion);
+      expect(await concreteVersion.version()).to.equal(oldVersion);
 
       await concreteVersion.setVersion(newVersion);
-      expect(await concreteVersion.getVersion()).to.equal(newVersion);
+      expect(await concreteVersion.version()).to.equal(newVersion);
     });
   });
 

--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -172,7 +172,7 @@ describe('DecentPaymasterV1', function () {
     });
 
     it('Should have a version', async function () {
-      const version = await decentPaymaster.getVersion();
+      const version = await decentPaymaster.version();
       expect(version).to.equal(1);
     });
   });
@@ -415,7 +415,7 @@ describe('DecentPaymasterV1', function () {
 
   describe('Version', () => {
     it('should return the correct version number', async () => {
-      expect(await decentPaymaster.getVersion()).to.equal(1);
+      expect(await decentPaymaster.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.test.ts
@@ -709,7 +709,7 @@ describe('LinearERC20VotingV1ValidatorV1', function () {
 
   describe('Version', function () {
     it('Should return correct version', async function () {
-      expect(await validator.getVersion()).to.equal(1);
+      expect(await validator.version()).to.equal(1);
     });
   });
 });

--- a/test/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.test.ts
@@ -411,7 +411,7 @@ describe('LinearERC721VotingV1ValidatorV1', function () {
 
   describe('Version', function () {
     it('Should return correct version', async function () {
-      void expect(await validator.getVersion()).to.equal(1);
+      void expect(await validator.version()).to.equal(1);
     });
   });
 });

--- a/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
+++ b/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
@@ -89,7 +89,7 @@ describe('DecentAutonomousAdminV1', function () {
 
   describe('Version', () => {
     it('should return the correct version number', async () => {
-      expect(await decentAutonomousAdmin.getVersion()).to.equal(1);
+      expect(await decentAutonomousAdmin.version()).to.equal(1);
     });
   });
 });

--- a/test/deployables/erc20/VotesERC20LockableV1.test.ts
+++ b/test/deployables/erc20/VotesERC20LockableV1.test.ts
@@ -723,7 +723,7 @@ describe('VotesERC20LockableV1', () => {
         [],
         [],
       );
-      expect(await proxy.getVersion()).to.equal(1);
+      expect(await proxy.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -197,7 +197,7 @@ describe('VotesERC20StakedV1', () => {
     });
 
     it('should return the correct version number', async () => {
-      expect(await votesERC20Staked.getVersion()).to.equal(1);
+      expect(await votesERC20Staked.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/deployables/erc20/VotesERC20V1.test.ts
@@ -203,7 +203,7 @@ describe('VotesERC20V1', () => {
     });
 
     it('should return the correct version number', async () => {
-      expect(await votesERC20.getVersion()).to.equal(1);
+      expect(await votesERC20.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/AzoriusFreezeGuardV1.test.ts
@@ -202,7 +202,7 @@ describe('AzoriusFreezeGuardV1', () => {
 
     // Use the shared version test utility
     it('should return the correct version number', async () => {
-      expect(await azoriusFreezeGuard.getVersion()).to.equal(1);
+      expect(await azoriusFreezeGuard.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
+++ b/test/deployables/freeze-guard/MultisigFreezeGuardV1.test.ts
@@ -454,7 +454,7 @@ describe('MultisigFreezeGuardV1', () => {
   describe('Version', () => {
     // Use the shared version test utility
     it('should return the correct version number', async () => {
-      expect(await multisigFreezeGuard.getVersion()).to.equal(1);
+      expect(await multisigFreezeGuard.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
@@ -486,7 +486,7 @@ describe('ERC20FreezeVotingV1', () => {
   describe('Version', () => {
     // Use the shared version test utility
     it('should return the correct version number', async () => {
-      expect(await freezeVoting.getVersion()).to.equal(1);
+      expect(await freezeVoting.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
@@ -534,7 +534,7 @@ describe('ERC721FreezeVotingV1', () => {
 
   describe('Version', () => {
     it('should return the correct version number', async () => {
-      expect(await freezeVoting.getVersion()).to.equal(1);
+      expect(await freezeVoting.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
@@ -486,7 +486,7 @@ describe('MultisigFreezeVotingV1', () => {
 
   describe('Version', () => {
     it('should return the correct version number', async () => {
-      expect(await freezeVoting.getVersion()).to.equal(1);
+      expect(await freezeVoting.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -1562,7 +1562,7 @@ describe('AzoriusV1', () => {
 
     // Use the shared version test utility
     it('should return the correct version number', async () => {
-      expect(await azorius.getVersion()).to.equal(1);
+      expect(await azorius.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/modules/FractalModuleV1.test.ts
+++ b/test/deployables/modules/FractalModuleV1.test.ts
@@ -383,7 +383,7 @@ describe('FractalModuleV1', () => {
 
     // Use the shared version test utility
     it('should return the correct version number', async () => {
-      expect(await fractalModule.getVersion()).to.equal(1);
+      expect(await fractalModule.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -902,7 +902,7 @@ describe('StrategyV1', () => {
 
   describe('Version', () => {
     it('should return the correct version', async () => {
-      void expect(await strategy.getVersion()).to.equal(1);
+      void expect(await strategy.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/strategies/adapters/ERC20ProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20ProposerAdapterV1.test.ts
@@ -147,9 +147,9 @@ describe('ERC20ProposerAdapterV1', () => {
     });
   });
 
-  describe('getVersion', () => {
+  describe('version', () => {
     it('should return the correct version', async () => {
-      expect(await adapter.getVersion()).to.equal(1n);
+      expect(await adapter.version()).to.equal(1n);
     });
   });
 

--- a/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
@@ -454,7 +454,7 @@ describe('ERC20VotingAdapterV1', () => {
     });
   });
 
-  describe('getVersion()', () => {
+  describe('version()', () => {
     it('should return the correct version', async () => {
       const { adapter: erc20Adapter } = await deployERC20AdapterProxy(
         deployer,
@@ -464,7 +464,7 @@ describe('ERC20VotingAdapterV1', () => {
         DEFAULT_WEIGHT_PER_TOKEN,
       );
 
-      expect(await erc20Adapter.getVersion()).to.equal(1);
+      expect(await erc20Adapter.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/strategies/adapters/ERC721ProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721ProposerAdapterV1.test.ts
@@ -145,9 +145,9 @@ describe('ERC721ProposerAdapterV1', () => {
     });
   });
 
-  describe('getVersion', () => {
+  describe('version', () => {
     it('should return the correct version', async () => {
-      expect(await adapter.getVersion()).to.equal(1n);
+      expect(await adapter.version()).to.equal(1n);
     });
   });
 

--- a/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
@@ -454,7 +454,7 @@ describe('ERC721VotingAdapterV1', () => {
     });
   });
 
-  describe('getVersion()', () => {
+  describe('version()', () => {
     it('should return the correct version', async () => {
       const { mockNft, deployer: fixtureDeployer } = await loadFixture(
         deployMocksAndSignersERC721Fixture,
@@ -465,7 +465,7 @@ describe('ERC721VotingAdapterV1', () => {
         await mockNft.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
-      expect(await erc721Adapter.getVersion()).to.equal(1);
+      expect(await erc721Adapter.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
@@ -142,9 +142,9 @@ describe('HatsProposerAdapterV1', () => {
     });
   });
 
-  describe('getVersion', () => {
+  describe('version', () => {
     it('should return the correct version', async () => {
-      expect(await adapter.getVersion()).to.equal(1n);
+      expect(await adapter.version()).to.equal(1n);
     });
   });
 


### PR DESCRIPTION
This commit standardizes the naming convention for version retrieval functions by renaming `getVersion()` to `version()` in various contracts and interfaces, including `Version`, `IVersion`, and several implementations. This change enhances consistency and clarity in the codebase, ensuring that all version-related functions follow a uniform naming pattern.