### PR TITLE
refactor: Standardize initializer modifiers to `onlyInitializing` and update Version contract

### DIFF
--- a/contracts/deployables/Version.sol
+++ b/contracts/deployables/Version.sol
@@ -4,19 +4,8 @@ pragma solidity ^0.8.30;
 import {IVersion} from "../interfaces/decent/deployables/IVersion.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-/**
- * @title Version
- * @dev Abstract contract providing standardized contract identification
- *
- * Inheriting contracts MUST implement:
- * - version()
- */
 abstract contract Version is IVersion, ERC165 {
-    /**
-     * @dev Returns the version number of this contract implementation
-     * Inheriting contracts MUST override this function.
-     */
-    function version() public view virtual returns (uint16);
+    function version() public view virtual override returns (uint16);
 
     function supportsInterface(
         bytes4 interfaceId

--- a/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
+++ b/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
@@ -21,7 +21,7 @@ abstract contract SmartAccountValidationV1 is
 
     function __SmartAccountValidationV1_init(
         address lightAccountFactory_
-    ) internal initializer {
+    ) internal onlyInitializing {
         _lightAccountFactory = ILightAccountFactory(lightAccountFactory_);
     }
 

--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -28,7 +28,7 @@ abstract contract BaseFreezeVotingV1 is
         uint32 freezeProposalPeriod_,
         uint32 freezePeriod_,
         uint256 freezeVotesThreshold_
-    ) internal initializer {
+    ) internal onlyInitializing {
         __Ownable_init(owner_);
         __UUPSUpgradeable_init();
         _updateFreezeProposalPeriod(freezeProposalPeriod_);

--- a/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
+++ b/contracts/deployables/strategies/ERC4337VoterSupportV1.sol
@@ -16,7 +16,7 @@ abstract contract ERC4337VoterSupportV1 is
 
     function __ERC4337VoterSupportV1_init(
         address _lightAccountFactory
-    ) internal initializer {
+    ) internal onlyInitializing {
         __SmartAccountValidationV1_init(_lightAccountFactory);
     }
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/308

Fixes [ENG-1059](https://linear.app/decent-labs/issue/ENG-1059/standardize-initializer-modifiers-and-refine-versionsol)

This commit introduces two main improvements:
1.  Standardizes the use of initializer modifiers in several abstract/base contracts by replacing OpenZeppelin's `initializer` modifier with `onlyInitializing` for internal `__*_init` functions. This change aligns better with UUPS upgradeability patterns where these internal initializers are typically called once by a public `initialize` function in the final concrete contract during its proxy deployment. The `onlyInitializing` modifier ensures these setup routines are guarded appropriately.
2.  Refines the `Version.sol` abstract contract by adding the `override` keyword to its `version()` function declaration, making the override explicit and removing a redundant NatSpec comment.

**Key Changes:**

*   **Initializer Modifier Update:**
    *   In `SmartAccountValidationV1.sol`, `__SmartAccountValidationV1_init` now uses `onlyInitializing` instead of `initializer`.
    *   In `BaseFreezeVotingV1.sol`, `__BaseFreezeVotingV1_init` now uses `onlyInitializing` instead of `initializer`.
    *   In `ERC4337VoterSupportV1.sol`, `__ERC4337VoterSupportV1_init` now uses `onlyInitializing` instead of `initializer`.

*   **`Version.sol` Refinement:**
    *   The `version()` function declaration now includes the `override` keyword.
    *   The NatSpec comment instructing inheriting contracts to override `version()` has been removed as the `override` keyword and the `IVersion` interface make this clear.

These changes enhance contract clarity, adhere to best practices for upgradeable contracts, and ensure consistency in how initialization is handled.

See: https://forum.openzeppelin.com/t/whats-the-difference-between-onlyinitializing-and-initialzer/25789/2
