### PR TITLE
refactor: Standardize StrategyV1 and Adapters, rename Azorius to ProposalInitializer

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -55,6 +55,11 @@ contract StrategyV1 is
         _basisNumerator = basisNumerator_;
         _votingAdapters = votingAdapters_;
         _proposerAdapters = proposerAdapters_;
+
+        if (
+            basisNumerator_ >= BASIS_DENOMINATOR ||
+            basisNumerator_ < BASIS_DENOMINATOR / 2
+        ) revert InvalidBasisNumerator();
     }
 
     function proposalInitializer()

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -11,8 +11,8 @@ import {ERC4337VoterSupportV1} from "./ERC4337VoterSupportV1.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract StrategyV1 is
-    Initializable,
     IStrategyV1,
+    Initializable,
     ERC4337VoterSupportV1,
     Version
 {
@@ -20,7 +20,7 @@ contract StrategyV1 is
 
     uint256 public constant BASIS_DENOMINATOR = 1_000_000;
 
-    address internal _azorius;
+    address internal _proposalInitializer;
     uint32 internal _votingPeriod;
     uint256 internal _quorumThreshold;
     uint256 internal _basisNumerator;
@@ -29,12 +29,18 @@ contract StrategyV1 is
     address[] internal _votingAdapters;
     address[] internal _proposerAdapters;
 
+    modifier onlyProposalInitializer() {
+        if (msg.sender != _proposalInitializer)
+            revert InvalidProposalInitializer();
+        _;
+    }
+
     constructor() {
         _disableInitializers();
     }
 
     function initialize(
-        address azorius_,
+        address proposalInitializer_,
         uint32 votingPeriod_,
         uint256 quorumThreshold_,
         uint256 basisNumerator_,
@@ -42,46 +48,23 @@ contract StrategyV1 is
         address[] memory proposerAdapters_,
         address lightAccountFactory_
     ) public virtual override initializer {
-        if (azorius_ == address(0)) revert InvalidAzoriusAddress();
-
         __ERC4337VoterSupportV1_init(lightAccountFactory_);
-
-        _azorius = azorius_;
-
-        if (votingPeriod_ == 0) revert InvalidVotingPeriod();
+        _proposalInitializer = proposalInitializer_;
         _votingPeriod = votingPeriod_;
-
         _quorumThreshold = quorumThreshold_;
-
-        if (
-            basisNumerator_ >= BASIS_DENOMINATOR ||
-            basisNumerator_ < BASIS_DENOMINATOR / 2
-        ) revert InvalidBasisNumerator();
         _basisNumerator = basisNumerator_;
-
-        for (uint256 i = 0; i < votingAdapters_.length; i++) {
-            address adapter_ = votingAdapters_[i];
-            if (adapter_ == address(0)) revert VotingAdapterIsZeroAddress();
-            for (uint256 j = 0; j < _votingAdapters.length; j++) {
-                if (address(_votingAdapters[j]) == adapter_)
-                    revert VotingAdapterAlreadyExists();
-            }
-            _votingAdapters.push(adapter_);
-        }
-
-        for (uint256 i = 0; i < proposerAdapters_.length; i++) {
-            address adapter_ = proposerAdapters_[i];
-            if (adapter_ == address(0)) revert ProposerAdapterIsZeroAddress();
-            for (uint256 j = 0; j < _proposerAdapters.length; j++) {
-                if (address(_proposerAdapters[j]) == adapter_)
-                    revert ProposerAdapterAlreadyExists();
-            }
-            _proposerAdapters.push(adapter_);
-        }
+        _votingAdapters = votingAdapters_;
+        _proposerAdapters = proposerAdapters_;
     }
 
-    function azorius() external view virtual override returns (address) {
-        return _azorius;
+    function proposalInitializer()
+        external
+        view
+        virtual
+        override
+        returns (address)
+    {
+        return _proposalInitializer;
     }
 
     function votingPeriod() external view virtual override returns (uint32) {
@@ -132,10 +115,7 @@ contract StrategyV1 is
         uint32 proposalId,
         bytes32[] memory,
         bytes memory
-    ) external virtual override {
-        if (msg.sender != _azorius) revert InvalidAzoriusAddress();
-        if (_votingAdapters.length == 0) revert NoVotingAdapters();
-
+    ) external virtual override onlyProposalInitializer {
         ProposalVotingDetails storage proposal = _proposalVotingDetails[
             proposalId
         ];

--- a/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
@@ -28,8 +28,6 @@ contract ERC20ProposerAdapterV1 is
         address token_,
         uint256 proposerThreshold_
     ) external virtual override initializer {
-        if (token_ == address(0)) revert InvalidTokenAddress();
-
         _token = IVotes(token_);
         _proposerThreshold = proposerThreshold_;
     }

--- a/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
@@ -36,10 +36,6 @@ contract ERC20VotingAdapterV1 is
         address strategy_,
         uint256 weightPerToken_
     ) external virtual override initializer {
-        if (token_ == address(0)) revert InvalidTokenAddress();
-        if (strategy_ == address(0)) revert InvalidStrategyAddress();
-        if (weightPerToken_ == 0) revert InvalidWeightPerToken();
-
         _token = IVotes(token_);
         _strategy = IStrategyBaseV1(strategy_);
         _weightPerToken = weightPerToken_;

--- a/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
@@ -28,8 +28,6 @@ contract ERC721ProposerAdapterV1 is
         address token_,
         uint256 proposerThreshold_
     ) external virtual override initializer {
-        if (token_ == address(0)) revert InvalidTokenAddress();
-
         _token = IERC721(token_);
         _proposerThreshold = proposerThreshold_;
     }

--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -29,9 +29,6 @@ contract ERC721VotingAdapterV1 is
         address token_,
         uint256 weightPerToken_
     ) external virtual override initializer {
-        if (token_ == address(0)) revert InvalidTokenAddress();
-        if (weightPerToken_ == 0) revert InvalidWeightPerToken();
-
         _token = IERC721(token_);
         _weightPerToken = weightPerToken_;
     }

--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -28,18 +28,8 @@ contract HatsProposerAdapterV1 is
         address hatsContract_,
         uint256[] memory whitelistedHatIds_
     ) public virtual override initializer {
-        if (hatsContract_ == address(0)) revert MissingHatsContract();
         _hatsContract = IHats(hatsContract_);
-
-        if (whitelistedHatIds_.length == 0) revert NoHatsWhitelisted();
-        for (uint256 i = 0; i < whitelistedHatIds_.length; i++) {
-            uint256 _hatId = whitelistedHatIds_[i];
-            for (uint256 j = 0; j < _whitelistedHatIds.length; j++) {
-                if (_whitelistedHatIds[j] == _hatId)
-                    revert HatAlreadyWhitelisted();
-            }
-            _whitelistedHatIds.push(_hatId);
-        }
+        _whitelistedHatIds = whitelistedHatIds_;
     }
 
     function hatsContract() external view virtual override returns (address) {

--- a/contracts/interfaces/decent/deployables/IERC20ProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC20ProposerAdapterV1.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.30;
 import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
 
 interface IERC20ProposerAdapterV1 is IProposerAdapterV1 {
-    error InvalidTokenAddress();
-
     function initialize(address token, uint256 proposerThreshold) external;
 
     function token() external view returns (address);

--- a/contracts/interfaces/decent/deployables/IERC20VotingAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC20VotingAdapterV1.sol
@@ -4,11 +4,8 @@ pragma solidity ^0.8.30;
 import {IVotingAdapterV1} from "./IVotingAdapterV1.sol";
 
 interface IERC20VotingAdapterV1 is IVotingAdapterV1 {
-    error InvalidTokenAddress();
-    error InvalidWeightPerToken();
     error ProposalNotReadyForSnapshot();
     error AlreadyVoted();
-    error InvalidStrategyAddress();
 
     function initialize(
         address token,

--- a/contracts/interfaces/decent/deployables/IERC721ProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC721ProposerAdapterV1.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.30;
 import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
 
 interface IERC721ProposerAdapterV1 is IProposerAdapterV1 {
-    error InvalidTokenAddress();
-
     function initialize(address token, uint256 proposerThreshold) external;
 
     function token() external view returns (address);

--- a/contracts/interfaces/decent/deployables/IERC721VotingAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC721VotingAdapterV1.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.30;
 import {IVotingAdapterV1} from "./IVotingAdapterV1.sol";
 
 interface IERC721VotingAdapterV1 is IVotingAdapterV1 {
-    error InvalidTokenAddress();
-    error InvalidWeightPerToken();
     error NoTokenIdsPassed();
     error TokenIdAlreadyUsedForVote(uint256 tokenId);
     error TokenIdNotOwnedByVoter(uint256 tokenId);

--- a/contracts/interfaces/decent/deployables/IHatsProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IHatsProposerAdapterV1.sol
@@ -4,10 +4,6 @@ pragma solidity ^0.8.30;
 import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
 
 interface IHatsProposerAdapterV1 is IProposerAdapterV1 {
-    error MissingHatsContract();
-    error NoHatsWhitelisted();
-    error HatAlreadyWhitelisted();
-
     function initialize(
         address hatsContractAddress,
         uint256[] memory whitelistedHats

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -32,14 +32,7 @@ interface IStrategyV1 is IStrategyBaseV1 {
         uint32 votingStartBlock
     );
 
-    error InvalidAzoriusAddress();
-    error InvalidVotingPeriod();
-    error InvalidBasisNumerator();
-    error VotingAdapterIsZeroAddress();
-    error VotingAdapterAlreadyExists();
-    error NoVotingAdapters();
-    error ProposerAdapterIsZeroAddress();
-    error ProposerAdapterAlreadyExists();
+    error InvalidProposalInitializer();
     error ProposalNotFoundOrNotActive();
     error NoVotingWeight();
     error InvalidVoteType();
@@ -48,7 +41,7 @@ interface IStrategyV1 is IStrategyBaseV1 {
     error InvalidVotingAdapter();
 
     function initialize(
-        address azorius,
+        address proposalInitializer,
         uint32 votingPeriod,
         uint256 quorumThreshold,
         uint256 basisNumerator,
@@ -57,7 +50,7 @@ interface IStrategyV1 is IStrategyBaseV1 {
         address lightAccountFactory
     ) external;
 
-    function azorius() external view returns (address);
+    function proposalInitializer() external view returns (address);
 
     function votingPeriod() external view returns (uint32);
 

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -32,6 +32,7 @@ interface IStrategyV1 is IStrategyBaseV1 {
         uint32 votingStartBlock
     );
 
+    error InvalidBasisNumerator();
     error InvalidProposalInitializer();
     error ProposalNotFoundOrNotActive();
     error NoVotingWeight();

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -23,7 +23,7 @@ import { calculateInterfaceId } from '../../helpers/utils';
 describe('StrategyV1', () => {
   // Signers
   let deployer: SignerWithAddress;
-  let azoriusMock: SignerWithAddress; // To simulate calls from Azorius
+  let proposerInitializer: SignerWithAddress; // To simulate calls from proposer initializer
   let nonOwner: SignerWithAddress;
   let user1: SignerWithAddress;
   let voter1: SignerWithAddress, voter2: SignerWithAddress, voter3: SignerWithAddress;
@@ -46,7 +46,7 @@ describe('StrategyV1', () => {
   let defaultInitialProposerAdapters: string[];
 
   async function deployStrategyProxy(
-    azoriusAddress: string,
+    proposerInitializerAddress: string,
     votingPeriod: number,
     quorumThreshold: bigint,
     basisNumerator: bigint,
@@ -55,7 +55,7 @@ describe('StrategyV1', () => {
     lightAccountFactoryAddress: string,
   ): Promise<StrategyV1> {
     const initializeCalldata = strategyImplementation.interface.encodeFunctionData('initialize', [
-      azoriusAddress,
+      proposerInitializerAddress,
       votingPeriod,
       quorumThreshold,
       basisNumerator,
@@ -71,7 +71,7 @@ describe('StrategyV1', () => {
   }
 
   beforeEach(async () => {
-    [deployer, azoriusMock, nonOwner, user1, voter2, voter3] = await ethers.getSigners();
+    [deployer, proposerInitializer, nonOwner, user1, voter2, voter3] = await ethers.getSigners();
     voter1 = user1; // Alias for clarity in some tests
 
     strategyImplementation = await new StrategyV1__factory(deployer).deploy();
@@ -95,7 +95,7 @@ describe('StrategyV1', () => {
     defaultInitialProposerAdapters = [await mockProposerAdapter1.getAddress()];
 
     strategy = await deployStrategyProxy(
-      azoriusMock.address,
+      proposerInitializer.address,
       DEFAULT_VOTING_PERIOD,
       DEFAULT_QUORUM_THRESHOLD,
       DEFAULT_BASIS_NUMERATOR,
@@ -107,7 +107,7 @@ describe('StrategyV1', () => {
 
   describe('Initialization', () => {
     it('should initialize with correct parameters', async () => {
-      const azoriusAddress = azoriusMock.address;
+      const proposerInitializerAddress = proposerInitializer.address;
       const lightAccountFactoryAddress = lightAccountFactoryMockAddress;
       const initialVotingAdapters: string[] = [
         await mockAdapter1.getAddress(),
@@ -122,7 +122,7 @@ describe('StrategyV1', () => {
       const basisNumerator = DEFAULT_BASIS_NUMERATOR + 1n;
 
       const testStrategy = await deployStrategyProxy(
-        azoriusAddress,
+        proposerInitializerAddress,
         votingPeriod,
         quorumThreshold,
         basisNumerator,
@@ -131,181 +131,13 @@ describe('StrategyV1', () => {
         lightAccountFactoryAddress,
       );
 
-      expect(await testStrategy.azorius()).to.equal(azoriusAddress);
+      expect(await testStrategy.proposalInitializer()).to.equal(proposerInitializer);
       expect(await testStrategy.votingPeriod()).to.equal(votingPeriod);
       expect(await testStrategy.quorumThreshold()).to.equal(quorumThreshold);
       expect(await testStrategy.basisNumerator()).to.equal(basisNumerator);
       expect(await testStrategy.lightAccountFactory()).to.equal(lightAccountFactoryAddress);
       expect(await testStrategy.votingAdapters()).to.deep.equal(initialVotingAdapters);
       expect(await testStrategy.proposerAdapters()).to.deep.equal(initialProposerAdapters);
-    });
-
-    it('should revert if azorius address is zero', async () => {
-      await expect(
-        deployStrategyProxy(
-          ethers.ZeroAddress, // Invalid Azorius
-          DEFAULT_VOTING_PERIOD,
-          DEFAULT_QUORUM_THRESHOLD,
-          DEFAULT_BASIS_NUMERATOR,
-          [],
-          [],
-          lightAccountFactoryMockAddress,
-        ),
-      ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidAzoriusAddress');
-    });
-
-    it('should revert if voting period is zero during initialization', async () => {
-      await expect(
-        deployStrategyProxy(
-          azoriusMock.address,
-          0, // Invalid voting period
-          DEFAULT_QUORUM_THRESHOLD,
-          DEFAULT_BASIS_NUMERATOR,
-          [],
-          [],
-          lightAccountFactoryMockAddress,
-        ),
-      ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidVotingPeriod');
-    });
-
-    it('should revert if basis numerator is invalid (too high) during initialization', async () => {
-      await expect(
-        deployStrategyProxy(
-          azoriusMock.address,
-          DEFAULT_VOTING_PERIOD,
-          DEFAULT_QUORUM_THRESHOLD,
-          1_000_001n,
-          [],
-          [],
-          lightAccountFactoryMockAddress,
-        ),
-      ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
-    });
-
-    it('should revert if basis numerator is invalid (too low, <50%) during initialization', async () => {
-      await expect(
-        deployStrategyProxy(
-          azoriusMock.address,
-          DEFAULT_VOTING_PERIOD,
-          DEFAULT_QUORUM_THRESHOLD,
-          499_999n,
-          [],
-          [],
-          lightAccountFactoryMockAddress,
-        ),
-      ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
-    });
-
-    it('should initialize correctly with zero quorum threshold', async () => {
-      const testStrategy = await deployStrategyProxy(
-        azoriusMock.address,
-        DEFAULT_VOTING_PERIOD,
-        0n, // Zero quorum threshold
-        DEFAULT_BASIS_NUMERATOR,
-        [],
-        [],
-        lightAccountFactoryMockAddress,
-      );
-      expect(await testStrategy.quorumThreshold()).to.equal(0n);
-    });
-
-    it('should initialize correctly with basis numerator at 50%', async () => {
-      const testStrategy = await deployStrategyProxy(
-        azoriusMock.address,
-        DEFAULT_VOTING_PERIOD,
-        DEFAULT_QUORUM_THRESHOLD,
-        500_000n, // 50% basis numerator
-        [],
-        [],
-        lightAccountFactoryMockAddress,
-      );
-      expect(await testStrategy.basisNumerator()).to.equal(500_000n);
-    });
-
-    it('should revert when initializing with basis numerator at 100% (1,000,000)', async () => {
-      await expect(
-        deployStrategyProxy(
-          azoriusMock.address,
-          DEFAULT_VOTING_PERIOD,
-          DEFAULT_QUORUM_THRESHOLD,
-          1_000_000n, // 100% basis numerator - now invalid
-          [],
-          [],
-          lightAccountFactoryMockAddress,
-        ),
-      ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
-    });
-
-    it('should initialize correctly with basis numerator at new maximum (BASIS_DENOMINATOR - 1)', async () => {
-      const maxValidBasis = 1_000_000n - 1n; // BASIS_DENOMINATOR - 1
-      const testStrategy = await deployStrategyProxy(
-        azoriusMock.address,
-        DEFAULT_VOTING_PERIOD,
-        DEFAULT_QUORUM_THRESHOLD,
-        maxValidBasis,
-        [],
-        [],
-        lightAccountFactoryMockAddress,
-      );
-      expect(await testStrategy.basisNumerator()).to.equal(maxValidBasis);
-    });
-
-    it('should revert if a voting adapter address is zero', async () => {
-      await expect(
-        deployStrategyProxy(
-          azoriusMock.address,
-          DEFAULT_VOTING_PERIOD,
-          DEFAULT_QUORUM_THRESHOLD,
-          DEFAULT_BASIS_NUMERATOR,
-          [ethers.ZeroAddress],
-          [],
-          lightAccountFactoryMockAddress,
-        ),
-      ).to.be.revertedWithCustomError(strategyImplementation, 'VotingAdapterIsZeroAddress');
-    });
-
-    it('should revert if a voting adapter address is repeated', async () => {
-      const adapterAddr = await mockAdapter1.getAddress();
-      await expect(
-        deployStrategyProxy(
-          azoriusMock.address,
-          DEFAULT_VOTING_PERIOD,
-          DEFAULT_QUORUM_THRESHOLD,
-          DEFAULT_BASIS_NUMERATOR,
-          [adapterAddr, adapterAddr],
-          [],
-          lightAccountFactoryMockAddress,
-        ),
-      ).to.be.revertedWithCustomError(strategyImplementation, 'VotingAdapterAlreadyExists');
-    });
-
-    it('should revert if a proposer adapter address is zero', async () => {
-      await expect(
-        deployStrategyProxy(
-          azoriusMock.address,
-          DEFAULT_VOTING_PERIOD,
-          DEFAULT_QUORUM_THRESHOLD,
-          DEFAULT_BASIS_NUMERATOR,
-          [],
-          [ethers.ZeroAddress],
-          lightAccountFactoryMockAddress,
-        ),
-      ).to.be.revertedWithCustomError(strategyImplementation, 'ProposerAdapterIsZeroAddress');
-    });
-
-    it('should revert if a proposer adapter address is repeated', async () => {
-      const adapterAddr = await mockProposerAdapter1.getAddress();
-      await expect(
-        deployStrategyProxy(
-          azoriusMock.address,
-          DEFAULT_VOTING_PERIOD,
-          DEFAULT_QUORUM_THRESHOLD,
-          DEFAULT_BASIS_NUMERATOR,
-          [],
-          [adapterAddr, adapterAddr],
-          lightAccountFactoryMockAddress,
-        ),
-      ).to.be.revertedWithCustomError(strategyImplementation, 'ProposerAdapterAlreadyExists');
     });
   });
 
@@ -328,27 +160,10 @@ describe('StrategyV1', () => {
       defaultProposalId = 1;
     });
 
-    it('should revert if called by a non-azorius address', async () => {
+    it('should revert if called by a non-proposer initializer address', async () => {
       await expect(
         strategy.connect(nonOwner).initializeProposal(defaultProposalId, [], ethers.ZeroHash),
-      ).to.be.revertedWithCustomError(strategy, 'InvalidAzoriusAddress');
-    });
-
-    it('should revert if no voting adapters are configured', async () => {
-      const noAdapterStrategy = await deployStrategyProxy(
-        azoriusMock.address,
-        DEFAULT_VOTING_PERIOD,
-        DEFAULT_QUORUM_THRESHOLD,
-        DEFAULT_BASIS_NUMERATOR,
-        [], // NO voting adapters
-        [],
-        lightAccountFactoryMockAddress,
-      );
-      await expect(
-        noAdapterStrategy
-          .connect(azoriusMock)
-          .initializeProposal(defaultProposalId, [], ethers.ZeroHash),
-      ).to.be.revertedWithCustomError(noAdapterStrategy, 'NoVotingAdapters');
+      ).to.be.revertedWithCustomError(strategy, 'InvalidProposalInitializer');
     });
 
     it('should correctly initialize proposal details and emit event', async () => {
@@ -358,7 +173,9 @@ describe('StrategyV1', () => {
       const blockNumberBefore = blockBefore.number;
 
       await expect(
-        strategy.connect(azoriusMock).initializeProposal(defaultProposalId, [], ethers.ZeroHash),
+        strategy
+          .connect(proposerInitializer)
+          .initializeProposal(defaultProposalId, [], ethers.ZeroHash),
       )
         .to.emit(strategy, 'ProposalInitialized')
         .withArgs(
@@ -382,11 +199,11 @@ describe('StrategyV1', () => {
 
     it('should reset vote counts for a re-initialized proposal', async () => {
       await strategy
-        .connect(azoriusMock)
+        .connect(proposerInitializer)
         .initializeProposal(defaultProposalId, [], ethers.ZeroHash);
 
       await strategy
-        .connect(azoriusMock)
+        .connect(proposerInitializer)
         .initializeProposal(defaultProposalId, [], ethers.ZeroHash); // Re-initialize
 
       const proposalDetails = await strategy.proposalVotingDetails(defaultProposalId);
@@ -399,7 +216,7 @@ describe('StrategyV1', () => {
   describe('isProposer', () => {
     it('should return false if no proposer adapters are configured at init', async () => {
       const noProposerAdapterStrategy = await deployStrategyProxy(
-        azoriusMock.address,
+        proposerInitializer.address,
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         DEFAULT_BASIS_NUMERATOR,
@@ -412,7 +229,7 @@ describe('StrategyV1', () => {
 
     it('should return true if any configured adapter identifies the address as a proposer', async () => {
       const multiProposerStrategy = await deployStrategyProxy(
-        azoriusMock.address,
+        proposerInitializer.address,
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         DEFAULT_BASIS_NUMERATOR,
@@ -432,7 +249,7 @@ describe('StrategyV1', () => {
       void expect(await strategy.isProposer(user1.address)).to.be.false;
 
       const multiProposerStrategy = await deployStrategyProxy(
-        azoriusMock.address,
+        proposerInitializer.address,
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         DEFAULT_BASIS_NUMERATOR,
@@ -456,7 +273,9 @@ describe('StrategyV1', () => {
 
     beforeEach(async () => {
       proposalId = 1;
-      await strategy.connect(azoriusMock).initializeProposal(proposalId, [], ethers.ZeroHash);
+      await strategy
+        .connect(proposerInitializer)
+        .initializeProposal(proposalId, [], ethers.ZeroHash);
     });
 
     it('should return correct timestamps and block after proposal initialization', async () => {
@@ -493,7 +312,9 @@ describe('StrategyV1', () => {
 
     beforeEach(async () => {
       proposalId = 1;
-      await strategy.connect(azoriusMock).initializeProposal(proposalId, [], ethers.ZeroHash);
+      await strategy
+        .connect(proposerInitializer)
+        .initializeProposal(proposalId, [], ethers.ZeroHash);
 
       adapter1Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[1]]);
       adapter2Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[2]]);
@@ -627,7 +448,7 @@ describe('StrategyV1', () => {
 
     it('should sum weights if multiple adapters are used in one vote call', async () => {
       const multiAdapterStrategy = await deployStrategyProxy(
-        azoriusMock.address,
+        proposerInitializer.address,
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         DEFAULT_BASIS_NUMERATOR,
@@ -636,7 +457,7 @@ describe('StrategyV1', () => {
         lightAccountFactoryMockAddress,
       );
       await multiAdapterStrategy
-        .connect(azoriusMock)
+        .connect(proposerInitializer)
         .initializeProposal(proposalId, [], ethers.ZeroHash);
 
       const weight1 = 60;
@@ -715,7 +536,7 @@ describe('StrategyV1', () => {
 
     it('should revert if any adapter call reverts in a multi-adapter vote (all-or-nothing)', async () => {
       const multiAdapterStrategy = await deployStrategyProxy(
-        azoriusMock.address,
+        proposerInitializer.address,
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         DEFAULT_BASIS_NUMERATOR,
@@ -724,7 +545,7 @@ describe('StrategyV1', () => {
         lightAccountFactoryMockAddress,
       );
       await multiAdapterStrategy
-        .connect(azoriusMock)
+        .connect(proposerInitializer)
         .initializeProposal(proposalId, [], ethers.ZeroHash);
 
       await mockAdapter1.setWeight(user1.address, 10);
@@ -767,7 +588,9 @@ describe('StrategyV1', () => {
   describe('isPassed', () => {
     const PROPOSAL_ID = 1;
     beforeEach(async () => {
-      await strategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await strategy
+        .connect(proposerInitializer)
+        .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
     });
 
     it('should revert with ProposalNotInitialized if proposal was not initialized', async () => {
@@ -800,7 +623,7 @@ describe('StrategyV1', () => {
 
     it('should return false if quorum is met but basis is not, after voting period', async () => {
       const specificStrategy = await deployStrategyProxy(
-        azoriusMock.address,
+        proposerInitializer.address,
         DEFAULT_VOTING_PERIOD,
         50n, // quorumThreshold
         500_001n, // basisNumerator (yes > no)
@@ -809,7 +632,7 @@ describe('StrategyV1', () => {
         lightAccountFactoryMockAddress,
       );
       await specificStrategy
-        .connect(azoriusMock)
+        .connect(proposerInitializer)
         .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
       await mockAdapter1.setWeight(voter1.address, 50n);
@@ -834,7 +657,7 @@ describe('StrategyV1', () => {
 
     it('should return false if basis is met but quorum is not, after voting period', async () => {
       const specificStrategy = await deployStrategyProxy(
-        azoriusMock.address,
+        proposerInitializer.address,
         DEFAULT_VOTING_PERIOD,
         100n, // quorumThreshold
         500_001n, // basisNumerator (yes > no)
@@ -843,7 +666,7 @@ describe('StrategyV1', () => {
         lightAccountFactoryMockAddress,
       );
       await specificStrategy
-        .connect(azoriusMock)
+        .connect(proposerInitializer)
         .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
       await mockAdapter1.setWeight(voter1.address, 60n); // YES
@@ -910,7 +733,9 @@ describe('StrategyV1', () => {
     const PROPOSAL_ID = 1;
 
     beforeEach(async () => {
-      await strategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await strategy
+        .connect(proposerInitializer)
+        .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
     });
 
     describe('isQuorumMet', () => {
@@ -924,7 +749,7 @@ describe('StrategyV1', () => {
       it('should return true if quorum is met exactly (yes + abstain == threshold)', async () => {
         const testQuorum = 100n;
         const qStrategy = await deployStrategyProxy(
-          azoriusMock.address,
+          proposerInitializer.address,
           DEFAULT_VOTING_PERIOD,
           testQuorum,
           DEFAULT_BASIS_NUMERATOR,
@@ -932,7 +757,9 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await qStrategy
+          .connect(proposerInitializer)
+          .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 40n);
@@ -948,7 +775,7 @@ describe('StrategyV1', () => {
       it('should return true if quorum is exceeded (yes + abstain > threshold)', async () => {
         const testQuorum = 100n;
         const qStrategy = await deployStrategyProxy(
-          azoriusMock.address,
+          proposerInitializer.address,
           DEFAULT_VOTING_PERIOD,
           testQuorum,
           DEFAULT_BASIS_NUMERATOR,
@@ -956,7 +783,9 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await qStrategy
+          .connect(proposerInitializer)
+          .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 41n); // Exceeds
@@ -972,7 +801,7 @@ describe('StrategyV1', () => {
       it('should return false if quorum is not met (yes + abstain < threshold)', async () => {
         const testQuorum = 100n;
         const qStrategy = await deployStrategyProxy(
-          azoriusMock.address,
+          proposerInitializer.address,
           DEFAULT_VOTING_PERIOD,
           testQuorum,
           DEFAULT_BASIS_NUMERATOR,
@@ -980,7 +809,9 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await qStrategy
+          .connect(proposerInitializer)
+          .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 50n);
         await mockAdapter1.setWeight(voter2.address, 40n); // 90 total, < 100
@@ -996,7 +827,7 @@ describe('StrategyV1', () => {
 
       it('should return true if quorum threshold is 0, even with no votes contributing to quorum count', async () => {
         const qStrategy = await deployStrategyProxy(
-          azoriusMock.address,
+          proposerInitializer.address,
           DEFAULT_VOTING_PERIOD,
           0n /* quorum */,
           DEFAULT_BASIS_NUMERATOR,
@@ -1004,7 +835,9 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await qStrategy
+          .connect(proposerInitializer)
+          .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 10n); // Only NO votes
         await qStrategy
@@ -1077,7 +910,7 @@ describe('StrategyV1', () => {
 
       it('should return true if basisNumerator is 500,000 (50%) and yes > no', async () => {
         const bStrategy = await deployStrategyProxy(
-          azoriusMock.address,
+          proposerInitializer.address,
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
           500_000n /* basis */,
@@ -1085,7 +918,9 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await bStrategy
+          .connect(proposerInitializer)
+          .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 101n);
         await mockAdapter1.setWeight(voter2.address, 100n);
@@ -1100,7 +935,7 @@ describe('StrategyV1', () => {
 
       it('should return false if basisNumerator is 500,000 (50%) and yes == no', async () => {
         const bStrategy = await deployStrategyProxy(
-          azoriusMock.address,
+          proposerInitializer.address,
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
           500_000n /* basis */,
@@ -1108,7 +943,9 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await bStrategy
+          .connect(proposerInitializer)
+          .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 100n);
@@ -1124,7 +961,7 @@ describe('StrategyV1', () => {
       it('should return true if basisNumerator is max valid (DENOMINATOR - 1) and yes > 0, no == 0', async () => {
         const maxValidBasis = 1_000_000n - 1n;
         const bStrategy = await deployStrategyProxy(
-          azoriusMock.address,
+          proposerInitializer.address,
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
           maxValidBasis,
@@ -1132,7 +969,9 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await bStrategy
+          .connect(proposerInitializer)
+          .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await bStrategy
@@ -1144,7 +983,7 @@ describe('StrategyV1', () => {
       it('should return false if basisNumerator is max valid (DENOMINATOR - 1) and yes > 0, no > 0', async () => {
         const maxValidBasis = 1_000_000n - 1n;
         const bStrategy = await deployStrategyProxy(
-          azoriusMock.address,
+          proposerInitializer.address,
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
           maxValidBasis,
@@ -1152,7 +991,9 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(azoriusMock).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await bStrategy
+          .connect(proposerInitializer)
+          .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 1n);

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -139,6 +139,88 @@ describe('StrategyV1', () => {
       expect(await testStrategy.votingAdapters()).to.deep.equal(initialVotingAdapters);
       expect(await testStrategy.proposerAdapters()).to.deep.equal(initialProposerAdapters);
     });
+
+    it('should revert if basis numerator is invalid (too high) during initialization', async () => {
+      await expect(
+        deployStrategyProxy(
+          proposerInitializer.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          1_000_001n,
+          [],
+          [],
+          lightAccountFactoryMockAddress,
+        ),
+      ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
+    });
+
+    it('should revert if basis numerator is invalid (too low, <50%) during initialization', async () => {
+      await expect(
+        deployStrategyProxy(
+          proposerInitializer.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          499_999n,
+          [],
+          [],
+          lightAccountFactoryMockAddress,
+        ),
+      ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
+    });
+
+    it('should initialize correctly with zero quorum threshold', async () => {
+      const testStrategy = await deployStrategyProxy(
+        proposerInitializer.address,
+        DEFAULT_VOTING_PERIOD,
+        0n, // Zero quorum threshold
+        DEFAULT_BASIS_NUMERATOR,
+        [],
+        [],
+        lightAccountFactoryMockAddress,
+      );
+      expect(await testStrategy.quorumThreshold()).to.equal(0n);
+    });
+
+    it('should initialize correctly with basis numerator at 50%', async () => {
+      const testStrategy = await deployStrategyProxy(
+        proposerInitializer.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        500_000n, // 50% basis numerator
+        [],
+        [],
+        lightAccountFactoryMockAddress,
+      );
+      expect(await testStrategy.basisNumerator()).to.equal(500_000n);
+    });
+
+    it('should revert when initializing with basis numerator at 100% (1,000,000)', async () => {
+      await expect(
+        deployStrategyProxy(
+          proposerInitializer.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          1_000_000n, // 100% basis numerator - now invalid
+          [],
+          [],
+          lightAccountFactoryMockAddress,
+        ),
+      ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
+    });
+
+    it('should initialize correctly with basis numerator at new maximum (BASIS_DENOMINATOR - 1)', async () => {
+      const maxValidBasis = 1_000_000n - 1n; // BASIS_DENOMINATOR - 1
+      const testStrategy = await deployStrategyProxy(
+        proposerInitializer.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        maxValidBasis,
+        [],
+        [],
+        lightAccountFactoryMockAddress,
+      );
+      expect(await testStrategy.basisNumerator()).to.equal(maxValidBasis);
+    });
   });
 
   describe('votingAdapters', () => {

--- a/test/deployables/strategies/adapters/ERC20ProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20ProposerAdapterV1.test.ts
@@ -69,17 +69,6 @@ describe('ERC20ProposerAdapterV1', () => {
       expect(await adapter.proposerThreshold()).to.equal(DEFAULT_PROPOSER_THRESHOLD);
     });
 
-    it('should revert if token address is zero during proxy initialization', async () => {
-      await expect(
-        deployERC20ProposerAdapterProxy(
-          deployer,
-          await adapterImplementation.getAddress(),
-          ethers.ZeroAddress,
-          DEFAULT_PROPOSER_THRESHOLD,
-        ),
-      ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidTokenAddress');
-    });
-
     it('should allow proposerThreshold to be zero during proxy initialization', async () => {
       const localAdapter = await deployERC20ProposerAdapterProxy(
         deployer,

--- a/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
@@ -127,57 +127,6 @@ describe('ERC20VotingAdapterV1', () => {
       expect(await erc20Adapter.weightPerToken()).to.equal(DEFAULT_WEIGHT_PER_TOKEN);
     });
 
-    it('should revert if token address is zero', async () => {
-      const erc20AdapterImplementation = ERC20VotingAdapterV1__factory.connect(
-        erc20AdapterImplementationAddressG,
-        deployerG,
-      );
-
-      await expect(
-        deployERC20AdapterProxy(
-          deployer,
-          erc20AdapterImplementationAddressG,
-          ethers.ZeroAddress,
-          await mockStrategy.getAddress(),
-          DEFAULT_WEIGHT_PER_TOKEN,
-        ),
-      ).to.be.revertedWithCustomError(erc20AdapterImplementation, 'InvalidTokenAddress');
-    });
-
-    it('should revert if strategy address is zero', async () => {
-      const erc20AdapterImplementation = ERC20VotingAdapterV1__factory.connect(
-        erc20AdapterImplementationAddressG,
-        deployerG,
-      );
-
-      await expect(
-        deployERC20AdapterProxy(
-          deployer,
-          erc20AdapterImplementationAddressG,
-          await mockToken.getAddress(),
-          ethers.ZeroAddress,
-          DEFAULT_WEIGHT_PER_TOKEN,
-        ),
-      ).to.be.revertedWithCustomError(erc20AdapterImplementation, 'InvalidStrategyAddress');
-    });
-
-    it('should revert if weightPerToken is zero', async () => {
-      const erc20AdapterImplementation = ERC20VotingAdapterV1__factory.connect(
-        erc20AdapterImplementationAddressG,
-        deployerG,
-      );
-
-      await expect(
-        deployERC20AdapterProxy(
-          deployer,
-          erc20AdapterImplementationAddressG,
-          await mockToken.getAddress(),
-          await mockStrategy.getAddress(),
-          0n,
-        ),
-      ).to.be.revertedWithCustomError(erc20AdapterImplementation, 'InvalidWeightPerToken');
-    });
-
     it('should not allow reinitialization', async () => {
       const { adapter: erc20Adapter } = await deployERC20AdapterProxy(
         deployer,

--- a/test/deployables/strategies/adapters/ERC721ProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721ProposerAdapterV1.test.ts
@@ -69,27 +69,6 @@ describe('ERC721ProposerAdapterV1', () => {
       expect(await adapter.proposerThreshold()).to.equal(DEFAULT_PROPOSER_THRESHOLD);
     });
 
-    it('should revert if token address is zero during proxy initialization', async () => {
-      await expect(
-        deployERC721ProposerAdapterProxy(
-          deployer,
-          await adapterImplementation.getAddress(),
-          ethers.ZeroAddress,
-          DEFAULT_PROPOSER_THRESHOLD,
-        ),
-      ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidTokenAddress');
-    });
-
-    it('should allow proposerThreshold to be zero during proxy initialization', async () => {
-      const localAdapter = await deployERC721ProposerAdapterProxy(
-        deployer,
-        await adapterImplementation.getAddress(),
-        await mockNft.getAddress(),
-        0n,
-      );
-      expect(await localAdapter.proposerThreshold()).to.equal(0n);
-    });
-
     it('should prevent reinitialization on proxied adapter', async () => {
       await expect(
         adapter.initialize(await mockNft.getAddress(), DEFAULT_PROPOSER_THRESHOLD),

--- a/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
@@ -41,7 +41,6 @@ async function deployERC721AdapterProxy(
 describe('ERC721VotingAdapterV1', () => {
   // Globally scoped (from first fixture load in `before`)
   let erc721AdapterImplementationAddressG: string;
-  let deployerG: SignerWithAddress;
 
   // Default Test Params
   const DEFAULT_WEIGHT_PER_NFT = 1n;
@@ -52,7 +51,6 @@ describe('ERC721VotingAdapterV1', () => {
     const deployedAdapterImpl = await adapterImplFactory.deploy();
     await deployedAdapterImpl.waitForDeployment();
     erc721AdapterImplementationAddressG = await deployedAdapterImpl.getAddress();
-    deployerG = deployer;
     return { erc721AdapterImplementationAddress: erc721AdapterImplementationAddressG, deployer };
   }
 
@@ -121,40 +119,6 @@ describe('ERC721VotingAdapterV1', () => {
 
       expect(await erc721Adapter.token()).to.equal(await mockNft.getAddress());
       expect(await erc721Adapter.weightPerToken()).to.equal(DEFAULT_WEIGHT_PER_NFT);
-    });
-
-    it('should revert if token address is zero', async () => {
-      const { deployer: fixtureDeployer } = await loadFixture(deployMocksAndSignersERC721Fixture);
-      const erc721AdapterImplementation = ERC721VotingAdapterV1__factory.connect(
-        erc721AdapterImplementationAddressG,
-        deployerG,
-      );
-      await expect(
-        deployERC721AdapterProxy(
-          fixtureDeployer,
-          erc721AdapterImplementationAddressG,
-          ethers.ZeroAddress,
-          DEFAULT_WEIGHT_PER_NFT,
-        ),
-      ).to.be.revertedWithCustomError(erc721AdapterImplementation, 'InvalidTokenAddress');
-    });
-
-    it('should revert if weightPerNft is zero', async () => {
-      const { mockNft, deployer: fixtureDeployer } = await loadFixture(
-        deployMocksAndSignersERC721Fixture,
-      );
-      const erc721AdapterImplementation = ERC721VotingAdapterV1__factory.connect(
-        erc721AdapterImplementationAddressG,
-        deployerG,
-      );
-      await expect(
-        deployERC721AdapterProxy(
-          fixtureDeployer,
-          erc721AdapterImplementationAddressG,
-          await mockNft.getAddress(),
-          0n, // Invalid weight
-        ),
-      ).to.be.revertedWithCustomError(erc721AdapterImplementation, 'InvalidWeightPerToken');
     });
 
     it('should not allow reinitialization', async () => {

--- a/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
@@ -72,28 +72,6 @@ describe('HatsProposerAdapterV1', () => {
       expect(whitelistedHats).to.deep.equal([HAT_ID_1]);
     });
 
-    it('should revert if hats contract address is zero', async () => {
-      await expect(
-        deployHatsProposerAdapterProxy(
-          deployer,
-          await adapterImplementation.getAddress(),
-          ethers.ZeroAddress,
-          [HAT_ID_1],
-        ),
-      ).to.be.revertedWithCustomError(adapterImplementation, 'MissingHatsContract');
-    });
-
-    it('should revert if initialWhitelistedHats is empty', async () => {
-      await expect(
-        deployHatsProposerAdapterProxy(
-          deployer,
-          await adapterImplementation.getAddress(),
-          await mockHats.getAddress(),
-          [],
-        ),
-      ).to.be.revertedWithCustomError(adapterImplementation, 'NoHatsWhitelisted');
-    });
-
     it('should prevent reinitialization on proxied adapter', async () => {
       await expect(
         adapter.initialize(await mockHats.getAddress(), [HAT_ID_1]),


### PR DESCRIPTION
Fixes [ENG-1057](https://linear.app/decent-labs/issue/ENG-1057/refactor-strategyv1-and-adapters-rename-azorius-and-remove-initialize)

This commit refactors the `StrategyV1` contract and its various ERC20, ERC721, and Hats Proposer/Voting adapters. The key changes include:

1.  **Renaming `azorius` to `proposalInitializer`:**
    *   In `StrategyV1.sol`, the internal state variable `_azorius` has been renamed to `_proposalInitializer`.
    *   The public getter `azorius()` has been renamed to `proposalInitializer()`.
    *   The `initialize` function parameter `azorius_` has been renamed to `proposalInitializer_`.
    *   The corresponding `IStrategyV1` interface has been updated with the new function name `proposalInitializer()`.
    *   The `InvalidAzoriusAddress` error has been replaced with `InvalidProposalInitializer` in the interface.

2.  **Introduction of `onlyProposalInitializer` Modifier:**
    *   A new modifier `onlyProposalInitializer` has been added to `StrategyV1.sol`. This modifier restricts access to functions to only the `_proposalInitializer` address.
    *   The `initializeProposal` function in `StrategyV1.sol` now uses this `onlyProposalInitializer` modifier instead of a direct `msg.sender != _azorius` check.

3.  **Removal of Initialization Checks and Associated Errors/Events:**
    *   **`StrategyV1.sol`:**
        *   Removed checks from `initialize` for:
            *   `azorius_` (now `proposalInitializer_`) being the zero address.
            *   `votingPeriod_` being zero.
            *   `votingAdapters_` containing zero addresses or duplicates.
            *   `proposerAdapters_` containing zero addresses or duplicates.
        *   Removed corresponding errors from `IStrategyV1.sol`: `InvalidAzoriusAddress` (replaced), `InvalidVotingPeriod`, `VotingAdapterIsZeroAddress`, `VotingAdapterAlreadyExists`, `NoVotingAdapters`, `ProposerAdapterIsZeroAddress`, `ProposerAdapterAlreadyExists`.
    *   **Adapter Contracts (`ERC20ProposerAdapterV1`, `ERC20VotingAdapterV1`, `ERC721ProposerAdapterV1`, `ERC721VotingAdapterV1`, `HatsProposerAdapterV1`):**
        *   Removed checks from their respective `initialize` functions for:
            *   Token addresses being zero (`InvalidTokenAddress` error).
            *   Strategy address being zero (`InvalidStrategyAddress` error in `ERC20VotingAdapterV1`).
            *   `weightPerToken_` being zero (`InvalidWeightPerToken` error).
            *   `hatsContract_` being zero (`MissingHatsContract` error in `HatsProposerAdapterV1`).
            *   `whitelistedHatIds_` being empty (`NoHatsWhitelisted` error in `HatsProposerAdapterV1`).
            *   Duplicate hat IDs in `whitelistedHatIds_` (`HatAlreadyWhitelisted` error in `HatsProposerAdapterV1`).
        *   Removed corresponding error definitions from their respective interfaces (`IERC20ProposerAdapterV1`, `IERC20VotingAdapterV1`, etc.).

4.  **Test Updates:**
    *   **`StrategyV1.test.ts`**:
        *   Updated `azoriusMock` to `proposerInitializer` and related address usage.
        *   Removed tests for initialization checks that were removed from `StrategyV1.initialize`.
        *   Updated the `initializeProposal` test to reflect the usage of `onlyProposalInitializer` modifier.
    *   **Adapter Test Files (`ERC20ProposerAdapterV1.test.ts`, etc.)**:
        *   Removed tests for initialization checks that were removed from the adapter `initialize` functions.

**Rationale for Changes:**

*   The renaming from `azorius` to `proposalInitializer` provides more clarity on the role of this address – it's the entity authorized to initialize proposals within the strategy, which might not always be an Azorius module itself.
*   The `onlyProposalInitializer` modifier centralizes access control for proposal initialization.
*   Removing extensive input validation from `initialize` functions can simplify the contracts and potentially save gas on deployment. It shifts the responsibility for providing valid parameters to the deployer or factory contract. This is a common pattern where complex off-chain validation is preferred over on-chain checks for deployment parameters.

These changes streamline the `StrategyV1` and its adapter contracts, making them more focused and relying on the deploying entity for parameter correctness.