### PR TITLE
feat: Add adapter lookup mappings and view functions to StrategyV1

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -30,6 +30,8 @@ contract StrategyV1 is
 
     address[] internal _votingAdapters;
     address[] internal _proposerAdapters;
+    mapping(address => bool) internal _isVotingAdapter;
+    mapping(address => bool) internal _isProposerAdapter;
 
     modifier onlyProposalInitializer() {
         if (msg.sender != _proposalInitializer)
@@ -50,6 +52,19 @@ contract StrategyV1 is
         address[] memory proposerAdapters_,
         address lightAccountFactory_
     ) public virtual override initializer {
+        if (votingAdapters_.length == 0) {
+            revert NoVotingAdapters();
+        }
+
+        if (proposerAdapters_.length == 0) {
+            revert NoProposerAdapters();
+        }
+
+        if (
+            basisNumerator_ >= BASIS_DENOMINATOR ||
+            basisNumerator_ < BASIS_DENOMINATOR / 2
+        ) revert InvalidBasisNumerator();
+
         __ERC4337VoterSupportV1_init(lightAccountFactory_);
         _proposalInitializer = proposalInitializer_;
         _votingPeriod = votingPeriod_;
@@ -58,18 +73,12 @@ contract StrategyV1 is
         _votingAdapters = votingAdapters_;
         _proposerAdapters = proposerAdapters_;
 
-        if (_proposerAdapters.length == 0) {
-            revert NoProposerAdapters();
+        for (uint256 i = 0; i < votingAdapters_.length; i++) {
+            _isVotingAdapter[votingAdapters_[i]] = true;
         }
-
-        if (_votingAdapters.length == 0) {
-            revert NoVotingAdapters();
+        for (uint256 i = 0; i < proposerAdapters_.length; i++) {
+            _isProposerAdapter[proposerAdapters_[i]] = true;
         }
-
-        if (
-            basisNumerator_ >= BASIS_DENOMINATOR ||
-            basisNumerator_ < BASIS_DENOMINATOR / 2
-        ) revert InvalidBasisNumerator();
     }
 
     function proposalInitializer()
@@ -114,6 +123,18 @@ contract StrategyV1 is
         returns (address[] memory)
     {
         return _votingAdapters;
+    }
+
+    function isVotingAdapter(
+        address votingAdapter_
+    ) external view virtual override returns (bool) {
+        return _isVotingAdapter[votingAdapter_];
+    }
+
+    function isProposerAdapter(
+        address proposerAdapter_
+    ) external view virtual override returns (bool) {
+        return _isProposerAdapter[proposerAdapter_];
     }
 
     function proposerAdapters()
@@ -264,26 +285,26 @@ contract StrategyV1 is
     }
 
     function isProposer(
-        address _address,
-        address _proposerAdapter,
-        bytes calldata _proposerAdapterData
+        address address_,
+        address proposerAdapter_,
+        bytes calldata proposerAdapterData_
     ) external view virtual override returns (bool) {
         bool foundAdapter = false;
         for (uint256 i = 0; i < _proposerAdapters.length; i++) {
-            if (_proposerAdapters[i] == _proposerAdapter) {
+            if (_proposerAdapters[i] == proposerAdapter_) {
                 foundAdapter = true;
                 break;
             }
         }
 
         if (!foundAdapter) {
-            revert InvalidProposerAdapter(_proposerAdapter);
+            revert InvalidProposerAdapter(proposerAdapter_);
         }
 
         return
-            IProposerAdapterBaseV1(_proposerAdapter).isProposer(
-                _address,
-                _proposerAdapterData
+            IProposerAdapterBaseV1(proposerAdapter_).isProposer(
+                address_,
+                proposerAdapterData_
             );
     }
 

--- a/contracts/interfaces/decent/deployables/IStrategyBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyBaseV1.sol
@@ -5,24 +5,32 @@ interface IStrategyBaseV1 {
     error InvalidProposerAdapter(address _proposerAdapter);
 
     function isProposer(
-        address _address,
-        address _proposerAdapter,
-        bytes calldata _proposerAdapterData
+        address address_,
+        address proposerAdapter_,
+        bytes calldata proposerAdapterData_
     ) external view returns (bool);
 
     function initializeProposal(
-        uint32 _proposalId,
-        bytes32[] memory _txHashes,
-        bytes memory _proposalInitializerData
+        uint32 proposalId_,
+        bytes32[] memory txHashes_,
+        bytes memory proposalInitializerData_
     ) external;
 
-    function isPassed(uint32 _proposalId) external view returns (bool);
+    function isPassed(uint32 proposalId_) external view returns (bool);
 
     function getVotingTimestamps(
-        uint32 _proposalId
+        uint32 proposalId_
     ) external view returns (uint48 startTime, uint48 endTime);
 
     function getVotingStartBlock(
-        uint32 _proposalId
+        uint32 proposalId_
     ) external view returns (uint32 votingStartBlock);
+
+    function isVotingAdapter(
+        address votingAdapter_
+    ) external view returns (bool);
+
+    function isProposerAdapter(
+        address proposerAdapter_
+    ) external view returns (bool);
 }

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -13,6 +13,8 @@ contract MockVotingStrategy is IStrategyBaseV1 {
     mapping(uint32 => bool) private _isPassed;
     mapping(uint32 => TimestampPoints) private _proposalTimestamps;
     mapping(uint32 => uint32) public mockVotingStartBlock;
+    mapping(address => bool) private _isVotingAdapter;
+    mapping(address => bool) private _isProposerAdapter;
 
     constructor(address _proposer) {
         proposer = _proposer;
@@ -49,6 +51,18 @@ contract MockVotingStrategy is IStrategyBaseV1 {
         return mockVotingStartBlock[_proposalId];
     }
 
+    function isVotingAdapter(
+        address votingAdapter_
+    ) external view override returns (bool) {
+        return _isVotingAdapter[votingAdapter_];
+    }
+
+    function isProposerAdapter(
+        address proposerAdapter_
+    ) external view override returns (bool) {
+        return _isProposerAdapter[proposerAdapter_];
+    }
+
     // mock setters
 
     function setIsPassed(uint32 proposalId, bool passed) external {
@@ -71,5 +85,19 @@ contract MockVotingStrategy is IStrategyBaseV1 {
         uint32 startBlock
     ) external {
         mockVotingStartBlock[proposalId] = startBlock;
+    }
+
+    function setVotingAdapter(
+        address votingAdapter_,
+        bool isVotingAdapter_
+    ) external {
+        _isVotingAdapter[votingAdapter_] = isVotingAdapter_;
+    }
+
+    function setProposerAdapter(
+        address proposerAdapter_,
+        bool isProposerAdapter_
+    ) external {
+        _isProposerAdapter[proposerAdapter_] = isProposerAdapter_;
     }
 }

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -265,6 +265,60 @@ describe('StrategyV1', () => {
     });
   });
 
+  describe('isVotingAdapter', () => {
+    it('should return true for a configured voting adapter', async () => {
+      const configuredAdapter = defaultInitialVotingAdapters[0];
+      void expect(await strategy.isVotingAdapter(configuredAdapter)).to.be.true;
+    });
+
+    it('should return false for an unconfigured address', async () => {
+      void expect(await strategy.isVotingAdapter(nonOwner.address)).to.be.false;
+    });
+
+    it('should return false for a configured proposer adapter that is not a voting adapter', async () => {
+      const proposerOnlyAdapter = await new MockProposerAdapter__factory(deployer).deploy();
+      await proposerOnlyAdapter.waitForDeployment();
+      const testStrategy = await deployStrategyProxy(
+        proposerInitializer.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        defaultInitialVotingAdapters, // mockAdapter1
+        [await proposerOnlyAdapter.getAddress()],
+        lightAccountFactoryMockAddress,
+      );
+      void expect(await testStrategy.isVotingAdapter(await proposerOnlyAdapter.getAddress())).to.be
+        .false;
+    });
+  });
+
+  describe('isProposerAdapter', () => {
+    it('should return true for a configured proposer adapter', async () => {
+      const configuredAdapter = defaultInitialProposerAdapters[0];
+      void expect(await strategy.isProposerAdapter(configuredAdapter)).to.be.true;
+    });
+
+    it('should return false for an unconfigured address', async () => {
+      void expect(await strategy.isProposerAdapter(nonOwner.address)).to.be.false;
+    });
+
+    it('should return false for a configured voting adapter that is not a proposer adapter', async () => {
+      const votingOnlyAdapter = await new MockVotingAdapter__factory(deployer).deploy();
+      await votingOnlyAdapter.waitForDeployment();
+      const testStrategy = await deployStrategyProxy(
+        proposerInitializer.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        [await votingOnlyAdapter.getAddress()],
+        defaultInitialProposerAdapters, // mockProposerAdapter1
+        lightAccountFactoryMockAddress,
+      );
+      void expect(await testStrategy.isProposerAdapter(await votingOnlyAdapter.getAddress())).to.be
+        .false;
+    });
+  });
+
   describe('initializeProposal', () => {
     let defaultProposalId: number;
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/314

Fixes [ENG-1072](https://linear.app/decent-labs/issue/ENG-1072/implement-efficient-adapter-lookup-in-strategyv1)

This commit enhances the `StrategyV1` contract by introducing two internal mappings:
-   `_votingAdapter`: `mapping(address => bool)`
-   `_proposerAdapter`: `mapping(address => bool)`

These mappings are populated during the `initialize` function based on the `votingAdapters_` and `proposerAdapters_` arrays passed in. They provide an O(1) lookup mechanism to check if a given address is a configured voting or proposer adapter.

Two new public `view` functions have been added to expose this information:
-   `votingAdapter(address votingAdapter_) external view returns (bool)`
-   `proposerAdapter(address proposerAdapter_) external view returns (bool)`

The `IStrategyBaseV1` interface has been updated to include these new view functions. The `MockVotingStrategy` has also been updated to include stub implementations for these functions.

**Key Changes:**

*   **`StrategyV1.sol`:**
    *   Added `_votingAdapter` and `_proposerAdapter` internal mappings.
    *   The `initialize` function now iterates through the input adapter arrays and populates these mappings.
    *   Added `votingAdapter(address)` and `proposerAdapter(address)` public view functions.
*   **`IStrategyBaseV1.sol`:**
    *   Added declarations for `votingAdapter(address)` and `proposerAdapter(address)`.
*   **`MockVotingStrategy.sol`:**
    *   Added internal mappings and public view functions to mock the new adapter lookup functionality.
*   **`StrategyV1.test.ts`:**
    *   Added new test suites for the `votingAdapter` and `proposerAdapter` functions to verify their correctness, including checks for configured and unconfigured adapters, and cross-checking between voting and proposer adapter types.

**Rationale:**

These changes provide a more efficient way to check if an adapter is part of the strategy's configuration, which can be useful both internally and for external inspection. Previously, checking if an adapter was configured would require iterating through the `_votingAdapters` or `_proposerAdapters` arrays.