### PR TITLE
perf: Optimize loop increments with unchecked arithmetic

### DIFF
--- a/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC20VotingV1ValidatorV1.sol
@@ -109,7 +109,7 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
         // Iterate backwards through checkpoints to find the relevant one for startTimestamp.
         // This is potentially more efficient than binary search if startTimestamp is recent.
         uint256 votingWeight = 0;
-        for (uint256 i = numCheckpoints; i > 0; i--) {
+        for (uint256 i = numCheckpoints; i > 0; ) {
             // Checkpoint indices are 0-based, loop index 'i' is 1-based count.
             Checkpoint208 memory checkpoint = governanceToken.checkpoints(
                 lightAccountOwner,
@@ -128,6 +128,10 @@ contract LinearERC20VotingV1ValidatorV1 is IFunctionValidator, ERC165, Version {
             if (checkpoint.key <= startTimestamp) {
                 votingWeight = checkpoint.value;
                 break; // Exit loop once the correct checkpoint is found
+            }
+
+            unchecked {
+                --i;
             }
         }
         // If the loop completes without finding a checkpoint where fromTimestamp <= startTimestamp,

--- a/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/LinearERC721VotingV1ValidatorV1.sol
@@ -94,7 +94,7 @@ contract LinearERC721VotingV1ValidatorV1 is
 
         // Validate each token in the arrays
         uint256 totalWeight = 0;
-        for (uint256 i = 0; i < tokenAddresses.length; i++) {
+        for (uint256 i = 0; i < tokenAddresses.length; ) {
             address tokenAddress = tokenAddresses[i];
             uint256 tokenId = tokenIds[i];
 
@@ -117,6 +117,10 @@ contract LinearERC721VotingV1ValidatorV1 is
             // Check if voter owns the token
             if (IERC721(tokenAddress).ownerOf(tokenId) != lightAccountOwner) {
                 return false;
+            }
+
+            unchecked {
+                ++i;
             }
         }
 

--- a/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/ERC721FreezeVotingV1.sol
@@ -86,17 +86,23 @@ contract ERC721FreezeVotingV1 is
     ) internal virtual returns (uint256) {
         uint256 votes = 0;
 
-        for (uint256 i = 0; i < _tokenAddresses.length; i++) {
+        for (uint256 i = 0; i < _tokenAddresses.length; ) {
             address tokenAddress = _tokenAddresses[i];
             uint256 tokenId = _tokenIds[i];
 
             if (_voter != IERC721(tokenAddress).ownerOf(tokenId)) {
+                unchecked {
+                    ++i;
+                }
                 continue;
             }
 
             if (
                 _idHasFreezeVoted[_freezeProposalCreated][tokenAddress][tokenId]
             ) {
+                unchecked {
+                    ++i;
+                }
                 continue;
             }
 
@@ -105,6 +111,10 @@ contract ERC721FreezeVotingV1 is
             _idHasFreezeVoted[_freezeProposalCreated][tokenAddress][
                 tokenId
             ] = true;
+
+            unchecked {
+                ++i;
+            }
         }
 
         return votes;

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -74,11 +74,17 @@ contract StrategyV1 is
         _votingAdapters = votingAdapters_;
         _proposerAdapters = proposerAdapters_;
 
-        for (uint256 i = 0; i < votingAdapters_.length; i++) {
+        for (uint256 i = 0; i < votingAdapters_.length; ) {
             _isVotingAdapter[votingAdapters_[i]] = true;
+            unchecked {
+                ++i;
+            }
         }
-        for (uint256 i = 0; i < proposerAdapters_.length; i++) {
+        for (uint256 i = 0; i < proposerAdapters_.length; ) {
             _isProposerAdapter[proposerAdapters_[i]] = true;
+            unchecked {
+                ++i;
+            }
         }
     }
 
@@ -194,7 +200,7 @@ contract StrategyV1 is
 
         uint256 totalWeightForThisVoteTransaction = 0;
 
-        for (uint256 i = 0; i < _votingAdaptersToUse.length; i++) {
+        for (uint256 i = 0; i < _votingAdaptersToUse.length; ) {
             address votingAdapter = _votingAdaptersToUse[i];
 
             if (!_isVotingAdapter[votingAdapter]) {
@@ -204,6 +210,10 @@ contract StrategyV1 is
             totalWeightForThisVoteTransaction += IBaseVotingAdapterV1(
                 votingAdapter
             ).recordVote(resolvedVoter, _proposalId, _votingAdapterVoteData[i]);
+
+            unchecked {
+                ++i;
+            }
         }
 
         if (totalWeightForThisVoteTransaction == 0) revert NoVotingWeight();

--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -62,17 +62,25 @@ contract ERC721VotingAdapterV1 is
         uniqueTokenIds = new uint256[](tokenIds.length);
         uint256 uniqueCount = 0;
 
-        for (uint256 i = 0; i < tokenIds.length; i++) {
+        for (uint256 i = 0; i < tokenIds.length; ) {
             bool isDuplicate = false;
-            for (uint256 j = 0; j < uniqueCount; j++) {
+            for (uint256 j = 0; j < uniqueCount; ) {
                 if (uniqueTokenIds[j] == tokenIds[i]) {
                     isDuplicate = true;
                     break;
+                }
+
+                unchecked {
+                    ++j;
                 }
             }
             if (!isDuplicate) {
                 uniqueTokenIds[uniqueCount] = tokenIds[i];
                 uniqueCount++;
+            }
+
+            unchecked {
+                ++i;
             }
         }
 
@@ -88,10 +96,14 @@ contract ERC721VotingAdapterV1 is
         ownedTokenIds = new uint256[](tokenIds.length);
         uint256 ownedTokenCount = 0;
 
-        for (uint256 i = 0; i < tokenIds.length; i++) {
+        for (uint256 i = 0; i < tokenIds.length; ) {
             if (_token.ownerOf(tokenIds[i]) == voter) {
                 ownedTokenIds[ownedTokenCount] = tokenIds[i];
                 ownedTokenCount++;
+            }
+
+            unchecked {
+                ++i;
             }
         }
 
@@ -107,10 +119,14 @@ contract ERC721VotingAdapterV1 is
         unusedTokenIds = new uint256[](tokenIds.length);
         uint256 unusedTokenCount = 0;
 
-        for (uint256 i = 0; i < tokenIds.length; i++) {
+        for (uint256 i = 0; i < tokenIds.length; ) {
             if (!_tokenIdUsedForVote[proposalId][tokenIds[i]]) {
                 unusedTokenIds[unusedTokenCount] = tokenIds[i];
                 unusedTokenCount++;
+            }
+
+            unchecked {
+                ++i;
             }
         }
 
@@ -191,7 +207,7 @@ contract ERC721VotingAdapterV1 is
             revert NoTokenIdsPassed();
         }
 
-        for (uint256 i = 0; i < tokenIds.length; i++) {
+        for (uint256 i = 0; i < tokenIds.length; ) {
             uint256 tokenId = tokenIds[i];
             if (_token.ownerOf(tokenId) != _voter) {
                 revert TokenIdNotOwnedByVoter(tokenId);
@@ -200,6 +216,10 @@ contract ERC721VotingAdapterV1 is
                 revert TokenIdAlreadyUsedForVote(tokenId);
             }
             _tokenIdUsedForVote[_proposalId][tokenId] = true;
+
+            unchecked {
+                ++i;
+            }
         }
 
         weightCasted = tokenIds.length * _weightPerToken;

--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -31,8 +31,12 @@ contract HatsProposerAdapterV1 is
     ) public virtual override initializer {
         _hatsContract = IHats(hatsContract_);
         _whitelistedHatIds = whitelistedHatIds_;
-        for (uint256 i = 0; i < whitelistedHatIds_.length; i++) {
+        for (uint256 i = 0; i < whitelistedHatIds_.length; ) {
             _hatIdToIsWhitelisted[whitelistedHatIds_[i]] = true;
+
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/contracts/mocks/MockLinearERC20VotingV1.sol
+++ b/contracts/mocks/MockLinearERC20VotingV1.sol
@@ -72,8 +72,12 @@ contract MockLinearERC20VotingV1 {
         }
 
         // Add new checkpoints one by one
-        for (uint32 i = 0; i < checkpointsData.length; i++) {
+        for (uint32 i = 0; i < checkpointsData.length; ) {
             _checkpoints[account].push(checkpointsData[i]);
+
+            unchecked {
+                ++i;
+            }
         }
 
         // Update the checkpoint count

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -152,7 +152,7 @@ contract MockVotingStrategy is IStrategyV1 {
         address[] calldata _votingAdaptersToUse,
         bytes[] calldata _votingAdapterVoteData
     ) external virtual override {
-        for (uint256 i = 0; i < _votingAdaptersToUse.length; i++) {
+        for (uint256 i = 0; i < _votingAdaptersToUse.length; ) {
             address adapterAddress = _votingAdaptersToUse[i];
             bytes calldata adapterData = _votingAdapterVoteData[i];
 
@@ -161,6 +161,10 @@ contract MockVotingStrategy is IStrategyV1 {
                 _proposalId,
                 adapterData
             );
+
+            unchecked {
+                ++i;
+            }
         }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/323

Fixes [ENG-1087](https://linear.app/decent-labs/issue/ENG-1087/optimize-for-loop-incrementsdecrements-with-unchecked-arithmetic)

This commit applies a gas optimization technique to various `for` loops across the codebase by using `unchecked { ++i; }` for increments (or `unchecked { --i; }` for decrements). This is done in loops where the loop conditions inherently prevent overflow/underflow of the iterator, making the default checked arithmetic unnecessary and allowing for minor gas savings per iteration.

**Contracts Affected and Loop Contexts:**

*   **`LinearERC20VotingV1ValidatorV1.sol`**: In the loop iterating backwards through checkpoints.
*   **`LinearERC721VotingV1ValidatorV1.sol`**: In the loop validating token addresses and IDs.
*   **`ERC721FreezeVotingV1.sol`**: In the `_getVotesAndUpdateHasVoted` function's loop.
*   **`StrategyV1.sol`**: In `initialize` (loops for populating `_isVotingAdapter` and `_isProposerAdapter` mappings) and in the `vote` function's loop through `_votingAdaptersToUse`.
*   **`ERC721VotingAdapterV1.sol`**: In `_getUniqueTokenIds`, `_getOwnedTokenIds`, `_getUnusedTokenIds`, and `recordVote` loops.
*   **`HatsProposerAdapterV1.sol`**: In the `initialize` loop for populating `_hatIdToIsWhitelisted`.
*   **`MockLinearERC20VotingV1.sol`**: In the `setCheckpoints` loop.
*   **`MockVotingStrategy.sol`**: In the `vote` function's loop.

This change is purely a performance optimization and does not alter the functional logic of the contracts. The use of `unchecked` is safe in these contexts because the loop bounds and logic ensure that the iterator `i` will not overflow or underflow.