### PR TITLE
refactor: Simplify BaseFreezeVotingV1 by removing UUPS and parameter update functions

### DIFF
--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -2,13 +2,11 @@
 pragma solidity ^0.8.30;
 
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 abstract contract BaseFreezeVotingV1 is
     IBaseFreezeVotingV1,
-    UUPSUpgradeable,
     Ownable2StepUpgradeable,
     ERC165
 {
@@ -30,15 +28,10 @@ abstract contract BaseFreezeVotingV1 is
         uint256 freezeVotesThreshold_
     ) internal onlyInitializing {
         __Ownable_init(owner_);
-        __UUPSUpgradeable_init();
-        _updateFreezeProposalPeriod(freezeProposalPeriod_);
-        _updateFreezePeriod(freezePeriod_);
-        _updateFreezeVotesThreshold(freezeVotesThreshold_);
+        _freezeVotesThreshold = freezeVotesThreshold_;
+        _freezeProposalPeriod = freezeProposalPeriod_;
+        _freezePeriod = freezePeriod_;
     }
-
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {}
 
     function freezeProposalCreated()
         external
@@ -100,43 +93,6 @@ abstract contract BaseFreezeVotingV1 is
     function unfreeze() external virtual override onlyOwner {
         _freezeProposalCreated = 0;
         _freezeProposalVoteCount = 0;
-    }
-
-    function updateFreezeVotesThreshold(
-        uint256 freezeVotesThreshold_
-    ) external virtual override onlyOwner {
-        _updateFreezeVotesThreshold(freezeVotesThreshold_);
-    }
-
-    function updateFreezeProposalPeriod(
-        uint32 freezeProposalPeriod_
-    ) external virtual override onlyOwner {
-        _updateFreezeProposalPeriod(freezeProposalPeriod_);
-    }
-
-    function updateFreezePeriod(
-        uint32 freezePeriod_
-    ) external virtual override onlyOwner {
-        _updateFreezePeriod(freezePeriod_);
-    }
-
-    function _updateFreezeVotesThreshold(
-        uint256 freezeVotesThreshold_
-    ) internal virtual {
-        _freezeVotesThreshold = freezeVotesThreshold_;
-        emit FreezeVotesThresholdUpdated(freezeVotesThreshold_);
-    }
-
-    function _updateFreezeProposalPeriod(
-        uint32 freezeProposalPeriod_
-    ) internal virtual {
-        _freezeProposalPeriod = freezeProposalPeriod_;
-        emit FreezeProposalPeriodUpdated(freezeProposalPeriod_);
-    }
-
-    function _updateFreezePeriod(uint32 freezePeriod_) internal virtual {
-        _freezePeriod = freezePeriod_;
-        emit FreezePeriodUpdated(freezePeriod_);
     }
 
     function supportsInterface(

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.30;
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {Version} from "../Version.sol";
 import {IERC20FreezeVotingV1} from "../../interfaces/decent/deployables/IERC20FreezeVotingV1.sol";
-import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 
 contract ERC20FreezeVotingV1 is

--- a/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
@@ -4,9 +4,6 @@ pragma solidity ^0.8.30;
 interface IBaseFreezeVotingV1 {
     event FreezeVoteCast(address indexed voter, uint256 votesCast);
     event FreezeProposalCreated(address indexed creator);
-    event FreezeVotesThresholdUpdated(uint256 freezeVotesThreshold);
-    event FreezePeriodUpdated(uint32 freezePeriod);
-    event FreezeProposalPeriodUpdated(uint32 freezeProposalPeriod);
 
     function freezeProposalCreated() external view returns (uint48);
 
@@ -26,10 +23,4 @@ interface IBaseFreezeVotingV1 {
     function isFrozen() external view returns (bool);
 
     function unfreeze() external;
-
-    function updateFreezeVotesThreshold(uint256 _freezeVotesThreshold) external;
-
-    function updateFreezeProposalPeriod(uint32 _freezeProposalPeriod) external;
-
-    function updateFreezePeriod(uint32 _freezePeriod) external;
 }

--- a/contracts/mocks/MockFreezeVoting.sol
+++ b/contracts/mocks/MockFreezeVoting.sol
@@ -3,68 +3,27 @@ pragma solidity ^0.8.30;
 
 import {IBaseFreezeVotingV1} from "../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 
-/**
- * A mock contract implementing IBaseFreezeVotingV1 for testing.
- */
 contract MockFreezeVoting is IBaseFreezeVotingV1 {
     bool private _isFrozen;
     uint256 private _freezeVotesThreshold;
     uint32 private _freezeProposalPeriod;
     uint32 private _freezePeriod;
 
-    /**
-     * Sets whether the mock should return that the DAO is frozen.
-     */
     function setIsFrozen(bool frozen) external {
         _isFrozen = frozen;
     }
 
-    /**
-     * @inheritdoc IBaseFreezeVotingV1
-     */
     function isFrozen() external view returns (bool) {
         return _isFrozen;
     }
 
     function castFreezeVote() external {
-        // Mock implementation - does nothing except emit an event for testing
         emit FreezeVoteCast(msg.sender);
     }
 
-    /**
-     * @inheritdoc IBaseFreezeVotingV1
-     */
     function unfreeze() external {
         _isFrozen = false;
         emit DAOUnfrozen(msg.sender);
-    }
-
-    /**
-     * @inheritdoc IBaseFreezeVotingV1
-     */
-    function updateFreezeVotesThreshold(
-        uint256 freezeVotesThreshold_
-    ) external override {
-        _freezeVotesThreshold = freezeVotesThreshold_;
-        emit FreezeVotesThresholdUpdated(freezeVotesThreshold_);
-    }
-
-    /**
-     * @inheritdoc IBaseFreezeVotingV1
-     */
-    function updateFreezeProposalPeriod(
-        uint32 freezeProposalPeriod_
-    ) external override {
-        _freezeProposalPeriod = freezeProposalPeriod_;
-        emit FreezeProposalPeriodUpdated(freezeProposalPeriod_);
-    }
-
-    /**
-     * @inheritdoc IBaseFreezeVotingV1
-     */
-    function updateFreezePeriod(uint32 freezePeriod_) external override {
-        _freezePeriod = freezePeriod_;
-        emit FreezePeriodUpdated(freezePeriod_);
     }
 
     // Mock events for testing

--- a/contracts/mocks/concretes/deployables/freeze-voting/ConcreteBaseFreezeVotingV1.sol
+++ b/contracts/mocks/concretes/deployables/freeze-voting/ConcreteBaseFreezeVotingV1.sol
@@ -3,36 +3,19 @@ pragma solidity ^0.8.30;
 
 import {BaseFreezeVotingV1} from "../../../../deployables/freeze-voting/BaseFreezeVotingV1.sol";
 
-/**
- * A minimal concrete implementation of BaseFreezeVotingV1 for testing.
- */
 contract ConcreteBaseFreezeVotingV1 is BaseFreezeVotingV1 {
-    /**
-     * Initialize function, will be triggered when a new instance is deployed.
-     *
-     * @param _owner The owner of the contract
-     * @param _freezeVotesThreshold The number of votes required to activate a freeze
-     * @param _freezeProposalPeriod The number of blocks a freeze proposal has to succeed
-     * @param _freezePeriod The number of blocks a freeze lasts
-     */
     function initialize(
-        address _owner,
-        uint256 _freezeVotesThreshold,
-        uint32 _freezeProposalPeriod,
-        uint32 _freezePeriod
+        address owner_,
+        uint256 freezeVotesThreshold_,
+        uint32 freezeProposalPeriod_,
+        uint32 freezePeriod_
     ) public initializer {
-        __Ownable_init(_owner);
-        __UUPSUpgradeable_init();
-        _updateFreezeVotesThreshold(_freezeVotesThreshold);
-        _updateFreezeProposalPeriod(_freezeProposalPeriod);
-        _updateFreezePeriod(_freezePeriod);
+        __Ownable_init(owner_);
+        _freezeVotesThreshold = freezeVotesThreshold_;
+        _freezeProposalPeriod = freezeProposalPeriod_;
+        _freezePeriod = freezePeriod_;
     }
 
-    /**
-     * Implements the abstract castFreezeVote function.
-     *
-     * Each call counts as one vote by default, or as many votes as set by setMockVotePower.
-     */
     function castFreezeVote() external {
         // If no freeze proposal exists yet, create one
         if (_freezeProposalCreated == 0) {

--- a/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
@@ -10,7 +10,6 @@ import {
   IERC165__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
-import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
 // Helper function for deploying ConcreteBaseFreezeVoting instances using ERC1967Proxy
 async function deployConcreteBaseFreezeVotingProxy(
@@ -45,7 +44,6 @@ describe('BaseFreezeVotingV1', () => {
   let voter1: SignerWithAddress;
   let voter2: SignerWithAddress;
   let voter3: SignerWithAddress;
-  let nonOwner: SignerWithAddress;
 
   // contracts
   let masterCopy: string;
@@ -58,7 +56,7 @@ describe('BaseFreezeVotingV1', () => {
 
   beforeEach(async () => {
     // Get signers
-    [proxyDeployer, owner, voter1, voter2, voter3, nonOwner] = await ethers.getSigners();
+    [proxyDeployer, owner, voter1, voter2, voter3] = await ethers.getSigners();
 
     // Deploy implementation
     const implementation = await new ConcreteBaseFreezeVotingV1__factory(proxyDeployer).deploy();
@@ -278,72 +276,6 @@ describe('BaseFreezeVotingV1', () => {
     });
   });
 
-  describe('Parameter Updates', () => {
-    it('should allow owner to update freezeVotesThreshold', async () => {
-      const newThreshold = 5;
-
-      await expect(freezeVoting.connect(owner).updateFreezeVotesThreshold(newThreshold))
-        .to.emit(freezeVoting, 'FreezeVotesThresholdUpdated')
-        .withArgs(newThreshold);
-
-      expect(await freezeVoting.freezeVotesThreshold()).to.equal(newThreshold);
-    });
-
-    it('should allow owner to update freezeProposalPeriod', async () => {
-      const newPeriod = 15;
-
-      await expect(freezeVoting.connect(owner).updateFreezeProposalPeriod(newPeriod))
-        .to.emit(freezeVoting, 'FreezeProposalPeriodUpdated')
-        .withArgs(newPeriod);
-
-      expect(await freezeVoting.freezeProposalPeriod()).to.equal(newPeriod);
-    });
-
-    it('should allow owner to update freezePeriod', async () => {
-      const newPeriod = 20;
-
-      await expect(freezeVoting.connect(owner).updateFreezePeriod(newPeriod))
-        .to.emit(freezeVoting, 'FreezePeriodUpdated')
-        .withArgs(newPeriod);
-
-      expect(await freezeVoting.freezePeriod()).to.equal(newPeriod);
-    });
-
-    it('should not allow non-owner to update freezeVotesThreshold', async () => {
-      await expect(
-        freezeVoting.connect(voter1).updateFreezeVotesThreshold(5),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should not allow non-owner to update freezeProposalPeriod', async () => {
-      await expect(
-        freezeVoting.connect(voter1).updateFreezeProposalPeriod(15),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should not allow non-owner to update freezePeriod', async () => {
-      await expect(
-        freezeVoting.connect(voter1).updateFreezePeriod(20),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should affect freeze status when threshold is updated', async () => {
-      // Cast votes but below the new threshold we'll set
-      await freezeVoting.connect(voter1).castFreezeVote();
-      await freezeVoting.connect(voter2).castFreezeVote();
-      await freezeVoting.connect(voter3).castFreezeVote();
-
-      // Should be frozen with the default threshold of 3
-      void expect(await freezeVoting.isFrozen()).to.be.true;
-
-      // Increase threshold to 4
-      await freezeVoting.connect(owner).updateFreezeVotesThreshold(4);
-
-      // Should no longer be frozen as we're below the new threshold
-      void expect(await freezeVoting.isFrozen()).to.be.false;
-    });
-  });
-
   describe('User Has Voted Tracking', () => {
     it('should correctly track if a user has voted on a proposal', async () => {
       // Initial state - user has not voted
@@ -390,46 +322,23 @@ describe('BaseFreezeVotingV1', () => {
   });
 
   describe('ERC165', function () {
-    let iBaseFreezeVotingV1InterfaceId: string;
-    let iERC165InterfaceId: string;
-
-    beforeEach(async function () {
-      // Dynamically calculate interface IDs
-      const IBaseFreezeVotingV1Interface = IBaseFreezeVotingV1__factory.createInterface();
-      iBaseFreezeVotingV1InterfaceId = calculateInterfaceId(IBaseFreezeVotingV1Interface);
-
-      const IERC165Interface = IERC165__factory.createInterface();
-      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
-    });
-
     it('Should support IERC165 interface', async function () {
-      // Cast the freezeVoting instance to any type to bypass TypeScript checking
-      // since we know the actual contract implements supportsInterface
-      const supported = await freezeVoting.supportsInterface(iERC165InterfaceId);
+      const supported = await freezeVoting.supportsInterface(
+        calculateInterfaceId(IERC165__factory.createInterface()),
+      );
       void expect(supported).to.be.true;
     });
 
     it('Should support IBaseFreezeVotingV1 interface', async function () {
-      const supported = await freezeVoting.supportsInterface(iBaseFreezeVotingV1InterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IBaseFreezeVotingV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should not support random interface', async function () {
-      const randomInterfaceId = '0x12345678';
-      const supported = await freezeVoting.supportsInterface(randomInterfaceId);
-      void expect(supported).to.be.false;
-    });
-  });
-
-  describe('UUPS Upgradeability', function () {
-    runUUPSUpgradeabilityTests({
-      getContract: () => freezeVoting,
-      createNewImplementation: async () => {
-        const newImplementation = await new ConcreteBaseFreezeVotingV1__factory(owner).deploy();
-        return newImplementation;
-      },
-      owner: () => owner,
-      nonOwner: () => nonOwner,
+      void expect(await freezeVoting.supportsInterface('0x12345678')).to.be.false;
     });
   });
 });

--- a/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC20FreezeVotingV1.test.ts
@@ -14,7 +14,6 @@ import {
   MockERC20Votes__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
-import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
 // Helper function for deploying ERC20FreezeVotingV1 instances using ERC1967Proxy
 async function deployERC20FreezeVotingProxy(
@@ -57,7 +56,6 @@ describe('ERC20FreezeVotingV1', () => {
   let voter2: SignerWithAddress;
   let voter3: SignerWithAddress;
   let nonVoter: SignerWithAddress;
-  let nonOwner: SignerWithAddress;
 
   // contracts
   let masterCopy: string;
@@ -76,7 +74,7 @@ describe('ERC20FreezeVotingV1', () => {
 
   beforeEach(async () => {
     // Get signers
-    [proxyDeployer, owner, voter1, voter2, voter3, nonVoter, nonOwner] = await ethers.getSigners();
+    [proxyDeployer, owner, voter1, voter2, voter3, nonVoter] = await ethers.getSigners();
 
     // Deploy the voting token
     votesToken = await new MockERC20Votes__factory(proxyDeployer).deploy();
@@ -356,78 +354,6 @@ describe('ERC20FreezeVotingV1', () => {
     });
   });
 
-  describe('Parameter Updates', () => {
-    it('should allow owner to update freezeVotesThreshold', async () => {
-      const newThreshold = 500;
-
-      await expect(freezeVoting.connect(owner).updateFreezeVotesThreshold(newThreshold))
-        .to.emit(freezeVoting, 'FreezeVotesThresholdUpdated')
-        .withArgs(newThreshold);
-
-      expect(await freezeVoting.freezeVotesThreshold()).to.equal(newThreshold);
-    });
-
-    it('should allow owner to update freezeProposalPeriod', async () => {
-      const newPeriod = 15;
-
-      await expect(freezeVoting.connect(owner).updateFreezeProposalPeriod(newPeriod))
-        .to.emit(freezeVoting, 'FreezeProposalPeriodUpdated')
-        .withArgs(newPeriod);
-
-      expect(await freezeVoting.freezeProposalPeriod()).to.equal(newPeriod);
-    });
-
-    it('should allow owner to update freezePeriod', async () => {
-      const newPeriod = 20;
-
-      await expect(freezeVoting.connect(owner).updateFreezePeriod(newPeriod))
-        .to.emit(freezeVoting, 'FreezePeriodUpdated')
-        .withArgs(newPeriod);
-
-      expect(await freezeVoting.freezePeriod()).to.equal(newPeriod);
-    });
-
-    it('should not allow non-owner to update freezeVotesThreshold', async () => {
-      await expect(
-        freezeVoting.connect(voter1).updateFreezeVotesThreshold(500),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should not allow non-owner to update freezeProposalPeriod', async () => {
-      await expect(
-        freezeVoting.connect(voter1).updateFreezeProposalPeriod(15),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should not allow non-owner to update freezePeriod', async () => {
-      await expect(
-        freezeVoting.connect(voter1).updateFreezePeriod(20),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should affect freeze status when threshold is updated', async () => {
-      // Set up mock past votes for all voters
-      const voteTimestamp = await time.latest();
-      await votesToken.setPastVotes(voter1.address, voteTimestamp, VOTER1_TOKENS);
-      await votesToken.setPastVotes(voter2.address, voteTimestamp, VOTER2_TOKENS);
-      await votesToken.setPastVotes(voter3.address, voteTimestamp, VOTER3_TOKENS);
-
-      // Cast votes to meet the threshold of 300
-      await freezeVoting.connect(voter1).castFreezeVote();
-      await freezeVoting.connect(voter2).castFreezeVote();
-      await freezeVoting.connect(voter3).castFreezeVote();
-
-      // Total votes: 100 + 150 + 200 = 450, above threshold of 300
-      void expect(await freezeVoting.isFrozen()).to.be.true;
-
-      // Increase threshold to 500
-      await freezeVoting.connect(owner).updateFreezeVotesThreshold(500);
-
-      // Should no longer be frozen as 450 < 500
-      void expect(await freezeVoting.isFrozen()).to.be.false;
-    });
-  });
-
   describe('User Has Voted Tracking', () => {
     beforeEach(async () => {
       // Set up mock past votes for voter1
@@ -527,18 +453,6 @@ describe('ERC20FreezeVotingV1', () => {
 
     it('should not support a random interface', async () => {
       void expect(await freezeVoting.supportsInterface('0x12345678')).to.be.false;
-    });
-  });
-
-  describe('UUPS Upgradeability', function () {
-    runUUPSUpgradeabilityTests({
-      getContract: () => freezeVoting,
-      createNewImplementation: async () => {
-        const newImplementation = await new ERC20FreezeVotingV1__factory(owner).deploy();
-        return newImplementation;
-      },
-      owner: () => owner,
-      nonOwner: () => nonOwner,
     });
   });
 });

--- a/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/ERC721FreezeVotingV1.test.ts
@@ -16,7 +16,6 @@ import {
   MockERC721VotingStrategy__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
-import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
 // Helper function for deploying ERC721FreezeVotingV1 proxy instances using ERC1967Proxy
 async function deployERC721FreezeVotingProxy(
@@ -64,7 +63,6 @@ describe('ERC721FreezeVotingV1', () => {
   let voter2: SignerWithAddress;
   let voter3: SignerWithAddress;
   let nonVoter: SignerWithAddress;
-  let nonOwner: SignerWithAddress;
 
   // contracts
   let masterCopy: string;
@@ -92,7 +90,7 @@ describe('ERC721FreezeVotingV1', () => {
 
   beforeEach(async () => {
     // Get signers
-    [proxyDeployer, owner, voter1, voter2, voter3, nonVoter, nonOwner] = await ethers.getSigners();
+    [proxyDeployer, owner, voter1, voter2, voter3, nonVoter] = await ethers.getSigners();
 
     // Deploy NFT collections
     nftCollection1 = await new MockERC721__factory(proxyDeployer).deploy();
@@ -402,70 +400,6 @@ describe('ERC721FreezeVotingV1', () => {
     });
   });
 
-  describe('Parameter Updates', () => {
-    it('should allow owner to update freezeVotesThreshold', async () => {
-      const newThreshold = 5;
-
-      await expect(freezeVoting.connect(owner).updateFreezeVotesThreshold(newThreshold))
-        .to.emit(freezeVoting, 'FreezeVotesThresholdUpdated')
-        .withArgs(newThreshold);
-
-      expect(await freezeVoting.freezeVotesThreshold()).to.equal(newThreshold);
-    });
-
-    it('should allow owner to update freezeProposalPeriod', async () => {
-      const newPeriod = 15;
-
-      await expect(freezeVoting.connect(owner).updateFreezeProposalPeriod(newPeriod))
-        .to.emit(freezeVoting, 'FreezeProposalPeriodUpdated')
-        .withArgs(newPeriod);
-
-      expect(await freezeVoting.freezeProposalPeriod()).to.equal(newPeriod);
-    });
-
-    it('should allow owner to update freezePeriod', async () => {
-      const newPeriod = 20;
-
-      await expect(freezeVoting.connect(owner).updateFreezePeriod(newPeriod))
-        .to.emit(freezeVoting, 'FreezePeriodUpdated')
-        .withArgs(newPeriod);
-
-      expect(await freezeVoting.freezePeriod()).to.equal(newPeriod);
-    });
-
-    it('should not allow non-owner to update freezeVotesThreshold', async () => {
-      await expect(
-        freezeVoting.connect(voter1).updateFreezeVotesThreshold(5),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should not allow non-owner to update freezeProposalPeriod', async () => {
-      await expect(
-        freezeVoting.connect(voter1).updateFreezeProposalPeriod(15),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should not allow non-owner to update freezePeriod', async () => {
-      await expect(
-        freezeVoting.connect(voter1).updateFreezePeriod(20),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should affect freeze status when threshold is updated', async () => {
-      // Cast votes to meet the threshold of 3
-      await freezeVoting.connect(voter3).castFreezeVote(voter3TokenAddresses, voter3TokenIds);
-
-      // DAO should be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.true;
-
-      // Increase threshold to 4
-      await freezeVoting.connect(owner).updateFreezeVotesThreshold(4);
-
-      // Should no longer be frozen as 3 < 4
-      void expect(await freezeVoting.isFrozen()).to.be.false;
-    });
-  });
-
   describe('Token Has Voted Tracking', () => {
     it('should correctly track if a token has been used to vote', async () => {
       const createdTimestamp = 0; // Initial state
@@ -575,18 +509,6 @@ describe('ERC721FreezeVotingV1', () => {
 
     it('should not support a random interface', async () => {
       void expect(await freezeVoting.supportsInterface('0x12345678')).to.be.false;
-    });
-  });
-
-  describe('UUPS Upgradeability', function () {
-    runUUPSUpgradeabilityTests({
-      getContract: () => freezeVoting,
-      createNewImplementation: async () => {
-        const newImplementation = await new ERC721FreezeVotingV1__factory(owner).deploy();
-        return newImplementation;
-      },
-      owner: () => owner,
-      nonOwner: () => nonOwner,
     });
   });
 });

--- a/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
@@ -14,7 +14,6 @@ import {
   MultisigFreezeVotingV1__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
-import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
 // Helper function for deploying MultisigFreezeVotingV1 proxy instances using ERC1967Proxy
 async function deployMultisigFreezeVotingProxy(
@@ -56,7 +55,7 @@ describe('MultisigFreezeVotingV1', () => {
   let safeOwner1: SignerWithAddress;
   let safeOwner2: SignerWithAddress;
   let nonSafeOwner: SignerWithAddress;
-  let nonOwner: SignerWithAddress;
+
   // contracts
   let masterCopy: string;
   let freezeVoting: MultisigFreezeVotingV1;
@@ -69,8 +68,7 @@ describe('MultisigFreezeVotingV1', () => {
 
   beforeEach(async () => {
     // Get signers
-    [proxyDeployer, owner, safeOwner1, safeOwner2, nonSafeOwner, nonOwner] =
-      await ethers.getSigners();
+    [proxyDeployer, owner, safeOwner1, safeOwner2, nonSafeOwner] = await ethers.getSigners();
 
     // Deploy mock Safe
     mockSafe = await new MockSafe__factory(proxyDeployer).deploy();
@@ -360,79 +358,6 @@ describe('MultisigFreezeVotingV1', () => {
     });
   });
 
-  describe('Parameter Updates', () => {
-    it('should allow owner to update freezeVotesThreshold', async () => {
-      const newThreshold = 3;
-
-      await expect(freezeVoting.connect(owner).updateFreezeVotesThreshold(newThreshold))
-        .to.emit(freezeVoting, 'FreezeVotesThresholdUpdated')
-        .withArgs(newThreshold);
-
-      expect(await freezeVoting.freezeVotesThreshold()).to.equal(newThreshold);
-    });
-
-    it('should allow owner to update freezeProposalPeriod', async () => {
-      const newPeriod = 15;
-
-      await expect(freezeVoting.connect(owner).updateFreezeProposalPeriod(newPeriod))
-        .to.emit(freezeVoting, 'FreezeProposalPeriodUpdated')
-        .withArgs(newPeriod);
-
-      expect(await freezeVoting.freezeProposalPeriod()).to.equal(newPeriod);
-    });
-
-    it('should allow owner to update freezePeriod', async () => {
-      const newPeriod = 20;
-
-      await expect(freezeVoting.connect(owner).updateFreezePeriod(newPeriod))
-        .to.emit(freezeVoting, 'FreezePeriodUpdated')
-        .withArgs(newPeriod);
-
-      expect(await freezeVoting.freezePeriod()).to.equal(newPeriod);
-    });
-
-    it('should not allow non-owner to update freezeVotesThreshold', async () => {
-      await expect(
-        freezeVoting.connect(nonSafeOwner).updateFreezeVotesThreshold(3),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should not allow non-owner to update freezeProposalPeriod', async () => {
-      await expect(
-        freezeVoting.connect(nonSafeOwner).updateFreezeProposalPeriod(15),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should not allow non-owner to update freezePeriod', async () => {
-      await expect(
-        freezeVoting.connect(nonSafeOwner).updateFreezePeriod(20),
-      ).to.be.revertedWithCustomError(freezeVoting, 'OwnableUnauthorizedAccount');
-    });
-
-    it('should affect freeze status when threshold is updated', async () => {
-      // Set first Safe owner
-      await mockSafe.setOwner(safeOwner1.address);
-
-      // First vote
-      await freezeVoting.connect(safeOwner1).castFreezeVote();
-
-      // Change Safe owner for second vote
-      await mockSafe.setOwner(safeOwner2.address);
-
-      // Second vote to reach threshold
-      await freezeVoting.connect(safeOwner2).castFreezeVote();
-
-      // DAO should be frozen with threshold of 2 and 2 votes
-      void expect(await freezeVoting.isFrozen()).to.be.true;
-
-      // Increase threshold to 3
-      await freezeVoting.connect(owner).updateFreezeVotesThreshold(3);
-
-      // Should no longer be frozen as 2 < 3
-      void expect(await freezeVoting.isFrozen()).to.be.false;
-    });
-  });
-
   describe('User Has Voted Tracking', () => {
     it('should correctly track if a user has voted on a proposal', async () => {
       // Set Safe owner
@@ -527,18 +452,6 @@ describe('MultisigFreezeVotingV1', () => {
 
     it('should not support a random interface', async () => {
       void expect(await freezeVoting.supportsInterface('0x12345678')).to.be.false;
-    });
-  });
-
-  describe('UUPS Upgradeability', function () {
-    runUUPSUpgradeabilityTests({
-      getContract: () => freezeVoting,
-      createNewImplementation: async () => {
-        const newImplementation = await new MultisigFreezeVotingV1__factory(owner).deploy();
-        return newImplementation;
-      },
-      owner: () => owner,
-      nonOwner: () => nonOwner,
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/311

Fixes [ENG-1061](https://linear.app/decent-labs/issue/ENG-1061/simplify-basefreezevotingv1-remove-uups-and-parameter-setters)

This commit refactors the `BaseFreezeVotingV1` abstract contract to simplify its design and responsibilities. The key changes include:

1.  **Removal of UUPS Upgradeability:**
    *   The contract no longer inherits from OpenZeppelin's `UUPSUpgradeable`.
    *   The internal `__UUPSUpgradeable_init()` call has been removed from `__BaseFreezeVotingV1_init`.
    *   The `_authorizeUpgrade` function has been removed.
    *   This change implies that contracts inheriting from `BaseFreezeVotingV1` will manage their own upgradeability if needed, or they are intended to be non-upgradeable.

2.  **Removal of Parameter Update Functions and Events:**
    *   The public functions `updateFreezeVotesThreshold`, `updateFreezeProposalPeriod`, and `updateFreezePeriod` have been removed.
    *   The internal helper functions `_updateFreezeVotesThreshold`, `_updateFreezeProposalPeriod`, and `_updateFreezePeriod` have also been removed.
    *   Consequently, the events `FreezeVotesThresholdUpdated`, `FreezePeriodUpdated`, and `FreezeProposalPeriodUpdated` have been removed from `IBaseFreezeVotingV1` and are no longer emitted.
    *   Freeze parameters (`_freezeVotesThreshold`, `_freezeProposalPeriod`, `_freezePeriod`) are now set directly within the `__BaseFreezeVotingV1_init` internal initializer function. This means these parameters are intended to be immutable after deployment via the concrete contract's `initialize` function.

3.  **Interface (`IBaseFreezeVotingV1.sol`) Update:**
    *   Removed declarations for the deleted update functions and their associated events.

4.  **Mock Contract Updates:**
    *   `MockFreezeVoting.sol`: Removed implementations of the deleted update functions and their event emissions.
    *   `ConcreteBaseFreezeVotingV1.sol`: The `initialize` function now directly sets the internal freeze parameter state variables instead of calling the removed internal update helper functions.

5.  **Test Suite (`BaseFreezeVotingV1.test.ts`, etc.) Updates:**
    *   Removed all tests related to UUPS upgradeability for `BaseFreezeVotingV1`.
    *   Removed tests for the `updateFreezeVotesThreshold`, `updateFreezeProposalPeriod`, and `updateFreezePeriod` functions, including checks for owner-only access and event emissions.
    *   Removed the `nonOwner` signer from test setups where it was only used for testing non-owner access to these removed update functions.
    *   Streamlined ERC165 tests by calculating interface IDs directly in assertions.

**Rationale:**

This simplification makes `BaseFreezeVotingV1` a more focused base contract for freeze voting logic, leaving upgradeability and parameter immutability decisions to the concrete inheriting contracts. Setting parameters only at initialization makes the contract behavior more predictable post-deployment.