### PR TITLE
refactor: Simplify lock and whitelist logic in VotesERC20LockableV1

### DIFF
--- a/contracts/deployables/erc20/VotesERC20LockableV1.sol
+++ b/contracts/deployables/erc20/VotesERC20LockableV1.sol
@@ -60,9 +60,6 @@ contract VotesERC20LockableV1 is IVotesERC20LockableV1, VotesERC20V1 {
     }
 
     function lock(bool locked_) external virtual override onlyOwner {
-        if (locked_ == _locked) {
-            revert CannotSwitchLockState(locked_);
-        }
         _locked = locked_;
         emit Locked(_locked);
     }
@@ -71,11 +68,8 @@ contract VotesERC20LockableV1 is IVotesERC20LockableV1, VotesERC20V1 {
         address account,
         bool isWhitelisted
     ) external virtual override onlyOwner {
-        bool currentlyWhitelisted = _whitelisted[account];
         _whitelisted[account] = isWhitelisted;
-        if (currentlyWhitelisted != isWhitelisted) {
-            emit Whitelisted(account, isWhitelisted);
-        }
+        emit Whitelisted(account, isWhitelisted);
     }
 
     function setMaxTotalSupply(

--- a/contracts/interfaces/decent/deployables/IVotesERC20LockableV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20LockableV1.sol
@@ -9,7 +9,6 @@ interface IVotesERC20LockableV1 is IVotesERC20V1 {
     event MaxTotalSupplyUpdated(uint256 newMaxTotalSupply);
 
     error IsLocked();
-    error CannotSwitchLockState(bool newLockState);
     error ExceedMaxTotalSupply();
     error InvalidMaxTotalSupply();
 

--- a/test/deployables/erc20/VotesERC20LockableV1.test.ts
+++ b/test/deployables/erc20/VotesERC20LockableV1.test.ts
@@ -174,12 +174,9 @@ describe('VotesERC20LockableV1', () => {
         });
       });
 
-      describe('Trying to lock should fail', () => {
-        it('should revert', async () => {
-          await expect(proxy.connect(owner).lock(true)).to.be.revertedWithCustomError(
-            proxy,
-            'CannotSwitchLockState(bool true)',
-          );
+      describe('Trying to lock (despite being locked) should succeed', () => {
+        it('should succeed', async () => {
+          await expect(proxy.connect(owner).lock(true)).to.not.be.reverted;
         });
       });
     });
@@ -227,12 +224,9 @@ describe('VotesERC20LockableV1', () => {
         });
       });
 
-      describe('Trying to unlock should fail', () => {
-        it('should revert', async () => {
-          await expect(proxy.connect(owner).lock(false)).to.be.revertedWithCustomError(
-            proxy,
-            'CannotSwitchLockState(bool false)',
-          );
+      describe('Trying to unlock (despite being unlocked) should succeed', () => {
+        it('should succeed', async () => {
+          await expect(proxy.connect(owner).lock(false)).to.not.be.reverted;
         });
       });
     });
@@ -276,8 +270,10 @@ describe('VotesERC20LockableV1', () => {
             addTx = await proxy.connect(owner).whitelist(whitelistMember.address, true);
           });
 
-          it('should not emit an event', async () => {
-            await expect(addTx).to.not.emit(proxy, 'Whitelisted');
+          it('should emit an event again', async () => {
+            await expect(addTx)
+              .to.emit(proxy, 'Whitelisted')
+              .withArgs(whitelistMember.address, true);
           });
         });
       });
@@ -316,8 +312,10 @@ describe('VotesERC20LockableV1', () => {
             removeTx = await proxy.connect(owner).whitelist(whitelistMember.address, false);
           });
 
-          it('should not emit an event', async () => {
-            await expect(removeTx).to.not.emit(proxy, 'Whitelisted');
+          it('should emit an event again', async () => {
+            await expect(removeTx)
+              .to.emit(proxy, 'Whitelisted')
+              .withArgs(whitelistMember.address, false);
           });
         });
       });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/310

Fixes [ENG-1060](https://linear.app/decent-labs/issue/ENG-1060/simplify-lock-and-whitelist-functions-in-voteserc20lockablev1)

This commit simplifies the `lock(bool)` and `whitelist(address, bool)` functions in the `VotesERC20LockableV1` contract.

The key changes are:
-   Removed the check in the `lock` function that prevented setting the lock status to its current value. The `CannotSwitchLockState` error has also been removed from the contract and its interface (`IVotesERC20LockableV1`). Setting the lock to its existing state will now succeed silently and still emit the `Locked` event.
-   Removed the conditional check in the `whitelist` function that only emitted the `Whitelisted` event if the whitelist status was actually changed. The `Whitelisted` event will now be emitted every time the `whitelist` function is called, regardless of whether the state changed.

Corresponding test cases in `VotesERC20LockableV1.test.ts` have been updated to reflect these changes:
-   Tests for attempting to set the lock to its current state now expect success instead of a revert.
-   Tests for whitelisting/unwhitelisting an account that is already in that state now expect the `Whitelisted` event to be emitted.

This simplification makes the functions more idempotent in terms of state change (though events are still emitted) and can slightly reduce gas costs by removing conditional checks.
