### PR TITLE
refactor: Enhance ERC721VotingAdapterV1 with new token ID handling functions

### DIFF
--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -60,29 +60,25 @@ contract ERC721VotingAdapterV1 is
     function _getUniqueTokenIds(
         uint256[] memory tokenIds
     ) internal view virtual returns (uint256[] memory uniqueTokenIds) {
-        uint256[] memory tempUniqueTokenIds = new uint256[](tokenIds.length);
+        uniqueTokenIds = new uint256[](tokenIds.length);
         uint256 uniqueCount = 0;
+
         for (uint256 i = 0; i < tokenIds.length; i++) {
             bool isDuplicate = false;
             for (uint256 j = 0; j < uniqueCount; j++) {
-                if (tempUniqueTokenIds[j] == tokenIds[i]) {
+                if (uniqueTokenIds[j] == tokenIds[i]) {
                     isDuplicate = true;
                     break;
                 }
             }
             if (!isDuplicate) {
-                tempUniqueTokenIds[uniqueCount] = tokenIds[i];
+                uniqueTokenIds[uniqueCount] = tokenIds[i];
                 uniqueCount++;
             }
         }
 
-        if (uniqueCount == 0) {
-            return new uint256[](0);
-        }
-
-        uniqueTokenIds = new uint256[](uniqueCount);
-        for (uint256 i = 0; i < uniqueCount; i++) {
-            uniqueTokenIds[i] = tempUniqueTokenIds[i];
+        assembly {
+            mstore(uniqueTokenIds, uniqueCount)
         }
     }
 
@@ -90,49 +86,37 @@ contract ERC721VotingAdapterV1 is
         address voter,
         uint256[] memory tokenIds
     ) internal view virtual returns (uint256[] memory ownedTokenIds) {
-        bool[] memory isTokenOwnedByVoter = new bool[](tokenIds.length);
+        ownedTokenIds = new uint256[](tokenIds.length);
         uint256 ownedTokenCount = 0;
+
         for (uint256 i = 0; i < tokenIds.length; i++) {
             if (_token.ownerOf(tokenIds[i]) == voter) {
-                isTokenOwnedByVoter[i] = true;
+                ownedTokenIds[ownedTokenCount] = tokenIds[i];
                 ownedTokenCount++;
             }
         }
 
-        if (ownedTokenCount == 0) {
-            return new uint256[](0);
-        }
-
-        ownedTokenIds = new uint256[](ownedTokenCount);
-        uint256 ownedTokenCurrentIndex = 0;
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            if (isTokenOwnedByVoter[i]) {
-                ownedTokenIds[ownedTokenCurrentIndex] = tokenIds[i];
-                ownedTokenCurrentIndex++;
-            }
+        assembly {
+            mstore(ownedTokenIds, ownedTokenCount)
         }
     }
 
     function _getUnusedTokenIds(
         uint32 proposalId,
-        uint256[] memory ownedTokenIds
+        uint256[] memory tokenIds
     ) internal view virtual returns (uint256[] memory unusedTokenIds) {
-        bool[] memory isTokenUnused = new bool[](ownedTokenIds.length);
+        unusedTokenIds = new uint256[](tokenIds.length);
         uint256 unusedTokenCount = 0;
-        for (uint256 i = 0; i < ownedTokenIds.length; i++) {
-            if (!_tokenIdUsedForVote[proposalId][ownedTokenIds[i]]) {
-                isTokenUnused[i] = true;
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            if (!_tokenIdUsedForVote[proposalId][tokenIds[i]]) {
+                unusedTokenIds[unusedTokenCount] = tokenIds[i];
                 unusedTokenCount++;
             }
         }
 
-        unusedTokenIds = new uint256[](unusedTokenCount);
-        uint256 unusedTokenCurrentIndex = 0;
-        for (uint256 i = 0; i < ownedTokenIds.length; i++) {
-            if (isTokenUnused[i]) {
-                unusedTokenIds[unusedTokenCurrentIndex] = ownedTokenIds[i];
-                unusedTokenCurrentIndex++;
-            }
+        assembly {
+            mstore(unusedTokenIds, unusedTokenCount)
         }
     }
 

--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -51,57 +51,125 @@ contract ERC721VotingAdapterV1 is
         return _tokenIdUsedForVote[proposalId][tokenId];
     }
 
-    function _getValidUnvotedTokenIdsAndWeight(
-        address _voter,
-        uint32 _proposalId,
+    function _decodeTokenIds(
         bytes calldata _adapterVoteData
+    ) internal view virtual returns (uint256[] memory tokenIds) {
+        tokenIds = abi.decode(_adapterVoteData, (uint256[]));
+    }
+
+    function _getUniqueTokenIds(
+        uint256[] memory tokenIds
+    ) internal view virtual returns (uint256[] memory uniqueTokenIds) {
+        uint256[] memory tempUniqueTokenIds = new uint256[](tokenIds.length);
+        uint256 uniqueCount = 0;
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            bool isDuplicate = false;
+            for (uint256 j = 0; j < uniqueCount; j++) {
+                if (tempUniqueTokenIds[j] == tokenIds[i]) {
+                    isDuplicate = true;
+                    break;
+                }
+            }
+            if (!isDuplicate) {
+                tempUniqueTokenIds[uniqueCount] = tokenIds[i];
+                uniqueCount++;
+            }
+        }
+
+        if (uniqueCount == 0) {
+            return new uint256[](0);
+        }
+
+        uniqueTokenIds = new uint256[](uniqueCount);
+        for (uint256 i = 0; i < uniqueCount; i++) {
+            uniqueTokenIds[i] = tempUniqueTokenIds[i];
+        }
+    }
+
+    function _getOwnedTokenIds(
+        address voter,
+        uint256[] memory tokenIds
+    ) internal view virtual returns (uint256[] memory ownedTokenIds) {
+        bool[] memory isTokenOwnedByVoter = new bool[](tokenIds.length);
+        uint256 ownedTokenCount = 0;
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            if (_token.ownerOf(tokenIds[i]) == voter) {
+                isTokenOwnedByVoter[i] = true;
+                ownedTokenCount++;
+            }
+        }
+
+        if (ownedTokenCount == 0) {
+            return new uint256[](0);
+        }
+
+        ownedTokenIds = new uint256[](ownedTokenCount);
+        uint256 ownedTokenCurrentIndex = 0;
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            if (isTokenOwnedByVoter[i]) {
+                ownedTokenIds[ownedTokenCurrentIndex] = tokenIds[i];
+                ownedTokenCurrentIndex++;
+            }
+        }
+    }
+
+    function _getUnusedTokenIds(
+        uint32 proposalId,
+        uint256[] memory ownedTokenIds
+    ) internal view virtual returns (uint256[] memory unusedTokenIds) {
+        bool[] memory isTokenUnused = new bool[](ownedTokenIds.length);
+        uint256 unusedTokenCount = 0;
+        for (uint256 i = 0; i < ownedTokenIds.length; i++) {
+            if (!_tokenIdUsedForVote[proposalId][ownedTokenIds[i]]) {
+                isTokenUnused[i] = true;
+                unusedTokenCount++;
+            }
+        }
+
+        unusedTokenIds = new uint256[](unusedTokenCount);
+        uint256 unusedTokenCurrentIndex = 0;
+        for (uint256 i = 0; i < ownedTokenIds.length; i++) {
+            if (isTokenUnused[i]) {
+                unusedTokenIds[unusedTokenCurrentIndex] = ownedTokenIds[i];
+                unusedTokenCurrentIndex++;
+            }
+        }
+    }
+
+    function _getValidTokenIds(
+        address voter,
+        uint32 proposalId,
+        bytes calldata adapterVoteData
     )
         internal
         view
         virtual
-        returns (
-            uint256[] memory validTokenIdsForThisCall,
-            uint256 totalCalculatedWeight
-        )
+        returns (uint256 weight, uint256[] memory unusedTokenIds)
     {
-        uint256[] memory tokenIds = abi.decode(_adapterVoteData, (uint256[]));
-
-        if (tokenIds.length == 0) {
-            return (new uint256[](0), 0);
+        uint256[] memory allTokenIds = _decodeTokenIds(adapterVoteData);
+        if (allTokenIds.length == 0) {
+            return (0, new uint256[](0));
         }
 
-        uint256[] memory tempValidTokenIds = new uint256[](tokenIds.length);
-        uint256 validCount = 0;
-
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            uint256 tokenId = tokenIds[i];
-            if (_token.ownerOf(tokenId) != _voter) {
-                continue;
-            }
-
-            if (_tokenIdUsedForVote[_proposalId][tokenId]) {
-                continue;
-            }
-
-            bool alreadyProcessedInThisCall = false;
-            for (uint256 j = 0; j < validCount; j++) {
-                if (tempValidTokenIds[j] == tokenId) {
-                    alreadyProcessedInThisCall = true;
-                    break;
-                }
-            }
-
-            if (!alreadyProcessedInThisCall) {
-                tempValidTokenIds[validCount] = tokenId;
-                validCount++;
-                totalCalculatedWeight += _weightPerToken;
-            }
+        uint256[] memory uniqueTokenIds = _getUniqueTokenIds(allTokenIds);
+        if (uniqueTokenIds.length == 0) {
+            return (0, new uint256[](0));
         }
 
-        validTokenIdsForThisCall = new uint256[](validCount);
-        for (uint256 i = 0; i < validCount; i++) {
-            validTokenIdsForThisCall[i] = tempValidTokenIds[i];
+        uint256[] memory ownedTokenIds = _getOwnedTokenIds(
+            voter,
+            uniqueTokenIds
+        );
+        if (ownedTokenIds.length == 0) {
+            return (0, new uint256[](0));
         }
+
+        unusedTokenIds = _getUnusedTokenIds(proposalId, ownedTokenIds);
+        if (unusedTokenIds.length == 0) {
+            return (0, new uint256[](0));
+        }
+
+        weight = unusedTokenIds.length * _weightPerToken;
     }
 
     function weightOf(
@@ -109,12 +177,25 @@ contract ERC721VotingAdapterV1 is
         uint32 _proposalId,
         bytes calldata _adapterVoteData
     ) external view virtual override returns (uint256 weight) {
-        (, uint256 totalCalculatedWeight) = _getValidUnvotedTokenIdsAndWeight(
+        (weight, ) = _getValidTokenIds(_voter, _proposalId, _adapterVoteData);
+    }
+
+    function weightOfWithValidTokenIds(
+        address _voter,
+        uint32 _proposalId,
+        bytes calldata _adapterVoteData
+    )
+        external
+        view
+        virtual
+        override
+        returns (uint256 weight, uint256[] memory unusedTokenIds)
+    {
+        (weight, unusedTokenIds) = _getValidTokenIds(
             _voter,
             _proposalId,
             _adapterVoteData
         );
-        weight = totalCalculatedWeight;
     }
 
     function recordVote(
@@ -122,19 +203,23 @@ contract ERC721VotingAdapterV1 is
         uint32 _proposalId,
         bytes calldata _adapterVoteData
     ) external virtual override returns (uint256 weightCasted) {
-        (
-            uint256[] memory validTokenIdsToRecord,
-            uint256 totalCalculatedWeight
-        ) = _getValidUnvotedTokenIdsAndWeight(
-                _voter,
-                _proposalId,
-                _adapterVoteData
-            );
-
-        for (uint256 i = 0; i < validTokenIdsToRecord.length; i++) {
-            _tokenIdUsedForVote[_proposalId][validTokenIdsToRecord[i]] = true;
+        uint256[] memory tokenIds = _decodeTokenIds(_adapterVoteData);
+        if (tokenIds.length == 0) {
+            revert NoTokenIdsPassed();
         }
-        weightCasted = totalCalculatedWeight;
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            uint256 tokenId = tokenIds[i];
+            if (_token.ownerOf(tokenId) != _voter) {
+                revert TokenIdNotOwnedByVoter(tokenId);
+            }
+            if (_tokenIdUsedForVote[_proposalId][tokenId]) {
+                revert TokenIdAlreadyUsedForVote(tokenId);
+            }
+            _tokenIdUsedForVote[_proposalId][tokenId] = true;
+        }
+
+        weightCasted = tokenIds.length * _weightPerToken;
 
         emit VoteRecorded(_voter, _proposalId, weightCasted, _adapterVoteData);
     }

--- a/contracts/interfaces/decent/deployables/IERC721VotingAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC721VotingAdapterV1.sol
@@ -6,6 +6,9 @@ import {IVotingAdapterV1} from "./IVotingAdapterV1.sol";
 interface IERC721VotingAdapterV1 is IVotingAdapterV1 {
     error InvalidTokenAddress();
     error InvalidWeightPerToken();
+    error NoTokenIdsPassed();
+    error TokenIdAlreadyUsedForVote(uint256 tokenId);
+    error TokenIdNotOwnedByVoter(uint256 tokenId);
 
     function initialize(address token, uint256 weightPerToken) external;
 
@@ -17,4 +20,10 @@ interface IERC721VotingAdapterV1 is IVotingAdapterV1 {
         uint32 proposalId,
         uint256 tokenId
     ) external view returns (bool);
+
+    function weightOfWithValidTokenIds(
+        address _voter,
+        uint32 _proposalId,
+        bytes calldata _adapterVoteData
+    ) external view returns (uint256 weight, uint256[] memory unusedTokenIds);
 }

--- a/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
@@ -346,7 +346,7 @@ describe('ERC721VotingAdapterV1', () => {
     });
 
     it('should return correct weight and token IDs, filtering out unowned tokens', async () => {
-      const tokenIdsToVoteWith = [user1TokenIds[0], user2TokenIds[0]]; // User1 owns first (0), not second (3)
+      const tokenIdsToVoteWith = [user1TokenIds[0], user2TokenIds[0], user1TokenIds[1]]; // User1 owns first and third, user2 owns second
       const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
         ['uint256[]'],
         [tokenIdsToVoteWith],
@@ -356,8 +356,8 @@ describe('ERC721VotingAdapterV1', () => {
         proposalId,
         adapterVoteData,
       );
-      expect(weight).to.equal(1n * DEFAULT_WEIGHT_PER_NFT);
-      expect(unusedTokenIds).to.deep.equal([user1TokenIds[0]]);
+      expect(weight).to.equal(2n * DEFAULT_WEIGHT_PER_NFT);
+      expect(unusedTokenIds).to.deep.equal([user1TokenIds[0], user1TokenIds[1]]);
     });
 
     it('should return correct weight and token IDs, filtering out tokens already used in the proposal', async () => {

--- a/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
@@ -301,6 +301,208 @@ describe('ERC721VotingAdapterV1', () => {
     });
   });
 
+  describe('weightOfWithUnusedTokenIds', () => {
+    let adapter: ERC721VotingAdapterV1;
+    let mockNft: MockERC721;
+    let user1: SignerWithAddress;
+    let user1TokenIds: bigint[];
+    let user2TokenIds: bigint[];
+    let deployer: SignerWithAddress;
+
+    const proposalId = 1;
+    const proposalId2 = 2; // For testing used tokens across different proposals
+
+    beforeEach(async () => {
+      const fixture = await loadFixture(deployMocksAndSignersERC721Fixture);
+      mockNft = fixture.mockNft;
+      user1 = fixture.user1Signer;
+      user1TokenIds = fixture.user1TokenIds; // User1 owns [0, 1, 2]
+      user2TokenIds = fixture.user2TokenIds; // User2 owns [3, 4]
+      deployer = fixture.deployer;
+
+      const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
+        deployer,
+        erc721AdapterImplementationAddressG,
+        await mockNft.getAddress(),
+        DEFAULT_WEIGHT_PER_NFT,
+      );
+      adapter = deployedAdapter;
+    });
+
+    it('should return correct weight and token IDs if voter owns all provided, unvoted token IDs', async () => {
+      const tokenIdsToVoteWith = [user1TokenIds[0], user1TokenIds[1]]; // [0, 1]
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsToVoteWith],
+      );
+      const { weight, unusedTokenIds } = await adapter.weightOfWithValidTokenIds(
+        user1.address,
+        proposalId,
+        adapterVoteData,
+      );
+
+      expect(weight).to.equal(BigInt(tokenIdsToVoteWith.length) * DEFAULT_WEIGHT_PER_NFT);
+      expect(unusedTokenIds).to.deep.equal(tokenIdsToVoteWith);
+    });
+
+    it('should return correct weight and token IDs, filtering out unowned tokens', async () => {
+      const tokenIdsToVoteWith = [user1TokenIds[0], user2TokenIds[0]]; // User1 owns first (0), not second (3)
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsToVoteWith],
+      );
+      const { weight, unusedTokenIds } = await adapter.weightOfWithValidTokenIds(
+        user1.address,
+        proposalId,
+        adapterVoteData,
+      );
+      expect(weight).to.equal(1n * DEFAULT_WEIGHT_PER_NFT);
+      expect(unusedTokenIds).to.deep.equal([user1TokenIds[0]]);
+    });
+
+    it('should return correct weight and token IDs, filtering out tokens already used in the proposal', async () => {
+      const tokenToUseInitially = user1TokenIds[0];
+      const anotherValidToken = user1TokenIds[1];
+
+      // Record vote for tokenToUseInitially for proposalId
+      const initialAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[tokenToUseInitially]],
+      );
+      await adapter.connect(user1).recordVote(user1.address, proposalId, initialAdapterVoteData);
+
+      // Now, try to get weight for [tokenToUseInitially, anotherValidToken]
+      const tokenIdsForWeightCheck = [tokenToUseInitially, anotherValidToken];
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsForWeightCheck],
+      );
+      const { weight, unusedTokenIds } = await adapter.weightOfWithValidTokenIds(
+        user1.address,
+        proposalId,
+        adapterVoteData,
+      );
+      expect(weight).to.equal(1n * DEFAULT_WEIGHT_PER_NFT); // Only anotherValidToken should count
+      expect(unusedTokenIds).to.deep.equal([anotherValidToken]);
+    });
+
+    it('should correctly handle tokens used in a different proposal', async () => {
+      const tokenToUse = user1TokenIds[0];
+      // Record vote for tokenToUse for proposalId2
+      const initialAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[tokenToUse]],
+      );
+      await adapter.connect(user1).recordVote(user1.address, proposalId2, initialAdapterVoteData);
+
+      // Get weight for the same token but for proposalId (different proposal)
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[tokenToUse]],
+      );
+      const { weight, unusedTokenIds } = await adapter.weightOfWithValidTokenIds(
+        user1.address,
+        proposalId,
+        adapterVoteData,
+      );
+      expect(weight).to.equal(1n * DEFAULT_WEIGHT_PER_NFT); // Should be valid for this proposalId
+      expect(unusedTokenIds).to.deep.equal([tokenToUse]);
+    });
+
+    it('should count duplicate token IDs in _adapterVoteData only once', async () => {
+      const tokenIdsToVoteWith = [user1TokenIds[0], user1TokenIds[0], user1TokenIds[1]]; // Duplicate [0]
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsToVoteWith],
+      );
+      const { weight, unusedTokenIds } = await adapter.weightOfWithValidTokenIds(
+        user1.address,
+        proposalId,
+        adapterVoteData,
+      );
+      expect(weight).to.equal(2n * DEFAULT_WEIGHT_PER_NFT); // For [0] and [1]
+      expect(unusedTokenIds).to.deep.equal([user1TokenIds[0], user1TokenIds[1]]);
+    });
+
+    it('should return 0 weight and empty array if _adapterVoteData is empty or decodes to an empty array', async () => {
+      const emptyVoteData = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[]]);
+      const { weight, unusedTokenIds } = await adapter.weightOfWithValidTokenIds(
+        user1.address,
+        proposalId,
+        emptyVoteData,
+      );
+      expect(weight).to.equal(0n);
+      void expect(unusedTokenIds).to.be.an('array').that.is.empty;
+    });
+
+    it('should return 0 weight and empty array if voter owns none of the valid provided token IDs', async () => {
+      const tokenIdsToVoteWith = [user2TokenIds[0], user2TokenIds[1]]; // Owned by user2
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsToVoteWith],
+      );
+      const { weight, unusedTokenIds } = await adapter.weightOfWithValidTokenIds(
+        user1.address, // User1 tries to get weight
+        proposalId,
+        adapterVoteData,
+      );
+      expect(weight).to.equal(0n);
+      void expect(unusedTokenIds).to.be.an('array').that.is.empty;
+    });
+
+    it('should correctly apply weightPerToken > 1', async () => {
+      const customWeightPerToken = 3n;
+      const { adapter: customAdapter } = await deployERC721AdapterProxy(
+        deployer,
+        erc721AdapterImplementationAddressG,
+        await mockNft.getAddress(),
+        customWeightPerToken,
+      );
+
+      const tokenIdsToVoteWith = [user1TokenIds[0], user1TokenIds[1]];
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsToVoteWith],
+      );
+      const { weight, unusedTokenIds } = await customAdapter.weightOfWithValidTokenIds(
+        user1.address,
+        proposalId,
+        adapterVoteData,
+      );
+      expect(weight).to.equal(BigInt(tokenIdsToVoteWith.length) * customWeightPerToken);
+      expect(unusedTokenIds).to.deep.equal(tokenIdsToVoteWith);
+    });
+
+    it('should return 0 weight and empty array for a mix of invalid (unowned, used) and non-existent tokens', async () => {
+      const usedToken = user1TokenIds[0];
+      await adapter
+        .connect(user1)
+        .recordVote(
+          user1.address,
+          proposalId,
+          ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[usedToken]]),
+        );
+
+      const tokenIdsForWeightCheck = [
+        user2TokenIds[0], // Valid, existing token, but unowned by user1
+        usedToken, // Valid, existing token, owned by user1, but used for this proposalId
+      ];
+      const refinedAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsForWeightCheck],
+      );
+
+      const { weight, unusedTokenIds } = await adapter.weightOfWithValidTokenIds(
+        user1.address,
+        proposalId,
+        refinedAdapterVoteData,
+      );
+
+      expect(weight).to.equal(0n);
+      void expect(unusedTokenIds).to.be.an('array').that.is.empty;
+    });
+  });
+
   describe('recordVote', () => {
     let adapter: ERC721VotingAdapterV1;
     let mockNft: MockERC721;
@@ -354,7 +556,7 @@ describe('ERC721VotingAdapterV1', () => {
       expect(weightAfter).to.equal(0n);
     });
 
-    it('should return 0 and emit VoteRecorded if no valid NFTs are provided or all are already used', async () => {
+    it('should not allow voting with duplicate token IDs', async () => {
       const tokenToUse = user1TokenIds[0];
       const voteDataSingle = ethers.AbiCoder.defaultAbiCoder().encode(
         ['uint256[]'],
@@ -363,42 +565,33 @@ describe('ERC721VotingAdapterV1', () => {
       // First vote
       await adapter.connect(user1).recordVote(user1.address, proposalId, voteDataSingle);
 
-      // Attempt second vote with same token
-      const weightCastedStatically = await adapter
-        .connect(user1)
-        .recordVote.staticCall(user1.address, proposalId, voteDataSingle);
-      expect(weightCastedStatically).to.equal(0n);
+      // Attempt second vote with same token - should revert
       await expect(adapter.connect(user1).recordVote(user1.address, proposalId, voteDataSingle))
-        .to.emit(adapter, 'VoteRecorded')
-        .withArgs(user1.address, proposalId, 0n, voteDataSingle);
-
-      // Case 2: Empty token list
-      const emptyVoteData = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[]]);
-      const weightCastedEmptyStatically = await adapter
-        .connect(user1)
-        .recordVote.staticCall(user1.address, proposalId, emptyVoteData);
-      expect(weightCastedEmptyStatically).to.equal(0n);
-      await expect(adapter.connect(user1).recordVote(user1.address, proposalId, emptyVoteData))
-        .to.emit(adapter, 'VoteRecorded')
-        .withArgs(user1.address, proposalId, 0n, emptyVoteData);
+        .to.be.revertedWithCustomError(adapter, 'TokenIdAlreadyUsedForVote')
+        .withArgs(tokenToUse);
     });
 
-    it('should not allow voting with NFTs not owned by the voter, emit VoteRecorded with 0 weight', async () => {
+    it('should not allow voting with no NFTs provided', async () => {
+      // Case 2: Empty token list - should revert
+      const emptyVoteData = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[]]);
+      await expect(
+        adapter.connect(user1).recordVote(user1.address, proposalId, emptyVoteData),
+      ).to.be.revertedWithCustomError(adapter, 'NoTokenIdsPassed');
+    });
+
+    it('should not allow voting with NFTs not owned by the voter', async () => {
       const tokenIdsNotOwnedByUser1 = [user2TokenIds[0]]; // Owned by user2 (from fixture)
       const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
         ['uint256[]'],
         [tokenIdsNotOwnedByUser1],
       );
 
-      const weightCastedStatically = await adapter
-        .connect(user1)
-        .recordVote.staticCall(user1.address, proposalId, adapterVoteData);
-      expect(weightCastedStatically).to.equal(0n);
-
+      // Attempt to vote with unowned token - should revert
       await expect(adapter.connect(user1).recordVote(user1.address, proposalId, adapterVoteData))
-        .to.emit(adapter, 'VoteRecorded')
-        .withArgs(user1.address, proposalId, 0n, adapterVoteData);
+        .to.be.revertedWithCustomError(adapter, 'TokenIdNotOwnedByVoter')
+        .withArgs(tokenIdsNotOwnedByUser1[0]);
 
+      // Verify token was not marked as used
       void expect(await adapter.tokenIdUsedForVote(proposalId, user2TokenIds[0])).to.be.false;
     });
 


### PR DESCRIPTION
This commit introduces several improvements to the `ERC721VotingAdapterV1` contract, including:

1. **New Functions:**
   - Added `_decodeTokenIds`, `_getUniqueTokenIds`, `_getOwnedTokenIds`, and `_getUnusedTokenIds` to streamline token ID processing and improve clarity.
   - Introduced `weightOfWithValidTokenIds` to return both weight and unused token IDs, enhancing the voting logic.

2. **Error Handling:**
   - Implemented new error messages for better feedback during voting operations, including checks for unowned and already used token IDs.

3. **Test Coverage:**
   - Expanded test cases to validate the new functionality, ensuring correct weight calculations and proper handling of edge cases.

These changes improve the maintainability and functionality of the voting adapter, ensuring a more robust voting process.