### PR TITLE
refactor(strategy): Consolidate vote parameters into a struct

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -184,12 +184,8 @@ contract StrategyV1 is
     function vote(
         uint32 _proposalId,
         uint8 _voteType,
-        address[] calldata _votingAdaptersToUse,
-        bytes[] calldata _votingAdapterVoteData
+        VotingAdapterVoteData[] calldata votingAdaptersData
     ) external virtual override {
-        if (_votingAdaptersToUse.length != _votingAdapterVoteData.length)
-            revert MismatchedInputs();
-
         address resolvedVoter = voter(msg.sender);
         ProposalVotingDetails storage proposal = _proposalVotingDetails[
             _proposalId
@@ -214,8 +210,10 @@ contract StrategyV1 is
 
         uint256 totalWeightForThisVoteTransaction = 0;
 
-        for (uint256 i = 0; i < _votingAdaptersToUse.length; ) {
-            address votingAdapter = _votingAdaptersToUse[i];
+        for (uint256 i = 0; i < votingAdaptersData.length; ) {
+            VotingAdapterVoteData
+                memory votingAdapterVoteData = votingAdaptersData[i];
+            address votingAdapter = votingAdapterVoteData.votingAdapter;
 
             if (!_isVotingAdapter[votingAdapter]) {
                 revert InvalidVotingAdapter();
@@ -223,7 +221,11 @@ contract StrategyV1 is
 
             totalWeightForThisVoteTransaction += IBaseVotingAdapterV1(
                 votingAdapter
-            ).recordVote(resolvedVoter, _proposalId, _votingAdapterVoteData[i]);
+            ).recordVote(
+                    resolvedVoter,
+                    _proposalId,
+                    votingAdapterVoteData.adapterVoteData
+                );
 
             unchecked {
                 ++i;

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -11,6 +11,11 @@ interface IStrategyV1 {
         uint256 abstainVotes;
     }
 
+    struct VotingAdapterVoteData {
+        address votingAdapter;
+        bytes adapterVoteData;
+    }
+
     enum VoteType {
         NO,
         YES,
@@ -49,7 +54,6 @@ interface IStrategyV1 {
     error NoVotingWeight();
     error InvalidVoteType();
     error ProposalNotInitialized();
-    error MismatchedInputs();
     error InvalidVotingAdapter();
     error InvalidAddress();
 
@@ -116,8 +120,7 @@ interface IStrategyV1 {
     function vote(
         uint32 _proposalId,
         uint8 _voteType,
-        address[] calldata _votingAdaptersToUse,
-        bytes[] calldata _votingAdapterVoteData
+        VotingAdapterVoteData[] calldata votingAdaptersData
     ) external;
 
     function addAuthorizedFreezeVoter(address freezeVoterContract) external;

--- a/contracts/mocks/MockLightAccount.sol
+++ b/contracts/mocks/MockLightAccount.sol
@@ -30,12 +30,11 @@ contract MockLightAccount is ILightAccount {
         IStrategyV1 strategy,
         uint32 proposalId,
         uint8 voteType,
-        address[] calldata adaptersToUse,
-        bytes[] calldata adapterVoteData
+        IStrategyV1.VotingAdapterVoteData[] calldata votingAdaptersData
     ) external {
         // msg.sender here is the EOA calling MockLightAccount (e.g., relayer)
         // When strategy.vote is called, msg.sender from StrategyV1's perspective will be address(this)
-        strategy.vote(proposalId, voteType, adaptersToUse, adapterVoteData);
+        strategy.vote(proposalId, voteType, votingAdaptersData);
     }
 
     // Function specifically for freeze voting tests via smart account

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -170,20 +170,20 @@ contract MockVotingStrategy is IStrategyV1, ERC4337VoterSupportV1 {
     function vote(
         uint32 _proposalId,
         uint8 _voteType,
-        address[] calldata _votingAdaptersToUse,
-        bytes[] calldata _votingAdapterVoteData
+        IStrategyV1.VotingAdapterVoteData[] calldata votingAdaptersData
     ) external virtual override {
         address resolvedVoter = voter(msg.sender);
         ProposalVotingDetails storage proposal = proposalVotingDetailsMap[
             _proposalId
         ];
         uint256 totalWeight = 0;
-        for (uint i = 0; i < _votingAdaptersToUse.length; i++) {
-            totalWeight += IBaseVotingAdapterV1(_votingAdaptersToUse[i])
-                .recordVote(
+        for (uint i = 0; i < votingAdaptersData.length; i++) {
+            totalWeight += IBaseVotingAdapterV1(
+                votingAdaptersData[i].votingAdapter
+            ).recordVote(
                     resolvedVoter,
                     _proposalId,
-                    _votingAdapterVoteData[i]
+                    votingAdaptersData[i].adapterVoteData
                 );
         }
         if (_voteType == uint8(VoteType.YES)) proposal.yesVotes += totalWeight;

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -504,20 +504,15 @@ describe('StrategyV1', () => {
       adapter2Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[2]]);
     });
 
-    it('should revert if _adaptersToUse and _adapterVoteData lengths mismatch', async () => {
-      const adaptersToUse = [await mockAdapter1.getAddress()]; // 1 adapter
-      const adapterVoteData: string[] = []; // 0 data entries
-      await expect(
-        strategy.connect(user1).vote(proposalId, 1, adaptersToUse, adapterVoteData),
-      ).to.be.revertedWithCustomError(strategy, 'MismatchedInputs');
-    });
-
     it('should revert if proposal is not initialized (votingEndTimestamp is 0)', async () => {
       const uninitializedProposalId = 999;
       await expect(
-        strategy
-          .connect(user1)
-          .vote(uninitializedProposalId, 1, [await mockAdapter1.getAddress()], [adapter1Data]),
+        strategy.connect(user1).vote(uninitializedProposalId, 1, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+        ]),
       ).to.be.revertedWithCustomError(strategy, 'ProposalNotInitialized');
     });
 
@@ -526,9 +521,12 @@ describe('StrategyV1', () => {
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
       // First call after period ends should emit event and not revert immediately
-      const tx = await strategy
-        .connect(user1)
-        .vote(proposalId, 1, [await mockAdapter1.getAddress()], [adapter1Data]);
+      const tx = await strategy.connect(user1).vote(proposalId, 1, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: adapter1Data,
+        },
+      ]);
 
       const currentBlockTimestamp = await time.latest();
       await expect(tx)
@@ -537,9 +535,12 @@ describe('StrategyV1', () => {
 
       // Subsequent calls should revert
       await expect(
-        strategy
-          .connect(user1)
-          .vote(proposalId, 1, [await mockAdapter1.getAddress()], [adapter1Data]),
+        strategy.connect(user1).vote(proposalId, 1, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+        ]),
       ).to.be.revertedWithCustomError(strategy, 'ProposalNotActive');
     });
 
@@ -548,9 +549,12 @@ describe('StrategyV1', () => {
       await time.increaseTo(proposalDetailsBefore.votingEndTimestamp + 1n);
 
       // First call after voting period ends
-      const tx = await strategy
-        .connect(user1)
-        .vote(proposalId, 1 /* YES */, [await mockAdapter1.getAddress()], [adapter1Data]);
+      const tx = await strategy.connect(user1).vote(proposalId, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: adapter1Data,
+        },
+      ]);
 
       const blockTimestampAfterVote = await time.latest();
       await expect(tx)
@@ -565,18 +569,24 @@ describe('StrategyV1', () => {
 
       // Further calls should revert
       await expect(
-        strategy
-          .connect(user1)
-          .vote(proposalId, 1 /* YES */, [await mockAdapter1.getAddress()], [adapter1Data]),
+        strategy.connect(user1).vote(proposalId, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+        ]),
       ).to.be.revertedWithCustomError(strategy, 'ProposalNotActive');
     });
 
     it('should revert if total weight cast is zero (e.g., adapter.recordVote returns 0)', async () => {
       await mockAdapter1.setWeight(user1.address, 0);
       await expect(
-        strategy
-          .connect(user1)
-          .vote(proposalId, 1, [await mockAdapter1.getAddress()], [adapter1Data]),
+        strategy.connect(user1).vote(proposalId, 1, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+        ]),
       ).to.be.revertedWithCustomError(strategy, 'NoVotingWeight');
     });
 
@@ -584,9 +594,12 @@ describe('StrategyV1', () => {
       const invalidVoteType = 3; // VoteType enum is 0, 1, 2
       await mockAdapter1.setWeight(user1.address, 10);
       await expect(
-        strategy
-          .connect(user1)
-          .vote(proposalId, invalidVoteType, [await mockAdapter1.getAddress()], [adapter1Data]),
+        strategy.connect(user1).vote(proposalId, invalidVoteType, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+        ]),
       ).to.be.revertedWithCustomError(strategy, 'InvalidVoteType');
     });
 
@@ -597,11 +610,19 @@ describe('StrategyV1', () => {
 
       await mockAdapter1.setWeight(user1.address, 10);
 
-      const adaptersToUse = [await mockAdapter1.getAddress(), unconfiguredAdapterAddress];
-      const adapterDataArray = [adapter1Data, adapter1Data];
+      const adapterData = [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: adapter1Data,
+        },
+        {
+          votingAdapter: unconfiguredAdapterAddress,
+          adapterVoteData: adapter1Data,
+        },
+      ];
 
       await expect(
-        strategy.connect(user1).vote(proposalId, 1 /* YES */, adaptersToUse, adapterDataArray),
+        strategy.connect(user1).vote(proposalId, 1 /* YES */, adapterData),
       ).to.be.revertedWithCustomError(strategy, 'InvalidVotingAdapter');
     });
 
@@ -609,9 +630,12 @@ describe('StrategyV1', () => {
       const voteWeight = 100;
       await mockAdapter1.setWeight(user1.address, voteWeight);
 
-      const tx = await strategy
-        .connect(user1)
-        .vote(proposalId, 1 /* YES */, [await mockAdapter1.getAddress()], [adapter1Data]);
+      const tx = await strategy.connect(user1).vote(proposalId, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: adapter1Data,
+        },
+      ]);
 
       await expect(tx)
         .to.emit(strategy, 'Voted')
@@ -638,9 +662,12 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(user1.address, voteWeight);
 
       await expect(
-        strategy
-          .connect(user1)
-          .vote(proposalId, 0 /* NO */, [await mockAdapter1.getAddress()], [adapter1Data]),
+        strategy.connect(user1).vote(proposalId, 0 /* NO */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+        ]),
       )
         .to.emit(strategy, 'Voted')
         .withArgs(user1.address, proposalId, 0 /* NO */, voteWeight);
@@ -656,9 +683,12 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(user1.address, voteWeight);
 
       await expect(
-        strategy
-          .connect(user1)
-          .vote(proposalId, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [adapter1Data]),
+        strategy.connect(user1).vote(proposalId, 2 /* ABSTAIN */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+        ]),
       )
         .to.emit(strategy, 'Voted')
         .withArgs(user1.address, proposalId, 2 /* ABSTAIN */, voteWeight);
@@ -688,17 +718,18 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(user1.address, weight1);
       await mockAdapter2.setWeight(user1.address, weight2);
 
-      const adaptersToUseAddresses = [
-        await mockAdapter1.getAddress(),
-        await mockAdapter2.getAddress(),
+      const adapterData = [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: adapter1Data,
+        },
+        {
+          votingAdapter: await mockAdapter2.getAddress(),
+          adapterVoteData: adapter2Data,
+        },
       ];
-      const adapterVoteDataArray = [adapter1Data, adapter2Data];
 
-      await expect(
-        multiAdapterStrategy
-          .connect(user1)
-          .vote(proposalId, 1 /* YES */, adaptersToUseAddresses, adapterVoteDataArray),
-      )
+      await expect(multiAdapterStrategy.connect(user1).vote(proposalId, 1 /* YES */, adapterData))
         .to.emit(multiAdapterStrategy, 'Voted')
         .withArgs(user1.address, proposalId, 1 /* YES */, weight1 + weight2);
 
@@ -728,13 +759,12 @@ describe('StrategyV1', () => {
 
       const tx = await mockSmartAccount
         .connect(relayer)
-        .callStrategyVote(
-          await strategy.getAddress(),
-          proposalId,
-          1 /* YES */,
-          [await mockAdapter1.getAddress()],
-          [adapter1Data],
-        );
+        .callStrategyVote(await strategy.getAddress(), proposalId, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+        ]);
 
       await expect(tx)
         .to.emit(strategy, 'Voted')
@@ -751,9 +781,12 @@ describe('StrategyV1', () => {
       await mockAdapter1.setShouldRevertOnRecordVote(true);
 
       await expect(
-        strategy
-          .connect(user1)
-          .vote(proposalId, 1 /* YES */, [await mockAdapter1.getAddress()], [adapter1Data]),
+        strategy.connect(user1).vote(proposalId, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+        ]),
       ).to.be.revertedWith('MockVotingAdapter: recordVote forced revert');
     });
 
@@ -777,24 +810,24 @@ describe('StrategyV1', () => {
       await mockAdapter1.setShouldRevertOnRecordVote(false);
       await mockAdapter2.setShouldRevertOnRecordVote(true); // Adapter 2 will revert
 
-      const adaptersToUseAddresses = [
-        await mockAdapter1.getAddress(),
-        await mockAdapter2.getAddress(),
-      ];
-      const adapterDataForVoter1Adapter1 = ethers.AbiCoder.defaultAbiCoder().encode(
+      const adapter1DataForVoter1 = ethers.AbiCoder.defaultAbiCoder().encode(
         ['uint256[]'],
         [[777]],
       );
-      const adapterDataForVoter1Adapter2 = ethers.AbiCoder.defaultAbiCoder().encode(
-        ['uint256[]'],
-        [[888]],
-      );
-      const adapterVoteDataArray = [adapterDataForVoter1Adapter1, adapterDataForVoter1Adapter2];
+
+      const adapterData = [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: adapter1DataForVoter1,
+        },
+        {
+          votingAdapter: await mockAdapter2.getAddress(),
+          adapterVoteData: ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[888]]),
+        },
+      ];
 
       await expect(
-        multiAdapterStrategy
-          .connect(user1)
-          .vote(proposalId, 1 /* YES */, adaptersToUseAddresses, adapterVoteDataArray),
+        multiAdapterStrategy.connect(user1).vote(proposalId, 1 /* YES */, adapterData),
       ).to.be.revertedWith('MockVotingAdapter: recordVote forced revert');
 
       const proposalDetails = await multiAdapterStrategy.proposalVotingDetails(proposalId);
@@ -802,7 +835,7 @@ describe('StrategyV1', () => {
       expect(proposalDetails.noVotes).to.equal(0);
       expect(proposalDetails.abstainVotes).to.equal(0);
 
-      const dataHashAdapter1 = ethers.keccak256(adapterDataForVoter1Adapter1);
+      const dataHashAdapter1 = ethers.keccak256(adapter1DataForVoter1);
       void expect(await mockAdapter1.hasRecordedVote(user1.address, proposalId, dataHashAdapter1))
         .to.be.false;
     });
@@ -824,17 +857,23 @@ describe('StrategyV1', () => {
 
     it('should return false if voting period is not over', async () => {
       await mockAdapter1.setWeight(voter1.address, DEFAULT_QUORUM_THRESHOLD + 10n);
-      await strategy
-        .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+      await strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
       void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.false; // Voting not over
     });
 
     it('should return true if quorum and basis are met and voting is over', async () => {
       await mockAdapter1.setWeight(voter1.address, DEFAULT_QUORUM_THRESHOLD + 10n);
-      await strategy
-        .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+      await strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
 
       const proposalDetails = await strategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
@@ -860,15 +899,24 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(voter2.address, 50n);
       await mockAdapter1.setWeight(voter3.address, 10n);
 
-      await specificStrategy
-        .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-      await specificStrategy
-        .connect(voter2)
-        .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-      await specificStrategy
-        .connect(voter3)
-        .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+      await specificStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
+      await specificStrategy.connect(voter2).vote(PROPOSAL_ID, 0 /* NO */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
+      await specificStrategy.connect(voter3).vote(PROPOSAL_ID, 2 /* ABSTAIN */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
 
       const proposalDetails = await specificStrategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
@@ -893,12 +941,18 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(voter1.address, 60n); // YES
       await mockAdapter1.setWeight(voter2.address, 10n); // NO
 
-      await specificStrategy
-        .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-      await specificStrategy
-        .connect(voter2)
-        .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+      await specificStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
+      await specificStrategy.connect(voter2).vote(PROPOSAL_ID, 0 /* NO */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
 
       const proposalDetails = await specificStrategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
@@ -939,9 +993,12 @@ describe('StrategyV1', () => {
       await time.increaseTo(
         (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp + 1n,
       );
-      await strategy
-        .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+      await strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
 
       result = await strategy.votingPeriodEnded(PROPOSAL_ID);
       void expect(result).to.be.true;
@@ -951,9 +1008,12 @@ describe('StrategyV1', () => {
       await time.increaseTo(
         (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp + 1n,
       );
-      await strategy
-        .connect(voter1)
-        .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+      await strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
       void expect(await strategy.votingPeriodEnded(PROPOSAL_ID)).to.be.true;
 
       await time.increaseTo(
@@ -964,9 +1024,12 @@ describe('StrategyV1', () => {
 
     it('should not emit VotingPeriodEnded event when casting a vote before voting period ends', async () => {
       await expect(
-        strategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]),
+        strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]),
       ).not.to.emit(strategy, 'VotingPeriodEnded');
     });
 
@@ -975,9 +1038,12 @@ describe('StrategyV1', () => {
         (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp + 1n,
       );
       await expect(
-        strategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]),
+        strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]),
       )
         .to.emit(strategy, 'VotingPeriodEnded')
         .withArgs(
@@ -1067,12 +1133,18 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 40n);
-        await qStrategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-        await qStrategy
-          .connect(voter2)
-          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await qStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+        await qStrategy.connect(voter2).vote(PROPOSAL_ID, 2 /* ABSTAIN */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
         void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
       });
 
@@ -1091,12 +1163,18 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 41n); // Exceeds
-        await qStrategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-        await qStrategy
-          .connect(voter2)
-          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await qStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+        await qStrategy.connect(voter2).vote(PROPOSAL_ID, 2 /* ABSTAIN */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
         void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
       });
 
@@ -1115,12 +1193,18 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 50n);
         await mockAdapter1.setWeight(voter2.address, 40n); // 90 total, < 100
-        await qStrategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-        await qStrategy
-          .connect(voter2)
-          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await qStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+        await qStrategy.connect(voter2).vote(PROPOSAL_ID, 2 /* ABSTAIN */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
 
         void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
       });
@@ -1138,18 +1222,24 @@ describe('StrategyV1', () => {
         await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 10n); // Only NO votes
-        await qStrategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await qStrategy.connect(voter1).vote(PROPOSAL_ID, 0 /* NO */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
 
         void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if only NO votes are cast and quorum threshold > 0', async () => {
         await mockAdapter1.setWeight(voter1.address, 150n);
-        await strategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await strategy.connect(voter1).vote(PROPOSAL_ID, 0 /* NO */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
         void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
       });
     });
@@ -1165,44 +1255,66 @@ describe('StrategyV1', () => {
       it('should return true if basis is met (yes > no for >50% basis)', async () => {
         await mockAdapter1.setWeight(voter1.address, 101n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await strategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-        await strategy
-          .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+        await strategy.connect(voter2).vote(PROPOSAL_ID, 0 /* NO */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
         void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if basis is not met (yes == no for >50% basis)', async () => {
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await strategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-        await strategy
-          .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+        await strategy.connect(voter2).vote(PROPOSAL_ID, 0 /* NO */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
         void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return false if basis is not met (yes < no for >50% basis)', async () => {
         await mockAdapter1.setWeight(voter1.address, 99n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await strategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-        await strategy
-          .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+        await strategy.connect(voter2).vote(PROPOSAL_ID, 0 /* NO */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
         void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return false if totalYesAndNoVotes is 0 (only abstain)', async () => {
         await mockAdapter1.setWeight(voter1.address, 100n);
-        await strategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 2 /* ABSTAIN */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await strategy.connect(voter1).vote(PROPOSAL_ID, 2 /* ABSTAIN */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+
         void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
@@ -1220,12 +1332,18 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 101n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await bStrategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-        await bStrategy
-          .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await bStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+        await bStrategy.connect(voter2).vote(PROPOSAL_ID, 0 /* NO */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
         void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.true;
       });
 
@@ -1243,12 +1361,18 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await bStrategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-        await bStrategy
-          .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await bStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+        await bStrategy.connect(voter2).vote(PROPOSAL_ID, 0 /* NO */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
         void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
@@ -1266,9 +1390,12 @@ describe('StrategyV1', () => {
         await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
-        await bStrategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await bStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
         void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.true;
       });
 
@@ -1287,12 +1414,18 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 1n);
-        await bStrategy
-          .connect(voter1)
-          .vote(PROPOSAL_ID, 1 /* YES */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
-        await bStrategy
-          .connect(voter2)
-          .vote(PROPOSAL_ID, 0 /* NO */, [await mockAdapter1.getAddress()], [ethers.ZeroHash]);
+        await bStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
+        await bStrategy.connect(voter2).vote(PROPOSAL_ID, 0 /* NO */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]);
 
         void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });

--- a/test/deployables/strategies/adapters/BaseVotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/BaseVotingAdapterV1.test.ts
@@ -116,8 +116,12 @@ describe('BaseVotingAdapterV1', () => {
         mockStrategyContract.connect(nonStrategySigner).vote(
           proposalId,
           0, // voteType (e.g., YES)
-          [await adapter.getAddress()], // Adapter to use
-          [adapterVoteData], // Data for that adapter
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: adapterVoteData,
+            },
+          ],
         ),
       ).to.not.be.reverted; // Primary check: the call succeeds
     });

--- a/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC20VotingAdapterV1.test.ts
@@ -263,8 +263,12 @@ describe('ERC20VotingAdapterV1', () => {
       await mockStrategy.connect(user1Signer).vote(
         proposalId,
         0, // voteType
-        [await adapter.getAddress()],
-        [mockExtraData],
+        [
+          {
+            votingAdapter: await adapter.getAddress(),
+            adapterVoteData: mockExtraData,
+          },
+        ],
       );
       const weight = await adapter.weightOf(user1Signer.address, proposalId, mockExtraData);
       expect(weight).to.equal(0);
@@ -327,8 +331,12 @@ describe('ERC20VotingAdapterV1', () => {
         strategy.connect(voter).vote(
           proposalId,
           0, // voteType
-          [await adapter.getAddress()],
-          [mockExtraData],
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: mockExtraData,
+            },
+          ],
         ),
       )
         .to.emit(adapter, 'VoteRecorded')
@@ -359,8 +367,12 @@ describe('ERC20VotingAdapterV1', () => {
         strategy.connect(voter).vote(
           proposalId,
           0, // voteType
-          [await adapter.getAddress()],
-          [mockExtraData],
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: mockExtraData,
+            },
+          ],
         ),
       )
         .to.emit(adapter, 'VoteRecorded')
@@ -379,15 +391,23 @@ describe('ERC20VotingAdapterV1', () => {
       await strategy.connect(voter).vote(
         proposalId,
         0, // voteType
-        [await adapter.getAddress()],
-        [mockExtraData],
+        [
+          {
+            votingAdapter: await adapter.getAddress(),
+            adapterVoteData: mockExtraData,
+          },
+        ],
       );
       await expect(
         strategy.connect(voter).vote(
           proposalId,
           0, // voteType
-          [await adapter.getAddress()],
-          [mockExtraData],
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: mockExtraData,
+            },
+          ],
         ),
       ).to.be.revertedWithCustomError(adapter, 'AlreadyVoted');
     });
@@ -404,8 +424,12 @@ describe('ERC20VotingAdapterV1', () => {
       await strategy.connect(voter).vote(
         proposalId,
         0, // voteType
-        [await adapter.getAddress()],
-        [mockExtraData],
+        [
+          {
+            votingAdapter: await adapter.getAddress(),
+            adapterVoteData: mockExtraData,
+          },
+        ],
       );
       const weight = await adapter.weightOf(voter.address, proposalId, mockExtraData);
       expect(weight).to.equal(0);
@@ -418,8 +442,12 @@ describe('ERC20VotingAdapterV1', () => {
         strategy.connect(voter).vote(
           proposalId,
           0, // voteType
-          [await adapter.getAddress()],
-          [mockExtraData],
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: mockExtraData,
+            },
+          ],
         ),
       ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
     });
@@ -431,8 +459,12 @@ describe('ERC20VotingAdapterV1', () => {
         strategy.connect(voter).vote(
           proposalId,
           0, // voteType
-          [await adapter.getAddress()],
-          [mockExtraData],
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: mockExtraData,
+            },
+          ],
         ),
       ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
     });
@@ -497,8 +529,12 @@ describe('ERC20VotingAdapterV1', () => {
         await strategy.connect(voter).vote(
           proposalId,
           0, // voteType
-          [await adapter.getAddress()],
-          [ZERO_EXTRA_DATA],
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: ZERO_EXTRA_DATA,
+            },
+          ],
         );
 
         // Check the state
@@ -527,8 +563,12 @@ describe('ERC20VotingAdapterV1', () => {
         await strategy.connect(voter).vote(
           proposalId,
           0, // voteType
-          [await adapter.getAddress()],
-          [ZERO_EXTRA_DATA],
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: ZERO_EXTRA_DATA,
+            },
+          ],
         );
 
         // Check states

--- a/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
@@ -713,8 +713,12 @@ describe('ERC721VotingAdapterV1', () => {
         await mockStrategy.connect(voter1).vote(
           proposalId,
           0, // voteType
-          [await adapter.getAddress()],
-          [adapterVoteData],
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: adapterVoteData,
+            },
+          ],
         );
 
         // Check the state
@@ -736,8 +740,12 @@ describe('ERC721VotingAdapterV1', () => {
         await mockStrategy.connect(voter1).vote(
           proposalId,
           0, // voteType
-          [await adapter.getAddress()],
-          [adapterVoteData],
+          [
+            {
+              votingAdapter: await adapter.getAddress(),
+              adapterVoteData: adapterVoteData,
+            },
+          ],
         );
 
         // Check the original proposal/token ID


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/328

Fixes [ENG-1108](https://linear.app/decent-labs/issue/ENG-1108/refactor-vote-function-to-use-struct-for-parameters)

This commit refactors the `vote` function in `StrategyV1` and its interface to improve clarity, safety, and efficiency. Previously, the function accepted two separate parallel arrays: `_votingAdaptersToUse` and `_votingAdapterVoteData`. This design is prone to errors, as a mismatch in the lengths of these arrays could lead to undefined behavior.

This change introduces a new `VotingAdapterVoteData` struct, which encapsulates a `votingAdapter` address and its corresponding `adapterVoteData`. The `vote` function now accepts a single array of this struct, eliminating the possibility of mismatched inputs and making the function signature more readable and robust.

Key changes include:
- A new `VotingAdapterVoteData` struct has been added to the `IStrategyV1` interface.
- The `vote` function signature has been updated in `IStrategyV1`, `StrategyV1`, and all related mock contracts to accept an array of the new struct.
- The now-redundant `MismatchedInputs` error has been removed.
- All unit tests that call the `vote` function have been updated to use the new struct-based format.