### PR TITLE
feat(validation): Pass full inner calldata to function validators

### DIFF
--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -94,20 +94,16 @@ contract DecentPaymasterV1 is
         (
             address lightAccountOwner,
             address target,
-            bytes4 selector
+            bytes memory innerCallData
         ) = validateUserOp(userOp);
+
+        bytes4 selector = bytes4(innerCallData);
 
         // Check if function has a validator
         address validator = _functionValidators[target][selector];
         if (validator == address(0)) {
             revert NoValidatorSet(target, selector);
         }
-
-        // Extract the inner calldata from the UserOp
-        (, , bytes memory innerCallData) = abi.decode(
-            userOp.callData[4:],
-            (address, uint256, bytes)
-        );
 
         // Validate the operation will succeed
         bool isValid = IFunctionValidator(validator).validateOperation(

--- a/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
+++ b/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
@@ -69,7 +69,7 @@ abstract contract SmartAccountValidationV1 is
 
     function validateUserOp(
         PackedUserOperation calldata userOp
-    ) internal view virtual returns (address, address, bytes4) {
+    ) internal view virtual returns (address, address, bytes memory) {
         (bool isValid, address lightAccountOwner) = validateSmartAccount(
             userOp.sender
         );
@@ -108,6 +108,6 @@ abstract contract SmartAccountValidationV1 is
             revert InvalidInnerCallDataLength();
         }
 
-        return (lightAccountOwner, target, bytes4(innerCallData));
+        return (lightAccountOwner, target, innerCallData);
     }
 }

--- a/contracts/mocks/concretes/deployables/account-abstraction/ConcreteSmartAccountValidation.sol
+++ b/contracts/mocks/concretes/deployables/account-abstraction/ConcreteSmartAccountValidation.sol
@@ -17,7 +17,7 @@ contract ConcreteSmartAccountValidation is SmartAccountValidationV1 {
 
     function validateUserOpPublic(
         PackedUserOperation calldata userOp
-    ) public view returns (address, address, bytes4) {
+    ) public view returns (address, address, bytes memory) {
         return validateUserOp(userOp);
     }
 }

--- a/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
+++ b/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
@@ -143,6 +143,7 @@ describe('SmartAccountValidationV1', function () {
     let mockUserOp: PackedUserOperation;
     let mockTarget: MockGaslessTarget;
     let FOO_SELECTOR: string;
+    let expectedInnerCallData: string;
 
     beforeEach(async function () {
       // Deploy MockGaslessTarget
@@ -152,7 +153,7 @@ describe('SmartAccountValidationV1', function () {
       FOO_SELECTOR = mockTarget.interface.getFunction('foo').selector;
 
       // Create mock UserOperation with properly encoded calldata
-      const innerCalldata = mockTarget.interface.encodeFunctionData('foo', [
+      expectedInnerCallData = mockTarget.interface.encodeFunctionData('foo', [
         123, // uint32 someNumber
         1, // uint8 someFlag
       ]);
@@ -160,7 +161,7 @@ describe('SmartAccountValidationV1', function () {
       const executeCalldata = mockLightAccount.interface.encodeFunctionData('execute', [
         await mockTarget.getAddress(),
         0n, // value
-        innerCalldata,
+        expectedInnerCallData,
       ]);
 
       mockUserOp = {
@@ -184,11 +185,12 @@ describe('SmartAccountValidationV1', function () {
         await mockLightAccount.getAddress(),
       );
 
-      const [lightAccountOwner, target, selector] =
+      const [lightAccountOwner, target, returnedInnerCallData] =
         await concreteSmartAccountValidation.validateUserOpPublic(mockUserOp);
       expect(lightAccountOwner).to.equal(await mockLightAccount.owner());
       expect(target).to.equal(await mockTarget.getAddress());
-      expect(selector).to.equal(FOO_SELECTOR);
+      expect(returnedInnerCallData.slice(0, 10)).to.equal(FOO_SELECTOR);
+      expect(returnedInnerCallData).to.equal(expectedInnerCallData);
     });
 
     it('should revert when the sender is not a valid smart account', async function () {


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/327

Fixes [ENG-1107](https://linear.app/decent-labs/issue/ENG-1107/enhance-function-validators-to-receive-full-inner-calldata)

This commit enhances the function validation framework by providing more context to the validator contracts. Previously, the `validateUserOp` function would only return the 4-byte selector of the inner call, limiting validators to only checking *which* function was being called, not *what parameters* it was called with.

This change modifies `SmartAccountValidationV1.validateUserOp` to return the complete `innerCallData` (`bytes`) of the `execute` call. This allows `DecentPaymasterV1` to pass the full calldata to the relevant `IFunctionValidator`, enabling more powerful and sophisticated validation based on the function's arguments.

Key changes include:
- The return signature of `SmartAccountValidationV1.validateUserOp` has been changed from `(address, address, bytes4)` to `(address, address, bytes memory)`.
- `DecentPaymasterV1` has been simplified to use this new return value directly, removing the need for it to decode the `userOp.callData` itself.
- Tests for `SmartAccountValidationV1` have been updated to assert that the full inner calldata is returned correctly.
- All related mock contracts have been updated to reflect these interface changes.