### PR TITLE
feat: Enhance proposer checks with data parameter and refactor HatsProposerAdapter

### DIFF
--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -151,11 +151,17 @@ contract AzoriusV1 is
     function submitProposal(
         Transaction[] calldata _transactions,
         string calldata _metadata,
-        bytes memory _proposerData,
-        bytes memory _proposalData
+        address _proposerAdapter,
+        bytes calldata _proposerAdapterData,
+        bytes calldata _proposalInitializerData
     ) external virtual override {
-        if (!_strategy.isProposer(msg.sender, _proposerData))
-            revert InvalidProposer();
+        if (
+            !_strategy.isProposer(
+                msg.sender,
+                _proposerAdapter,
+                _proposerAdapterData
+            )
+        ) revert InvalidProposer();
 
         bytes32[] memory txHashes = new bytes32[](_transactions.length);
         uint256 transactionsLength = _transactions.length;
@@ -179,7 +185,7 @@ contract AzoriusV1 is
         _strategy.initializeProposal(
             _totalProposalCount,
             txHashes,
-            _proposalData
+            _proposalInitializerData
         );
 
         emit ProposalCreated(

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -151,9 +151,11 @@ contract AzoriusV1 is
     function submitProposal(
         Transaction[] calldata _transactions,
         string calldata _metadata,
-        bytes memory _data
+        bytes memory _proposerData,
+        bytes memory _proposalData
     ) external virtual override {
-        if (!_strategy.isProposer(msg.sender)) revert InvalidProposer();
+        if (!_strategy.isProposer(msg.sender, _proposerData))
+            revert InvalidProposer();
 
         bytes32[] memory txHashes = new bytes32[](_transactions.length);
         uint256 transactionsLength = _transactions.length;
@@ -174,7 +176,11 @@ contract AzoriusV1 is
         _proposals[_totalProposalCount].timelockPeriod = _timelockPeriod;
         _proposals[_totalProposalCount].executionPeriod = _executionPeriod;
 
-        _strategy.initializeProposal(_totalProposalCount, txHashes, _data);
+        _strategy.initializeProposal(
+            _totalProposalCount,
+            txHashes,
+            _proposalData
+        );
 
         emit ProposalCreated(
             address(_strategy),

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -254,13 +254,15 @@ contract StrategyV1 is
     }
 
     function isProposer(
-        address _address
+        address _address,
+        bytes memory _data
     ) external view virtual override returns (bool) {
         if (_proposerAdapters.length == 0) return false;
         for (uint256 i = 0; i < _proposerAdapters.length; i++) {
             if (
                 IProposerAdapterBaseV1(_proposerAdapters[i]).isProposer(
-                    _address
+                    _address,
+                    _data
                 )
             ) {
                 return true;

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -56,6 +56,14 @@ contract StrategyV1 is
         _votingAdapters = votingAdapters_;
         _proposerAdapters = proposerAdapters_;
 
+        if (_proposerAdapters.length == 0) {
+            revert NoProposerAdapters();
+        }
+
+        if (_votingAdapters.length == 0) {
+            revert NoVotingAdapters();
+        }
+
         if (
             basisNumerator_ >= BASIS_DENOMINATOR ||
             basisNumerator_ < BASIS_DENOMINATOR / 2
@@ -255,20 +263,26 @@ contract StrategyV1 is
 
     function isProposer(
         address _address,
-        bytes memory _data
+        address _proposerAdapter,
+        bytes calldata _proposerAdapterData
     ) external view virtual override returns (bool) {
-        if (_proposerAdapters.length == 0) return false;
+        bool foundAdapter = false;
         for (uint256 i = 0; i < _proposerAdapters.length; i++) {
-            if (
-                IProposerAdapterBaseV1(_proposerAdapters[i]).isProposer(
-                    _address,
-                    _data
-                )
-            ) {
-                return true;
+            if (_proposerAdapters[i] == _proposerAdapter) {
+                foundAdapter = true;
+                break;
             }
         }
-        return false;
+
+        if (!foundAdapter) {
+            revert InvalidProposerAdapter(_proposerAdapter);
+        }
+
+        return
+            IProposerAdapterBaseV1(_proposerAdapter).isProposer(
+                _address,
+                _proposerAdapterData
+            );
     }
 
     function getVotingTimestamps(

--- a/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
@@ -47,7 +47,8 @@ contract ERC20ProposerAdapterV1 is
     }
 
     function isProposer(
-        address _proposer
+        address _proposer,
+        bytes memory
     ) external view virtual override returns (bool) {
         return _token.getVotes(_proposer) >= _proposerThreshold;
     }

--- a/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
@@ -47,7 +47,8 @@ contract ERC721ProposerAdapterV1 is
     }
 
     function isProposer(
-        address _proposer
+        address _proposer,
+        bytes memory
     ) external view virtual override returns (bool) {
         return _token.balanceOf(_proposer) >= _proposerThreshold;
     }

--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -17,6 +17,7 @@ contract HatsProposerAdapterV1 is
 {
     IHats internal _hatsContract;
     uint256[] internal _whitelistedHatIds;
+    mapping(uint256 => bool) internal _hatIdToIsWhitelisted;
 
     uint16 public constant VERSION = 1;
 
@@ -30,6 +31,9 @@ contract HatsProposerAdapterV1 is
     ) public virtual override initializer {
         _hatsContract = IHats(hatsContract_);
         _whitelistedHatIds = whitelistedHatIds_;
+        for (uint256 i = 0; i < whitelistedHatIds_.length; i++) {
+            _hatIdToIsWhitelisted[whitelistedHatIds_[i]] = true;
+        }
     }
 
     function hatsContract() external view virtual override returns (address) {
@@ -47,14 +51,13 @@ contract HatsProposerAdapterV1 is
     }
 
     function isProposer(
-        address _proposer
+        address _proposer,
+        bytes memory _data
     ) public view virtual override returns (bool) {
-        for (uint256 i = 0; i < _whitelistedHatIds.length; i++) {
-            if (_hatsContract.isWearerOfHat(_proposer, _whitelistedHatIds[i])) {
-                return true;
-            }
-        }
-        return false;
+        uint256 hatId = abi.decode(_data, (uint256));
+        return
+            _hatIdToIsWhitelisted[hatId] &&
+            _hatsContract.isWearerOfHat(_proposer, hatId);
     }
 
     function version() public pure virtual override returns (uint16) {

--- a/contracts/interfaces/decent/deployables/IAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IAzoriusV1.sol
@@ -79,7 +79,8 @@ interface IAzoriusV1 {
     function submitProposal(
         Transaction[] calldata _transactions,
         string calldata _metadata,
-        bytes memory _data
+        bytes memory _proposerData,
+        bytes memory _proposalData
     ) external;
 
     function executeProposal(

--- a/contracts/interfaces/decent/deployables/IAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IAzoriusV1.sol
@@ -79,8 +79,9 @@ interface IAzoriusV1 {
     function submitProposal(
         Transaction[] calldata _transactions,
         string calldata _metadata,
-        bytes memory _proposerData,
-        bytes memory _proposalData
+        address _proposerAdapter,
+        bytes calldata _proposerAdapterData,
+        bytes calldata _proposalInitializerData
     ) external;
 
     function executeProposal(

--- a/contracts/interfaces/decent/deployables/IProposerAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IProposerAdapterBaseV1.sol
@@ -2,5 +2,8 @@
 pragma solidity ^0.8.30;
 
 interface IProposerAdapterBaseV1 {
-    function isProposer(address _proposer) external view returns (bool);
+    function isProposer(
+        address _address,
+        bytes memory _data
+    ) external view returns (bool);
 }

--- a/contracts/interfaces/decent/deployables/IStrategyBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyBaseV1.sol
@@ -2,15 +2,18 @@
 pragma solidity ^0.8.30;
 
 interface IStrategyBaseV1 {
+    error InvalidProposerAdapter(address _proposerAdapter);
+
     function isProposer(
         address _address,
-        bytes memory _data
+        address _proposerAdapter,
+        bytes calldata _proposerAdapterData
     ) external view returns (bool);
 
     function initializeProposal(
         uint32 _proposalId,
         bytes32[] memory _txHashes,
-        bytes memory _data
+        bytes memory _proposalInitializerData
     ) external;
 
     function isPassed(uint32 _proposalId) external view returns (bool);

--- a/contracts/interfaces/decent/deployables/IStrategyBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyBaseV1.sol
@@ -2,6 +2,11 @@
 pragma solidity ^0.8.30;
 
 interface IStrategyBaseV1 {
+    function isProposer(
+        address _address,
+        bytes memory _data
+    ) external view returns (bool);
+
     function initializeProposal(
         uint32 _proposalId,
         bytes32[] memory _txHashes,
@@ -9,8 +14,6 @@ interface IStrategyBaseV1 {
     ) external;
 
     function isPassed(uint32 _proposalId) external view returns (bool);
-
-    function isProposer(address _address) external view returns (bool);
 
     function getVotingTimestamps(
         uint32 _proposalId

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -32,6 +32,8 @@ interface IStrategyV1 is IStrategyBaseV1 {
         uint32 votingStartBlock
     );
 
+    error NoVotingAdapters();
+    error NoProposerAdapters();
     error InvalidBasisNumerator();
     error InvalidProposalInitializer();
     error ProposalNotFoundOrNotActive();

--- a/contracts/mocks/MockProposerAdapter.sol
+++ b/contracts/mocks/MockProposerAdapter.sol
@@ -7,7 +7,8 @@ contract MockProposerAdapter is IProposerAdapterBaseV1 {
     mapping(address => bool) private _isProposer;
 
     function isProposer(
-        address _proposer
+        address _proposer,
+        bytes memory
     ) external view override returns (bool) {
         return _isProposer[_proposer];
     }

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -30,6 +30,7 @@ contract MockVotingStrategy is IStrategyBaseV1 {
 
     function isProposer(
         address _address,
+        address,
         bytes memory
     ) external view override returns (bool) {
         return _address == proposer;

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -29,9 +29,10 @@ contract MockVotingStrategy is IStrategyBaseV1 {
     }
 
     function isProposer(
-        address _proposer
+        address _address,
+        bytes memory
     ) external view override returns (bool) {
-        return _proposer == proposer;
+        return _address == proposer;
     }
 
     function getVotingTimestamps(

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -430,7 +430,13 @@ describe('AzoriusV1', () => {
 
         const tx = await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], proposalMetadata, ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            proposalMetadata,
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
 
         const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
         if (!receipt) throw new Error('Transaction failed');
@@ -455,7 +461,13 @@ describe('AzoriusV1', () => {
         await expect(
           azorius
             .connect(user)
-            .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash),
+            .submitProposal(
+              [proposalTx],
+              'Test proposal',
+              ethers.ZeroAddress,
+              ethers.ZeroHash,
+              ethers.ZeroHash,
+            ),
         ).to.be.revertedWithCustomError(azorius, 'InvalidProposer');
       });
 
@@ -467,7 +479,13 @@ describe('AzoriusV1', () => {
         await expect(
           azorius
             .connect(proposer)
-            .submitProposal([], proposalMetadata, ethers.ZeroHash, ethers.ZeroHash),
+            .submitProposal(
+              [],
+              proposalMetadata,
+              ethers.ZeroAddress,
+              ethers.ZeroHash,
+              ethers.ZeroHash,
+            ),
         )
           .to.emit(azorius, 'ProposalCreated')
           .withArgs(mockStrategyAddress, proposalId, proposer.address, [], proposalMetadata);
@@ -523,7 +541,13 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'Test proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         // Now totalProposalCount is 1. Accessing proposalState(1) should revert.
         await expect(azorius.proposalState(1)).to.be.revertedWithCustomError(
           azorius,
@@ -543,7 +567,13 @@ describe('AzoriusV1', () => {
         // First create a valid proposal
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'Test proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
 
         // Try to access an invalid tx index
         await expect(azorius.getProposalTxHash(0, 999)).to.be.reverted; // Will revert with array out of bounds
@@ -567,7 +597,13 @@ describe('AzoriusV1', () => {
         // Submit proposal with multiple transactions
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [tx1, tx2],
+            'Test proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
 
         // Get hashes directly
         const hash1 = await azorius.getTxHash(tx1.to, tx1.value, tx1.data, tx1.operation);
@@ -598,7 +634,13 @@ describe('AzoriusV1', () => {
         // Submit the proposal
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], metadata, ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            metadata,
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const proposalId = 0;
 
         const expectedTxHash = await azorius.getTxHash(
@@ -650,7 +692,13 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Partial Exec Test', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [tx1, tx2],
+            'Partial Exec Test',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const proposalId = 0;
 
         // --- Setup for execution ---
@@ -710,7 +758,13 @@ describe('AzoriusV1', () => {
         // Submit a proposal
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'Test proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
 
         proposalId = 0;
 
@@ -933,7 +987,13 @@ describe('AzoriusV1', () => {
 
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [tx1, tx2],
+            'Test proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
 
         // Set voting to passed and move past timelock on mock strategy
         await mockStrategy.setVotingTimestamps(0, 0, 0);
@@ -1007,7 +1067,13 @@ describe('AzoriusV1', () => {
         // Submit proposal with both transactions (proposalId will be 1 for this new proposal)
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [tx1, tx2],
+            'Test proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
 
         // Get current block number and set up proposal state for the new proposal (ID 1)
         const currentBlockTimestamp = await time.latest();
@@ -1060,7 +1126,13 @@ describe('AzoriusV1', () => {
           proposalId = Number(await azorius.totalProposalCount());
           await azorius
             .connect(proposer)
-            .submitProposal([validTx], 'Test for Reverts', ethers.ZeroHash, ethers.ZeroHash);
+            .submitProposal(
+              [validTx],
+              'Test for Reverts',
+              ethers.ZeroAddress,
+              ethers.ZeroHash,
+              ethers.ZeroHash,
+            );
 
           // Setup proposal to be EXECUTABLE for most tests here
           const chainTimeBeforeStrategyUpdate = await time.latest();
@@ -1325,7 +1397,13 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'New proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const proposalId = 0; // First proposal
 
         const [, , timelock, ,] = await azorius.getProposal(proposalId);
@@ -1342,7 +1420,13 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'Existing proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const existingProposalId = 0;
 
         // Update the timelock period
@@ -1358,6 +1442,7 @@ describe('AzoriusV1', () => {
           .submitProposal(
             [proposalTx],
             'New proposal post-update',
+            ethers.ZeroAddress,
             ethers.ZeroHash,
             ethers.ZeroHash,
           );
@@ -1394,7 +1479,13 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'New proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const proposalId = 0;
 
         const [, , , executionPeriod] = await azorius.getProposal(proposalId);
@@ -1410,7 +1501,13 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'Existing proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const existingProposalId = 0;
 
         await azorius.connect(owner).updateExecutionPeriod(NEW_EXECUTION_PERIOD);
@@ -1423,6 +1520,7 @@ describe('AzoriusV1', () => {
           .submitProposal(
             [proposalTx],
             'New proposal post-update',
+            ethers.ZeroAddress,
             ethers.ZeroHash,
             ethers.ZeroHash,
           );
@@ -1474,7 +1572,13 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'New proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const proposalId = 0;
 
         const [strategyAddress, , , ,] = await azorius.getProposal(proposalId);
@@ -1490,7 +1594,13 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroHash, ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'Existing proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const existingProposalId = 0;
 
         await azorius.connect(owner).updateStrategy(newMockStrategyAddress);
@@ -1503,6 +1613,7 @@ describe('AzoriusV1', () => {
           .submitProposal(
             [proposalTx],
             'New proposal post-update',
+            ethers.ZeroAddress,
             ethers.ZeroHash,
             ethers.ZeroHash,
           );
@@ -1527,6 +1638,7 @@ describe('AzoriusV1', () => {
           .submitProposal(
             [proposalTx],
             'Existing proposal with mockStrategy',
+            ethers.ZeroAddress,
             ethers.ZeroHash,
             ethers.ZeroHash,
           );

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -430,7 +430,7 @@ describe('AzoriusV1', () => {
 
         const tx = await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], proposalMetadata, ethers.ZeroHash);
+          .submitProposal([proposalTx], proposalMetadata, ethers.ZeroHash, ethers.ZeroHash);
 
         const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
         if (!receipt) throw new Error('Transaction failed');
@@ -453,7 +453,9 @@ describe('AzoriusV1', () => {
 
       it('should not allow non-proposer to submit proposal', async () => {
         await expect(
-          azorius.connect(user).submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash),
+          azorius
+            .connect(user)
+            .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash),
         ).to.be.revertedWithCustomError(azorius, 'InvalidProposer');
       });
 
@@ -463,7 +465,9 @@ describe('AzoriusV1', () => {
 
         // Submit with empty transactions array
         await expect(
-          azorius.connect(proposer).submitProposal([], proposalMetadata, ethers.ZeroHash),
+          azorius
+            .connect(proposer)
+            .submitProposal([], proposalMetadata, ethers.ZeroHash, ethers.ZeroHash),
         )
           .to.emit(azorius, 'ProposalCreated')
           .withArgs(mockStrategyAddress, proposalId, proposer.address, [], proposalMetadata);
@@ -519,7 +523,7 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash);
+          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
         // Now totalProposalCount is 1. Accessing proposalState(1) should revert.
         await expect(azorius.proposalState(1)).to.be.revertedWithCustomError(
           azorius,
@@ -539,7 +543,7 @@ describe('AzoriusV1', () => {
         // First create a valid proposal
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash);
+          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
 
         // Try to access an invalid tx index
         await expect(azorius.getProposalTxHash(0, 999)).to.be.reverted; // Will revert with array out of bounds
@@ -563,7 +567,7 @@ describe('AzoriusV1', () => {
         // Submit proposal with multiple transactions
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroHash);
+          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
 
         // Get hashes directly
         const hash1 = await azorius.getTxHash(tx1.to, tx1.value, tx1.data, tx1.operation);
@@ -592,7 +596,9 @@ describe('AzoriusV1', () => {
         const metadata = 'Test GetProposal';
 
         // Submit the proposal
-        await azorius.connect(proposer).submitProposal([proposalTx], metadata, ethers.ZeroHash);
+        await azorius
+          .connect(proposer)
+          .submitProposal([proposalTx], metadata, ethers.ZeroHash, ethers.ZeroHash);
         const proposalId = 0;
 
         const expectedTxHash = await azorius.getTxHash(
@@ -644,7 +650,7 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Partial Exec Test', ethers.ZeroHash);
+          .submitProposal([tx1, tx2], 'Partial Exec Test', ethers.ZeroHash, ethers.ZeroHash);
         const proposalId = 0;
 
         // --- Setup for execution ---
@@ -704,7 +710,7 @@ describe('AzoriusV1', () => {
         // Submit a proposal
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash);
+          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
 
         proposalId = 0;
 
@@ -927,7 +933,7 @@ describe('AzoriusV1', () => {
 
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroHash);
+          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
 
         // Set voting to passed and move past timelock on mock strategy
         await mockStrategy.setVotingTimestamps(0, 0, 0);
@@ -1001,7 +1007,7 @@ describe('AzoriusV1', () => {
         // Submit proposal with both transactions (proposalId will be 1 for this new proposal)
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroHash);
+          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroHash, ethers.ZeroHash);
 
         // Get current block number and set up proposal state for the new proposal (ID 1)
         const currentBlockTimestamp = await time.latest();
@@ -1054,7 +1060,7 @@ describe('AzoriusV1', () => {
           proposalId = Number(await azorius.totalProposalCount());
           await azorius
             .connect(proposer)
-            .submitProposal([validTx], 'Test for Reverts', ethers.ZeroHash);
+            .submitProposal([validTx], 'Test for Reverts', ethers.ZeroHash, ethers.ZeroHash);
 
           // Setup proposal to be EXECUTABLE for most tests here
           const chainTimeBeforeStrategyUpdate = await time.latest();
@@ -1319,7 +1325,7 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal', ethers.ZeroHash);
+          .submitProposal([proposalTx], 'New proposal', ethers.ZeroHash, ethers.ZeroHash);
         const proposalId = 0; // First proposal
 
         const [, , timelock, ,] = await azorius.getProposal(proposalId);
@@ -1336,7 +1342,7 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroHash);
+          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroHash, ethers.ZeroHash);
         const existingProposalId = 0;
 
         // Update the timelock period
@@ -1349,7 +1355,12 @@ describe('AzoriusV1', () => {
         // Submit a new proposal to ensure it gets the new period
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal post-update', ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'New proposal post-update',
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const newProposalId = 1;
         const [, , newTimelock, ,] = await azorius.getProposal(newProposalId);
         expect(newTimelock).to.equal(NEW_TIMELOCK_PERIOD);
@@ -1383,7 +1394,7 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal', ethers.ZeroHash);
+          .submitProposal([proposalTx], 'New proposal', ethers.ZeroHash, ethers.ZeroHash);
         const proposalId = 0;
 
         const [, , , executionPeriod] = await azorius.getProposal(proposalId);
@@ -1399,7 +1410,7 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroHash);
+          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroHash, ethers.ZeroHash);
         const existingProposalId = 0;
 
         await azorius.connect(owner).updateExecutionPeriod(NEW_EXECUTION_PERIOD);
@@ -1409,7 +1420,12 @@ describe('AzoriusV1', () => {
 
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal post-update', ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'New proposal post-update',
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const newProposalId = 1;
         const [, , , newExecution] = await azorius.getProposal(newProposalId);
         expect(newExecution).to.equal(NEW_EXECUTION_PERIOD);
@@ -1458,7 +1474,7 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal', ethers.ZeroHash);
+          .submitProposal([proposalTx], 'New proposal', ethers.ZeroHash, ethers.ZeroHash);
         const proposalId = 0;
 
         const [strategyAddress, , , ,] = await azorius.getProposal(proposalId);
@@ -1474,7 +1490,7 @@ describe('AzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroHash);
+          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroHash, ethers.ZeroHash);
         const existingProposalId = 0;
 
         await azorius.connect(owner).updateStrategy(newMockStrategyAddress);
@@ -1484,7 +1500,12 @@ describe('AzoriusV1', () => {
 
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal post-update', ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'New proposal post-update',
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
         const newProposalId = 1;
         const [newStrategy, , , ,] = await azorius.getProposal(newProposalId);
         expect(newStrategy).to.equal(newMockStrategyAddress);
@@ -1503,7 +1524,12 @@ describe('AzoriusV1', () => {
         // The azorius instance is already configured with mockStrategyAddress in the parent beforeEach
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal with mockStrategy', ethers.ZeroHash);
+          .submitProposal(
+            [proposalTx],
+            'Existing proposal with mockStrategy',
+            ethers.ZeroHash,
+            ethers.ZeroHash,
+          );
 
         // 2. Configure initial strategy (mockStrategy) for this proposal
         const currentTimestamp = await time.latest();

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -147,8 +147,8 @@ describe('StrategyV1', () => {
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
           1_000_001n,
-          [],
-          [],
+          [await mockAdapter1.getAddress()],
+          [await mockProposerAdapter1.getAddress()],
           lightAccountFactoryMockAddress,
         ),
       ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
@@ -161,8 +161,8 @@ describe('StrategyV1', () => {
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
           499_999n,
-          [],
-          [],
+          [await mockAdapter1.getAddress()],
+          [await mockProposerAdapter1.getAddress()],
           lightAccountFactoryMockAddress,
         ),
       ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
@@ -174,8 +174,8 @@ describe('StrategyV1', () => {
         DEFAULT_VOTING_PERIOD,
         0n, // Zero quorum threshold
         DEFAULT_BASIS_NUMERATOR,
-        [],
-        [],
+        [await mockAdapter1.getAddress()],
+        [await mockProposerAdapter1.getAddress()],
         lightAccountFactoryMockAddress,
       );
       expect(await testStrategy.quorumThreshold()).to.equal(0n);
@@ -187,8 +187,8 @@ describe('StrategyV1', () => {
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         500_000n, // 50% basis numerator
-        [],
-        [],
+        [await mockAdapter1.getAddress()],
+        [await mockProposerAdapter1.getAddress()],
         lightAccountFactoryMockAddress,
       );
       expect(await testStrategy.basisNumerator()).to.equal(500_000n);
@@ -201,8 +201,8 @@ describe('StrategyV1', () => {
           DEFAULT_VOTING_PERIOD,
           DEFAULT_QUORUM_THRESHOLD,
           1_000_000n, // 100% basis numerator - now invalid
-          [],
-          [],
+          [await mockAdapter1.getAddress()],
+          [await mockProposerAdapter1.getAddress()],
           lightAccountFactoryMockAddress,
         ),
       ).to.be.revertedWithCustomError(strategyImplementation, 'InvalidBasisNumerator');
@@ -215,11 +215,39 @@ describe('StrategyV1', () => {
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         maxValidBasis,
-        [],
-        [],
+        [await mockAdapter1.getAddress()],
+        [await mockProposerAdapter1.getAddress()],
         lightAccountFactoryMockAddress,
       );
       expect(await testStrategy.basisNumerator()).to.equal(maxValidBasis);
+    });
+
+    it('should revert if initialProposerAdapters is empty', async () => {
+      await expect(
+        deployStrategyProxy(
+          proposerInitializer.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          DEFAULT_BASIS_NUMERATOR,
+          defaultInitialVotingAdapters, // Non-empty
+          [], // Empty proposer adapters
+          lightAccountFactoryMockAddress,
+        ),
+      ).to.be.revertedWithCustomError(strategyImplementation, 'NoProposerAdapters');
+    });
+
+    it('should revert if initialVotingAdapters is empty', async () => {
+      await expect(
+        deployStrategyProxy(
+          proposerInitializer.address,
+          DEFAULT_VOTING_PERIOD,
+          DEFAULT_QUORUM_THRESHOLD,
+          DEFAULT_BASIS_NUMERATOR,
+          [], // Empty voting adapters
+          defaultInitialProposerAdapters, // Non-empty
+          lightAccountFactoryMockAddress,
+        ),
+      ).to.be.revertedWithCustomError(strategyImplementation, 'NoVotingAdapters');
     });
   });
 
@@ -296,60 +324,82 @@ describe('StrategyV1', () => {
   });
 
   describe('isProposer', () => {
-    it('should return false if no proposer adapters are configured at init', async () => {
-      const noProposerAdapterStrategy = await deployStrategyProxy(
-        proposerInitializer.address,
-        DEFAULT_VOTING_PERIOD,
-        DEFAULT_QUORUM_THRESHOLD,
-        DEFAULT_BASIS_NUMERATOR,
-        defaultInitialVotingAdapters,
-        [], // NO proposer adapters
-        lightAccountFactoryMockAddress,
-      );
-      void expect(await noProposerAdapterStrategy.isProposer(user1.address, ethers.ZeroHash)).to.be
-        .false;
-    });
-
     it('should return true if any configured adapter identifies the address as a proposer', async () => {
+      const mockProposerAdapter1Address = await mockProposerAdapter1.getAddress();
+      const mockProposerAdapter2Address = await mockProposerAdapter2.getAddress();
       const multiProposerStrategy = await deployStrategyProxy(
         proposerInitializer.address,
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         DEFAULT_BASIS_NUMERATOR,
         defaultInitialVotingAdapters,
-        [await mockProposerAdapter1.getAddress(), await mockProposerAdapter2.getAddress()],
+        [mockProposerAdapter1Address, mockProposerAdapter2Address],
         lightAccountFactoryMockAddress,
       );
 
       await mockProposerAdapter1.setProposerStatus(user1.address, false);
       await mockProposerAdapter2.setProposerStatus(user1.address, true);
 
-      void expect(await multiProposerStrategy.isProposer(user1.address, ethers.ZeroHash)).to.be
-        .true;
+      // Check against adapter 1 (should be false)
+      void expect(
+        await multiProposerStrategy.isProposer(
+          user1.address,
+          mockProposerAdapter1Address,
+          ethers.ZeroHash,
+        ),
+      ).to.be.false;
+
+      // Check against adapter 2 (should be true)
+      void expect(
+        await multiProposerStrategy.isProposer(
+          user1.address,
+          mockProposerAdapter2Address,
+          ethers.ZeroHash,
+        ),
+      ).to.be.true;
     });
 
     it('should return false if no configured adapter identifies the address as a proposer', async () => {
+      const mockProposerAdapter1Address = await mockProposerAdapter1.getAddress();
       await mockProposerAdapter1.setProposerStatus(user1.address, false);
-      void expect(await strategy.isProposer(user1.address, ethers.ZeroHash)).to.be.false;
+      void expect(
+        await strategy.isProposer(user1.address, mockProposerAdapter1Address, ethers.ZeroHash),
+      ).to.be.false;
 
+      const mockProposerAdapter2Address = await mockProposerAdapter2.getAddress();
       const multiProposerStrategy = await deployStrategyProxy(
         proposerInitializer.address,
         DEFAULT_VOTING_PERIOD,
         DEFAULT_QUORUM_THRESHOLD,
         DEFAULT_BASIS_NUMERATOR,
         defaultInitialVotingAdapters,
-        [await mockProposerAdapter1.getAddress(), await mockProposerAdapter2.getAddress()],
+        [mockProposerAdapter1Address, mockProposerAdapter2Address],
         lightAccountFactoryMockAddress,
       );
       await mockProposerAdapter1.setProposerStatus(user1.address, false);
       await mockProposerAdapter2.setProposerStatus(user1.address, false);
-      void expect(await multiProposerStrategy.isProposer(user1.address, ethers.ZeroHash)).to.be
-        .false;
+      void expect(
+        await multiProposerStrategy.isProposer(
+          user1.address,
+          mockProposerAdapter1Address,
+          ethers.ZeroHash,
+        ),
+      ).to.be.false;
+      void expect(
+        await multiProposerStrategy.isProposer(
+          user1.address,
+          mockProposerAdapter2Address,
+          ethers.ZeroHash,
+        ),
+      ).to.be.false;
     });
 
     it('should return true if the first configured adapter identifies the address as a proposer', async () => {
+      const mockProposerAdapter1Address = await mockProposerAdapter1.getAddress();
       await mockProposerAdapter1.setProposerStatus(user1.address, true);
-      void expect(await strategy.isProposer(user1.address, ethers.ZeroHash)).to.be.true;
+      void expect(
+        await strategy.isProposer(user1.address, mockProposerAdapter1Address, ethers.ZeroHash),
+      ).to.be.true;
     });
   });
 

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -306,7 +306,8 @@ describe('StrategyV1', () => {
         [], // NO proposer adapters
         lightAccountFactoryMockAddress,
       );
-      void expect(await noProposerAdapterStrategy.isProposer(user1.address)).to.be.false;
+      void expect(await noProposerAdapterStrategy.isProposer(user1.address, ethers.ZeroHash)).to.be
+        .false;
     });
 
     it('should return true if any configured adapter identifies the address as a proposer', async () => {
@@ -323,12 +324,13 @@ describe('StrategyV1', () => {
       await mockProposerAdapter1.setProposerStatus(user1.address, false);
       await mockProposerAdapter2.setProposerStatus(user1.address, true);
 
-      void expect(await multiProposerStrategy.isProposer(user1.address)).to.be.true;
+      void expect(await multiProposerStrategy.isProposer(user1.address, ethers.ZeroHash)).to.be
+        .true;
     });
 
     it('should return false if no configured adapter identifies the address as a proposer', async () => {
       await mockProposerAdapter1.setProposerStatus(user1.address, false);
-      void expect(await strategy.isProposer(user1.address)).to.be.false;
+      void expect(await strategy.isProposer(user1.address, ethers.ZeroHash)).to.be.false;
 
       const multiProposerStrategy = await deployStrategyProxy(
         proposerInitializer.address,
@@ -341,12 +343,13 @@ describe('StrategyV1', () => {
       );
       await mockProposerAdapter1.setProposerStatus(user1.address, false);
       await mockProposerAdapter2.setProposerStatus(user1.address, false);
-      void expect(await multiProposerStrategy.isProposer(user1.address)).to.be.false;
+      void expect(await multiProposerStrategy.isProposer(user1.address, ethers.ZeroHash)).to.be
+        .false;
     });
 
     it('should return true if the first configured adapter identifies the address as a proposer', async () => {
       await mockProposerAdapter1.setProposerStatus(user1.address, true);
-      void expect(await strategy.isProposer(user1.address)).to.be.true;
+      void expect(await strategy.isProposer(user1.address, ethers.ZeroHash)).to.be.true;
     });
   });
 

--- a/test/deployables/strategies/adapters/ERC20ProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20ProposerAdapterV1.test.ts
@@ -96,14 +96,14 @@ describe('ERC20ProposerAdapterV1', () => {
     it('should return true if user meets the proposer threshold', async () => {
       await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
       await mockToken.connect(user1).delegate(user1.address);
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
 
     it('should return true if user exceeds the proposer threshold', async () => {
       await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
       await mockToken.connect(user1).delegate(user1.address);
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
 
@@ -113,13 +113,13 @@ describe('ERC20ProposerAdapterV1', () => {
 
       await mockToken.connect(user1).delegate(user1.address);
 
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.false;
     });
 
     it('should return false if user has no votes (or token balance)', async () => {
       await mockToken.connect(user1).delegate(user1.address);
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.false;
     });
 
@@ -131,7 +131,7 @@ describe('ERC20ProposerAdapterV1', () => {
         0n,
       );
       await mockToken.connect(user1).delegate(user1.address);
-      const canPropose = await localAdapter.isProposer(user1.address);
+      const canPropose = await localAdapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
   });

--- a/test/deployables/strategies/adapters/ERC721ProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721ProposerAdapterV1.test.ts
@@ -87,7 +87,7 @@ describe('ERC721ProposerAdapterV1', () => {
       for (let i = 0; i < 5; i++) {
         await mockNft.connect(deployer).mint(user1.address);
       }
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
 
@@ -95,7 +95,7 @@ describe('ERC721ProposerAdapterV1', () => {
       for (let i = 0; i < 6; i++) {
         await mockNft.connect(deployer).mint(user1.address);
       }
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
 
@@ -103,12 +103,12 @@ describe('ERC721ProposerAdapterV1', () => {
       for (let i = 0; i < 4; i++) {
         await mockNft.connect(deployer).mint(user1.address);
       }
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.false;
     });
 
     it('should return false if user has no NFTs', async () => {
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.false;
     });
 
@@ -119,7 +119,7 @@ describe('ERC721ProposerAdapterV1', () => {
         await mockNft.getAddress(),
         0n,
       );
-      const canPropose = await localAdapter.isProposer(user1.address);
+      const canPropose = await localAdapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
   });

--- a/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/HatsProposerAdapterV1.test.ts
@@ -90,19 +90,37 @@ describe('HatsProposerAdapterV1', () => {
 
     it('should return true if user wears a whitelisted hat', async () => {
       await mockHats.setWearerStatus(user1.address, HAT_ID_1, true);
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(
+        user1.address,
+        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_1]),
+      );
       void expect(canPropose).to.be.true;
     });
 
     it('should return false if user does not wear any whitelisted hat', async () => {
       await mockHats.setWearerStatus(user1.address, HAT_ID_1, false);
       await mockHats.setWearerStatus(user1.address, HAT_ID_2, true); // Wears a non-whitelisted hat
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(
+        user1.address,
+        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_1]),
+      );
+      void expect(canPropose).to.be.false;
+    });
+
+    it('should return false if user wears a hat that is not whitelisted', async () => {
+      await mockHats.setWearerStatus(user1.address, HAT_ID_2, true); // Wears a non-whitelisted hat
+      const canPropose = await adapter.isProposer(
+        user1.address,
+        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_2]),
+      );
       void expect(canPropose).to.be.false;
     });
 
     it('should return false if user wears no hats', async () => {
-      const canPropose = await adapter.isProposer(user1.address);
+      const canPropose = await adapter.isProposer(
+        user1.address,
+        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_1]),
+      );
       void expect(canPropose).to.be.false;
     });
 
@@ -115,7 +133,10 @@ describe('HatsProposerAdapterV1', () => {
       );
       await mockHats.setWearerStatus(user1.address, HAT_ID_1, false);
       await mockHats.setWearerStatus(user1.address, HAT_ID_2, true); // Wears the second whitelisted hat
-      const canPropose = await localAdapter.isProposer(user1.address);
+      const canPropose = await localAdapter.isProposer(
+        user1.address,
+        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_2]),
+      );
       void expect(canPropose).to.be.true;
     });
   });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/307

Fixes [ENG-1058](https://linear.app/decent-labs/issue/ENG-1058/enhance-proposer-validation-with-data-parameter-and-refactor)

This commit introduces a `bytes memory _data` parameter to the `isProposer` function in `IStrategyBaseV1`, `StrategyV1`, `IProposerAdapterBaseV1`, and all concrete proposer adapter implementations (`ERC20ProposerAdapterV1`, `ERC721ProposerAdapterV1`, `HatsProposerAdapterV1`).

The `AzoriusV1.submitProposal` function has been updated to accept two new parameters: `_proposerData` and `_proposalData`. The `_proposerData` is now passed to the strategy's `isProposer` check, and `_proposalData` is passed to the strategy's `initializeProposal` function.

**Key Changes:**

1.  **`isProposer` Function Signature Update:**
    *   `IStrategyBaseV1.sol`: `isProposer(address _address)` changed to `isProposer(address _address, bytes memory _data)`.
    *   `StrategyV1.sol`: Updated to match the interface and now passes `_data` to each `IProposerAdapterBaseV1(_proposerAdapters[i]).isProposer(_address, _data)`.
    *   `IProposerAdapterBaseV1.sol`: `isProposer(address _proposer)` changed to `isProposer(address _proposer, bytes memory _data)`.
    *   `ERC20ProposerAdapterV1.sol`: `isProposer(address _proposer)` changed to `isProposer(address _proposer, bytes memory /*_data*/)`, the `_data` parameter is currently unused.
    *   `ERC721ProposerAdapterV1.sol`: `isProposer(address _proposer)` changed to `isProposer(address _proposer, bytes memory /*_data*/)`, the `_data` parameter is currently unused.
    *   `MockProposerAdapter.sol` & `MockVotingStrategy.sol`: Updated to match the new `isProposer` signature.

2.  **`AzoriusV1.submitProposal` Update:**
    *   Signature changed from `submitProposal(Transaction[] calldata _transactions, string calldata _metadata, bytes memory _data)` to `submitProposal(Transaction[] calldata _transactions, string calldata _metadata, bytes memory _proposerData, bytes memory _proposalData)`.
    *   The `_strategy.isProposer(msg.sender, _proposerData)` check now uses `_proposerData`.
    *   The `_strategy.initializeProposal(_totalProposalCount, txHashes, _proposalData)` call now uses `_proposalData`.
    *   `IAzoriusV1.sol`: Interface updated to reflect the new `submitProposal` signature.
    *   `AzoriusV1.test.ts`: All calls to `submitProposal` updated to pass two `ethers.ZeroHash` arguments for the new data parameters.

3.  **`HatsProposerAdapterV1.sol` Refactoring:**
    *   A new internal mapping `_hatIdToIsWhitelisted` is introduced to store whitelisted hat IDs for O(1) lookup.
    *   The `initialize` function now populates this mapping from the `whitelistedHatIds_` array.
    *   The `isProposer(address _proposer, bytes memory _data)` function has been significantly changed:
        *   It now expects `_data` to be ABI-encoded `uint256 hatId`.
        *   It decodes `hatId` from `_data`.
        *   It checks if this `hatId` is in `_hatIdToIsWhitelisted` AND if the `_proposer` is a wearer of that specific `hatId` using `_hatsContract.isWearerOfHat(_proposer, hatId)`.
        *   The previous logic of iterating through all `_whitelistedHatIds` has been removed.

4.  **Test Updates:**
    *   `AzoriusV1.test.ts`: Updated `submitProposal` calls.
    *   `StrategyV1.test.ts`: Updated `isProposer` calls to include `ethers.ZeroHash` for the new data parameter.
    *   `ERC20ProposerAdapterV1.test.ts` & `ERC721ProposerAdapterV1.test.ts`: Updated `isProposer` calls.
    *   `HatsProposerAdapterV1.test.ts`:
        *   Updated `isProposer` calls to pass ABI-encoded hat ID as data.
        *   Tests now check for proposing with specific hats rather than any whitelisted hat.

**Impact and Rationale:**

*   Passing `_data` to `isProposer` allows for more flexible and context-specific proposer validation logic within adapters. For example, an adapter might require specific data to determine if an address is a valid proposer for a certain type of proposal.
*   The `HatsProposerAdapterV1` refactoring makes proposer checks more targeted: a proposer must now specify *which* whitelisted hat they are using to propose, and the adapter verifies they wear *that specific* hat. This is a shift from the previous behavior where wearing *any* whitelisted hat was sufficient. The use of a mapping improves lookup efficiency.
*   Separating `_proposerData` and `_proposalData` in `AzoriusV1.submitProposal` provides a clearer distinction between data needed for proposer validation and data needed for initializing the proposal's voting details within the strategy.