### PR TITLE
perf: Optimize gas usage with calldata and Transaction structs

### DIFF
--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -37,7 +37,7 @@ contract DecentPaymasterV1 is
         address owner_,
         address entryPoint_,
         address lightAccountFactory_
-    ) public virtual override initializer {
+    ) external virtual override initializer {
         __BasePaymasterV1_init(owner_, IEntryPoint(entryPoint_));
         __SmartAccountValidationV1_init(lightAccountFactory_);
     }

--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -12,8 +12,8 @@ interface ILinearERC721VotingV1 {
     function vote(
         uint32 proposalId,
         uint8 voteType,
-        address[] memory tokenAddresses,
-        uint256[] memory tokenIds
+        address[] calldata tokenAddresses,
+        uint256[] calldata tokenIds
     ) external;
 
     function hasVoted(

--- a/contracts/deployables/erc20/VotesERC20LockableV1.sol
+++ b/contracts/deployables/erc20/VotesERC20LockableV1.sol
@@ -33,14 +33,13 @@ contract VotesERC20LockableV1 is IVotesERC20LockableV1, VotesERC20V1 {
     }
 
     function initialize(
+        Metadata calldata metadata_,
+        Allocation[] calldata allocations_,
         address owner_,
         bool locked_,
-        uint256 maxTotalSupply_,
-        string memory name_,
-        string memory symbol_,
-        Allocation[] memory allocations_
+        uint256 maxTotalSupply_
     ) public virtual override initializer {
-        super.initialize(name_, symbol_, allocations_, owner_);
+        super.initialize(metadata_, allocations_, owner_);
         _locked = locked_;
         _maxTotalSupply = maxTotalSupply_;
     }

--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -42,14 +42,13 @@ contract VotesERC20StakedV1 is
     receive() external payable {}
 
     function initialize(
-        string memory name_,
-        string memory symbol_,
+        Metadata calldata metadata_,
         address owner_,
         address stakedToken_,
         uint256 minimumStakingPeriod_,
-        address[] memory rewardsTokens_
+        address[] calldata rewardsTokens_
     ) public virtual override initializer {
-        __ERC20_init(name_, symbol_);
+        __ERC20_init(metadata_.name, metadata_.symbol);
         __ERC20Votes_init();
         __UUPSUpgradeable_init();
         __Ownable_init(owner_);
@@ -59,7 +58,7 @@ contract VotesERC20StakedV1 is
     }
 
     function addRewardsTokens(
-        address[] memory rewardsTokens_
+        address[] calldata rewardsTokens_
     ) external virtual override onlyOwner {
         _addRewardsTokens(rewardsTokens_);
     }
@@ -118,7 +117,7 @@ contract VotesERC20StakedV1 is
     }
 
     function distributeRewards(
-        address[] memory _tokens
+        address[] calldata _tokens
     ) external virtual override {
         if (_totalStaked == 0) revert ZeroStaked();
 
@@ -151,7 +150,7 @@ contract VotesERC20StakedV1 is
         emit RewardsDistributed(_token, amountToDistribute, newRewardsRate);
     }
 
-    function _addRewardsTokens(address[] memory rewardsTokens_) internal {
+    function _addRewardsTokens(address[] calldata rewardsTokens_) internal {
         for (uint256 i = 0; i < rewardsTokens_.length; ) {
             if (_rewardsTokenDatas[rewardsTokens_[i]].enabled)
                 revert DuplicateRewardsToken();
@@ -313,7 +312,7 @@ contract VotesERC20StakedV1 is
     }
 
     function distributableRewards(
-        address[] memory rewardsTokens_
+        address[] calldata rewardsTokens_
     ) external view virtual override returns (uint256[] memory) {
         uint256[] memory distributableRewards_ = new uint256[](
             rewardsTokens_.length

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -32,13 +32,12 @@ contract VotesERC20V1 is
     }
 
     function initialize(
-        string memory name,
-        string memory symbol,
-        Allocation[] memory allocations,
+        Metadata calldata metadata,
+        Allocation[] calldata allocations,
         address owner
     ) public virtual override initializer {
-        __ERC20_init(name, symbol);
-        __ERC20Permit_init(name);
+        __ERC20_init(metadata.name, metadata.symbol);
+        __ERC20Permit_init(metadata.name);
         __ERC20Votes_init();
         __UUPSUpgradeable_init();
         __Ownable_init(owner);

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -83,7 +83,7 @@ contract MultisigFreezeGuardV1 is
         uint256 gasPrice,
         address gasToken,
         address payable refundReceiver,
-        bytes memory signatures,
+        bytes calldata signatures,
         uint256 nonce
     ) external virtual override {
         bytes32 signaturesHash = keccak256(signatures);

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -56,8 +56,8 @@ contract ERC721FreezeVotingV1 is
     }
 
     function castFreezeVote(
-        address[] memory _tokenAddresses,
-        uint256[] memory _tokenIds
+        address[] calldata _tokenAddresses,
+        uint256[] calldata _tokenIds
     ) external virtual override {
         if (_tokenAddresses.length != _tokenIds.length) revert UnequalArrays();
 
@@ -80,8 +80,8 @@ contract ERC721FreezeVotingV1 is
     }
 
     function _getVotesAndUpdateHasVoted(
-        address[] memory _tokenAddresses,
-        uint256[] memory _tokenIds,
+        address[] calldata _tokenAddresses,
+        uint256[] calldata _tokenIds,
         address _voter
     ) internal virtual returns (uint256) {
         uint256 votes = 0;

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.30;
 
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
-import {IAzoriusV1, Enum} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
+import {IAzoriusV1} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
+import {Transaction} from "../../interfaces/decent/Module.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {Version} from "../Version.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
@@ -169,12 +170,7 @@ contract AzoriusV1 is
         bytes32[] memory txHashes = new bytes32[](_transactions.length);
         uint256 transactionsLength = _transactions.length;
         for (uint256 i; i < transactionsLength; ) {
-            txHashes[i] = getTxHash(
-                _transactions[i].to,
-                _transactions[i].value,
-                _transactions[i].data,
-                _transactions[i].operation
-            );
+            txHashes[i] = getTxHash(_transactions[i]);
             unchecked {
                 ++i;
             }
@@ -204,31 +200,17 @@ contract AzoriusV1 is
 
     function executeProposal(
         uint32 _proposalId,
-        address[] memory _targets,
-        uint256[] memory _values,
-        bytes[] memory _data,
-        Enum.Operation[] memory _operations
+        Transaction[] calldata _transactions
     ) external virtual override {
-        if (_targets.length == 0) revert InvalidTxs();
+        if (_transactions.length == 0) revert InvalidTxs();
         if (
-            _targets.length != _values.length ||
-            _targets.length != _data.length ||
-            _targets.length != _operations.length
-        ) revert InvalidArrayLengths();
-        if (
-            _proposals[_proposalId].executionCounter + _targets.length >
+            _proposals[_proposalId].executionCounter + _transactions.length >
             _proposals[_proposalId].txHashes.length
         ) revert InvalidTxs();
-        uint256 targetsLength = _targets.length;
-        bytes32[] memory txHashes = new bytes32[](targetsLength);
-        for (uint256 i; i < targetsLength; ) {
-            txHashes[i] = _executeProposalTx(
-                _proposalId,
-                _targets[i],
-                _values[i],
-                _data[i],
-                _operations[i]
-            );
+        uint256 transactionsLength = _transactions.length;
+        bytes32[] memory txHashes = new bytes32[](transactionsLength);
+        for (uint256 i; i < transactionsLength; ) {
+            txHashes[i] = _executeProposalTx(_proposalId, _transactions[i]);
             unchecked {
                 ++i;
             }
@@ -306,10 +288,7 @@ contract AzoriusV1 is
     }
 
     function generateTxHashData(
-        address _to,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation,
+        Transaction calldata _transaction,
         uint256 _nonce
     ) public view virtual override returns (bytes memory) {
         uint256 chainId = block.chainid;
@@ -319,10 +298,10 @@ contract AzoriusV1 is
         bytes32 transactionHash = keccak256(
             abi.encode(
                 TRANSACTION_TYPEHASH,
-                _to,
-                _value,
-                keccak256(_data),
-                _operation,
+                _transaction.to,
+                _transaction.value,
+                keccak256(_transaction.data),
+                _transaction.operation,
                 _nonce
             )
         );
@@ -336,24 +315,18 @@ contract AzoriusV1 is
     }
 
     function getTxHash(
-        address _to,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation
+        Transaction calldata _transaction
     ) public view virtual override returns (bytes32) {
-        return keccak256(generateTxHashData(_to, _value, _data, _operation, 0));
+        return keccak256(generateTxHashData(_transaction, 0));
     }
 
     function _executeProposalTx(
         uint32 _proposalId,
-        address _target,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation
+        Transaction calldata _transaction
     ) internal virtual returns (bytes32 txHash) {
         if (proposalState(_proposalId) != ProposalState.EXECUTABLE)
             revert ProposalNotExecutable();
-        txHash = getTxHash(_target, _value, _data, _operation);
+        txHash = getTxHash(_transaction);
         if (
             _proposals[_proposalId].txHashes[
                 _proposals[_proposalId].executionCounter
@@ -362,7 +335,14 @@ contract AzoriusV1 is
 
         _proposals[_proposalId].executionCounter++;
 
-        if (!exec(_target, _value, _data, _operation)) revert TxFailed();
+        if (
+            !exec(
+                _transaction.to,
+                _transaction.value,
+                _transaction.data,
+                _transaction.operation
+            )
+        ) revert TxFailed();
     }
 
     function _updateTimelockPeriod(uint32 timelockPeriod_) internal virtual {

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IFractalModuleV1} from "../../interfaces/decent/deployables/IFractalModuleV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {Transaction} from "../../interfaces/decent/Module.sol";
 import {Version} from "../Version.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
@@ -53,12 +54,16 @@ contract FractalModuleV1 is
     ) internal virtual override onlyOwner {}
 
     function execTx(
-        address _target,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation
+        Transaction calldata _transaction
     ) public virtual override onlyOwner {
-        if (!exec(_target, _value, _data, _operation)) revert TxFailed();
+        if (
+            !exec(
+                _transaction.to,
+                _transaction.value,
+                _transaction.data,
+                _transaction.operation
+            )
+        ) revert TxFailed();
     }
 
     function version() public view virtual override returns (uint16) {

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -49,8 +49,8 @@ contract StrategyV1 is
         uint32 votingPeriod_,
         uint256 quorumThreshold_,
         uint256 basisNumerator_,
-        address[] memory votingAdapters_,
-        address[] memory proposerAdapters_,
+        address[] calldata votingAdapters_,
+        address[] calldata proposerAdapters_,
         address lightAccountFactory_
     ) public virtual override initializer {
         if (votingAdapters_.length == 0) {
@@ -150,8 +150,8 @@ contract StrategyV1 is
 
     function initializeProposal(
         uint32 proposalId,
-        bytes32[] memory,
-        bytes memory
+        bytes32[] calldata,
+        bytes calldata
     ) external virtual override onlyProposalInitializer {
         ProposalVotingDetails storage proposal = _proposalVotingDetails[
             proposalId

--- a/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
@@ -48,7 +48,7 @@ contract ERC20ProposerAdapterV1 is
 
     function isProposer(
         address _proposer,
-        bytes memory
+        bytes calldata
     ) external view virtual override returns (bool) {
         return _token.getVotes(_proposer) >= _proposerThreshold;
     }

--- a/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
@@ -48,7 +48,7 @@ contract ERC721ProposerAdapterV1 is
 
     function isProposer(
         address _proposer,
-        bytes memory
+        bytes calldata
     ) external view virtual override returns (bool) {
         return _token.balanceOf(_proposer) >= _proposerThreshold;
     }

--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -27,7 +27,7 @@ contract HatsProposerAdapterV1 is
 
     function initialize(
         address hatsContract_,
-        uint256[] memory whitelistedHatIds_
+        uint256[] calldata whitelistedHatIds_
     ) public virtual override initializer {
         _hatsContract = IHats(hatsContract_);
         _whitelistedHatIds = whitelistedHatIds_;
@@ -52,7 +52,7 @@ contract HatsProposerAdapterV1 is
 
     function isProposer(
         address _proposer,
-        bytes memory _data
+        bytes calldata _data
     ) public view virtual override returns (bool) {
         uint256 hatId = abi.decode(_data, (uint256));
         return

--- a/contracts/interfaces/decent/Module.sol
+++ b/contracts/interfaces/decent/Module.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+
+struct Transaction {
+    address to;
+    uint256 value;
+    bytes data;
+    Enum.Operation operation;
+}

--- a/contracts/interfaces/decent/deployables/IAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IAzoriusV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+import {Transaction} from "../Module.sol";
 
 interface IAzoriusV1 {
     event ProposalCreated(
@@ -23,14 +23,6 @@ interface IAzoriusV1 {
     error InvalidTxHash();
     error TxFailed();
     error InvalidTxs();
-    error InvalidArrayLengths();
-
-    struct Transaction {
-        address to;
-        uint256 value;
-        bytes data;
-        Enum.Operation operation;
-    }
 
     struct Proposal {
         uint32 executionCounter;
@@ -86,10 +78,7 @@ interface IAzoriusV1 {
 
     function executeProposal(
         uint32 _proposalId,
-        address[] memory _targets,
-        uint256[] memory _values,
-        bytes[] memory _data,
-        Enum.Operation[] memory _operations
+        Transaction[] calldata _transactions
     ) external;
 
     function proposalState(
@@ -97,18 +86,12 @@ interface IAzoriusV1 {
     ) external view returns (ProposalState);
 
     function generateTxHashData(
-        address _to,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation,
+        Transaction calldata _transaction,
         uint256 _nonce
     ) external view returns (bytes memory);
 
     function getTxHash(
-        address _to,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation
+        Transaction calldata _transaction
     ) external view returns (bytes32);
 
     function getProposalTxHash(

--- a/contracts/interfaces/decent/deployables/IERC721FreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC721FreezeVotingV1.sol
@@ -16,8 +16,8 @@ interface IERC721FreezeVotingV1 is IBaseFreezeVotingV1 {
     ) external;
 
     function castFreezeVote(
-        address[] memory tokenAddresses,
-        uint256[] memory tokenIds
+        address[] calldata tokenAddresses,
+        uint256[] calldata tokenIds
     ) external;
 
     function strategy() external view returns (address);

--- a/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
+++ b/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
@@ -1,17 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+import {Transaction} from "../Module.sol";
 
 interface IFractalModuleV1 {
     error TxFailed();
 
     function initialize(address owner, address avatar, address target) external;
 
-    function execTx(
-        address _target,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation
-    ) external;
+    function execTx(Transaction calldata _transaction) external;
 }

--- a/contracts/interfaces/decent/deployables/IHatsProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IHatsProposerAdapterV1.sol
@@ -6,7 +6,7 @@ import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
 interface IHatsProposerAdapterV1 is IProposerAdapterV1 {
     function initialize(
         address hatsContractAddress,
-        uint256[] memory whitelistedHats
+        uint256[] calldata whitelistedHats
     ) external;
 
     function hatsContract() external view returns (address);

--- a/contracts/interfaces/decent/deployables/IMultisigFreezeGuardV1.sol
+++ b/contracts/interfaces/decent/deployables/IMultisigFreezeGuardV1.sol
@@ -42,7 +42,7 @@ interface IMultisigFreezeGuardV1 is IBaseFreezeGuardV1 {
         uint256 _gasPrice,
         address _gasToken,
         address payable _refundReceiver,
-        bytes memory _signatures,
+        bytes calldata _signatures,
         uint256 _nonce
     ) external;
 

--- a/contracts/interfaces/decent/deployables/IProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IProposerAdapterV1.sol
@@ -4,6 +4,6 @@ pragma solidity ^0.8.30;
 interface IProposerAdapterV1 {
     function isProposer(
         address _address,
-        bytes memory _data
+        bytes calldata _data
     ) external view returns (bool);
 }

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -47,8 +47,8 @@ interface IStrategyV1 {
         uint32 votingPeriod,
         uint256 quorumThreshold,
         uint256 basisNumerator,
-        address[] memory votingAdapters,
-        address[] memory proposerAdapters,
+        address[] calldata votingAdapters,
+        address[] calldata proposerAdapters,
         address lightAccountFactory
     ) external;
 
@@ -60,8 +60,8 @@ interface IStrategyV1 {
 
     function initializeProposal(
         uint32 proposalId_,
-        bytes32[] memory txHashes_,
-        bytes memory proposalInitializerData_
+        bytes32[] calldata txHashes_,
+        bytes calldata proposalInitializerData_
     ) external;
 
     function isPassed(uint32 proposalId_) external view returns (bool);

--- a/contracts/interfaces/decent/deployables/IVotesERC20LockableV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20LockableV1.sol
@@ -13,12 +13,11 @@ interface IVotesERC20LockableV1 is IVotesERC20V1 {
     error InvalidMaxTotalSupply();
 
     function initialize(
+        Metadata calldata metadata_,
+        Allocation[] calldata allocations_,
         address owner_,
         bool locked_,
-        uint256 maxTotalSupply_,
-        string memory name_,
-        string memory symbol_,
-        Allocation[] memory allocations_
+        uint256 maxTotalSupply_
     ) external;
 
     function lock(bool _locked) external;

--- a/contracts/interfaces/decent/deployables/IVotesERC20StakedV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20StakedV1.sol
@@ -2,6 +2,11 @@
 pragma solidity ^0.8.30;
 
 interface IVotesERC20StakedV1 {
+    struct Metadata {
+        string name;
+        string symbol;
+    }
+
     struct StakerData {
         uint256 stakedAmount;
         uint256 lastStakeTimestamp;
@@ -34,15 +39,14 @@ interface IVotesERC20StakedV1 {
     error MinimumStakingPeriod();
 
     function initialize(
-        string memory name,
-        string memory symbol,
+        Metadata calldata metadata,
         address owner,
         address _stakedToken,
         uint256 _minimumStakingPeriod,
-        address[] memory _rewardsTokens
+        address[] calldata _rewardsTokens
     ) external;
 
-    function addRewardsTokens(address[] memory rewardsTokens_) external;
+    function addRewardsTokens(address[] calldata rewardsTokens_) external;
 
     function updateMinimumStakingPeriod(
         uint256 newMinimumStakingPeriod
@@ -54,7 +58,7 @@ interface IVotesERC20StakedV1 {
 
     function distributeRewards() external;
 
-    function distributeRewards(address[] memory _tokens) external;
+    function distributeRewards(address[] calldata _tokens) external;
 
     function clock() external view returns (uint48);
 
@@ -82,7 +86,7 @@ interface IVotesERC20StakedV1 {
     function distributableRewards() external view returns (uint256[] memory);
 
     function distributableRewards(
-        address[] memory rewardsTokens_
+        address[] calldata rewardsTokens_
     ) external view returns (uint256[] memory);
 
     function stakerData(

--- a/contracts/interfaces/decent/deployables/IVotesERC20V1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20V1.sol
@@ -2,15 +2,19 @@
 pragma solidity ^0.8.30;
 
 interface IVotesERC20V1 {
+    struct Metadata {
+        string name;
+        string symbol;
+    }
+
     struct Allocation {
         address to;
         uint256 amount;
     }
 
     function initialize(
-        string memory _name,
-        string memory _symbol,
-        Allocation[] memory _allocations,
+        Metadata calldata _metadata,
+        Allocation[] calldata _allocations,
         address owner
     ) external;
 

--- a/contracts/interfaces/decent/singletons/IProxyFactory.sol
+++ b/contracts/interfaces/decent/singletons/IProxyFactory.sol
@@ -2,33 +2,17 @@
 pragma solidity ^0.8.30;
 
 interface IProxyFactory {
-    // Events
     event ProxyDeployed(address indexed proxy, address indexed implementation);
 
-    /**
-     * @dev Deploys a proxy for any implementation with arbitrary initialization data
-     * @param implementation The implementation contract address
-     * @param initData The initialization data to be passed to the proxy
-     * @param salt A unique value to ensure deterministic address generation
-     * @return proxy The address of the deployed proxy
-     */
     function deployProxy(
         address implementation,
-        bytes memory initData,
+        bytes calldata initData,
         bytes32 salt
     ) external returns (address proxy);
 
-    /**
-     * @dev Predicts the address where a proxy will be deployed
-     * @param implementation The implementation contract address
-     * @param initData The initialization data to be passed to the proxy
-     * @param salt A unique value to ensure deterministic address generation
-     * @param deployer The address that will deploy the proxy
-     * @return The predicted address
-     */
     function predictProxyAddress(
         address implementation,
-        bytes memory initData,
+        bytes calldata initData,
         bytes32 salt,
         address deployer
     ) external view returns (address);

--- a/contracts/interfaces/safe/ISafe.sol
+++ b/contracts/interfaces/safe/ISafe.sol
@@ -3,50 +3,11 @@ pragma solidity ^0.8.30;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
-/**
- * The specification of methods available on a Safe contract wallet.
- *
- * This interface does not encompass every available function on a Safe,
- * only those which are used within the Azorius contracts.
- *
- * For the complete set of functions available on a Safe, see:
- * https://github.com/safe-global/safe-contracts/blob/main/contracts/Safe.sol
- */
 interface ISafe {
-    /**
-     * Returns the current transaction nonce of the Safe.
-     * Each transaction should has a different nonce to prevent replay attacks.
-     *
-     * @return uint256 current transaction nonce
-     */
     function nonce() external view returns (uint256);
 
-    /**
-     * Set a guard contract that checks transactions before execution.
-     * This can only be done via a Safe transaction.
-     *
-     * See https://docs.gnosis-safe.io/learn/safe-tools/guards.
-     * See https://github.com/safe-global/safe-contracts/blob/main/contracts/base/GuardManager.sol.
-     *
-     * @param _guard address of the guard to be used or the 0 address to disable a guard
-     */
     function setGuard(address _guard) external;
 
-    /**
-     * Executes an arbitrary transaction on the Safe.
-     *
-     * @param _to destination address
-     * @param _value ETH value
-     * @param _data data payload
-     * @param _operation Operation type, Call or DelegateCall
-     * @param _safeTxGas gas that should be used for the safe transaction
-     * @param _baseGas gas costs that are independent of the transaction execution
-     * @param _gasPrice max gas price that should be used for this transaction
-     * @param _gasToken token address (or 0 if ETH) that is used for the payment
-     * @param _refundReceiver address of the receiver of gas payment (or 0 if tx.origin)
-     * @param _signatures packed signature data
-     * @return success bool whether the transaction was successful or not
-     */
     function execTransaction(
         address _to,
         uint256 _value,
@@ -60,35 +21,12 @@ interface ISafe {
         bytes memory _signatures
     ) external payable returns (bool success);
 
-    /**
-     * Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
-     *
-     * @param _dataHash Hash of the data (could be either a message hash or transaction hash)
-     * @param _data That should be signed (this is passed to an external validator contract)
-     * @param _signatures Signature data that should be verified. Can be packed ECDSA signature
-     *      ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
-     */
     function checkSignatures(
         bytes32 _dataHash,
         bytes memory _data,
         bytes memory _signatures
     ) external view;
 
-    /**
-     * Returns the pre-image of the transaction hash.
-     *
-     * @param _to destination address
-     * @param _value ETH value
-     * @param _data data payload
-     * @param _operation Operation type, Call or DelegateCall
-     * @param _safeTxGas gas that should be used for the safe transaction
-     * @param _baseGas gas costs that are independent of the transaction execution
-     * @param _gasPrice max gas price that should be used for this transaction
-     * @param _gasToken token address (or 0 if ETH) that is used for the payment
-     * @param _refundReceiver address of the receiver of gas payment (or 0 if tx.origin)
-     * @param _nonce transaction nonce
-     * @return bytes hash bytes
-     */
     function encodeTransactionData(
         address _to,
         uint256 _value,
@@ -102,13 +40,5 @@ interface ISafe {
         uint256 _nonce
     ) external view returns (bytes memory);
 
-    /**
-     * Returns if the given address is an owner of the Safe.
-     *
-     * See https://github.com/safe-global/safe-contracts/blob/main/contracts/base/OwnerManager.sol.
-     *
-     * @param _owner the address to check
-     * @return bool whether _owner is an owner of the Safe
-     */
     function isOwner(address _owner) external view returns (bool);
 }

--- a/contracts/mocks/MockLinearERC721VotingV1.sol
+++ b/contracts/mocks/MockLinearERC721VotingV1.sol
@@ -21,8 +21,8 @@ contract MockLinearERC721VotingV1 {
     function vote(
         uint32 proposalId,
         uint8 voteType,
-        address[] memory tokenAddresses,
-        uint256[] memory tokenIds
+        address[] calldata tokenAddresses,
+        uint256[] calldata tokenIds
     ) external {
         // Mock implementation - just for interface matching
     }

--- a/contracts/mocks/MockProposerAdapter.sol
+++ b/contracts/mocks/MockProposerAdapter.sol
@@ -8,7 +8,7 @@ contract MockProposerAdapter is IProposerAdapterV1 {
 
     function isProposer(
         address _proposer,
-        bytes memory
+        bytes calldata
     ) external view override returns (bool) {
         return _isProposer[_proposer];
     }

--- a/contracts/mocks/MockSafe.sol
+++ b/contracts/mocks/MockSafe.sol
@@ -58,8 +58,8 @@ contract MockSafe is ISafe {
 
     function checkSignatures(
         bytes32 txHash,
-        bytes memory,
-        bytes memory signatures
+        bytes calldata,
+        bytes calldata signatures
     ) external view {
         if (_shouldRevertOnCheckSignatures[txHash]) {
             revert("Invalid signatures");

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -23,8 +23,8 @@ contract MockVotingStrategy is IStrategyV1 {
 
     function initializeProposal(
         uint32 _proposalId,
-        bytes32[] memory _txHashes,
-        bytes memory _data
+        bytes32[] calldata _txHashes,
+        bytes calldata _data
     ) external override {}
 
     function isPassed(uint32 proposalId) external view override returns (bool) {
@@ -34,7 +34,7 @@ contract MockVotingStrategy is IStrategyV1 {
     function isProposer(
         address _address,
         address,
-        bytes memory
+        bytes calldata
     ) external view override returns (bool) {
         return _address == proposer;
     }
@@ -107,8 +107,8 @@ contract MockVotingStrategy is IStrategyV1 {
         uint32 votingPeriod_,
         uint256 quorumThreshold_,
         uint256 basisNumerator_,
-        address[] memory votingAdapters_,
-        address[] memory proposerAdapters_,
+        address[] calldata votingAdapters_,
+        address[] calldata proposerAdapters_,
         address lightAccountFactory_
     ) external override {}
 

--- a/contracts/mocks/concretes/singletons/MinimalUpgradeableContract.sol
+++ b/contracts/mocks/concretes/singletons/MinimalUpgradeableContract.sol
@@ -31,7 +31,7 @@ contract MinimalUpgradeableContract is UUPSUpgradeable, OwnableUpgradeable {
      * @param _largeData A potentially large string to test initialization gas limits
      */
     function initializeWithLargeData(
-        string memory _largeData
+        string calldata _largeData
     ) public initializer {
         __UUPSUpgradeable_init();
         __Ownable_init(msg.sender);

--- a/contracts/mocks/concretes/singletons/UpgradeContractV1.sol
+++ b/contracts/mocks/concretes/singletons/UpgradeContractV1.sol
@@ -22,7 +22,7 @@ contract UpgradeContractV1 is UUPSUpgradeable, OwnableUpgradeable {
      * @param _owner Address that will own the proxy and be able to upgrade it
      */
     function initialize(
-        string memory _name,
+        string calldata _name,
         address _owner
     ) public virtual initializer {
         __UUPSUpgradeable_init();

--- a/contracts/singletons/ProxyFactory.sol
+++ b/contracts/singletons/ProxyFactory.sol
@@ -13,7 +13,7 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
 contract ProxyFactory is IProxyFactory {
     function deployProxy(
         address implementation,
-        bytes memory initData,
+        bytes calldata initData,
         bytes32 salt
     ) public returns (address proxy) {
         // Validate the implementation address
@@ -41,7 +41,7 @@ contract ProxyFactory is IProxyFactory {
 
     function predictProxyAddress(
         address implementation,
-        bytes memory initData,
+        bytes calldata initData,
         bytes32 salt,
         address deployer
     ) public view returns (address) {

--- a/test/deployables/erc20/VotesERC20LockableV1.test.ts
+++ b/test/deployables/erc20/VotesERC20LockableV1.test.ts
@@ -31,14 +31,25 @@ async function deployVotesERC20Lockable(
     amount: allocationAmounts[index],
   }));
 
+  const metadata = {
+    name,
+    symbol,
+  };
+
   const fullInitData =
     VotesERC20LockableV1__factory.createInterface().getFunction(
-      'initialize(address,bool,uint256,string,string,(address,uint256)[])',
+      'initialize((string,string),(address,uint256)[],address,bool,uint256)',
     ).selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(
-        ['address', 'bool', 'uint256', 'string', 'string', 'tuple(address to, uint256 amount)[]'],
-        [owner.address, locked, maxTotalSupply, name, symbol, allocations],
+        [
+          'tuple(string name, string symbol)',
+          'tuple(address to, uint256 amount)[]',
+          'address',
+          'bool',
+          'uint256',
+        ],
+        [metadata, allocations, owner.address, locked, maxTotalSupply],
       )
       .slice(2);
 
@@ -117,13 +128,12 @@ describe('VotesERC20LockableV1', () => {
 
       it('should revert if initializer is called after deployment', async () => {
         await expect(
-          proxy['initialize(address,bool,uint256,string,string,(address,uint256)[])'](
+          proxy['initialize((string,string),(address,uint256)[],address,bool,uint256)'](
+            { name: 'Test', symbol: 'TEST' },
+            [],
             owner.address,
             false,
             ethers.parseEther('2100'),
-            'Test',
-            'TEST',
-            [],
           ),
         ).to.be.revertedWithCustomError(proxy, 'InvalidInitialization');
       });

--- a/test/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -28,13 +28,18 @@ async function deployVotesERC20StakedProxy(
   minimumStakingPeriod: bigint,
   rewardsTokens: string[],
 ): Promise<VotesERC20StakedV1> {
+  const metadata = {
+    name,
+    symbol,
+  };
+
   // Create initialization data with function selector
   const fullInitData =
     VotesERC20StakedV1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(
-        ['string', 'string', 'address', 'address', 'uint256', 'address[]'],
-        [name, symbol, owner.address, stakedToken, minimumStakingPeriod, rewardsTokens],
+        ['tuple(string name, string symbol)', 'address', 'address', 'uint256', 'address[]'],
+        [metadata, owner.address, stakedToken, minimumStakingPeriod, rewardsTokens],
       )
       .slice(2);
 
@@ -123,8 +128,7 @@ describe('VotesERC20StakedV1', () => {
 
       await expect(
         votesERC20Staked.initialize(
-          'New Name',
-          'NEW',
+          { name: 'New Name', symbol: 'NEW' },
           owner.address,
           await stakedToken.getAddress(),
           604800n,
@@ -142,8 +146,7 @@ describe('VotesERC20StakedV1', () => {
 
       await expect(
         implementationContract.initialize(
-          'New Name',
-          'NEW',
+          { name: 'New Name', symbol: 'NEW' },
           owner.address,
           await stakedToken.getAddress(),
           604800n,

--- a/test/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/deployables/erc20/VotesERC20V1.test.ts
@@ -33,12 +33,17 @@ async function deployVotesERC20Proxy(
     amount: allocationAmounts[index],
   }));
 
+  const metadata = {
+    name,
+    symbol,
+  };
+
   const fullInitData =
     VotesERC20V1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(
-        ['string', 'string', 'tuple(address to, uint256 amount)[]', 'address'],
-        [name, symbol, allocations, owner.address],
+        ['tuple(string name, string symbol)', 'tuple(address to, uint256 amount)[]', 'address'],
+        [metadata, allocations, owner.address],
       )
       .slice(2);
 
@@ -137,7 +142,7 @@ describe('VotesERC20V1', () => {
       );
 
       await expect(
-        votesERC20.initialize('New Name', 'NEW', [], owner.address),
+        votesERC20.initialize({ name: 'New Name', symbol: 'NEW' }, [], owner.address),
       ).to.be.revertedWithCustomError(votesERC20, 'InvalidInitialization');
     });
 
@@ -145,7 +150,7 @@ describe('VotesERC20V1', () => {
       const implementationContract = VotesERC20V1__factory.connect(masterCopy, proxyDeployer);
 
       await expect(
-        implementationContract.initialize('New Name', 'NEW', [], owner.address),
+        implementationContract.initialize({ name: 'New Name', symbol: 'NEW' }, [], owner.address),
       ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
     });
 

--- a/test/deployables/modules/AzoriusV1.test.ts
+++ b/test/deployables/modules/AzoriusV1.test.ts
@@ -606,8 +606,8 @@ describe('AzoriusV1', () => {
           );
 
         // Get hashes directly
-        const hash1 = await azorius.getTxHash(tx1.to, tx1.value, tx1.data, tx1.operation);
-        const hash2 = await azorius.getTxHash(tx2.to, tx2.value, tx2.data, tx2.operation);
+        const hash1 = await azorius.getTxHash(tx1);
+        const hash2 = await azorius.getTxHash(tx2);
 
         // Verify proposal tx hashes match
         expect(await azorius.getProposalTxHash(0, 0)).to.equal(hash1);
@@ -643,12 +643,7 @@ describe('AzoriusV1', () => {
           );
         const proposalId = 0;
 
-        const expectedTxHash = await azorius.getTxHash(
-          proposalTx.to,
-          proposalTx.value,
-          proposalTx.data,
-          proposalTx.operation,
-        );
+        const expectedTxHash = await azorius.getTxHash(proposalTx);
 
         const [strategy, txHashes, timelock, execution, counter] =
           await azorius.getProposal(proposalId);
@@ -724,13 +719,7 @@ describe('AzoriusV1', () => {
         await time.increaseTo(targetExecutionTimestamp);
 
         // Execute only the first transaction
-        await azorius.executeProposal(
-          proposalId,
-          [tx1.to],
-          [tx1.value],
-          [tx1.data],
-          [tx1.operation],
-        );
+        await azorius.executeProposal(proposalId, [tx1]);
 
         const [, , , , counter] = await azorius.getProposal(proposalId);
         expect(counter).to.equal(1); // Execution counter should be 1
@@ -820,13 +809,7 @@ describe('AzoriusV1', () => {
         await avatar.enableModule(await azorius.getAddress());
 
         // Execute proposal
-        await azorius.executeProposal(
-          proposalId,
-          [proposalTx.to],
-          [proposalTx.value],
-          [proposalTx.data],
-          [proposalTx.operation],
-        );
+        await azorius.executeProposal(proposalId, [proposalTx]);
 
         // Verify token transfer
         expect(await mockToken.balanceOf(user.address)).to.equal(100);
@@ -838,13 +821,7 @@ describe('AzoriusV1', () => {
         await mockStrategy.setIsPassed(proposalId, true);
 
         await expect(
-          azorius.executeProposal(
-            proposalId,
-            [proposalTx.to],
-            [proposalTx.value],
-            [proposalTx.data],
-            [proposalTx.operation],
-          ),
+          azorius.executeProposal(proposalId, [proposalTx]),
         ).to.be.revertedWithCustomError(azorius, 'ProposalNotExecutable');
       });
 
@@ -857,13 +834,7 @@ describe('AzoriusV1', () => {
         await time.increase(TIMELOCK_PERIOD + EXECUTION_PERIOD + 1);
 
         await expect(
-          azorius.executeProposal(
-            proposalId,
-            [proposalTx.to],
-            [proposalTx.value],
-            [proposalTx.data],
-            [proposalTx.operation],
-          ),
+          azorius.executeProposal(proposalId, [proposalTx]),
         ).to.be.revertedWithCustomError(azorius, 'ProposalNotExecutable');
       });
 
@@ -1021,7 +992,7 @@ describe('AzoriusV1', () => {
 
         it('should allow partial execution of proposal transactions', async () => {
           // Execute only the first transaction
-          await azorius.executeProposal(0, [tx1.to], [tx1.value], [tx1.data], [tx1.operation]);
+          await azorius.executeProposal(0, [tx1]);
 
           // Verify first transaction was executed
           expect(await mockToken.balanceOf(user.address)).to.equal(100);
@@ -1033,10 +1004,10 @@ describe('AzoriusV1', () => {
 
         it('should allow execution of remaining transactions after partial execution', async () => {
           // Execute first transaction
-          await azorius.executeProposal(0, [tx1.to], [tx1.value], [tx1.data], [tx1.operation]);
+          await azorius.executeProposal(0, [tx1]);
 
           // Execute the second transaction
-          await azorius.executeProposal(0, [tx2.to], [tx2.value], [tx2.data], [tx2.operation]);
+          await azorius.executeProposal(0, [tx2]);
 
           // Verify second transaction was executed (balance should now be 300)
           expect(await mockToken.balanceOf(user.address)).to.equal(300);
@@ -1048,19 +1019,6 @@ describe('AzoriusV1', () => {
           // Verify proposal state is now EXECUTED
           expect(await azorius.proposalState(0)).to.equal(3); // EXECUTED
         });
-      });
-
-      it('should revert on invalid array lengths', async () => {
-        // Try to execute with mismatched array lengths
-        await expect(
-          azorius.executeProposal(
-            0,
-            [tx1.to],
-            [], // Empty value array
-            [tx1.data],
-            [tx1.operation],
-          ),
-        ).to.be.revertedWithCustomError(azorius, 'InvalidArrayLengths');
       });
 
       it('should revert on execution counter overflow', async () => {
@@ -1091,18 +1049,13 @@ describe('AzoriusV1', () => {
         expect(await azorius.proposalState(1)).to.equal(2); // EXECUTABLE
 
         // First execute all transactions
-        await azorius.executeProposal(
-          1,
-          [tx1.to, tx2.to],
-          [tx1.value, tx2.value],
-          [tx1.data, tx2.data],
-          [tx1.operation, tx2.operation],
-        );
+        await azorius.executeProposal(1, [tx1, tx2]);
 
         // Try to execute more transactions than exist
-        await expect(
-          azorius.executeProposal(1, [tx1.to], [tx1.value], [tx1.data], [tx1.operation]),
-        ).to.be.revertedWithCustomError(azorius, 'InvalidTxs');
+        await expect(azorius.executeProposal(1, [tx1])).to.be.revertedWithCustomError(
+          azorius,
+          'InvalidTxs',
+        );
       });
 
       describe('executeProposal Specific Reverts', () => {
@@ -1154,9 +1107,10 @@ describe('AzoriusV1', () => {
         });
 
         it('should revert with InvalidTxs if targets array is empty', async () => {
-          await expect(
-            azorius.executeProposal(proposalId, [], [], [], []),
-          ).to.be.revertedWithCustomError(azorius, 'InvalidTxs');
+          await expect(azorius.executeProposal(proposalId, [])).to.be.revertedWithCustomError(
+            azorius,
+            'InvalidTxs',
+          );
         });
 
         it('should revert with InvalidTxHash if provided tx details do not match stored hash', async () => {
@@ -1164,14 +1118,14 @@ describe('AzoriusV1', () => {
             user.address,
             999, // Different amount means different data, thus different hash
           ]);
+          const invalidTx = {
+            to: validTx.to,
+            value: validTx.value,
+            data: invalidTxData,
+            operation: validTx.operation,
+          };
           await expect(
-            azorius.executeProposal(
-              proposalId,
-              [validTx.to],
-              [validTx.value],
-              [invalidTxData], // Using different data
-              [validTx.operation],
-            ),
+            azorius.executeProposal(proposalId, [invalidTx]),
           ).to.be.revertedWithCustomError(azorius, 'InvalidTxHash');
         });
       });
@@ -1186,7 +1140,7 @@ describe('AzoriusV1', () => {
           operation: 0,
         };
 
-        const txHash = await azorius.getTxHash(tx.to, tx.value, tx.data, tx.operation);
+        const txHash = await azorius.getTxHash(tx);
 
         expect(txHash).to.be.properHex(64); // 32 bytes (64 chars) + 0x prefix
       });
@@ -1206,8 +1160,8 @@ describe('AzoriusV1', () => {
           operation: 0,
         };
 
-        const txHash1 = await azorius.getTxHash(tx1.to, tx1.value, tx1.data, tx1.operation);
-        const txHash2 = await azorius.getTxHash(tx2.to, tx2.value, tx2.data, tx2.operation);
+        const txHash1 = await azorius.getTxHash(tx1);
+        const txHash2 = await azorius.getTxHash(tx2);
 
         expect(txHash1).to.not.equal(txHash2);
       });
@@ -1219,8 +1173,8 @@ describe('AzoriusV1', () => {
         value: bigint;
         data: string;
         operation: number;
-        nonce: bigint;
       };
+      let nonce: bigint;
 
       beforeEach(async () => {
         // Re-deploy Azorius and mocks if they are not available in this scope
@@ -1231,18 +1185,12 @@ describe('AzoriusV1', () => {
           value: 0n,
           data: mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
           operation: 0, // Call
-          nonce: 0n,
         };
+        nonce = 0n;
       });
 
       it('should generate a non-empty bytes string', async () => {
-        const hashData = await azorius.generateTxHashData(
-          txParams.to,
-          txParams.value,
-          txParams.data,
-          txParams.operation,
-          txParams.nonce,
-        );
+        const hashData = await azorius.generateTxHashData(txParams, nonce);
         expect(hashData).to.be.a('string');
         expect(hashData).to.not.equal('0x');
         void expect(ethers.isHexString(hashData)).to.be.true;
@@ -1250,95 +1198,47 @@ describe('AzoriusV1', () => {
 
       it('should produce different hash data for different nonces', async () => {
         const hashData1 = await azorius.generateTxHashData(
-          txParams.to,
-          txParams.value,
-          txParams.data,
-          txParams.operation,
+          txParams,
           0n, // Nonce 0
         );
         const hashData2 = await azorius.generateTxHashData(
-          txParams.to,
-          txParams.value,
-          txParams.data,
-          txParams.operation,
+          txParams,
           1n, // Nonce 1
         );
         expect(hashData1).to.not.equal(hashData2);
       });
 
       it('should produce different hash data for different to addresses', async () => {
-        const hashData1 = await azorius.generateTxHashData(
-          txParams.to,
-          txParams.value,
-          txParams.data,
-          txParams.operation,
-          txParams.nonce,
-        );
-        const hashData2 = await azorius.generateTxHashData(
-          owner.address, // Different 'to'
-          txParams.value,
-          txParams.data,
-          txParams.operation,
-          txParams.nonce,
-        );
+        const hashData1 = await azorius.generateTxHashData(txParams, nonce);
+
+        txParams.to = owner.address; // Different 'to'
+        const hashData2 = await azorius.generateTxHashData(txParams, nonce);
         expect(hashData1).to.not.equal(hashData2);
       });
 
       it('should produce different hash data for different values', async () => {
-        const hashData1 = await azorius.generateTxHashData(
-          txParams.to,
-          txParams.value, // Original value (e.g., 0)
-          txParams.data,
-          txParams.operation,
-          txParams.nonce,
-        );
-        const hashData2 = await azorius.generateTxHashData(
-          txParams.to,
-          1n, // Different value
-          txParams.data,
-          txParams.operation,
-          txParams.nonce,
-        );
+        const hashData1 = await azorius.generateTxHashData(txParams, nonce);
+        txParams.value = 1n; // Different value
+        const hashData2 = await azorius.generateTxHashData(txParams, nonce);
         expect(hashData1).to.not.equal(hashData2);
       });
 
       it('should produce different hash data for different data', async () => {
-        const hashData1 = await azorius.generateTxHashData(
-          txParams.to,
-          txParams.value,
-          txParams.data, // Original data
-          txParams.operation,
-          txParams.nonce,
-        );
+        const hashData1 = await azorius.generateTxHashData(txParams, nonce);
+        txParams.data = mockToken.interface.encodeFunctionData('transfer', [user.address, 200]); // Different data
         const differentData = mockToken.interface.encodeFunctionData('transfer', [
           user.address,
           200,
         ]);
-        const hashData2 = await azorius.generateTxHashData(
-          txParams.to,
-          txParams.value,
-          differentData, // Different data
-          txParams.operation,
-          txParams.nonce,
-        );
+        txParams.data = differentData;
+        const hashData2 = await azorius.generateTxHashData(txParams, nonce);
         expect(hashData1).to.not.equal(hashData2);
       });
 
       it('should produce different hash data for different operations', async () => {
-        const hashData1 = await azorius.generateTxHashData(
-          txParams.to,
-          txParams.value,
-          txParams.data,
-          0, // Operation Call
-          txParams.nonce,
-        );
-        const hashData2 = await azorius.generateTxHashData(
-          txParams.to,
-          txParams.value,
-          txParams.data,
-          1, // Operation DelegateCall
-          txParams.nonce,
-        );
+        const hashData1 = await azorius.generateTxHashData(txParams, nonce);
+        txParams.operation = 1; // Different operation
+        const hashData2 = await azorius.generateTxHashData(txParams, nonce);
         expect(hashData1).to.not.equal(hashData2);
       });
     });

--- a/test/deployables/modules/FractalModuleV1.test.ts
+++ b/test/deployables/modules/FractalModuleV1.test.ts
@@ -245,62 +245,74 @@ describe('FractalModuleV1', () => {
     });
 
     describe('Authorization', () => {
-      let target: string;
-      let value: bigint;
-      let data: string;
-      let operation: number;
+      let tx: {
+        to: string;
+        value: bigint;
+        data: string;
+        operation: number;
+      };
 
       beforeEach(async () => {
         await mockToken.mint(await avatar.getAddress(), 1000); // Mint tokens for these tests
 
-        target = await mockToken.getAddress();
-        value = 0n;
-        data = mockToken.interface.encodeFunctionData('transfer', [user.address, 100]);
-        operation = 0;
+        tx = {
+          to: await mockToken.getAddress(),
+          value: 0n,
+          data: mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
+          operation: 0,
+        };
       });
 
       it('should allow owner to execute transactions', async () => {
         await mockToken.mint(await avatar.getAddress(), 1000);
-        await fractalModule.execTx(target, value, data, operation);
+        await fractalModule.execTx(tx);
         expect(await mockToken.balanceOf(user.address)).to.equal(100);
       });
 
       it('should revert with OwnableUnauthorizedAccount for non-owner', async () => {
-        await expect(
-          fractalModule.connect(user).execTx(target, value, data, operation),
-        ).to.be.revertedWithCustomError(fractalModule, 'OwnableUnauthorizedAccount');
+        await expect(fractalModule.connect(user).execTx(tx)).to.be.revertedWithCustomError(
+          fractalModule,
+          'OwnableUnauthorizedAccount',
+        );
       });
     });
 
     describe('Transaction Success/Failure', () => {
-      let target: string;
-      let value: bigint;
-      let data: string;
-      let operation: number;
+      let tx: {
+        to: string;
+        value: bigint;
+        data: string;
+        operation: number;
+      };
 
       beforeEach(async () => {
-        target = await mockToken.getAddress();
-        value = 0n;
-        data = mockToken.interface.encodeFunctionData('transfer', [user.address, 100]);
-        operation = 0;
+        tx = {
+          to: await mockToken.getAddress(),
+          value: 0n,
+          data: mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
+          operation: 0,
+        };
       });
 
       it('should execute successful transactions', async () => {
         await mockToken.mint(await avatar.getAddress(), 1000);
-        await fractalModule.execTx(target, value, data, operation);
+        await fractalModule.execTx(tx);
         expect(await mockToken.balanceOf(user.address)).to.equal(100);
       });
 
       it('should revert with TxFailed on failed transactions', async () => {
         // No tokens minted to avatar, so transfer should fail
-        target = await mockToken.getAddress();
-        value = 0n;
-        data = mockToken.interface.encodeFunctionData('transfer', [user.address, 100]);
-        operation = 0;
+        tx = {
+          to: await mockToken.getAddress(),
+          value: 0n,
+          data: mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
+          operation: 0,
+        };
 
-        await expect(
-          fractalModule.execTx(target, value, data, operation),
-        ).to.be.revertedWithCustomError(fractalModule, 'TxFailed');
+        await expect(fractalModule.execTx(tx)).to.be.revertedWithCustomError(
+          fractalModule,
+          'TxFailed',
+        );
       });
     });
 
@@ -312,25 +324,29 @@ describe('FractalModuleV1', () => {
           value: ethers.parseEther('1.0'),
         });
 
-        const target = user.address;
-        const value = ethers.parseEther('0.5');
-        const data = '0x';
-        const operation = 0;
+        const tx = {
+          to: user.address,
+          value: ethers.parseEther('0.5'),
+          data: '0x',
+          operation: 0,
+        };
 
         const initialBalance = await ethers.provider.getBalance(user.address);
-        await fractalModule.execTx(target, value, data, operation);
+        await fractalModule.execTx(tx);
         const finalBalance = await ethers.provider.getBalance(user.address);
 
         expect(finalBalance - initialBalance).to.equal(ethers.parseEther('0.5'));
       });
 
       it('should handle transactions with empty data', async () => {
-        const target = user.address;
-        const value = 0n;
-        const data = '0x';
-        const operation = 0;
+        const tx = {
+          to: user.address,
+          value: 0n,
+          data: '0x',
+          operation: 0,
+        };
 
-        await fractalModule.execTx(target, value, data, operation);
+        await fractalModule.execTx(tx);
       });
 
       it('should handle transactions with both value and data', async () => {
@@ -342,22 +358,26 @@ describe('FractalModuleV1', () => {
         await mockToken.mint(await avatar.getAddress(), 1000);
 
         // First send ETH to user
-        const ethTxTarget = user.address;
-        const ethTxValue = ethers.parseEther('0.5');
-        const ethTxData = '0x';
-        const ethTxOperation = 0;
+        const ethTx = {
+          to: user.address,
+          value: ethers.parseEther('0.5'),
+          data: '0x',
+          operation: 0,
+        };
 
         // Then do token transfer
-        const tokenTxTarget = await mockToken.getAddress();
-        const tokenTxValue = 0n;
-        const tokenTxData = mockToken.interface.encodeFunctionData('transfer', [user.address, 100]);
-        const tokenTxOperation = 0;
+        const tokenTx = {
+          to: await mockToken.getAddress(),
+          value: 0n,
+          data: mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
+          operation: 0,
+        };
 
         const initialEthBalance = await ethers.provider.getBalance(user.address);
 
         // Execute both transactions
-        await fractalModule.execTx(ethTxTarget, ethTxValue, ethTxData, ethTxOperation);
-        await fractalModule.execTx(tokenTxTarget, tokenTxValue, tokenTxData, tokenTxOperation);
+        await fractalModule.execTx(ethTx);
+        await fractalModule.execTx(tokenTx);
 
         const finalEthBalance = await ethers.provider.getBalance(user.address);
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/322

Fixes [ENG-1086](https://linear.app/decent-labs/issue/ENG-1086/optimize-gas-with-calldata-and-refactor-transaction-handling-with)

This commit introduces gas optimizations and improves code readability by:
1.  Changing function parameters from `memory` to `calldata` where appropriate. This applies to array and struct parameters that are read-only within the function body, potentially saving gas by avoiding unnecessary memory allocations and copying.
2.  Refactoring `AzoriusV1.executeProposal` and `FractalModuleV1.execTx` to accept a `Transaction[] calldata _transactions` (for Azorius) or `Transaction calldata _transaction` (for FractalModule) struct instead of individual parameters for `to`, `value`, `data`, and `operation`. This improves readability and can also lead to gas savings by reducing the number of parameters passed on the stack.

**Key Changes:**

*   **Parameter Storage Location (`memory` -> `calldata`):**
    *   `ILinearERC721VotingV1ValidatorV1.sol` (embedded interface): `vote` function parameters `tokenAddresses` and `tokenIds` changed to `calldata`.
    *   `VotesERC20LockableV1.sol`: `initialize` parameter `allocations_` changed to `calldata`. (Note: `metadata_` was already calldata).
    *   `VotesERC20StakedV1.sol`: `initialize` parameter `rewardsTokens_`, and `addRewardsTokens` parameter `rewardsTokens_`, and `distributeRewards(address[])` parameter `_tokens` changed to `calldata`.
    *   `VotesERC20V1.sol`: `initialize` parameters `metadata` and `allocations` changed to `calldata`.
    *   `MultisigFreezeGuardV1.sol`: `timelockTransaction` parameter `signatures` changed to `calldata`.
    *   `ERC721FreezeVotingV1.sol`: `castFreezeVote` parameters `_tokenAddresses` and `_tokenIds` changed to `calldata`. `_getVotesAndUpdateHasVoted` also updated.
    *   `StrategyV1.sol`: `initialize` parameters `votingAdapters_` and `proposerAdapters_` changed to `calldata`. `initializeProposal` parameters also changed.
    *   Proposer Adapters (`ERC20ProposerAdapterV1`, `ERC721ProposerAdapterV1`, `HatsProposerAdapterV1`): `isProposer` parameter `_data` changed to `calldata`. `HatsProposerAdapterV1.initialize` parameter `whitelistedHatIds_` changed to `calldata`.
    *   `IProxyFactory.sol`: `deployProxy` parameter `initData` and `predictProxyAddress` parameter `initData` changed to `calldata`.
    *   `ProxyFactory.sol`: Implemented the `calldata` changes from `IProxyFactory`.
    *   `MinimalUpgradeableContract.sol`: `initializeWithLargeData` parameter `_largeData` changed to `calldata`.
    *   `UpgradeContractV1.sol`: `initialize` parameter `_name` changed to `calldata`.
    *   `MockLinearERC721VotingV1.sol`: `vote` parameters changed to `calldata`.
    *   `MockSafe.sol`: `checkSignatures` parameter `_data` and `_signatures` changed to `calldata`.
    *   `MockVotingStrategy.sol`: Various parameters changed to `calldata`.

*   **Transaction Struct Refactoring:**
    *   `IAzoriusV1.sol`:
        *   `executeProposal` now takes `Transaction[] calldata _transactions` instead of separate memory arrays for targets, values, data, and operations.
        *   `generateTxHashData` now takes `Transaction calldata _transaction` instead of individual parameters.
        *   `getTxHash` now takes `Transaction calldata _transaction`.
        *   Removed `InvalidArrayLengths` error as it's no longer applicable with the struct array.
    *   `AzoriusV1.sol`:
        *   Implemented the `Transaction` struct changes for `executeProposal`, `generateTxHashData`, `getTxHash`, and `_executeProposalTx`.
    *   `IFractalModuleV1.sol`:
        *   Added `Transaction` struct definition.
        *   `execTx` now takes `Transaction calldata _transaction` instead of individual parameters.
    *   `FractalModuleV1.sol`:
        *   Implemented the `Transaction` struct change for `execTx`.
    *   Test files (`AzoriusV1.test.ts`, `FractalModuleV1.test.ts`) updated to use the new `Transaction` struct when calling these functions.

**Rationale:**

*   **Gas Optimization:** Using `calldata` for external function parameters that are not modified within the function can significantly reduce gas costs by avoiding unnecessary data copying from calldata to memory.
*   **Readability and Maintainability:** Using a `Transaction` struct in `AzoriusV1` and `FractalModuleV1` makes the function signatures cleaner and the code easier to understand and maintain, as related transaction parameters are grouped together.
*   **Consistency:** Applying `calldata` where appropriate provides a more consistent coding style.

These changes contribute to a more optimized and readable codebase.