### PR TITLE
style: Add descriptive names to mappings

### DIFF
--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -27,7 +27,8 @@ contract DecentPaymasterV1 is
 {
     uint16 private constant VERSION = 1;
 
-    mapping(address => mapping(bytes4 => address)) internal _functionValidators;
+    mapping(address target => mapping(bytes4 selector => address validator))
+        internal _functionValidators;
 
     constructor() {
         _disableInitializers();

--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -30,10 +30,11 @@ contract VotesERC20StakedV1 is
     uint256 internal _minimumStakingPeriod;
     uint256 internal _totalStaked;
 
-    mapping(address => StakerData) internal _stakerData;
+    mapping(address staker => StakerData stakerData) internal _stakerData;
 
     address[] internal _rewardsTokens;
-    mapping(address => RewardsTokenData) internal _rewardsTokenDatas;
+    mapping(address rewardsToken => RewardsTokenData rewardsTokenData)
+        internal _rewardsTokenDatas;
 
     constructor() {
         _disableInitializers();

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -26,7 +26,8 @@ contract MultisigFreezeGuardV1 is
     uint32 internal _timelockPeriod;
     uint32 internal _executionPeriod;
     ISafe internal _childGnosisSafe;
-    mapping(bytes32 => uint48) internal transactionTimelocked;
+    mapping(bytes32 signaturesHash => uint48 timelockedTimestamp)
+        internal transactionTimelocked;
 
     constructor() {
         _disableInitializers();

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -20,7 +20,7 @@ contract MultisigFreezeVotingV1 is
     uint16 private constant VERSION = 1;
 
     ISafe internal _parentSafe;
-    mapping(uint48 freezeProposalCreated => mapping(address voter => bool))
+    mapping(uint48 freezeProposalCreated => mapping(address voter => bool hasFreezeVoted))
         internal _userHasFreezeVoted;
 
     constructor() {

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -50,7 +50,7 @@ contract AzoriusV1 is
     uint32 internal _totalProposalCount;
     uint32 internal _timelockPeriod;
     uint32 internal _executionPeriod;
-    mapping(uint256 => Proposal) internal _proposals;
+    mapping(uint32 proposalId => Proposal proposal) internal _proposals;
     IStrategyV1 internal _strategy;
 
     constructor() {

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -27,17 +27,22 @@ contract StrategyV1 is
     uint32 internal _votingPeriod;
     uint256 internal _quorumThreshold;
     uint256 internal _basisNumerator;
-    mapping(uint32 => ProposalVotingDetails) internal _proposalVotingDetails;
+    mapping(uint32 proposalId => ProposalVotingDetails proposalVotingDetails)
+        internal _proposalVotingDetails;
 
     address[] internal _votingAdapters;
     address[] internal _proposerAdapters;
-    mapping(address => bool) internal _isVotingAdapter;
-    mapping(address => bool) internal _isProposerAdapter;
+    mapping(address votingAdapter => bool isVotingAdapter)
+        internal _isVotingAdapter;
+    mapping(address proposerAdapter => bool isProposerAdapter)
+        internal _isProposerAdapter;
 
-    mapping(address => bool) internal _authorizedFreezeVotersMapping;
+    mapping(address freezeVoterContract => bool isAuthorizedFreezeVoter)
+        internal _authorizedFreezeVotersMapping;
     address[] internal _authorizedFreezeVotersArray;
 
-    mapping(uint32 => bool) internal _votingPeriodEnded;
+    mapping(uint32 proposalId => bool isVotingPeriodEnded)
+        internal _votingPeriodEnded;
 
     modifier onlyStrategyAdmin() {
         if (msg.sender != _strategyAdmin) revert InvalidStrategyAdmin();

--- a/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
@@ -24,9 +24,9 @@ contract ERC20VotingAdapterV1 is
     IVotes internal _token;
     uint256 internal _weightPerToken;
     ClockMode internal _tokenClockMode;
-    mapping(uint32 => mapping(address => bool))
+    mapping(uint32 proposalId => mapping(address voter => bool hasCastedVote))
         internal _hasCastedVoteForProposal;
-    mapping(address => mapping(uint48 => mapping(address => bool)))
+    mapping(address freezeVoteContract => mapping(uint48 freezeProposalSnapshotAndId => mapping(address voter => bool hasCastedVote)))
         internal _hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract;
 
     constructor() {

--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -19,8 +19,9 @@ contract ERC721VotingAdapterV1 is
 
     IERC721 internal _token;
     uint256 internal _weightPerToken;
-    mapping(uint32 => mapping(uint256 => bool)) internal _tokenIdUsedForVote;
-    mapping(address => mapping(uint48 => mapping(uint256 => bool)))
+    mapping(uint32 proposalId => mapping(uint256 tokenId => bool hasBeenUsedForVote))
+        internal _tokenIdUsedForVote;
+    mapping(address freezeVoteContract => mapping(uint48 freezeProposalSnapshotAndId => mapping(uint256 tokenId => bool hasBeenUsedForVote)))
         internal _tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract;
 
     constructor() {

--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -17,7 +17,7 @@ contract HatsProposerAdapterV1 is
 {
     IHats internal _hatsContract;
     uint256[] internal _whitelistedHatIds;
-    mapping(uint256 => bool) internal _hatIdToIsWhitelisted;
+    mapping(uint256 hatId => bool isWhitelisted) internal _hatIdToIsWhitelisted;
 
     uint16 public constant VERSION = 1;
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/331

Fixes [ENG-1110](https://linear.app/decent-labs/issue/ENG-1110/add-descriptive-names-to-contract-mappings)

This commit adds descriptive names to the keys and values of `mapping` state variables across various contracts. This is a code style improvement that enhances readability and developer experience, making the intent of each mapping clearer without affecting the compiled bytecode.

This change has been applied to the following contracts:
- `DecentPaymasterV1`
- `VotesERC20LockableV1`
- `VotesERC20StakedV1`
- `MultisigFreezeGuardV1`
- `MultisigFreezeVotingV1`
- `AzoriusV1`
- `StrategyV1`
- `ERC20VotingAdapterV1`
- `ERC721VotingAdapterV1`
- `HatsProposerAdapterV1`