### PR TITLE
refactor: Replace transferOwnership with _transferOwnership in AzoriusV1 and FractalModuleV1 contracts

### DIFF
--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -71,7 +71,7 @@ contract AzoriusV1 is
         _updateTimelockPeriod(timelockPeriod_);
         _updateExecutionPeriod(executionPeriod_);
 
-        OwnableUpgradeable.transferOwnership(owner_);
+        _transferOwnership(owner_);
     }
 
     function setUp(

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -32,7 +32,7 @@ contract FractalModuleV1 is
         setAvatar(avatar_);
         setTarget(target_);
 
-        OwnableUpgradeable.transferOwnership(owner_);
+        _transferOwnership(owner_);
     }
 
     function setUp(


### PR DESCRIPTION
This commit updates the ownership transfer method in both the `AzoriusV1` and `FractalModuleV1` contracts by replacing the `OwnableUpgradeable.transferOwnership` call with the internal `_transferOwnership` function. This change enhances consistency in ownership management across the contracts.