### PR TITLE
refactor: Decentralize ERC165 and streamline IVersion support

### DIFF
--- a/contracts/deployables/Version.sol
+++ b/contracts/deployables/Version.sol
@@ -2,16 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IVersion} from "../interfaces/decent/deployables/IVersion.sol";
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-abstract contract Version is IVersion, ERC165 {
+abstract contract Version is IVersion {
     function version() public view virtual override returns (uint16);
-
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override returns (bool) {
-        return
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
-    }
 }

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IDecentPaymasterV1} from "../../interfaces/decent/deployables/IDecentPaymasterV1.sol";
 import {IFunctionValidator} from "../../interfaces/decent/deployables/IFunctionValidator.sol";
 import {ISmartAccountValidationV1} from "../../interfaces/decent/deployables/ISmartAccountValidationV1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {BasePaymasterV1} from "./BasePaymasterV1.sol";
 import {SmartAccountValidationV1} from "./SmartAccountValidationV1.sol";
 import {Version} from "../Version.sol";
@@ -13,6 +14,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 contract DecentPaymasterV1 is
     IDecentPaymasterV1,
@@ -20,7 +22,8 @@ contract DecentPaymasterV1 is
     BasePaymasterV1,
     SmartAccountValidationV1,
     Ownable2StepUpgradeable,
-    UUPSUpgradeable
+    UUPSUpgradeable,
+    ERC165
 {
     uint16 private constant VERSION = 1;
 
@@ -51,7 +54,7 @@ contract DecentPaymasterV1 is
         if (validator == address(0)) revert InvalidValidator();
 
         if (
-            !IFunctionValidator(validator).supportsInterface(
+            !IERC165(validator).supportsInterface(
                 type(IFunctionValidator).interfaceId
             )
         ) {
@@ -132,6 +135,7 @@ contract DecentPaymasterV1 is
             interfaceId == type(IDecentPaymasterV1).interfaceId ||
             interfaceId == type(ISmartAccountValidationV1).interfaceId ||
             interfaceId == type(IPaymaster).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IFunctionValidator} from "../../../interfaces/decent/deployables/IFunctionValidator.sol";
+import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
 import {Version} from "../../Version.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
@@ -149,15 +150,10 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
 
     function supportsInterface(
         bytes4 interfaceId
-    )
-        public
-        view
-        virtual
-        override(ERC165, Version, IFunctionValidator)
-        returns (bool)
-    {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IFunctionValidator).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IFunctionValidator} from "../../../interfaces/decent/deployables/IFunctionValidator.sol";
+import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
 import {Version} from "../../Version.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
@@ -134,15 +135,10 @@ contract LinearERC721VotingV1ValidatorV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    )
-        public
-        view
-        virtual
-        override(ERC165, Version, IFunctionValidator)
-        returns (bool)
-    {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IFunctionValidator).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.30;
 
 import {IHatsElectionsEligibility} from "../../interfaces/hats/modules/IHatsElectionsEligibility.sol";
 import {IDecentAutonomousAdminV1} from "../../interfaces/decent/deployables/IDecentAutonomousAdminV1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {Version} from "../Version.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract DecentAutonomousAdminV1 is IDecentAutonomousAdminV1, Version {
+contract DecentAutonomousAdminV1 is IDecentAutonomousAdminV1, Version, ERC165 {
     uint16 private constant VERSION = 1;
 
     function triggerStartNextTerm(
@@ -36,6 +37,7 @@ contract DecentAutonomousAdminV1 is IDecentAutonomousAdminV1, Version {
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IDecentAutonomousAdminV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {Version} from "../Version.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -9,13 +10,15 @@ import {ERC20VotesUpgradeable, VotesUpgradeable} from "@openzeppelin/contracts-u
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {IVotesERC20StakedV1} from "../../interfaces/decent/deployables/IVotesERC20StakedV1.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract VotesERC20StakedV1 is
     IVotesERC20StakedV1,
     Version,
     ERC20VotesUpgradeable,
     UUPSUpgradeable,
-    Ownable2StepUpgradeable
+    Ownable2StepUpgradeable,
+    ERC165
 {
     using SafeERC20 for IERC20;
 
@@ -390,6 +393,7 @@ contract VotesERC20StakedV1 is
             interfaceId == type(IVotesERC20StakedV1).interfaceId ||
             interfaceId == type(IERC20).interfaceId ||
             interfaceId == type(IVotes).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {Version} from "../Version.sol";
 import {IVotesERC20V1} from "../../interfaces/decent/deployables/IVotesERC20V1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
@@ -21,7 +22,8 @@ contract VotesERC20V1 is
     ERC20VotesUpgradeable,
     ERC20PermitUpgradeable,
     UUPSUpgradeable,
-    Ownable2StepUpgradeable
+    Ownable2StepUpgradeable,
+    ERC165
 {
     uint16 private constant VERSION = 1;
 
@@ -106,6 +108,7 @@ contract VotesERC20V1 is
             interfaceId == type(IERC20).interfaceId ||
             interfaceId == type(IERC20Permit).interfaceId ||
             interfaceId == type(IVotes).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {Version} from "../Version.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IAzoriusFreezeGuardV1} from "../../interfaces/decent/deployables/IAzoriusFreezeGuardV1.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
@@ -70,11 +71,12 @@ contract AzoriusFreezeGuardV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IAzoriusFreezeGuardV1).interfaceId ||
             interfaceId == type(IFreezeGuardBaseV1).interfaceId ||
             interfaceId == type(IGuard).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {Version} from "../Version.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IMultisigFreezeGuardV1} from "../../interfaces/decent/deployables/IMultisigFreezeGuardV1.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
+import {Version} from "../Version.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -188,11 +189,12 @@ contract MultisigFreezeGuardV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IMultisigFreezeGuardV1).interfaceId ||
             interfaceId == type(IFreezeGuardBaseV1).interfaceId ||
             interfaceId == type(IGuard).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -3,12 +3,10 @@ pragma solidity ^0.8.30;
 
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 abstract contract BaseFreezeVotingV1 is
     IBaseFreezeVotingV1,
-    Ownable2StepUpgradeable,
-    ERC165
+    Ownable2StepUpgradeable
 {
     uint48 internal _freezeProposalCreated;
     uint32 internal _freezeProposalPeriod;
@@ -93,13 +91,5 @@ abstract contract BaseFreezeVotingV1 is
     function unfreeze() external virtual override onlyOwner {
         _freezeProposalCreated = 0;
         _freezeProposalVoteCount = 0;
-    }
-
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override returns (bool) {
-        return
-            interfaceId == type(IBaseFreezeVotingV1).interfaceId ||
-            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC20FreezeVotingV1.sol
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+import {IERC20FreezeVotingV1} from "../../interfaces/decent/deployables/IERC20FreezeVotingV1.sol";
+import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {Version} from "../Version.sol";
-import {IERC20FreezeVotingV1} from "../../interfaces/decent/deployables/IERC20FreezeVotingV1.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract ERC20FreezeVotingV1 is
     IERC20FreezeVotingV1,
     BaseFreezeVotingV1,
-    Version
+    Version,
+    ERC165
 {
     uint16 private constant VERSION = 1;
 
@@ -85,9 +89,11 @@ contract ERC20FreezeVotingV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(BaseFreezeVotingV1, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IERC20FreezeVotingV1).interfaceId ||
+            interfaceId == type(IBaseFreezeVotingV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -3,14 +3,18 @@ pragma solidity ^0.8.30;
 
 import {IERC721VotingStrategyV1} from "../../interfaces/decent/deployables/IERC721VotingStrategyV1.sol";
 import {IERC721FreezeVotingV1} from "../../interfaces/decent/deployables/IERC721FreezeVotingV1.sol";
+import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {Version} from "../Version.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract ERC721FreezeVotingV1 is
     IERC721FreezeVotingV1,
     BaseFreezeVotingV1,
-    Version
+    Version,
+    ERC165
 {
     uint16 private constant VERSION = 1;
 
@@ -112,9 +116,11 @@ contract ERC721FreezeVotingV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(BaseFreezeVotingV1, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IERC721FreezeVotingV1).interfaceId ||
+            interfaceId == type(IBaseFreezeVotingV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
+import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {IMultisigFreezeVotingV1} from "../../interfaces/decent/deployables/IMultisigFreezeVotingV1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
+import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
 import {Version} from "../Version.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract MultisigFreezeVotingV1 is
     IMultisigFreezeVotingV1,
     BaseFreezeVotingV1,
-    Version
+    Version,
+    ERC165
 {
     uint16 private constant VERSION = 1;
 
@@ -63,9 +67,11 @@ contract MultisigFreezeVotingV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(BaseFreezeVotingV1, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IMultisigFreezeVotingV1).interfaceId ||
+            interfaceId == type(IBaseFreezeVotingV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -1,20 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {Version} from "../Version.sol";
 import {IStrategyBaseV1} from "../../interfaces/decent/deployables/IStrategyBaseV1.sol";
 import {IAzoriusV1, Enum} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract AzoriusV1 is
     IAzoriusV1,
     GuardableModule,
     Ownable2StepUpgradeable,
     Version,
-    UUPSUpgradeable
+    UUPSUpgradeable,
+    ERC165
 {
     uint16 private constant VERSION = 1;
     /**
@@ -387,6 +390,7 @@ contract AzoriusV1 is
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IAzoriusV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -1,19 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {Version} from "../Version.sol";
 import {IFractalModuleV1} from "../../interfaces/decent/deployables/IFractalModuleV1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../Version.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract FractalModuleV1 is
     IFractalModuleV1,
     GuardableModule,
     Ownable2StepUpgradeable,
     Version,
-    UUPSUpgradeable
+    UUPSUpgradeable,
+    ERC165
 {
     uint16 private constant VERSION = 1;
 
@@ -67,6 +70,7 @@ contract FractalModuleV1 is
     ) public view virtual override returns (bool) {
         return
             interfaceId == type(IFractalModuleV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -7,6 +7,7 @@ import {IVotingAdapterBaseV1} from "../../interfaces/decent/deployables/IVotingA
 import {IProposerAdapterBaseV1} from "../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {IERC4337VoterSupportV1} from "../../interfaces/decent/deployables/IERC4337VoterSupportV1.sol";
 import {ISmartAccountValidationV1} from "../../interfaces/decent/deployables/ISmartAccountValidationV1.sol";
+import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {Version} from "../Version.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {ERC4337VoterSupportV1} from "./ERC4337VoterSupportV1.sol";
@@ -16,7 +17,8 @@ contract StrategyV1 is
     IStrategyV1,
     Initializable,
     ERC4337VoterSupportV1,
-    Version
+    Version,
+    ERC165
 {
     uint16 public constant VERSION = 1;
 
@@ -346,6 +348,7 @@ contract StrategyV1 is
             interfaceId == type(IStrategyBaseV1).interfaceId ||
             interfaceId == type(IERC4337VoterSupportV1).interfaceId ||
             interfaceId == type(ISmartAccountValidationV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IERC20ProposerAdapterV1} from "../../../interfaces/decent/deployables/IERC20ProposerAdapterV1.sol";
 import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
 import {IProposerAdapterBaseV1} from "../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
+import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -59,11 +60,12 @@ contract ERC20ProposerAdapterV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IERC20ProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterBaseV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
@@ -6,6 +6,7 @@ import {IStrategyBaseV1} from "../../../interfaces/decent/deployables/IStrategyB
 import {IVotingAdapterV1} from "../../../interfaces/decent/deployables/IVotingAdapterV1.sol";
 import {IVotingAdapterBaseV1} from "../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {ClockMode} from "../../../interfaces/decent/ClockMode.sol";
+import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
 import {Version} from "../../Version.sol";
 import {ClockModeLib} from "../../../libs/ClockModeLib.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
@@ -105,11 +106,12 @@ contract ERC20VotingAdapterV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IERC20VotingAdapterV1).interfaceId ||
             interfaceId == type(IVotingAdapterV1).interfaceId ||
             interfaceId == type(IVotingAdapterBaseV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IERC721ProposerAdapterV1} from "../../../interfaces/decent/deployables/IERC721ProposerAdapterV1.sol";
 import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
 import {IProposerAdapterBaseV1} from "../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
+import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -59,11 +60,12 @@ contract ERC721ProposerAdapterV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IERC721ProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterBaseV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IERC721VotingAdapterV1} from "../../../interfaces/decent/deployables/IERC721VotingAdapterV1.sol";
 import {IVotingAdapterV1} from "../../../interfaces/decent/deployables/IVotingAdapterV1.sol";
 import {IVotingAdapterBaseV1} from "../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
+import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
 import {Version} from "../../Version.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
@@ -211,11 +212,12 @@ contract ERC721VotingAdapterV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IERC721VotingAdapterV1).interfaceId ||
             interfaceId == type(IVotingAdapterV1).interfaceId ||
             interfaceId == type(IVotingAdapterBaseV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -5,9 +5,10 @@ import {IHatsProposerAdapterV1} from "../../../interfaces/decent/deployables/IHa
 import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
 import {IProposerAdapterBaseV1} from "../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {IHats} from "../../../interfaces/hats/IHats.sol";
+import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
+import {Version} from "../../Version.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {Version} from "../../Version.sol";
 
 contract HatsProposerAdapterV1 is
     IHatsProposerAdapterV1,
@@ -66,11 +67,12 @@ contract HatsProposerAdapterV1 is
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165, Version) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IHatsProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterV1).interfaceId ||
             interfaceId == type(IProposerAdapterBaseV1).interfaceId ||
+            interfaceId == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/interfaces/decent/deployables/IFunctionValidator.sol
+++ b/contracts/interfaces/decent/deployables/IFunctionValidator.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.30;
 
 interface IFunctionValidator {
-    function supportsInterface(bytes4 interfaceId) external view returns (bool);
-
     function validateOperation(
         address userOpSender,
         address lightAccountOwner,

--- a/contracts/mocks/MockEntryPoint.sol
+++ b/contracts/mocks/MockEntryPoint.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.30;
 
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract MockEntryPoint is IEntryPoint, IERC165 {
+contract MockEntryPoint is IEntryPoint, ERC165 {
     mapping(address => uint256) public balances;
     mapping(address => uint256) public stakes;
     mapping(address => uint256) public unstakeDelaySecs;
@@ -105,10 +105,10 @@ contract MockEntryPoint is IEntryPoint, IERC165 {
 
     function supportsInterface(
         bytes4 interfaceId
-    ) external pure returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IEntryPoint).interfaceId ||
-            interfaceId == type(IERC165).interfaceId;
+            super.supportsInterface(interfaceId);
     }
 
     receive() external payable {

--- a/contracts/mocks/MockValidator.sol
+++ b/contracts/mocks/MockValidator.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.30;
 
 import {IFunctionValidator} from "../interfaces/decent/deployables/IFunctionValidator.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 contract MockValidator is IFunctionValidator, ERC165 {
     bool private shouldValidate;
@@ -24,7 +23,7 @@ contract MockValidator is IFunctionValidator, ERC165 {
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165, IFunctionValidator) returns (bool) {
+    ) public view virtual override returns (bool) {
         return
             interfaceId == type(IFunctionValidator).interfaceId ||
             super.supportsInterface(interfaceId);

--- a/test/deployables/Version.test.ts
+++ b/test/deployables/Version.test.ts
@@ -1,13 +1,7 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import {
-  ConcreteVersion,
-  ConcreteVersion__factory,
-  IERC165__factory,
-  IVersion__factory,
-} from '../../typechain-types';
-import { calculateInterfaceId } from '../helpers/utils';
+import { ConcreteVersion, ConcreteVersion__factory } from '../../typechain-types';
 
 describe('Version', () => {
   // Signers
@@ -41,36 +35,6 @@ describe('Version', () => {
 
       await concreteVersion.setVersion(newVersion);
       expect(await concreteVersion.version()).to.equal(newVersion);
-    });
-  });
-
-  describe('ERC165', () => {
-    let iVersionInterfaceId: string;
-    let iERC165InterfaceId: string;
-
-    beforeEach(async () => {
-      // Dynamically calculate interface IDs
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
-
-      const IERC165Interface = IERC165__factory.createInterface();
-      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
-    });
-
-    it('should support IERC165 interface', async () => {
-      const supported = await concreteVersion.supportsInterface(iERC165InterfaceId);
-      void expect(supported).to.be.true;
-    });
-
-    it('should support IVersion interface', async () => {
-      const supported = await concreteVersion.supportsInterface(iVersionInterfaceId);
-      void expect(supported).to.be.true;
-    });
-
-    it('should not support random interface', async () => {
-      const randomInterfaceId = '0x12345678';
-      const supported = await concreteVersion.supportsInterface(randomInterfaceId);
-      void expect(supported).to.be.false;
     });
   });
 });

--- a/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/BaseFreezeVotingV1.test.ts
@@ -6,10 +6,7 @@ import {
   ConcreteBaseFreezeVotingV1,
   ConcreteBaseFreezeVotingV1__factory,
   ERC1967Proxy__factory,
-  IBaseFreezeVotingV1__factory,
-  IERC165__factory,
 } from '../../../typechain-types';
-import { calculateInterfaceId } from '../../helpers/utils';
 
 // Helper function for deploying ConcreteBaseFreezeVoting instances using ERC1967Proxy
 async function deployConcreteBaseFreezeVotingProxy(
@@ -318,27 +315,6 @@ describe('BaseFreezeVotingV1', () => {
       // Check that user has voted on the new proposal
       void expect(await freezeVoting.userHasFreezeVoted(voter1.address, newCreatedTimestamp)).to.be
         .true;
-    });
-  });
-
-  describe('ERC165', function () {
-    it('Should support IERC165 interface', async function () {
-      const supported = await freezeVoting.supportsInterface(
-        calculateInterfaceId(IERC165__factory.createInterface()),
-      );
-      void expect(supported).to.be.true;
-    });
-
-    it('Should support IBaseFreezeVotingV1 interface', async function () {
-      void expect(
-        await freezeVoting.supportsInterface(
-          calculateInterfaceId(IBaseFreezeVotingV1__factory.createInterface()),
-        ),
-      ).to.be.true;
-    });
-
-    it('Should not support random interface', async function () {
-      void expect(await freezeVoting.supportsInterface('0x12345678')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Fixes [ENG-1082](https://linear.app/decent-labs/issue/ENG-1082/refactor-erc165-and-iversion-support)

This commit refactors how ERC165 and `IVersion` interface support is handled across various contracts. The primary changes are:

1.  **`Version.sol` Simplification:**
    *   The `Version` abstract contract no longer inherits from OpenZeppelin's `ERC165`.
    *   The `supportsInterface` function has been removed from `Version.sol`.
    *   Responsibility for `ERC165` inheritance and `supportsInterface` implementation (including checking for `IVersion`) is now delegated to the concrete contracts that inherit `Version`.

2.  **Centralized `ERC165` Inheritance:**
    *   Concrete contracts like `DecentPaymasterV1`, `DecentAutonomousAdminV1`, `VotesERC20StakedV1`, `VotesERC20V1`, all Freeze Voting implementations (`ERC20FreezeVotingV1`, `ERC721FreezeVotingV1`, `MultisigFreezeVotingV1`), Module contracts (`AzoriusV1`, `FractalModuleV1`), `StrategyV1`, and all Adapters (`ERC20ProposerAdapterV1`, etc.) now directly inherit `ERC165`.

3.  **Standardized `supportsInterface` in Concrete Contracts:**
    *   All contracts that inherit `Version` (and now `ERC165` directly) have updated their `supportsInterface` function to explicitly check for `type(IVersion).interfaceId` in addition to their own specific interfaces, before calling `super.supportsInterface(interfaceId)`.
    *   The `override` specifiers in `supportsInterface` functions have been simplified (e.g., just `override` instead of `override(ERC165, Version, SpecificInterface)`), relying on the compiler to correctly resolve overrides.

4.  **`IFunctionValidator.sol`:**
    *   Removed the `supportsInterface` declaration, as validators will inherit `ERC165` and implement it if they also implement `IVersion` or other interfaces.

5.  **Mock Contract Updates (`MockEntryPoint.sol`, `MockValidator.sol`):**
    *   `MockEntryPoint` now directly inherits `ERC165` and its `supportsInterface` calls `super`.
    *   `MockValidator` `supportsInterface` override simplified.

6.  **Test Updates:**
    *   `Version.test.ts`: Removed ERC165 tests as `Version` no longer handles `supportsInterface`.
    *   `BaseFreezeVotingV1.test.ts`: Removed ERC165 tests as `BaseFreezeVotingV1` no longer inherits `ERC165` directly (its concrete children do).
    *   Other test files are implicitly affected as the `supportsInterface` behavior of the tested contracts changes to include `IVersion` and correctly chain `super` calls.

**Rationale:**

*   **Clearer Responsibility:** This change makes it explicit which contracts are responsible for ERC165 support. Concrete, deployable contracts now own their `ERC165` compliance.
*   **Consistency:** Standardizes how `IVersion` support is reported via `supportsInterface` across the codebase.
*   **Reduced Redundancy:** `Version.sol` becomes a simpler abstract contract solely focused on the `version()` function.
*   **Compiler Reliance:** Simplifies `override` specifiers, trusting the Solidity compiler to manage the override chain correctly.