### PR TITLE
perf: Optimize adapter lookups in StrategyV1 using mappings

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -193,26 +193,16 @@ contract StrategyV1 is
         }
 
         uint256 totalWeightForThisVoteTransaction = 0;
-        uint256 numConfiguredAdapters = _votingAdapters.length;
 
         for (uint256 i = 0; i < _votingAdaptersToUse.length; i++) {
-            bool isValidAndConfiguredAdapter = false;
-            uint256 configuredAdapterIndex = 0;
+            address votingAdapter = _votingAdaptersToUse[i];
 
-            for (uint256 j = 0; j < numConfiguredAdapters; j++) {
-                if (_votingAdapters[j] == _votingAdaptersToUse[i]) {
-                    isValidAndConfiguredAdapter = true;
-                    configuredAdapterIndex = j;
-                    break;
-                }
-            }
-
-            if (!isValidAndConfiguredAdapter) {
+            if (!_isVotingAdapter[votingAdapter]) {
                 revert InvalidVotingAdapter();
             }
 
             totalWeightForThisVoteTransaction += IBaseVotingAdapterV1(
-                _votingAdapters[configuredAdapterIndex]
+                votingAdapter
             ).recordVote(resolvedVoter, _proposalId, _votingAdapterVoteData[i]);
         }
 
@@ -290,15 +280,7 @@ contract StrategyV1 is
         address proposerAdapter_,
         bytes calldata proposerAdapterData_
     ) external view virtual override returns (bool) {
-        bool foundAdapter = false;
-        for (uint256 i = 0; i < _proposerAdapters.length; i++) {
-            if (_proposerAdapters[i] == proposerAdapter_) {
-                foundAdapter = true;
-                break;
-            }
-        }
-
-        if (!foundAdapter) {
+        if (!_isProposerAdapter[proposerAdapter_]) {
             revert InvalidProposerAdapter(proposerAdapter_);
         }
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/321

Fixes [ENG-1085](https://linear.app/decent-labs/issue/ENG-1085/optimize-adapter-validation-in-strategyv1-with-mappings)

This commit optimizes the `vote` and `isProposer` functions within the `StrategyV1.sol` contract. Previously, these functions iterated through the `_votingAdapters` and `_proposerAdapters` arrays respectively to validate if a provided adapter address was part of the strategy's configuration.

This change leverages the `_isVotingAdapter` and `_isProposerAdapter` mappings (which are populated during initialization) to perform these checks in O(1) time.

**Key Changes:**

*   **`StrategyV1.sol` - `vote` function:**
    *   Removed the inner loop that iterated through `_votingAdapters` to find `_votingAdaptersToUse[i]`.
    *   Now directly checks `if (!_isVotingAdapter[votingAdapter])` where `votingAdapter = _votingAdaptersToUse[i]`.
*   **`StrategyV1.sol` - `isProposer` function:**
    *   Removed the loop that iterated through `_proposerAdapters` to find `proposerAdapter_`.
    *   Now directly checks `if (!_isProposerAdapter[proposerAdapter_])`.

This optimization improves the gas efficiency of these functions, especially in scenarios where a strategy might have a large number of configured adapters. The functional behavior remains unchanged.