### PR TITLE
style: Standardize function signatures and parameter naming

### DIFF
--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -44,59 +44,53 @@ contract DecentPaymasterV1 is
     }
 
     function _authorizeUpgrade(
-        address newImplementation
+        address newImplementation_
     ) internal virtual override onlyOwner {}
 
     function setFunctionValidator(
-        address target,
-        bytes4 selector,
-        address validator
+        address target_,
+        bytes4 selector_,
+        address validator_
     ) external virtual override onlyOwner {
-        if (validator == address(0)) revert InvalidValidator();
+        if (validator_ == address(0)) revert InvalidValidator();
 
         if (
-            !IERC165(validator).supportsInterface(
+            !IERC165(validator_).supportsInterface(
                 type(IFunctionValidator).interfaceId
             )
         ) {
             revert InvalidValidator();
         }
 
-        _functionValidators[target][selector] = validator;
-        emit FunctionValidatorSet(target, selector, validator);
+        _functionValidators[target_][selector_] = validator_;
+        emit FunctionValidatorSet(target_, selector_, validator_);
     }
 
     function removeFunctionValidator(
-        address target,
-        bytes4 selector
+        address target_,
+        bytes4 selector_
     ) external virtual override onlyOwner {
-        _functionValidators[target][selector] = address(0);
-        emit FunctionValidatorRemoved(target, selector);
+        _functionValidators[target_][selector_] = address(0);
+        emit FunctionValidatorRemoved(target_, selector_);
     }
 
     function getFunctionValidator(
-        address target,
-        bytes4 selector
+        address target_,
+        bytes4 selector_
     ) public view virtual override returns (address) {
-        return _functionValidators[target][selector];
+        return _functionValidators[target_][selector_];
     }
 
     function _validatePaymasterUserOp(
-        PackedUserOperation calldata userOp,
+        PackedUserOperation calldata userOp_,
         bytes32,
         uint256
-    )
-        internal
-        view
-        virtual
-        override
-        returns (bytes memory context, uint256 validationData)
-    {
+    ) internal view virtual override returns (bytes memory, uint256) {
         (
             address lightAccountOwner,
             address target,
             bytes memory innerCallData
-        ) = validateUserOp(userOp);
+        ) = validateUserOp(userOp_);
 
         bytes4 selector = bytes4(innerCallData);
 
@@ -108,7 +102,7 @@ contract DecentPaymasterV1 is
 
         // Validate the operation will succeed
         bool isValid = IFunctionValidator(validator).validateOperation(
-            userOp.sender,
+            userOp_.sender,
             lightAccountOwner,
             target,
             innerCallData
@@ -126,30 +120,30 @@ contract DecentPaymasterV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IDecentPaymasterV1).interfaceId ||
-            interfaceId == type(ISmartAccountValidationV1).interfaceId ||
-            interfaceId == type(IPaymaster).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IDecentPaymasterV1).interfaceId ||
+            interfaceId_ == type(ISmartAccountValidationV1).interfaceId ||
+            interfaceId_ == type(IPaymaster).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 
     function _transferOwnership(
-        address newOwner
+        address newOwner_
     ) internal virtual override(Ownable2StepUpgradeable, OwnableUpgradeable) {
-        Ownable2StepUpgradeable._transferOwnership(newOwner);
+        Ownable2StepUpgradeable._transferOwnership(newOwner_);
     }
 
     function transferOwnership(
-        address newOwner
+        address newOwner_
     )
         public
         virtual
         override(Ownable2StepUpgradeable, OwnableUpgradeable)
         onlyOwner
     {
-        Ownable2StepUpgradeable.transferOwnership(newOwner);
+        Ownable2StepUpgradeable.transferOwnership(newOwner_);
     }
 }

--- a/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
+++ b/contracts/deployables/account-abstraction/SmartAccountValidationV1.sol
@@ -34,12 +34,12 @@ abstract contract SmartAccountValidationV1 is
     }
 
     function validateSmartAccount(
-        address smartAccount
+        address smartAccount_
     ) internal view virtual returns (bool, address) {
         // First check if the address has code (is a contract)
         uint256 size;
         assembly {
-            size := extcodesize(smartAccount)
+            size := extcodesize(smartAccount_)
         }
 
         // If it's an EOA (no code), it's not a `LightAccount`
@@ -47,19 +47,19 @@ abstract contract SmartAccountValidationV1 is
             return (false, address(0));
         }
 
-        try ILightAccount(smartAccount).owner() returns (
-            address lightAccountOwner
+        try ILightAccount(smartAccount_).owner() returns (
+            address lightAccountOwner_
         ) {
             // Regenerate the expected light account address
             address lightAccountAddress = _lightAccountFactory.getAddress(
-                lightAccountOwner,
+                lightAccountOwner_,
                 0 // we assume that Decent App is only creating one account per user
             );
 
             // If the given `smartAccount` address is the same as the derived
             // `lightAccountAddress`, then we know that the `smartAccount`
             // was created by the `LightAccountFactory` and therefore can be trusted.
-            return (lightAccountAddress == smartAccount, lightAccountOwner);
+            return (lightAccountAddress == smartAccount_, lightAccountOwner_);
         } catch {
             // `smartAccount` does not implement `owner()`
             // so it's definitely not a `LightAccount`
@@ -68,10 +68,10 @@ abstract contract SmartAccountValidationV1 is
     }
 
     function validateUserOp(
-        PackedUserOperation calldata userOp
+        PackedUserOperation calldata userOp_
     ) internal view virtual returns (address, address, bytes memory) {
         (bool isValid, address lightAccountOwner) = validateSmartAccount(
-            userOp.sender
+            userOp_.sender
         );
         if (!isValid) {
             revert InvalidSmartAccount();
@@ -87,19 +87,19 @@ abstract contract SmartAccountValidationV1 is
         // encoded in the UserOp).
 
         // Validate that we have at least 4 bytes for the selector
-        if (userOp.callData.length < 4) {
+        if (userOp_.callData.length < 4) {
             revert InvalidUserOpCallDataLength();
         }
 
         // Extract and validate the LightAccount's "execute" function selector
         // 0xb61d27f6 = bytes4(keccak256("execute(address,uint256,bytes)"))
-        if (bytes4(userOp.callData) != 0xb61d27f6) {
+        if (bytes4(userOp_.callData) != 0xb61d27f6) {
             revert InvalidCallData();
         }
 
         // Decode the "execute" function parameters
         (address target, , bytes memory innerCallData) = abi.decode(
-            userOp.callData[4:],
+            userOp_.callData[4:],
             (address, uint256, bytes)
         );
 

--- a/contracts/deployables/account-abstraction/VoterResolverV1.sol
+++ b/contracts/deployables/account-abstraction/VoterResolverV1.sol
@@ -13,19 +13,19 @@ abstract contract VoterResolverV1 is
     }
 
     function __VoterResolverV1_init(
-        address _lightAccountFactory
+        address lightAccountFactory_
     ) internal onlyInitializing {
-        __SmartAccountValidationV1_init(_lightAccountFactory);
+        __SmartAccountValidationV1_init(lightAccountFactory_);
     }
 
     function voter(
-        address _msgSender
+        address voter_
     ) public view virtual override returns (address) {
         (bool isValid, address lightAccountOwner) = validateSmartAccount(
-            _msgSender
+            voter_
         );
         if (!isValid) {
-            return _msgSender;
+            return voter_;
         }
 
         return lightAccountOwner;

--- a/contracts/deployables/account-abstraction/validators/StrategyV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/StrategyV1ValidatorV1.sol
@@ -12,12 +12,12 @@ contract StrategyV1ValidatorV1 is IFunctionValidator, ERC165, Version {
 
     function validateOperation(
         address,
-        address lightAccountOwner,
-        address strategy,
-        bytes calldata callData
+        address lightAccountOwner_,
+        address strategy_,
+        bytes calldata callData_
     ) external view virtual override returns (bool) {
         // confirm here that the calldata selector is correct: `vote(uint32,uint8,(tuple(address,bytes))[])`
-        if (bytes4(callData) != IStrategyV1.vote.selector) {
+        if (bytes4(callData_) != IStrategyV1.vote.selector) {
             return false;
         }
 
@@ -28,13 +28,13 @@ contract StrategyV1ValidatorV1 is IFunctionValidator, ERC165, Version {
             uint8 voteType,
             IStrategyV1.VotingAdapterVoteData[] memory votingAdaptersData
         ) = abi.decode(
-                callData[4:], // skip selector
+                callData_[4:], // skip selector
                 (uint32, uint8, IStrategyV1.VotingAdapterVoteData[])
             );
 
         return
-            IStrategyV1(strategy).validStrategyVote(
-                lightAccountOwner,
+            IStrategyV1(strategy_).validStrategyVote(
+                lightAccountOwner_,
                 proposalId,
                 voteType,
                 votingAdaptersData
@@ -46,11 +46,11 @@ contract StrategyV1ValidatorV1 is IFunctionValidator, ERC165, Version {
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IFunctionValidator).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IFunctionValidator).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -11,20 +11,23 @@ contract DecentAutonomousAdminV1 is IDecentAutonomousAdminV1, Version, ERC165 {
     uint16 private constant VERSION = 1;
 
     function triggerStartNextTerm(
-        TriggerStartArgs calldata args
+        TriggerStartArgs calldata args_
     ) public virtual override {
         IHatsElectionsEligibility hatsElectionModule = IHatsElectionsEligibility(
-                args.hatsProtocol.getHatEligibilityModule(args.hatId)
+                args_.hatsProtocol.getHatEligibilityModule(args_.hatId)
             );
 
         hatsElectionModule.startNextTerm();
 
         // This will burn the hat if wearer is no longer eligible
-        args.hatsProtocol.checkHatWearerStatus(args.hatId, args.currentWearer);
+        args_.hatsProtocol.checkHatWearerStatus(
+            args_.hatId,
+            args_.currentWearer
+        );
 
         // This will mint the hat to the nominated wearer, if necessary
-        if (args.nominatedWearer != args.currentWearer) {
-            args.hatsProtocol.mintHat(args.hatId, args.nominatedWearer);
+        if (args_.nominatedWearer != args_.currentWearer) {
+            args_.hatsProtocol.mintHat(args_.hatId, args_.nominatedWearer);
         }
     }
 
@@ -33,11 +36,11 @@ contract DecentAutonomousAdminV1 is IDecentAutonomousAdminV1, Version, ERC165 {
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IDecentAutonomousAdminV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IDecentAutonomousAdminV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -65,29 +65,29 @@ contract VotesERC20StakedV1 is
     }
 
     function updateMinimumStakingPeriod(
-        uint256 newMinimumStakingPeriod
+        uint256 newMinimumStakingPeriod_
     ) external virtual override onlyOwner {
-        _updateMinimumStakingPeriod(newMinimumStakingPeriod);
+        _updateMinimumStakingPeriod(newMinimumStakingPeriod_);
     }
 
-    function stake(uint256 amount) external virtual override {
-        if (amount == 0) revert ZeroStake();
+    function stake(uint256 amount_) external virtual override {
+        if (amount_ == 0) revert ZeroStake();
 
         _accumulateRewards(msg.sender);
 
-        _stakerData[msg.sender].stakedAmount += amount;
+        _stakerData[msg.sender].stakedAmount += amount_;
         _stakerData[msg.sender].lastStakeTimestamp = block.timestamp;
-        _totalStaked += amount;
+        _totalStaked += amount_;
 
-        _mint(msg.sender, amount);
+        _mint(msg.sender, amount_);
 
-        _stakedToken.safeTransferFrom(msg.sender, address(this), amount);
+        _stakedToken.safeTransferFrom(msg.sender, address(this), amount_);
 
-        emit Staked(msg.sender, amount);
+        emit Staked(msg.sender, amount_);
     }
 
-    function unstake(uint256 amount) external virtual override {
-        if (amount == 0) revert ZeroUnstake();
+    function unstake(uint256 amount_) external virtual override {
+        if (amount_ == 0) revert ZeroUnstake();
         if (
             block.timestamp <
             _stakerData[msg.sender].lastStakeTimestamp + _minimumStakingPeriod
@@ -95,14 +95,14 @@ contract VotesERC20StakedV1 is
 
         _accumulateRewards(msg.sender);
 
-        _stakerData[msg.sender].stakedAmount -= amount;
-        _totalStaked -= amount;
+        _stakerData[msg.sender].stakedAmount -= amount_;
+        _totalStaked -= amount_;
 
-        _burn(msg.sender, amount);
+        _burn(msg.sender, amount_);
 
-        _stakedToken.safeTransfer(msg.sender, amount);
+        _stakedToken.safeTransfer(msg.sender, amount_);
 
-        emit Unstaked(msg.sender, amount);
+        emit Unstaked(msg.sender, amount_);
     }
 
     function distributeRewards() external virtual override {
@@ -118,12 +118,12 @@ contract VotesERC20StakedV1 is
     }
 
     function distributeRewards(
-        address[] calldata _tokens
+        address[] calldata tokens_
     ) external virtual override {
         if (_totalStaked == 0) revert ZeroStaked();
 
-        for (uint256 i = 0; i < _tokens.length; ) {
-            address token = _tokens[i];
+        for (uint256 i = 0; i < tokens_.length; ) {
+            address token = tokens_[i];
             if (!_rewardsTokenDatas[token].enabled)
                 revert InvalidRewardsToken(token);
 
@@ -135,9 +135,9 @@ contract VotesERC20StakedV1 is
         }
     }
 
-    function claimRewards(address _recipient) external virtual override {
+    function claimRewards(address recipient_) external virtual override {
         for (uint256 i = 0; i < _rewardsTokens.length; ) {
-            _claimRewards(msg.sender, _recipient, _rewardsTokens[i]);
+            _claimRewards(msg.sender, recipient_, _rewardsTokens[i]);
 
             unchecked {
                 ++i;
@@ -146,15 +146,15 @@ contract VotesERC20StakedV1 is
     }
 
     function claimRewards(
-        address _recipient,
-        address[] memory _tokens
+        address recipient_,
+        address[] calldata tokens_
     ) external virtual override {
-        for (uint256 i = 0; i < _tokens.length; ) {
-            address token = _tokens[i];
+        for (uint256 i = 0; i < tokens_.length; ) {
+            address token = tokens_[i];
             if (!_rewardsTokenDatas[token].enabled)
                 revert InvalidRewardsToken(token);
 
-            _claimRewards(msg.sender, _recipient, token);
+            _claimRewards(msg.sender, recipient_, token);
 
             unchecked {
                 ++i;
@@ -182,7 +182,7 @@ contract VotesERC20StakedV1 is
         address _claimer,
         address _recipient,
         address _token
-    ) internal {
+    ) internal virtual {
         uint256 amountToClaim = _claimableRewards(_claimer, _token);
 
         RewardsTokenData storage token = _rewardsTokenDatas[_token];
@@ -203,10 +203,10 @@ contract VotesERC20StakedV1 is
         emit RewardsClaimed(_claimer, _token, _recipient, amountToClaim);
     }
 
-    function _distributeRewards(address _token) internal {
-        RewardsTokenData storage token = _rewardsTokenDatas[_token];
+    function _distributeRewards(address token_) internal virtual {
+        RewardsTokenData storage token = _rewardsTokenDatas[token_];
 
-        uint256 amountToDistribute = _distributableRewards(_token);
+        uint256 amountToDistribute = _distributableRewards(token_);
 
         if (amountToDistribute == 0) return;
 
@@ -217,10 +217,12 @@ contract VotesERC20StakedV1 is
         token.rewardsDistributed += amountToDistribute;
         token.rewardsRate = newRewardsRate;
 
-        emit RewardsDistributed(_token, amountToDistribute, newRewardsRate);
+        emit RewardsDistributed(token_, amountToDistribute, newRewardsRate);
     }
 
-    function _addRewardsTokens(address[] calldata rewardsTokens_) internal {
+    function _addRewardsTokens(
+        address[] calldata rewardsTokens_
+    ) internal virtual {
         for (uint256 i = 0; i < rewardsTokens_.length; ) {
             if (_rewardsTokenDatas[rewardsTokens_[i]].enabled)
                 revert DuplicateRewardsToken();
@@ -237,18 +239,18 @@ contract VotesERC20StakedV1 is
         }
     }
 
-    function _accumulateRewards(address _staker) internal {
+    function _accumulateRewards(address staker_) internal virtual {
         for (uint256 i = 0; i < _rewardsTokens.length; ) {
             RewardsTokenData storage token = _rewardsTokenDatas[
                 _rewardsTokens[i]
             ];
 
-            token.stakerAccumulatedRewards[_staker] +=
-                (_stakerData[_staker].stakedAmount *
-                    (token.rewardsRate - token.stakerRewardsRates[_staker])) /
+            token.stakerAccumulatedRewards[staker_] +=
+                (_stakerData[staker_].stakedAmount *
+                    (token.rewardsRate - token.stakerRewardsRates[staker_])) /
                 PRECISION;
 
-            token.stakerRewardsRates[_staker] = token.rewardsRate;
+            token.stakerRewardsRates[staker_] = token.rewardsRate;
 
             unchecked {
                 ++i;
@@ -257,16 +259,14 @@ contract VotesERC20StakedV1 is
     }
 
     function _authorizeUpgrade(
-        address newImplementation
-    ) internal virtual override onlyOwner {
-        // Authorization is handled by the onlyOwner modifier
-    }
+        address newImplementation_
+    ) internal virtual override onlyOwner {}
 
     function _updateMinimumStakingPeriod(
-        uint256 newMinimumStakingPeriod
-    ) internal {
-        _minimumStakingPeriod = newMinimumStakingPeriod;
-        emit MinimumStakingPeriodUpdated(newMinimumStakingPeriod);
+        uint256 newMinimumStakingPeriod_
+    ) internal virtual {
+        _minimumStakingPeriod = newMinimumStakingPeriod_;
+        emit MinimumStakingPeriodUpdated(newMinimumStakingPeriod_);
     }
 
     function clock()
@@ -282,6 +282,7 @@ contract VotesERC20StakedV1 is
     function CLOCK_MODE()
         public
         pure
+        virtual
         override(IVotesERC20StakedV1, VotesUpgradeable)
         returns (string memory)
     {
@@ -321,25 +322,15 @@ contract VotesERC20StakedV1 is
     }
 
     function rewardsTokenData(
-        address token
-    )
-        external
-        view
-        virtual
-        override
-        returns (
-            uint256 rewardsRate,
-            uint256 rewardsDistributed,
-            uint256 rewardsClaimed
-        )
-    {
-        if (!_rewardsTokenDatas[token].enabled)
-            revert InvalidRewardsToken(token);
+        address token_
+    ) external view virtual override returns (uint256, uint256, uint256) {
+        if (!_rewardsTokenDatas[token_].enabled)
+            revert InvalidRewardsToken(token_);
 
         return (
-            _rewardsTokenDatas[token].rewardsRate,
-            _rewardsTokenDatas[token].rewardsDistributed,
-            _rewardsTokenDatas[token].rewardsClaimed
+            _rewardsTokenDatas[token_].rewardsRate,
+            _rewardsTokenDatas[token_].rewardsDistributed,
+            _rewardsTokenDatas[token_].rewardsClaimed
         );
     }
 
@@ -388,75 +379,59 @@ contract VotesERC20StakedV1 is
     }
 
     function _distributableRewards(
-        address _token
-    ) internal view returns (uint256) {
-        if (!_rewardsTokenDatas[_token].enabled)
-            revert InvalidRewardsToken(_token);
+        address token_
+    ) internal view virtual returns (uint256) {
+        if (!_rewardsTokenDatas[token_].enabled)
+            revert InvalidRewardsToken(token_);
 
         uint256 thisBalance;
-        if (_token == NATIVE_ASSET) {
+        if (token_ == NATIVE_ASSET) {
             thisBalance = address(this).balance;
-        } else if (_token == address(_stakedToken)) {
+        } else if (token_ == address(_stakedToken)) {
             thisBalance =
-                IERC20(_token).balanceOf(address(this)) -
+                IERC20(token_).balanceOf(address(this)) -
                 _totalStaked;
         } else {
-            thisBalance = IERC20(_token).balanceOf(address(this));
+            thisBalance = IERC20(token_).balanceOf(address(this));
         }
 
         return
             thisBalance +
-            _rewardsTokenDatas[_token].rewardsClaimed -
-            _rewardsTokenDatas[_token].rewardsDistributed;
+            _rewardsTokenDatas[token_].rewardsClaimed -
+            _rewardsTokenDatas[token_].rewardsDistributed;
     }
 
     function stakerData(
-        address staker
-    )
-        external
-        view
-        virtual
-        override
-        returns (uint256 stakedAmount, uint256 lastStakeTimestamp)
-    {
+        address staker_
+    ) external view virtual override returns (uint256, uint256) {
         return (
-            _stakerData[staker].stakedAmount,
-            _stakerData[staker].lastStakeTimestamp
+            _stakerData[staker_].stakedAmount,
+            _stakerData[staker_].lastStakeTimestamp
         );
     }
 
     function stakerRewardsData(
-        address token,
-        address staker
-    )
-        external
-        view
-        virtual
-        override
-        returns (uint256 rewardRate, uint256 accumulatedRewards)
-    {
-        if (!_rewardsTokenDatas[token].enabled)
-            revert InvalidRewardsToken(token);
+        address token_,
+        address staker_
+    ) external view virtual override returns (uint256, uint256) {
+        if (!_rewardsTokenDatas[token_].enabled)
+            revert InvalidRewardsToken(token_);
 
         return (
-            _rewardsTokenDatas[token].stakerRewardsRates[staker],
-            _rewardsTokenDatas[token].stakerAccumulatedRewards[staker]
+            _rewardsTokenDatas[token_].stakerRewardsRates[staker_],
+            _rewardsTokenDatas[token_].stakerAccumulatedRewards[staker_]
         );
     }
 
     function claimableRewards(
-        address _staker
-    )
-        external
-        view
-        virtual
-        override
-        returns (uint256[] memory claimableRewards_)
-    {
-        claimableRewards_ = new uint256[](_rewardsTokens.length);
+        address staker_
+    ) external view virtual override returns (uint256[] memory) {
+        uint256[] memory claimableRewards_ = new uint256[](
+            _rewardsTokens.length
+        );
         for (uint256 i = 0; i < _rewardsTokens.length; ) {
             claimableRewards_[i] = _claimableRewards(
-                _staker,
+                staker_,
                 _rewardsTokens[i]
             );
 
@@ -464,53 +439,51 @@ contract VotesERC20StakedV1 is
                 ++i;
             }
         }
+
+        return claimableRewards_;
     }
 
     function claimableRewards(
-        address _staker,
-        address[] memory _tokens
-    )
-        external
-        view
-        virtual
-        override
-        returns (uint256[] memory claimableRewards_)
-    {
-        claimableRewards_ = new uint256[](_tokens.length);
-        for (uint256 i = 0; i < _tokens.length; ) {
-            address token = _tokens[i];
+        address staker_,
+        address[] calldata tokens_
+    ) external view virtual override returns (uint256[] memory) {
+        uint256[] memory claimableRewards_ = new uint256[](tokens_.length);
+        for (uint256 i = 0; i < tokens_.length; ) {
+            address token = tokens_[i];
             if (!_rewardsTokenDatas[token].enabled)
                 revert InvalidRewardsToken(token);
 
-            claimableRewards_[i] = _claimableRewards(_staker, token);
+            claimableRewards_[i] = _claimableRewards(staker_, token);
 
             unchecked {
                 ++i;
             }
         }
+
+        return claimableRewards_;
     }
 
     function _claimableRewards(
-        address _staker,
-        address _token
-    ) internal view returns (uint256 claimableRewards_) {
-        RewardsTokenData storage token = _rewardsTokenDatas[_token];
+        address staker_,
+        address token_
+    ) internal view virtual returns (uint256) {
+        RewardsTokenData storage token = _rewardsTokenDatas[token_];
 
-        claimableRewards_ =
-            token.stakerAccumulatedRewards[_staker] +
-            ((_stakerData[_staker].stakedAmount *
-                (token.rewardsRate - token.stakerRewardsRates[_staker])) /
+        return
+            token.stakerAccumulatedRewards[staker_] +
+            ((_stakerData[staker_].stakedAmount *
+                (token.rewardsRate - token.stakerRewardsRates[staker_])) /
                 PRECISION);
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IVotesERC20StakedV1).interfaceId ||
-            interfaceId == type(IERC20).interfaceId ||
-            interfaceId == type(IVotes).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IVotesERC20StakedV1).interfaceId ||
+            interfaceId_ == type(IERC20).interfaceId ||
+            interfaceId_ == type(IVotes).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -32,19 +32,19 @@ contract VotesERC20V1 is
     }
 
     function initialize(
-        Metadata calldata metadata,
-        Allocation[] calldata allocations,
-        address owner
+        Metadata calldata metadata_,
+        Allocation[] calldata allocations_,
+        address owner_
     ) public virtual override initializer {
-        __ERC20_init(metadata.name, metadata.symbol);
-        __ERC20Permit_init(metadata.name);
+        __ERC20_init(metadata_.name, metadata_.symbol);
+        __ERC20Permit_init(metadata_.name);
         __ERC20Votes_init();
         __UUPSUpgradeable_init();
-        __Ownable_init(owner);
+        __Ownable_init(owner_);
 
-        uint256 holderCount = allocations.length;
+        uint256 holderCount = allocations_.length;
         for (uint256 i; i < holderCount; ) {
-            _mint(allocations[i].to, allocations[i].amount);
+            _mint(allocations_[i].to, allocations_[i].amount);
             unchecked {
                 ++i;
             }
@@ -52,7 +52,7 @@ contract VotesERC20V1 is
     }
 
     function _authorizeUpgrade(
-        address newImplementation
+        address newImplementation_
     ) internal virtual override onlyOwner {}
 
     function clock()
@@ -76,15 +76,15 @@ contract VotesERC20V1 is
     }
 
     function _update(
-        address from,
-        address to,
-        uint256 value
+        address from_,
+        address to_,
+        uint256 value_
     ) internal virtual override(ERC20Upgradeable, ERC20VotesUpgradeable) {
-        super._update(from, to, value);
+        super._update(from_, to_, value_);
     }
 
     function nonces(
-        address owner
+        address owner_
     )
         public
         view
@@ -92,7 +92,7 @@ contract VotesERC20V1 is
         override(ERC20PermitUpgradeable, NoncesUpgradeable)
         returns (uint256)
     {
-        return super.nonces(owner);
+        return super.nonces(owner_);
     }
 
     function version() public view virtual override returns (uint16) {
@@ -100,14 +100,14 @@ contract VotesERC20V1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IVotesERC20V1).interfaceId ||
-            interfaceId == type(IERC20).interfaceId ||
-            interfaceId == type(IERC20Permit).interfaceId ||
-            interfaceId == type(IVotes).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IVotesERC20V1).interfaceId ||
+            interfaceId_ == type(IERC20).interfaceId ||
+            interfaceId_ == type(IERC20Permit).interfaceId ||
+            interfaceId_ == type(IVotes).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/AzoriusFreezeGuardV1.sol
@@ -37,7 +37,7 @@ contract AzoriusFreezeGuardV1 is
     }
 
     function _authorizeUpgrade(
-        address newImplementation
+        address newImplementation_
     ) internal virtual override onlyOwner {}
 
     function freezeVoting() external view virtual override returns (address) {
@@ -70,13 +70,13 @@ contract AzoriusFreezeGuardV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IAzoriusFreezeGuardV1).interfaceId ||
-            interfaceId == type(IBaseFreezeGuardV1).interfaceId ||
-            interfaceId == type(IGuard).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IAzoriusFreezeGuardV1).interfaceId ||
+            interfaceId_ == type(IBaseFreezeGuardV1).interfaceId ||
+            interfaceId_ == type(IGuard).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
+++ b/contracts/deployables/freeze-guard/MultisigFreezeGuardV1.sol
@@ -49,7 +49,7 @@ contract MultisigFreezeGuardV1 is
     }
 
     function _authorizeUpgrade(
-        address newImplementation
+        address newImplementation_
     ) internal virtual override onlyOwner {}
 
     function timelockPeriod() external view virtual override returns (uint32) {
@@ -75,35 +75,35 @@ contract MultisigFreezeGuardV1 is
     }
 
     function timelockTransaction(
-        address to,
-        uint256 value,
-        bytes memory data,
+        address to_,
+        uint256 value_,
+        bytes memory data_,
         Enum.Operation operation,
-        uint256 safeTxGas,
-        uint256 baseGas,
-        uint256 gasPrice,
-        address gasToken,
-        address payable refundReceiver,
-        bytes calldata signatures,
-        uint256 nonce
+        uint256 safeTxGas_,
+        uint256 baseGas_,
+        uint256 gasPrice_,
+        address gasToken_,
+        address payable refundReceiver_,
+        bytes calldata signatures_,
+        uint256 nonce_
     ) external virtual override {
-        bytes32 signaturesHash = keccak256(signatures);
+        bytes32 signaturesHash = keccak256(signatures_);
 
         if (transactionTimelocked[signaturesHash] != 0)
             revert AlreadyTimelocked();
 
         bytes memory transactionHashData = _childGnosisSafe
             .encodeTransactionData(
-                to,
-                value,
-                data,
+                to_,
+                value_,
+                data_,
                 operation,
-                safeTxGas,
-                baseGas,
-                gasPrice,
-                gasToken,
-                refundReceiver,
-                nonce
+                safeTxGas_,
+                baseGas_,
+                gasPrice_,
+                gasToken_,
+                refundReceiver_,
+                nonce_
             );
 
         bytes32 transactionHash = keccak256(transactionHashData);
@@ -111,12 +111,12 @@ contract MultisigFreezeGuardV1 is
         _childGnosisSafe.checkSignatures(
             transactionHash,
             transactionHashData,
-            signatures
+            signatures_
         );
 
         transactionTimelocked[signaturesHash] = uint48(block.timestamp);
 
-        emit TransactionTimelocked(msg.sender, transactionHash, signatures);
+        emit TransactionTimelocked(msg.sender, transactionHash, signatures_);
     }
 
     function updateTimelockPeriod(
@@ -141,10 +141,10 @@ contract MultisigFreezeGuardV1 is
         uint256,
         address,
         address payable,
-        bytes memory signatures,
+        bytes memory signatures_,
         address
     ) external view virtual override {
-        bytes32 signaturesHash = keccak256(signatures);
+        bytes32 signaturesHash = keccak256(signatures_);
 
         if (transactionTimelocked[signaturesHash] == 0) revert NotTimelocked();
 
@@ -169,9 +169,9 @@ contract MultisigFreezeGuardV1 is
     ) external view virtual override {}
 
     function getTransactionTimelocked(
-        bytes32 _signaturesHash
+        bytes32 signaturesHash_
     ) public view virtual override returns (uint48) {
-        return transactionTimelocked[_signaturesHash];
+        return transactionTimelocked[signaturesHash_];
     }
 
     function _updateTimelockPeriod(uint32 timelockPeriod_) internal virtual {
@@ -189,13 +189,13 @@ contract MultisigFreezeGuardV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IMultisigFreezeGuardV1).interfaceId ||
-            interfaceId == type(IBaseFreezeGuardV1).interfaceId ||
-            interfaceId == type(IGuard).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IMultisigFreezeGuardV1).interfaceId ||
+            interfaceId_ == type(IBaseFreezeGuardV1).interfaceId ||
+            interfaceId_ == type(IGuard).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/freeze-voting/AzoriusFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/AzoriusFreezeVotingV1.sol
@@ -62,7 +62,7 @@ contract AzoriusFreezeVotingV1 is
     }
 
     function castFreezeVote(
-        VotingAdapterVoteData[] calldata _votingAdaptersToUse
+        VotingAdapterVoteData[] calldata votingAdaptersToUse_
     ) external virtual override {
         address resolvedVoter = voter(msg.sender);
 
@@ -74,16 +74,18 @@ contract AzoriusFreezeVotingV1 is
 
         recordFreezeVote(
             resolvedVoter,
-            _getVotes(resolvedVoter, _votingAdaptersToUse)
+            _getVotes(resolvedVoter, votingAdaptersToUse_)
         );
     }
 
     function _getVotes(
-        address voter,
-        VotingAdapterVoteData[] calldata votingAdaptersToUse
-    ) internal virtual returns (uint256 userVotes) {
-        for (uint256 i = 0; i < votingAdaptersToUse.length; ) {
-            address adapterAddress = votingAdaptersToUse[i].votingAdapter;
+        address voter_,
+        VotingAdapterVoteData[] calldata votingAdaptersToUse_
+    ) internal virtual returns (uint256) {
+        uint256 userVotes = 0;
+
+        for (uint256 i = 0; i < votingAdaptersToUse_.length; ) {
+            address adapterAddress = votingAdaptersToUse_[i].votingAdapter;
 
             if (
                 !IStrategyV1(_freezeProposalStrategy).isVotingAdapter(
@@ -94,15 +96,17 @@ contract AzoriusFreezeVotingV1 is
             }
 
             userVotes += IBaseVotingAdapterV1(adapterAddress).recordFreezeVote(
-                voter,
+                voter_,
                 _freezeProposalCreated,
-                votingAdaptersToUse[i].adapterVoteData
+                votingAdaptersToUse_[i].adapterVoteData
             );
 
             unchecked {
                 ++i;
             }
         }
+
+        return userVotes;
     }
 
     function unfreeze() public virtual override onlyOwner {
@@ -115,13 +119,13 @@ contract AzoriusFreezeVotingV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IAzoriusFreezeVotingV1).interfaceId ||
-            interfaceId == type(IBaseFreezeVotingV1).interfaceId ||
-            interfaceId == type(IVoterResolverV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IAzoriusFreezeVotingV1).interfaceId ||
+            interfaceId_ == type(IBaseFreezeVotingV1).interfaceId ||
+            interfaceId_ == type(IVoterResolverV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/BaseFreezeVotingV1.sol
@@ -92,18 +92,18 @@ abstract contract BaseFreezeVotingV1 is
     }
 
     function recordFreezeVote(
-        address voter,
-        uint256 weightCasted
+        address voter_,
+        uint256 weightCasted_
     ) internal virtual {
-        if (weightCasted == 0) revert NoVotes();
+        if (weightCasted_ == 0) revert NoVotes();
 
-        _freezeProposalVoteCount += weightCasted;
+        _freezeProposalVoteCount += weightCasted_;
 
         if (_freezeProposalVoteCount >= _freezeVotesThreshold) {
             _freezeActivated = uint48(block.timestamp);
         }
 
-        emit FreezeVoteCast(voter, weightCasted);
+        emit FreezeVoteCast(voter_, weightCasted_);
     }
 
     function unfreeze() public virtual override onlyOwner {

--- a/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
+++ b/contracts/deployables/freeze-voting/MultisigFreezeVotingV1.sol
@@ -21,7 +21,7 @@ contract MultisigFreezeVotingV1 is
 
     ISafe internal _parentSafe;
     mapping(uint48 freezeProposalCreated => mapping(address voter => bool hasFreezeVoted))
-        internal _userHasFreezeVoted;
+        internal _accountHasFreezeVoted;
 
     constructor() {
         _disableInitializers();
@@ -49,11 +49,11 @@ contract MultisigFreezeVotingV1 is
         return address(_parentSafe);
     }
 
-    function userHasFreezeVoted(
-        uint48 freezeProposalCreated,
-        address voter
+    function accountHasFreezeVoted(
+        uint48 freezeProposalCreated_,
+        address account_
     ) external view virtual override returns (bool) {
-        return _userHasFreezeVoted[freezeProposalCreated][voter];
+        return _accountHasFreezeVoted[freezeProposalCreated_][account_];
     }
 
     function castFreezeVote() external virtual override {
@@ -71,18 +71,19 @@ contract MultisigFreezeVotingV1 is
     }
 
     function _getVotesAndUpdateHasVoted(
-        address voter
-    ) internal virtual returns (uint256 userVotes) {
-        if (!_parentSafe.isOwner(voter)) {
+        address voter_
+    ) internal virtual returns (uint256) {
+        if (!_parentSafe.isOwner(voter_)) {
             return 0;
         }
 
-        if (_userHasFreezeVoted[_freezeProposalCreated][voter]) {
+        if (_accountHasFreezeVoted[_freezeProposalCreated][voter_]) {
             return 0;
         }
 
-        userVotes = 1;
-        _userHasFreezeVoted[_freezeProposalCreated][voter] = true;
+        _accountHasFreezeVoted[_freezeProposalCreated][voter_] = true;
+
+        return 1;
     }
 
     function version() public view virtual override returns (uint16) {
@@ -90,12 +91,12 @@ contract MultisigFreezeVotingV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IMultisigFreezeVotingV1).interfaceId ||
-            interfaceId == type(IBaseFreezeVotingV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IMultisigFreezeVotingV1).interfaceId ||
+            interfaceId_ == type(IBaseFreezeVotingV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/modules/AzoriusV1.sol
+++ b/contracts/deployables/modules/AzoriusV1.sol
@@ -79,7 +79,7 @@ contract AzoriusV1 is
     }
 
     function setUp(
-        bytes memory initializeParams
+        bytes memory initializeParams_
     ) public virtual override initializer {
         (
             address owner_,
@@ -89,7 +89,7 @@ contract AzoriusV1 is
             uint32 timelockPeriod_,
             uint32 executionPeriod_
         ) = abi.decode(
-                initializeParams,
+                initializeParams_,
                 (address, address, address, address, uint32, uint32)
             );
         initialize(
@@ -103,7 +103,7 @@ contract AzoriusV1 is
     }
 
     function _authorizeUpgrade(
-        address newImplementation
+        address newImplementation_
     ) internal virtual override onlyOwner {}
 
     function totalProposalCount()
@@ -125,9 +125,9 @@ contract AzoriusV1 is
     }
 
     function proposals(
-        uint32 _proposalId
+        uint32 proposalId_
     ) external view virtual override returns (Proposal memory) {
-        return _proposals[_proposalId];
+        return _proposals[proposalId_];
     }
 
     function strategy() external view virtual override returns (address) {
@@ -153,24 +153,24 @@ contract AzoriusV1 is
     }
 
     function submitProposal(
-        Transaction[] calldata _transactions,
-        string calldata _metadata,
-        address _proposerAdapter,
-        bytes calldata _proposerAdapterData,
-        bytes calldata _proposalInitializerData
+        Transaction[] calldata transactions_,
+        string calldata metadata_,
+        address proposerAdapter_,
+        bytes calldata proposerAdapterData_,
+        bytes calldata proposalInitializerData_
     ) external virtual override {
         if (
             !_strategy.isProposer(
                 msg.sender,
-                _proposerAdapter,
-                _proposerAdapterData
+                proposerAdapter_,
+                proposerAdapterData_
             )
         ) revert InvalidProposer();
 
-        bytes32[] memory txHashes = new bytes32[](_transactions.length);
-        uint256 transactionsLength = _transactions.length;
+        bytes32[] memory txHashes = new bytes32[](transactions_.length);
+        uint256 transactionsLength = transactions_.length;
         for (uint256 i; i < transactionsLength; ) {
-            txHashes[i] = getTxHash(_transactions[i]);
+            txHashes[i] = getTxHash(transactions_[i]);
             unchecked {
                 ++i;
             }
@@ -184,90 +184,86 @@ contract AzoriusV1 is
         _strategy.initializeProposal(
             _totalProposalCount,
             txHashes,
-            _proposalInitializerData
+            proposalInitializerData_
         );
 
         emit ProposalCreated(
             address(_strategy),
             _totalProposalCount,
             msg.sender,
-            _transactions,
-            _metadata
+            transactions_,
+            metadata_
         );
 
         _totalProposalCount++;
     }
 
     function executeProposal(
-        uint32 _proposalId,
-        Transaction[] calldata _transactions
+        uint32 proposalId_,
+        Transaction[] calldata transactions_
     ) external virtual override {
-        if (_transactions.length == 0) revert InvalidTxs();
+        if (transactions_.length == 0) revert InvalidTxs();
         if (
-            _proposals[_proposalId].executionCounter + _transactions.length >
-            _proposals[_proposalId].txHashes.length
+            _proposals[proposalId_].executionCounter + transactions_.length >
+            _proposals[proposalId_].txHashes.length
         ) revert InvalidTxs();
-        uint256 transactionsLength = _transactions.length;
+        uint256 transactionsLength = transactions_.length;
         bytes32[] memory txHashes = new bytes32[](transactionsLength);
         for (uint256 i; i < transactionsLength; ) {
-            txHashes[i] = _executeProposalTx(_proposalId, _transactions[i]);
+            txHashes[i] = _executeProposalTx(proposalId_, transactions_[i]);
             unchecked {
                 ++i;
             }
         }
-        emit ProposalExecuted(_proposalId, txHashes);
+        emit ProposalExecuted(proposalId_, txHashes);
     }
 
     function getProposalTxHash(
-        uint32 _proposalId,
-        uint32 _txIndex
+        uint32 proposalId_,
+        uint32 txIndex_
     ) external view virtual override returns (bytes32) {
-        return _proposals[_proposalId].txHashes[_txIndex];
+        return _proposals[proposalId_].txHashes[txIndex_];
     }
 
     function getProposalTxHashes(
-        uint32 _proposalId
+        uint32 proposalId_
     ) external view virtual override returns (bytes32[] memory) {
-        return _proposals[_proposalId].txHashes;
+        return _proposals[proposalId_].txHashes;
     }
 
     function getProposal(
-        uint32 _proposalId
+        uint32 proposalId_
     )
         external
         view
         virtual
         override
-        returns (
-            address strategy_,
-            bytes32[] memory txHashes_,
-            uint32 timelockPeriod_,
-            uint32 executionPeriod_,
-            uint32 executionCounter_
-        )
+        returns (address, bytes32[] memory, uint32, uint32, uint32)
     {
-        Proposal memory _proposal = _proposals[_proposalId];
-        strategy_ = _proposal.strategy;
-        txHashes_ = _proposal.txHashes;
-        timelockPeriod_ = _proposal.timelockPeriod;
-        executionPeriod_ = _proposal.executionPeriod;
-        executionCounter_ = _proposal.executionCounter;
+        Proposal memory _proposal = _proposals[proposalId_];
+        return (
+            _proposal.strategy,
+            _proposal.txHashes,
+            _proposal.timelockPeriod,
+            _proposal.executionPeriod,
+            _proposal.executionCounter
+        );
     }
 
     function proposalState(
-        uint32 _proposalId
+        uint32 proposalId_
     ) public view virtual override returns (ProposalState) {
-        if (_proposalId >= _totalProposalCount) revert InvalidProposal();
-        Proposal memory _proposal = _proposals[_proposalId];
+        if (proposalId_ >= _totalProposalCount) revert InvalidProposal();
+        Proposal memory _proposal = _proposals[proposalId_];
         IStrategyV1 strategy_ = IStrategyV1(_proposal.strategy);
 
         (, uint48 votingEndTimestamp) = strategy_.getVotingTimestamps(
-            _proposalId
+            proposalId_
         );
 
         if (block.timestamp <= votingEndTimestamp) {
             return ProposalState.ACTIVE;
-        } else if (!strategy_.isPassed(_proposalId)) {
+        } else if (!strategy_.isPassed(proposalId_)) {
             return ProposalState.FAILED;
         } else if (_proposal.executionCounter == _proposal.txHashes.length) {
             return ProposalState.EXECUTED;
@@ -288,8 +284,8 @@ contract AzoriusV1 is
     }
 
     function generateTxHashData(
-        Transaction calldata _transaction,
-        uint256 _nonce
+        Transaction calldata transaction_,
+        uint256 nonce_
     ) public view virtual override returns (bytes memory) {
         uint256 chainId = block.chainid;
         bytes32 domainSeparator = keccak256(
@@ -298,11 +294,11 @@ contract AzoriusV1 is
         bytes32 transactionHash = keccak256(
             abi.encode(
                 TRANSACTION_TYPEHASH,
-                _transaction.to,
-                _transaction.value,
-                keccak256(_transaction.data),
-                _transaction.operation,
-                _nonce
+                transaction_.to,
+                transaction_.value,
+                keccak256(transaction_.data),
+                transaction_.operation,
+                nonce_
             )
         );
         return
@@ -315,34 +311,36 @@ contract AzoriusV1 is
     }
 
     function getTxHash(
-        Transaction calldata _transaction
+        Transaction calldata transaction_
     ) public view virtual override returns (bytes32) {
-        return keccak256(generateTxHashData(_transaction, 0));
+        return keccak256(generateTxHashData(transaction_, 0));
     }
 
     function _executeProposalTx(
-        uint32 _proposalId,
-        Transaction calldata _transaction
-    ) internal virtual returns (bytes32 txHash) {
-        if (proposalState(_proposalId) != ProposalState.EXECUTABLE)
+        uint32 proposalId_,
+        Transaction calldata transaction_
+    ) internal virtual returns (bytes32) {
+        if (proposalState(proposalId_) != ProposalState.EXECUTABLE)
             revert ProposalNotExecutable();
-        txHash = getTxHash(_transaction);
+        bytes32 txHash = getTxHash(transaction_);
         if (
-            _proposals[_proposalId].txHashes[
-                _proposals[_proposalId].executionCounter
+            _proposals[proposalId_].txHashes[
+                _proposals[proposalId_].executionCounter
             ] != txHash
         ) revert InvalidTxHash();
 
-        _proposals[_proposalId].executionCounter++;
+        _proposals[proposalId_].executionCounter++;
 
         if (
             !exec(
-                _transaction.to,
-                _transaction.value,
-                _transaction.data,
-                _transaction.operation
+                transaction_.to,
+                transaction_.value,
+                transaction_.data,
+                transaction_.operation
             )
         ) revert TxFailed();
+
+        return txHash;
     }
 
     function _updateTimelockPeriod(uint32 timelockPeriod_) internal virtual {
@@ -366,28 +364,28 @@ contract AzoriusV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IAzoriusV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IAzoriusV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 
     function _transferOwnership(
-        address newOwner
+        address newOwner_
     ) internal virtual override(Ownable2StepUpgradeable, OwnableUpgradeable) {
-        Ownable2StepUpgradeable._transferOwnership(newOwner);
+        Ownable2StepUpgradeable._transferOwnership(newOwner_);
     }
 
     function transferOwnership(
-        address newOwner
+        address newOwner_
     )
         public
         virtual
         override(Ownable2StepUpgradeable, OwnableUpgradeable)
         onlyOwner
     {
-        Ownable2StepUpgradeable.transferOwnership(newOwner);
+        Ownable2StepUpgradeable.transferOwnership(newOwner_);
     }
 }

--- a/contracts/deployables/modules/FractalModuleV1.sol
+++ b/contracts/deployables/modules/FractalModuleV1.sol
@@ -40,28 +40,28 @@ contract FractalModuleV1 is
     }
 
     function setUp(
-        bytes memory initializeParams
+        bytes memory initializeParams_
     ) public virtual override initializer {
-        (address _owner, address _avatar, address _target) = abi.decode(
-            initializeParams,
+        (address owner_, address avatar_, address target_) = abi.decode(
+            initializeParams_,
             (address, address, address)
         );
-        initialize(_owner, _avatar, _target);
+        initialize(owner_, avatar_, target_);
     }
 
     function _authorizeUpgrade(
-        address newImplementation
+        address newImplementation_
     ) internal virtual override onlyOwner {}
 
     function execTx(
-        Transaction calldata _transaction
+        Transaction calldata transaction_
     ) public virtual override onlyOwner {
         if (
             !exec(
-                _transaction.to,
-                _transaction.value,
-                _transaction.data,
-                _transaction.operation
+                transaction_.to,
+                transaction_.value,
+                transaction_.data,
+                transaction_.operation
             )
         ) revert TxFailed();
     }
@@ -71,28 +71,28 @@ contract FractalModuleV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IFractalModuleV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IFractalModuleV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 
     function _transferOwnership(
-        address newOwner
+        address newOwner_
     ) internal virtual override(Ownable2StepUpgradeable, OwnableUpgradeable) {
-        Ownable2StepUpgradeable._transferOwnership(newOwner);
+        Ownable2StepUpgradeable._transferOwnership(newOwner_);
     }
 
     function transferOwnership(
-        address newOwner
+        address newOwner_
     )
         public
         virtual
         override(Ownable2StepUpgradeable, OwnableUpgradeable)
         onlyOwner
     {
-        Ownable2StepUpgradeable.transferOwnership(newOwner);
+        Ownable2StepUpgradeable.transferOwnership(newOwner_);
     }
 }

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -158,18 +158,18 @@ contract StrategyV1 is
     }
 
     function votingPeriodEnded(
-        uint32 _proposalId
+        uint32 proposalId_
     ) external view virtual override returns (bool) {
-        return _votingPeriodEnded[_proposalId];
+        return _votingPeriodEnded[proposalId_];
     }
 
     function initializeProposal(
-        uint32 proposalId,
+        uint32 proposalId_,
         bytes32[] calldata,
         bytes calldata
     ) external virtual override onlyStrategyAdmin {
         ProposalVotingDetails storage proposal = _proposalVotingDetails[
-            proposalId
+            proposalId_
         ];
         proposal.votingStartTimestamp = uint48(block.timestamp);
         proposal.votingEndTimestamp = uint48(block.timestamp + _votingPeriod);
@@ -179,7 +179,7 @@ contract StrategyV1 is
         proposal.abstainVotes = 0;
 
         emit ProposalInitialized(
-            proposalId,
+            proposalId_,
             proposal.votingStartTimestamp,
             proposal.votingEndTimestamp,
             proposal.votingStartBlock
@@ -187,13 +187,13 @@ contract StrategyV1 is
     }
 
     function vote(
-        uint32 _proposalId,
-        uint8 _voteType,
+        uint32 proposalId_,
+        uint8 voteType_,
         VotingAdapterVoteData[] calldata votingAdaptersData
     ) external virtual override {
         address resolvedVoter = voter(msg.sender);
         ProposalVotingDetails storage proposal = _proposalVotingDetails[
-            _proposalId
+            proposalId_
         ];
 
         if (proposal.votingEndTimestamp == 0) {
@@ -201,10 +201,10 @@ contract StrategyV1 is
         }
 
         if (block.timestamp > proposal.votingEndTimestamp) {
-            if (!_votingPeriodEnded[_proposalId]) {
-                _votingPeriodEnded[_proposalId] = true;
+            if (!_votingPeriodEnded[proposalId_]) {
+                _votingPeriodEnded[proposalId_] = true;
                 emit VotingPeriodEnded(
-                    _proposalId,
+                    proposalId_,
                     proposal.votingEndTimestamp,
                     uint48(block.timestamp)
                 );
@@ -228,7 +228,7 @@ contract StrategyV1 is
                 votingAdapter
             ).recordVote(
                     resolvedVoter,
-                    _proposalId,
+                    proposalId_,
                     votingAdapterVoteData.adapterVoteData
                 );
 
@@ -239,11 +239,11 @@ contract StrategyV1 is
 
         if (totalWeightForThisVoteTransaction == 0) revert NoVotingWeight();
 
-        if (_voteType == uint8(VoteType.YES)) {
+        if (voteType_ == uint8(VoteType.YES)) {
             proposal.yesVotes += totalWeightForThisVoteTransaction;
-        } else if (_voteType == uint8(VoteType.NO)) {
+        } else if (voteType_ == uint8(VoteType.NO)) {
             proposal.noVotes += totalWeightForThisVoteTransaction;
-        } else if (_voteType == uint8(VoteType.ABSTAIN)) {
+        } else if (voteType_ == uint8(VoteType.ABSTAIN)) {
             proposal.abstainVotes += totalWeightForThisVoteTransaction;
         } else {
             revert InvalidVoteType();
@@ -251,17 +251,17 @@ contract StrategyV1 is
 
         emit Voted(
             resolvedVoter,
-            _proposalId,
-            VoteType(_voteType),
+            proposalId_,
+            VoteType(voteType_),
             totalWeightForThisVoteTransaction
         );
     }
 
     function isQuorumMet(
-        uint32 _proposalId
+        uint32 proposalId_
     ) public view virtual override returns (bool) {
         ProposalVotingDetails storage proposal = _proposalVotingDetails[
-            _proposalId
+            proposalId_
         ];
 
         if (proposal.votingEndTimestamp == 0) {
@@ -323,49 +323,43 @@ contract StrategyV1 is
     }
 
     function getVotingTimestamps(
-        uint32 _proposalId
-    )
-        external
-        view
-        virtual
-        override
-        returns (uint48 startTime, uint48 endTime)
-    {
+        uint32 proposalId_
+    ) external view virtual override returns (uint48, uint48) {
         ProposalVotingDetails storage details = _proposalVotingDetails[
-            _proposalId
+            proposalId_
         ];
         if (details.votingEndTimestamp == 0) revert ProposalNotInitialized();
         return (details.votingStartTimestamp, details.votingEndTimestamp);
     }
 
     function getVotingStartBlock(
-        uint32 _proposalId
-    ) external view virtual override returns (uint32 votingStartBlock) {
+        uint32 proposalId_
+    ) external view virtual override returns (uint32) {
         ProposalVotingDetails storage details = _proposalVotingDetails[
-            _proposalId
+            proposalId_
         ];
         if (details.votingEndTimestamp == 0) revert ProposalNotInitialized();
         return details.votingStartBlock;
     }
 
     function addAuthorizedFreezeVoter(
-        address freezeVoterContract
+        address freezeVoterContract_
     ) external virtual override onlyStrategyAdmin {
-        if (freezeVoterContract == address(0)) revert InvalidAddress();
-        if (!_authorizedFreezeVotersMapping[freezeVoterContract]) {
-            _authorizedFreezeVotersArray.push(freezeVoterContract);
+        if (freezeVoterContract_ == address(0)) revert InvalidAddress();
+        if (!_authorizedFreezeVotersMapping[freezeVoterContract_]) {
+            _authorizedFreezeVotersArray.push(freezeVoterContract_);
         }
-        _authorizedFreezeVotersMapping[freezeVoterContract] = true;
-        emit FreezeVoterAuthorizationChanged(freezeVoterContract, true);
+        _authorizedFreezeVotersMapping[freezeVoterContract_] = true;
+        emit FreezeVoterAuthorizationChanged(freezeVoterContract_, true);
     }
 
     function removeAuthorizedFreezeVoter(
-        address freezeVoterContract
+        address freezeVoterContract_
     ) external virtual override onlyStrategyAdmin {
-        if (freezeVoterContract == address(0)) revert InvalidAddress();
-        if (_authorizedFreezeVotersMapping[freezeVoterContract]) {
+        if (freezeVoterContract_ == address(0)) revert InvalidAddress();
+        if (_authorizedFreezeVotersMapping[freezeVoterContract_]) {
             for (uint256 i = 0; i < _authorizedFreezeVotersArray.length; ) {
-                if (_authorizedFreezeVotersArray[i] == freezeVoterContract) {
+                if (_authorizedFreezeVotersArray[i] == freezeVoterContract_) {
                     _authorizedFreezeVotersArray[
                         i
                     ] = _authorizedFreezeVotersArray[
@@ -379,14 +373,14 @@ contract StrategyV1 is
                 }
             }
         }
-        _authorizedFreezeVotersMapping[freezeVoterContract] = false;
-        emit FreezeVoterAuthorizationChanged(freezeVoterContract, false);
+        _authorizedFreezeVotersMapping[freezeVoterContract_] = false;
+        emit FreezeVoterAuthorizationChanged(freezeVoterContract_, false);
     }
 
     function isAuthorizedFreezeVoter(
-        address freezeVoterContract
+        address freezeVoterContract_
     ) external view virtual override returns (bool) {
-        return _authorizedFreezeVotersMapping[freezeVoterContract];
+        return _authorizedFreezeVotersMapping[freezeVoterContract_];
     }
 
     function authorizedFreezeVoters()
@@ -469,13 +463,13 @@ contract StrategyV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IStrategyV1).interfaceId ||
-            interfaceId == type(IVoterResolverV1).interfaceId ||
-            interfaceId == type(ISmartAccountValidationV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IStrategyV1).interfaceId ||
+            interfaceId_ == type(IVoterResolverV1).interfaceId ||
+            interfaceId_ == type(ISmartAccountValidationV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20ProposerAdapterV1.sol
@@ -47,10 +47,10 @@ contract ERC20ProposerAdapterV1 is
     }
 
     function isProposer(
-        address _proposer,
+        address proposer_,
         bytes calldata
     ) external view virtual override returns (bool) {
-        return _token.getVotes(_proposer) >= _proposerThreshold;
+        return _token.getVotes(proposer_) >= _proposerThreshold;
     }
 
     function version() public pure virtual override returns (uint16) {
@@ -58,12 +58,12 @@ contract ERC20ProposerAdapterV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IERC20ProposerAdapterV1).interfaceId ||
-            interfaceId == type(IProposerAdapterV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IERC20ProposerAdapterV1).interfaceId ||
+            interfaceId_ == type(IProposerAdapterV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC20VotingAdapterV1.sol
@@ -53,60 +53,54 @@ contract ERC20VotingAdapterV1 is
     }
 
     function hasCastedVoteForProposal(
-        uint32 proposalId,
-        address voter
+        uint32 proposalId_,
+        address voter_
     ) external view virtual override returns (bool) {
-        return _hasCastedVoteForProposal[proposalId][voter];
+        return _hasCastedVoteForProposal[proposalId_][voter_];
     }
 
     function hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract(
-        address freezeVoteContract,
-        uint48 freezeProposalSnapshotAndId,
-        address voter
+        address freezeVoteContract_,
+        uint48 freezeProposalSnapshotAndId_,
+        address voter_
     ) external view virtual override returns (bool) {
         return
             _hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract[
-                freezeVoteContract
-            ][freezeProposalSnapshotAndId][voter];
+                freezeVoteContract_
+            ][freezeProposalSnapshotAndId_][voter_];
     }
 
     function _calculateWeightAtSnapshot(
-        address _voter,
-        uint48 _snapshotTimepoint
-    ) internal view virtual returns (uint256 weight) {
+        address voter_,
+        uint48 snapshotTimepoint_
+    ) internal view virtual returns (uint256) {
         return
-            _token.getPastVotes(_voter, _snapshotTimepoint) * _weightPerToken;
+            _token.getPastVotes(voter_, snapshotTimepoint_) * _weightPerToken;
     }
 
     function getFreezeVoteWeight(
-        address voter,
-        uint48 freezeProposalSnapshotAndId
-    ) external view virtual override returns (uint256 weight) {
-        weight = _calculateWeightAtSnapshot(voter, freezeProposalSnapshotAndId);
+        address voter_,
+        uint48 freezeProposalSnapshotAndId_
+    ) external view virtual override returns (uint256) {
+        return _calculateWeightAtSnapshot(voter_, freezeProposalSnapshotAndId_);
     }
 
     function recordFreezeVote(
-        address voter,
-        uint48 freezeProposalSnapshotAndId,
+        address voter_,
+        uint48 freezeProposalSnapshotAndId_,
         bytes calldata
-    )
-        external
-        virtual
-        override
-        onlyAuthorizedFreezeVoter
-        returns (uint256 weightCasted)
-    {
+    ) external virtual override onlyAuthorizedFreezeVoter returns (uint256) {
         if (
             _hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract[
                 msg.sender
-            ][freezeProposalSnapshotAndId][voter]
+            ][freezeProposalSnapshotAndId_][voter_]
         ) {
             revert AlreadyVoted();
         }
 
-        weightCasted = _calculateWeightAtSnapshot(
-            voter,
-            freezeProposalSnapshotAndId
+        uint256 weightCasted = _calculateWeightAtSnapshot(
+            voter_,
+            freezeProposalSnapshotAndId_
         );
 
         if (weightCasted == 0) {
@@ -114,57 +108,65 @@ contract ERC20VotingAdapterV1 is
         }
 
         _hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract[msg.sender][
-            freezeProposalSnapshotAndId
-        ][voter] = true;
+            freezeProposalSnapshotAndId_
+        ][voter_] = true;
 
         emit FreezeVoteRecorded(
-            voter,
-            freezeProposalSnapshotAndId,
+            voter_,
+            freezeProposalSnapshotAndId_,
             weightCasted,
             bytes("")
         );
+
+        return weightCasted;
     }
 
     function _getVoteWeightDetails(
-        address _voter,
-        uint32 _proposalId,
+        address voter_,
+        uint32 proposalId_,
         bytes calldata
-    ) internal view virtual returns (uint256 weight) {
+    ) internal view virtual returns (uint256) {
         uint48 startTimepoint;
         if (_tokenClockMode == ClockMode.Timestamp) {
-            (startTimepoint, ) = _strategy.getVotingTimestamps(_proposalId);
+            (startTimepoint, ) = _strategy.getVotingTimestamps(proposalId_);
         } else {
-            startTimepoint = _strategy.getVotingStartBlock(_proposalId);
+            startTimepoint = _strategy.getVotingStartBlock(proposalId_);
         }
 
         if (startTimepoint == 0) revert ProposalNotReadyForSnapshot();
-        weight = _calculateWeightAtSnapshot(_voter, startTimepoint);
+        return _calculateWeightAtSnapshot(voter_, startTimepoint);
     }
 
     function weightOf(
-        address _voter,
-        uint32 _proposalId,
-        bytes calldata _voteData
-    ) external view virtual override returns (uint256 weight) {
-        if (_hasCastedVoteForProposal[_proposalId][_voter]) {
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata voteData_
+    ) external view virtual override returns (uint256) {
+        if (_hasCastedVoteForProposal[proposalId_][voter_]) {
             return 0;
         }
-        weight = _getVoteWeightDetails(_voter, _proposalId, _voteData);
+        return _getVoteWeightDetails(voter_, proposalId_, voteData_);
     }
 
     function recordVote(
-        address _voter,
-        uint32 _proposalId,
-        bytes calldata _voteData
-    ) external virtual override onlyStrategy returns (uint256 weightCasted) {
-        if (_hasCastedVoteForProposal[_proposalId][_voter]) {
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata voteData_
+    ) external virtual override onlyStrategy returns (uint256) {
+        if (_hasCastedVoteForProposal[proposalId_][voter_]) {
             revert AlreadyVoted();
         }
-        _hasCastedVoteForProposal[_proposalId][_voter] = true;
+        _hasCastedVoteForProposal[proposalId_][voter_] = true;
 
-        weightCasted = _getVoteWeightDetails(_voter, _proposalId, _voteData);
+        uint256 weightCasted = _getVoteWeightDetails(
+            voter_,
+            proposalId_,
+            voteData_
+        );
 
-        emit VoteRecorded(_voter, _proposalId, weightCasted, bytes(""));
+        emit VoteRecorded(voter_, proposalId_, weightCasted, bytes(""));
+
+        return weightCasted;
     }
 
     function version() public pure virtual override returns (uint16) {
@@ -172,22 +174,22 @@ contract ERC20VotingAdapterV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IERC20VotingAdapterV1).interfaceId ||
-            interfaceId == type(IBaseVotingAdapterV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IERC20VotingAdapterV1).interfaceId ||
+            interfaceId_ == type(IBaseVotingAdapterV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 
     function validVotingAdapterVote(
-        address voter,
-        uint32 proposalId,
+        address voter_,
+        uint32 proposalId_,
         bytes calldata
     ) external view virtual override returns (bool, uint256) {
         // check if the user has voted
-        if (_hasCastedVoteForProposal[proposalId][voter]) {
+        if (_hasCastedVoteForProposal[proposalId_][voter_]) {
             return (false, 0);
         }
 
@@ -195,10 +197,10 @@ contract ERC20VotingAdapterV1 is
         ERC20Votes governanceToken = ERC20Votes(address(_token));
 
         // get the number of checkpoints for the voter
-        uint32 numCheckpoints = governanceToken.numCheckpoints(voter);
+        uint32 numCheckpoints = governanceToken.numCheckpoints(voter_);
 
         (uint48 startTimestamp, uint48 endTimestamp) = _strategy
-            .getVotingTimestamps(proposalId);
+            .getVotingTimestamps(proposalId_);
 
         // if there are no checkpoints, user has no voting weight
         if (numCheckpoints == 0) {
@@ -211,7 +213,7 @@ contract ERC20VotingAdapterV1 is
         for (uint256 i = numCheckpoints; i > 0; ) {
             // Checkpoint indices are 0-based, loop index 'j' is 1-based count.
             Checkpoints.Checkpoint208 memory checkpoint = governanceToken
-                .checkpoints(voter, uint32(i - 1));
+                .checkpoints(voter_, uint32(i - 1));
 
             // If this checkpoint's timestamp is after the proposal's endTimestamp,
             // it implies the current timestamp is also after endTimestamp.

--- a/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721ProposerAdapterV1.sol
@@ -47,10 +47,10 @@ contract ERC721ProposerAdapterV1 is
     }
 
     function isProposer(
-        address _proposer,
+        address proposer_,
         bytes calldata
     ) external view virtual override returns (bool) {
-        return _token.balanceOf(_proposer) >= _proposerThreshold;
+        return _token.balanceOf(proposer_) >= _proposerThreshold;
     }
 
     function version() public pure virtual override returns (uint16) {
@@ -58,12 +58,12 @@ contract ERC721ProposerAdapterV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IERC721ProposerAdapterV1).interfaceId ||
-            interfaceId == type(IProposerAdapterV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IERC721ProposerAdapterV1).interfaceId ||
+            interfaceId_ == type(IProposerAdapterV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/ERC721VotingAdapterV1.sol
@@ -47,27 +47,27 @@ contract ERC721VotingAdapterV1 is
     }
 
     function tokenIdUsedForVote(
-        uint32 proposalId,
-        uint256 tokenId
+        uint32 proposalId_,
+        uint256 tokenId_
     ) external view virtual override returns (bool) {
-        return _tokenIdUsedForVote[proposalId][tokenId];
+        return _tokenIdUsedForVote[proposalId_][tokenId_];
     }
 
     function _getUnusedFreezeTokenIds(
-        address freezeVoteContract,
-        uint48 freezeProposalSnapshotAndId,
-        uint256[] memory tokenIds
-    ) internal view returns (uint256[] memory unusedFreezeTokenIds) {
-        unusedFreezeTokenIds = new uint256[](tokenIds.length);
+        address freezeVoteContract_,
+        uint48 freezeProposalSnapshotAndId_,
+        uint256[] memory tokenIds_
+    ) internal view returns (uint256[] memory) {
+        uint256[] memory unusedFreezeTokenIds = new uint256[](tokenIds_.length);
         uint256 unusedTokenCount = 0;
 
-        for (uint256 i = 0; i < tokenIds.length; ) {
+        for (uint256 i = 0; i < tokenIds_.length; ) {
             if (
                 !_tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract[
-                    freezeVoteContract
-                ][freezeProposalSnapshotAndId][tokenIds[i]]
+                    freezeVoteContract_
+                ][freezeProposalSnapshotAndId_][tokenIds_[i]]
             ) {
-                unusedFreezeTokenIds[unusedTokenCount] = tokenIds[i];
+                unusedFreezeTokenIds[unusedTokenCount] = tokenIds_[i];
                 unusedTokenCount++;
             }
             unchecked {
@@ -77,15 +77,17 @@ contract ERC721VotingAdapterV1 is
         assembly {
             mstore(unusedFreezeTokenIds, unusedTokenCount)
         }
+
+        return unusedFreezeTokenIds;
     }
 
     function _getValidFreezeTokenIds(
-        address voter,
-        address freezeVoteContract,
-        uint48 freezeProposalSnapshotAndId,
-        bytes calldata adapterVoteData
-    ) internal view returns (uint256 weight, uint256[] memory validTokenIds) {
-        uint256[] memory allTokenIds = _decodeTokenIds(adapterVoteData);
+        address voter_,
+        address freezeVoteContract_,
+        uint48 freezeProposalSnapshotAndId_,
+        bytes calldata adapterVoteData_
+    ) internal view returns (uint256, uint256[] memory) {
+        uint256[] memory allTokenIds = _decodeTokenIds(adapterVoteData_);
         if (allTokenIds.length == 0) {
             return (0, new uint256[](0));
         }
@@ -96,62 +98,58 @@ contract ERC721VotingAdapterV1 is
         }
 
         uint256[] memory ownedTokenIds = _getOwnedTokenIds(
-            voter,
+            voter_,
             uniqueTokenIds
         );
         if (ownedTokenIds.length == 0) {
             return (0, new uint256[](0));
         }
 
-        validTokenIds = _getUnusedFreezeTokenIds(
-            freezeVoteContract,
-            freezeProposalSnapshotAndId,
+        uint256[] memory validTokenIds = _getUnusedFreezeTokenIds(
+            freezeVoteContract_,
+            freezeProposalSnapshotAndId_,
             ownedTokenIds
         );
         if (validTokenIds.length == 0) {
             return (0, new uint256[](0));
         }
 
-        weight = validTokenIds.length * _weightPerToken;
+        return (validTokenIds.length * _weightPerToken, validTokenIds);
     }
 
     function getFreezeVoteWeight(
-        address voter,
-        address freezeVoteContract,
-        uint48 freezeProposalSnapshotAndId,
-        bytes calldata adapterVoteData
-    ) external view virtual override returns (uint256 weight) {
-        (weight, ) = _getValidFreezeTokenIds(
-            voter,
-            freezeVoteContract,
-            freezeProposalSnapshotAndId,
-            adapterVoteData
+        address voter_,
+        address freezeVoteContract_,
+        uint48 freezeProposalSnapshotAndId_,
+        bytes calldata adapterVoteData_
+    ) external view virtual override returns (uint256) {
+        (uint256 weight, ) = _getValidFreezeTokenIds(
+            voter_,
+            freezeVoteContract_,
+            freezeProposalSnapshotAndId_,
+            adapterVoteData_
         );
+
+        return weight;
     }
 
     function tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract(
-        address freezeVoteContract,
-        uint48 freezeProposalSnapshotAndId,
-        uint256 tokenId
+        address freezeVoteContract_,
+        uint48 freezeProposalSnapshotAndId_,
+        uint256 tokenId_
     ) external view virtual override returns (bool) {
         return
             _tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract[
-                freezeVoteContract
-            ][freezeProposalSnapshotAndId][tokenId];
+                freezeVoteContract_
+            ][freezeProposalSnapshotAndId_][tokenId_];
     }
 
     function recordFreezeVote(
-        address voter,
-        uint48 freezeProposalSnapshotAndId,
-        bytes calldata adapterVoteData
-    )
-        external
-        virtual
-        override
-        onlyAuthorizedFreezeVoter
-        returns (uint256 weightCasted)
-    {
-        uint256[] memory tokenIds = _decodeTokenIds(adapterVoteData);
+        address voter_,
+        uint48 freezeProposalSnapshotAndId_,
+        bytes calldata adapterVoteData_
+    ) external virtual override onlyAuthorizedFreezeVoter returns (uint256) {
+        uint256[] memory tokenIds = _decodeTokenIds(adapterVoteData_);
         if (tokenIds.length == 0) {
             revert NoTokenIdsPassed();
         }
@@ -159,18 +157,18 @@ contract ERC721VotingAdapterV1 is
         uint256 currentWeightCasted = 0;
         for (uint256 i = 0; i < tokenIds.length; ) {
             uint256 tokenId = tokenIds[i];
-            if (_token.ownerOf(tokenId) != voter) {
+            if (_token.ownerOf(tokenId) != voter_) {
                 revert TokenIdNotOwnedByVoter(tokenId);
             }
             if (
                 _tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract[
                     msg.sender
-                ][freezeProposalSnapshotAndId][tokenId]
+                ][freezeProposalSnapshotAndId_][tokenId]
             ) {
                 revert TokenIdAlreadyUsedForVote(tokenId);
             }
             _tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract[msg.sender][
-                freezeProposalSnapshotAndId
+                freezeProposalSnapshotAndId_
             ][tokenId] = true;
             currentWeightCasted += _weightPerToken;
             unchecked {
@@ -181,31 +179,33 @@ contract ERC721VotingAdapterV1 is
         if (currentWeightCasted == 0) {
             revert NoFreezeVotingWeight();
         }
-        weightCasted = currentWeightCasted;
+
         emit FreezeVoteRecorded(
-            voter,
-            freezeProposalSnapshotAndId,
-            weightCasted,
-            adapterVoteData
+            voter_,
+            freezeProposalSnapshotAndId_,
+            currentWeightCasted,
+            adapterVoteData_
         );
+
+        return currentWeightCasted;
     }
 
     function _decodeTokenIds(
-        bytes calldata _adapterVoteData
-    ) internal view virtual returns (uint256[] memory tokenIds) {
-        tokenIds = abi.decode(_adapterVoteData, (uint256[]));
+        bytes calldata adapterVoteData_
+    ) internal view virtual returns (uint256[] memory) {
+        return abi.decode(adapterVoteData_, (uint256[]));
     }
 
     function _getUniqueTokenIds(
-        uint256[] memory tokenIds
-    ) internal view virtual returns (uint256[] memory uniqueTokenIds) {
-        uniqueTokenIds = new uint256[](tokenIds.length);
+        uint256[] memory tokenIds_
+    ) internal view virtual returns (uint256[] memory) {
+        uint256[] memory uniqueTokenIds = new uint256[](tokenIds_.length);
         uint256 uniqueCount = 0;
 
-        for (uint256 i = 0; i < tokenIds.length; ) {
+        for (uint256 i = 0; i < tokenIds_.length; ) {
             bool isDuplicate = false;
             for (uint256 j = 0; j < uniqueCount; ) {
-                if (uniqueTokenIds[j] == tokenIds[i]) {
+                if (uniqueTokenIds[j] == tokenIds_[i]) {
                     isDuplicate = true;
                     break;
                 }
@@ -215,7 +215,7 @@ contract ERC721VotingAdapterV1 is
                 }
             }
             if (!isDuplicate) {
-                uniqueTokenIds[uniqueCount] = tokenIds[i];
+                uniqueTokenIds[uniqueCount] = tokenIds_[i];
                 uniqueCount++;
             }
 
@@ -227,18 +227,20 @@ contract ERC721VotingAdapterV1 is
         assembly {
             mstore(uniqueTokenIds, uniqueCount)
         }
+
+        return uniqueTokenIds;
     }
 
     function _getOwnedTokenIds(
-        address voter,
-        uint256[] memory tokenIds
-    ) internal view virtual returns (uint256[] memory ownedTokenIds) {
-        ownedTokenIds = new uint256[](tokenIds.length);
+        address voter_,
+        uint256[] memory tokenIds_
+    ) internal view virtual returns (uint256[] memory) {
+        uint256[] memory ownedTokenIds = new uint256[](tokenIds_.length);
         uint256 ownedTokenCount = 0;
 
-        for (uint256 i = 0; i < tokenIds.length; ) {
-            if (_token.ownerOf(tokenIds[i]) == voter) {
-                ownedTokenIds[ownedTokenCount] = tokenIds[i];
+        for (uint256 i = 0; i < tokenIds_.length; ) {
+            if (_token.ownerOf(tokenIds_[i]) == voter_) {
+                ownedTokenIds[ownedTokenCount] = tokenIds_[i];
                 ownedTokenCount++;
             }
 
@@ -250,18 +252,20 @@ contract ERC721VotingAdapterV1 is
         assembly {
             mstore(ownedTokenIds, ownedTokenCount)
         }
+
+        return ownedTokenIds;
     }
 
     function _getUnusedTokenIds(
-        uint32 proposalId,
-        uint256[] memory tokenIds
-    ) internal view virtual returns (uint256[] memory unusedTokenIds) {
-        unusedTokenIds = new uint256[](tokenIds.length);
+        uint32 proposalId_,
+        uint256[] memory tokenIds_
+    ) internal view virtual returns (uint256[] memory) {
+        uint256[] memory unusedTokenIds = new uint256[](tokenIds_.length);
         uint256 unusedTokenCount = 0;
 
-        for (uint256 i = 0; i < tokenIds.length; ) {
-            if (!_tokenIdUsedForVote[proposalId][tokenIds[i]]) {
-                unusedTokenIds[unusedTokenCount] = tokenIds[i];
+        for (uint256 i = 0; i < tokenIds_.length; ) {
+            if (!_tokenIdUsedForVote[proposalId_][tokenIds_[i]]) {
+                unusedTokenIds[unusedTokenCount] = tokenIds_[i];
                 unusedTokenCount++;
             }
 
@@ -273,83 +277,82 @@ contract ERC721VotingAdapterV1 is
         assembly {
             mstore(unusedTokenIds, unusedTokenCount)
         }
+
+        return unusedTokenIds;
     }
 
     function _getValidTokenIds(
-        address voter,
-        uint32 proposalId,
-        uint256[] memory allTokenIds
-    )
-        internal
-        view
-        virtual
-        returns (uint256 weight, uint256[] memory unusedTokenIds)
-    {
-        uint256[] memory uniqueTokenIds = _getUniqueTokenIds(allTokenIds);
+        address voter_,
+        uint32 proposalId_,
+        uint256[] memory allTokenIds_
+    ) internal view virtual returns (uint256, uint256[] memory) {
+        uint256[] memory uniqueTokenIds = _getUniqueTokenIds(allTokenIds_);
         uint256[] memory ownedTokenIds = _getOwnedTokenIds(
-            voter,
+            voter_,
             uniqueTokenIds
         );
-        unusedTokenIds = _getUnusedTokenIds(proposalId, ownedTokenIds);
-        weight = unusedTokenIds.length * _weightPerToken;
+        uint256[] memory unusedTokenIds = _getUnusedTokenIds(
+            proposalId_,
+            ownedTokenIds
+        );
+
+        return (unusedTokenIds.length * _weightPerToken, unusedTokenIds);
     }
 
     function weightOf(
-        address _voter,
-        uint32 _proposalId,
-        bytes calldata _adapterVoteData
-    ) external view virtual override returns (uint256 weight) {
-        uint256[] memory allTokenIds = _decodeTokenIds(_adapterVoteData);
-        (weight, ) = _getValidTokenIds(_voter, _proposalId, allTokenIds);
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata adapterVoteData_
+    ) external view virtual override returns (uint256) {
+        uint256[] memory allTokenIds = _decodeTokenIds(adapterVoteData_);
+        (uint256 weight, ) = _getValidTokenIds(
+            voter_,
+            proposalId_,
+            allTokenIds
+        );
+
+        return weight;
     }
 
     function weightOfWithValidTokenIds(
-        address _voter,
-        uint32 _proposalId,
-        bytes calldata _adapterVoteData
-    )
-        external
-        view
-        virtual
-        override
-        returns (uint256 weight, uint256[] memory validTokenIds)
-    {
-        uint256[] memory allTokenIds = _decodeTokenIds(_adapterVoteData);
-        (weight, validTokenIds) = _getValidTokenIds(
-            _voter,
-            _proposalId,
-            allTokenIds
-        );
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata adapterVoteData_
+    ) external view virtual override returns (uint256, uint256[] memory) {
+        uint256[] memory allTokenIds = _decodeTokenIds(adapterVoteData_);
+        return _getValidTokenIds(voter_, proposalId_, allTokenIds);
     }
 
     function recordVote(
-        address _voter,
-        uint32 _proposalId,
-        bytes calldata _adapterVoteData
-    ) external virtual override onlyStrategy returns (uint256 weightCasted) {
-        uint256[] memory tokenIds = _decodeTokenIds(_adapterVoteData);
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata adapterVoteData_
+    ) external virtual override onlyStrategy returns (uint256) {
+        uint256[] memory tokenIds = _decodeTokenIds(adapterVoteData_);
         if (tokenIds.length == 0) {
             revert NoTokenIdsPassed();
         }
 
         for (uint256 i = 0; i < tokenIds.length; ) {
             uint256 tokenId = tokenIds[i];
-            if (_token.ownerOf(tokenId) != _voter) {
+            if (_token.ownerOf(tokenId) != voter_) {
                 revert TokenIdNotOwnedByVoter(tokenId);
             }
-            if (_tokenIdUsedForVote[_proposalId][tokenId]) {
+            if (_tokenIdUsedForVote[proposalId_][tokenId]) {
                 revert TokenIdAlreadyUsedForVote(tokenId);
             }
-            _tokenIdUsedForVote[_proposalId][tokenId] = true;
+            _tokenIdUsedForVote[proposalId_][tokenId] = true;
 
             unchecked {
                 ++i;
             }
         }
 
-        weightCasted = tokenIds.length * _weightPerToken;
+        uint256 weightCasted = tokenIds.length * _weightPerToken;
 
-        emit VoteRecorded(_voter, _proposalId, weightCasted, _adapterVoteData);
+        emit VoteRecorded(voter_, proposalId_, weightCasted, adapterVoteData_);
+
+        return weightCasted;
     }
 
     function version() public pure virtual override returns (uint16) {
@@ -357,25 +360,28 @@ contract ERC721VotingAdapterV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IERC721VotingAdapterV1).interfaceId ||
-            interfaceId == type(IBaseVotingAdapterV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IERC721VotingAdapterV1).interfaceId ||
+            interfaceId_ == type(IBaseVotingAdapterV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 
     function validVotingAdapterVote(
-        address voter,
-        uint32 proposalId,
-        bytes calldata adapterVoteData
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata adapterVoteData_
     ) external view virtual override returns (bool, uint256) {
-        uint256[] memory allTokenIds = abi.decode(adapterVoteData, (uint256[]));
+        uint256[] memory allTokenIds = abi.decode(
+            adapterVoteData_,
+            (uint256[])
+        );
         (
             uint256 votingWeight,
             uint256[] memory validTokenIds
-        ) = _getValidTokenIds(voter, proposalId, allTokenIds);
+        ) = _getValidTokenIds(voter_, proposalId_, allTokenIds);
 
         if (validTokenIds.length != allTokenIds.length || votingWeight == 0) {
             return (false, 0);

--- a/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
+++ b/contracts/deployables/strategies/adapters/HatsProposerAdapterV1.sol
@@ -55,13 +55,13 @@ contract HatsProposerAdapterV1 is
     }
 
     function isProposer(
-        address _proposer,
-        bytes calldata _data
+        address proposer_,
+        bytes calldata data_
     ) public view virtual override returns (bool) {
-        uint256 hatId = abi.decode(_data, (uint256));
+        uint256 hatId = abi.decode(data_, (uint256));
         return
             _hatIdToIsWhitelisted[hatId] &&
-            _hatsContract.isWearerOfHat(_proposer, hatId);
+            _hatsContract.isWearerOfHat(proposer_, hatId);
     }
 
     function version() public pure virtual override returns (uint16) {
@@ -69,12 +69,12 @@ contract HatsProposerAdapterV1 is
     }
 
     function supportsInterface(
-        bytes4 interfaceId
+        bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IHatsProposerAdapterV1).interfaceId ||
-            interfaceId == type(IProposerAdapterV1).interfaceId ||
-            interfaceId == type(IVersion).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId_ == type(IHatsProposerAdapterV1).interfaceId ||
+            interfaceId_ == type(IProposerAdapterV1).interfaceId ||
+            interfaceId_ == type(IVersion).interfaceId ||
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/interfaces/decent/deployables/IAzoriusFreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IAzoriusFreezeVotingV1.sol
@@ -24,10 +24,13 @@ interface IAzoriusFreezeVotingV1 {
     ) external;
 
     function castFreezeVote(
-        VotingAdapterVoteData[] calldata votingAdaptersToUse
+        VotingAdapterVoteData[] calldata votingAdaptersToUse_
     ) external;
 
-    function parentAzorius() external view returns (address);
+    function parentAzorius() external view returns (address parentAzorius);
 
-    function freezeProposalStrategy() external view returns (address);
+    function freezeProposalStrategy()
+        external
+        view
+        returns (address freezeProposalStrategy);
 }

--- a/contracts/interfaces/decent/deployables/IAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IAzoriusV1.sol
@@ -42,77 +42,80 @@ interface IAzoriusV1 {
     }
 
     function initialize(
-        address owner,
-        address avatar,
-        address target,
-        address strategy,
-        uint32 timelockPeriod,
-        uint32 executionPeriod
+        address owner_,
+        address avatar_,
+        address target_,
+        address strategy_,
+        uint32 timelockPeriod_,
+        uint32 executionPeriod_
     ) external;
 
-    function totalProposalCount() external view returns (uint32);
+    function totalProposalCount()
+        external
+        view
+        returns (uint32 totalProposalCount);
 
-    function timelockPeriod() external view returns (uint32);
+    function timelockPeriod() external view returns (uint32 timelockPeriod);
 
-    function executionPeriod() external view returns (uint32);
+    function executionPeriod() external view returns (uint32 executionPeriod);
 
     function proposals(
-        uint32 _proposalId
-    ) external view returns (Proposal memory);
+        uint32 proposalId_
+    ) external view returns (Proposal memory proposal);
 
-    function strategy() external view returns (address);
+    function strategy() external view returns (address strategy);
 
-    function updateTimelockPeriod(uint32 _timelockPeriod) external;
+    function updateTimelockPeriod(uint32 timelockPeriod_) external;
 
-    function updateExecutionPeriod(uint32 _executionPeriod) external;
+    function updateExecutionPeriod(uint32 executionPeriod_) external;
 
-    function updateStrategy(address _strategy) external;
+    function updateStrategy(address strategy_) external;
 
     function submitProposal(
-        Transaction[] calldata _transactions,
-        string calldata _metadata,
-        address _proposerAdapter,
-        bytes calldata _proposerAdapterData,
-        bytes calldata _proposalInitializerData
+        Transaction[] calldata transactions_,
+        string calldata metadata_,
+        address proposerAdapter_,
+        bytes calldata proposerAdapterData_,
+        bytes calldata proposalInitializerData_
     ) external;
 
     function executeProposal(
-        uint32 _proposalId,
-        Transaction[] calldata _transactions
+        uint32 proposalId_,
+        Transaction[] calldata transactions_
     ) external;
 
     function proposalState(
-        uint32 _proposalId
-    ) external view returns (ProposalState);
+        uint32 proposalId_
+    ) external view returns (ProposalState proposalState);
 
     function generateTxHashData(
-        Transaction calldata _transaction,
-        uint256 _nonce
-    ) external view returns (bytes memory);
+        Transaction calldata transaction_,
+        uint256 nonce_
+    ) external view returns (bytes memory txHashData);
 
     function getTxHash(
-        Transaction calldata _transaction
-    ) external view returns (bytes32);
+        Transaction calldata transaction_
+    ) external view returns (bytes32 txHash);
 
     function getProposalTxHash(
-        uint32 _proposalId,
-        uint32 _txIndex
-    ) external view returns (bytes32);
+        uint32 proposalId_,
+        uint32 txIndex_
+    ) external view returns (bytes32 txHash);
 
     function getProposalTxHashes(
-        uint32 _proposalId
-    ) external view returns (bytes32[] memory);
+        uint32 proposalId_
+    ) external view returns (bytes32[] memory txHashes);
 
     function getProposal(
-        uint32 _proposalId
+        uint32 proposalId_
     )
         external
         view
         returns (
-            address _strategy,
-            bytes32[] memory _txHashes,
-            uint32 _timelockPeriod,
-            uint32 _executionPeriod,
-            uint32 _executionCounter
+            address strategy,
+            bytes32[] memory txHashes,
+            uint32 timelockPeriod,
+            uint32 executionPeriod,
+            uint32 executionCounter
         );
 }

--- a/contracts/interfaces/decent/deployables/IBaseFreezeGuardV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseFreezeGuardV1.sol
@@ -6,5 +6,5 @@ import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 interface IBaseFreezeGuardV1 is IGuard {
     error DAOFrozen();
 
-    function freezeVoting() external view returns (address);
+    function freezeVoting() external view returns (address freezeVoting);
 }

--- a/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseFreezeVotingV1.sol
@@ -4,21 +4,33 @@ pragma solidity ^0.8.30;
 interface IBaseFreezeVotingV1 {
     error NoVotes();
 
-    event FreezeVoteCast(address indexed voter, uint256 votesCast);
+    event FreezeVoteCast(address indexed voter_, uint256 votesCast_);
 
-    function freezeProposalCreated() external view returns (uint48);
+    function freezeProposalCreated()
+        external
+        view
+        returns (uint48 freezeProposalCreated);
 
-    function freezeProposalVoteCount() external view returns (uint256);
+    function freezeProposalVoteCount()
+        external
+        view
+        returns (uint256 freezeProposalVoteCount);
 
-    function freezeProposalPeriod() external view returns (uint32);
+    function freezeProposalPeriod()
+        external
+        view
+        returns (uint32 freezeProposalPeriod);
 
-    function freezePeriod() external view returns (uint32);
+    function freezePeriod() external view returns (uint32 freezePeriod);
 
-    function freezeVotesThreshold() external view returns (uint256);
+    function freezeVotesThreshold()
+        external
+        view
+        returns (uint256 freezeVotesThreshold);
 
-    function freezeActivated() external view returns (uint48);
+    function freezeActivated() external view returns (uint48 freezeActivated);
 
-    function isFrozen() external view returns (bool);
+    function isFrozen() external view returns (bool isFrozen);
 
     function unfreeze() external;
 }

--- a/contracts/interfaces/decent/deployables/IBaseVotingAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IBaseVotingAdapterV1.sol
@@ -20,29 +20,29 @@ interface IBaseVotingAdapterV1 {
         bytes adapterVoteData
     );
 
-    function strategy() external view returns (address);
+    function strategy() external view returns (address strategy);
 
     function recordVote(
-        address _voter,
-        uint32 _proposalId,
-        bytes calldata _votingAdapterVoteData
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata votingAdapterVoteData_
     ) external returns (uint256 weightCasted);
 
     function weightOf(
-        address _voter,
-        uint32 _proposalId,
-        bytes calldata _votingAdapterVoteData
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata votingAdapterVoteData_
     ) external view returns (uint256 weight);
 
     function recordFreezeVote(
-        address voter,
-        uint48 freezeProposalSnapshotAndId,
-        bytes calldata adapterVoteData
+        address voter_,
+        uint48 freezeProposalSnapshotAndId_,
+        bytes calldata adapterVoteData_
     ) external returns (uint256 weightCasted);
 
     function validVotingAdapterVote(
-        address voter,
-        uint32 proposalId,
-        bytes calldata votingAdapterVoteData
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata votingAdapterVoteData_
     ) external view returns (bool isValid, uint256 votingWeight);
 }

--- a/contracts/interfaces/decent/deployables/IDecentAutonomousAdminV1.sol
+++ b/contracts/interfaces/decent/deployables/IDecentAutonomousAdminV1.sol
@@ -13,5 +13,5 @@ interface IDecentAutonomousAdminV1 {
         address nominatedWearer;
     }
 
-    function triggerStartNextTerm(TriggerStartArgs calldata args) external;
+    function triggerStartNextTerm(TriggerStartArgs calldata args_) external;
 }

--- a/contracts/interfaces/decent/deployables/IDecentPaymasterV1.sol
+++ b/contracts/interfaces/decent/deployables/IDecentPaymasterV1.sol
@@ -14,24 +14,24 @@ interface IDecentPaymasterV1 {
     error InvalidValidator();
 
     function initialize(
-        address _owner,
-        address _entryPoint,
-        address _lightAccountFactory
+        address owner_,
+        address entryPoint_,
+        address lightAccountFactory_
     ) external;
 
     function setFunctionValidator(
-        address contractAddress,
-        bytes4 selector,
-        address validator
+        address contractAddress_,
+        bytes4 selector_,
+        address validator_
     ) external;
 
     function removeFunctionValidator(
-        address contractAddress,
-        bytes4 selector
+        address contractAddress_,
+        bytes4 selector_
     ) external;
 
     function getFunctionValidator(
-        address contractAddress,
-        bytes4 selector
-    ) external view returns (address);
+        address contractAddress_,
+        bytes4 selector_
+    ) external view returns (address functionValidator);
 }

--- a/contracts/interfaces/decent/deployables/IERC20ProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC20ProposerAdapterV1.sol
@@ -4,9 +4,12 @@ pragma solidity ^0.8.30;
 import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
 
 interface IERC20ProposerAdapterV1 is IProposerAdapterV1 {
-    function initialize(address token, uint256 proposerThreshold) external;
+    function initialize(address token_, uint256 proposerThreshold_) external;
 
-    function token() external view returns (address);
+    function token() external view returns (address token);
 
-    function proposerThreshold() external view returns (uint256);
+    function proposerThreshold()
+        external
+        view
+        returns (uint256 proposerThreshold);
 }

--- a/contracts/interfaces/decent/deployables/IERC20VotingAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC20VotingAdapterV1.sol
@@ -6,28 +6,28 @@ interface IERC20VotingAdapterV1 {
     error AlreadyVoted();
 
     function initialize(
-        address token,
-        address strategy,
-        uint256 weightPerToken
+        address token_,
+        address strategy_,
+        uint256 weightPerToken_
     ) external;
 
-    function token() external view returns (address);
+    function token() external view returns (address token);
 
-    function weightPerToken() external view returns (uint256);
+    function weightPerToken() external view returns (uint256 weightPerToken);
 
     function getFreezeVoteWeight(
-        address voter,
-        uint48 freezeProposalSnapshotAndId
+        address voter_,
+        uint48 freezeProposalSnapshotAndId_
     ) external view returns (uint256 weight);
 
     function hasCastedVoteForProposal(
-        uint32 proposalId,
-        address voter
-    ) external view returns (bool);
+        uint32 proposalId_,
+        address voter_
+    ) external view returns (bool hasCastedVote);
 
     function hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract(
-        address freezeVoteContract,
-        uint48 freezeProposalSnapshotAndId,
-        address voter
-    ) external view returns (bool);
+        address freezeVoteContract_,
+        uint48 freezeProposalSnapshotAndId_,
+        address voter_
+    ) external view returns (bool hasCastedVote);
 }

--- a/contracts/interfaces/decent/deployables/IERC721ProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC721ProposerAdapterV1.sol
@@ -4,9 +4,12 @@ pragma solidity ^0.8.30;
 import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
 
 interface IERC721ProposerAdapterV1 is IProposerAdapterV1 {
-    function initialize(address token, uint256 proposerThreshold) external;
+    function initialize(address token_, uint256 proposerThreshold_) external;
 
-    function token() external view returns (address);
+    function token() external view returns (address token);
 
-    function proposerThreshold() external view returns (uint256);
+    function proposerThreshold()
+        external
+        view
+        returns (uint256 proposerThreshold);
 }

--- a/contracts/interfaces/decent/deployables/IERC721VotingAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IERC721VotingAdapterV1.sol
@@ -7,36 +7,36 @@ interface IERC721VotingAdapterV1 {
     error TokenIdNotOwnedByVoter(uint256 tokenId);
 
     function initialize(
-        address token,
-        address strategy,
-        uint256 weightPerToken
+        address token_,
+        address strategy_,
+        uint256 weightPerToken_
     ) external;
 
-    function token() external view returns (address);
+    function token() external view returns (address token);
 
-    function weightPerToken() external view returns (uint256);
+    function weightPerToken() external view returns (uint256 weightPerToken);
 
     function tokenIdUsedForVote(
-        uint32 proposalId,
-        uint256 tokenId
-    ) external view returns (bool);
+        uint32 proposalId_,
+        uint256 tokenId_
+    ) external view returns (bool tokenUsed);
 
     function weightOfWithValidTokenIds(
-        address _voter,
-        uint32 _proposalId,
-        bytes calldata _adapterVoteData
+        address voter_,
+        uint32 proposalId_,
+        bytes calldata adapterVoteData_
     ) external view returns (uint256 weight, uint256[] memory validTokenIds);
 
     function getFreezeVoteWeight(
-        address voter,
-        address freezeVoteContract,
-        uint48 freezeProposalSnapshotAndId,
-        bytes calldata adapterVoteData
+        address voter_,
+        address freezeVoteContract_,
+        uint48 freezeProposalSnapshotAndId_,
+        bytes calldata adapterVoteData_
     ) external view returns (uint256 weight);
 
     function tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract(
-        address freezeVoteContract,
-        uint48 freezeProposalSnapshotAndId,
-        uint256 tokenId
-    ) external view returns (bool);
+        address freezeVoteContract_,
+        uint48 freezeProposalSnapshotAndId_,
+        uint256 tokenId_
+    ) external view returns (bool tokenUsed);
 }

--- a/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
+++ b/contracts/interfaces/decent/deployables/IFractalModuleV1.sol
@@ -6,7 +6,11 @@ import {Transaction} from "../Module.sol";
 interface IFractalModuleV1 {
     error TxFailed();
 
-    function initialize(address owner, address avatar, address target) external;
+    function initialize(
+        address owner_,
+        address avatar_,
+        address target_
+    ) external;
 
-    function execTx(Transaction calldata _transaction) external;
+    function execTx(Transaction calldata transaction_) external;
 }

--- a/contracts/interfaces/decent/deployables/IFunctionValidator.sol
+++ b/contracts/interfaces/decent/deployables/IFunctionValidator.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.30;
 
 interface IFunctionValidator {
     function validateOperation(
-        address userOpSender,
-        address lightAccountOwner,
-        address target,
-        bytes calldata callData
+        address userOpSender_,
+        address lightAccountOwner_,
+        address target_,
+        bytes calldata callData_
     ) external view returns (bool isValid);
 }

--- a/contracts/interfaces/decent/deployables/IHatsProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IHatsProposerAdapterV1.sol
@@ -5,11 +5,14 @@ import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
 
 interface IHatsProposerAdapterV1 is IProposerAdapterV1 {
     function initialize(
-        address hatsContractAddress,
-        uint256[] calldata whitelistedHats
+        address hatsContractAddress_,
+        uint256[] calldata whitelistedHats_
     ) external;
 
-    function hatsContract() external view returns (address);
+    function hatsContract() external view returns (address hatsContract);
 
-    function whitelistedHatIds() external view returns (uint256[] memory);
+    function whitelistedHatIds()
+        external
+        view
+        returns (uint256[] memory whitelistedHatIds);
 }

--- a/contracts/interfaces/decent/deployables/IMultisigFreezeGuardV1.sol
+++ b/contracts/interfaces/decent/deployables/IMultisigFreezeGuardV1.sol
@@ -19,38 +19,38 @@ interface IMultisigFreezeGuardV1 is IBaseFreezeGuardV1 {
     error Expired();
 
     function initialize(
-        uint32 timelockPeriod,
-        uint32 executionPeriod,
-        address owner,
-        address freezeVoting,
-        address childGnosisSafe
+        uint32 timelockPeriod_,
+        uint32 executionPeriod_,
+        address owner_,
+        address freezeVoting_,
+        address childGnosisSafe_
     ) external;
 
-    function timelockPeriod() external view returns (uint32);
+    function timelockPeriod() external view returns (uint32 timelockPeriod);
 
-    function executionPeriod() external view returns (uint32);
+    function executionPeriod() external view returns (uint32 executionPeriod);
 
-    function childGnosisSafe() external view returns (address);
+    function childGnosisSafe() external view returns (address childGnosisSafe);
 
     function timelockTransaction(
-        address _to,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation,
-        uint256 _safeTxGas,
-        uint256 _baseGas,
-        uint256 _gasPrice,
-        address _gasToken,
-        address payable _refundReceiver,
-        bytes calldata _signatures,
-        uint256 _nonce
+        address to_,
+        uint256 value_,
+        bytes memory data_,
+        Enum.Operation operation_,
+        uint256 safeTxGas_,
+        uint256 baseGas_,
+        uint256 gasPrice_,
+        address gasToken_,
+        address payable refundReceiver_,
+        bytes calldata signatures_,
+        uint256 nonce_
     ) external;
 
-    function updateTimelockPeriod(uint32 _timelockPeriod) external;
+    function updateTimelockPeriod(uint32 timelockPeriod_) external;
 
-    function updateExecutionPeriod(uint32 _executionPeriod) external;
+    function updateExecutionPeriod(uint32 executionPeriod_) external;
 
     function getTransactionTimelocked(
-        bytes32 _signaturesHash
-    ) external view returns (uint48);
+        bytes32 signaturesHash_
+    ) external view returns (uint48 timelockedTimestamp);
 }

--- a/contracts/interfaces/decent/deployables/IMultisigFreezeVotingV1.sol
+++ b/contracts/interfaces/decent/deployables/IMultisigFreezeVotingV1.sol
@@ -5,20 +5,20 @@ interface IMultisigFreezeVotingV1 {
     event FreezeProposalCreated(address indexed creator);
 
     function initialize(
-        address owner,
-        uint256 freezeVotesThreshold,
-        uint32 freezeProposalPeriod,
-        uint32 freezePeriod,
-        address parentSafe,
+        address owner_,
+        uint256 freezeVotesThreshold_,
+        uint32 freezeProposalPeriod_,
+        uint32 freezePeriod_,
+        address parentSafe_,
         address lightAccountFactory
     ) external;
 
-    function parentSafe() external view returns (address);
+    function parentSafe() external view returns (address parentSafe);
 
     function castFreezeVote() external;
 
-    function userHasFreezeVoted(
-        uint48 freezeProposalCreated,
-        address voter
-    ) external view returns (bool);
+    function accountHasFreezeVoted(
+        uint48 freezeProposalCreated_,
+        address account_
+    ) external view returns (bool accountHasFreezeVoted);
 }

--- a/contracts/interfaces/decent/deployables/IProposerAdapterV1.sol
+++ b/contracts/interfaces/decent/deployables/IProposerAdapterV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 interface IProposerAdapterV1 {
     function isProposer(
-        address _address,
-        bytes calldata _data
-    ) external view returns (bool);
+        address address_,
+        bytes calldata data_
+    ) external view returns (bool isProposer);
 }

--- a/contracts/interfaces/decent/deployables/ISmartAccountValidationV1.sol
+++ b/contracts/interfaces/decent/deployables/ISmartAccountValidationV1.sol
@@ -7,5 +7,8 @@ interface ISmartAccountValidationV1 {
     error InvalidCallData();
     error InvalidInnerCallDataLength();
 
-    function lightAccountFactory() external view returns (address);
+    function lightAccountFactory()
+        external
+        view
+        returns (address lightAccountFactory);
 }

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -38,14 +38,13 @@ interface IStrategyV1 {
         address indexed freezeVoterContract,
         bool isAuthorized
     );
-
     event VotingPeriodEnded(
         uint32 indexed proposalId,
         uint48 votingEndTimestamp,
         uint48 currentTimestamp
     );
 
-    error InvalidProposerAdapter(address _proposerAdapter);
+    error InvalidProposerAdapter(address proposerAdapter);
     error NoVotingAdapters();
     error NoProposerAdapters();
     error InvalidBasisNumerator();
@@ -58,20 +57,20 @@ interface IStrategyV1 {
     error InvalidAddress();
 
     function initialize(
-        address strategyAdmin,
-        uint32 votingPeriod,
-        uint256 quorumThreshold,
-        uint256 basisNumerator,
-        address[] calldata votingAdapters,
-        address[] calldata proposerAdapters,
-        address lightAccountFactory
+        address strategyAdmin_,
+        uint32 votingPeriod_,
+        uint256 quorumThreshold_,
+        uint256 basisNumerator_,
+        address[] calldata votingAdapters_,
+        address[] calldata proposerAdapters_,
+        address lightAccountFactory_
     ) external;
 
     function isProposer(
         address address_,
         address proposerAdapter_,
         bytes calldata proposerAdapterData_
-    ) external view returns (bool);
+    ) external view returns (bool isProposer);
 
     function initializeProposal(
         uint32 proposalId_,
@@ -79,7 +78,7 @@ interface IStrategyV1 {
         bytes calldata proposalInitializerData_
     ) external;
 
-    function isPassed(uint32 proposalId_) external view returns (bool);
+    function isPassed(uint32 proposalId_) external view returns (bool isPassed);
 
     function getVotingTimestamps(
         uint32 proposalId_
@@ -91,49 +90,67 @@ interface IStrategyV1 {
 
     function isVotingAdapter(
         address votingAdapter_
-    ) external view returns (bool);
+    ) external view returns (bool isVotingAdapter);
 
     function isProposerAdapter(
         address proposerAdapter_
-    ) external view returns (bool);
+    ) external view returns (bool isProposerAdapter);
 
-    function strategyAdmin() external view returns (address);
+    function strategyAdmin() external view returns (address strategyAdmin);
 
-    function votingPeriod() external view returns (uint32);
+    function votingPeriod() external view returns (uint32 votingPeriod);
 
-    function quorumThreshold() external view returns (uint256);
+    function quorumThreshold() external view returns (uint256 quorumThreshold);
 
-    function basisNumerator() external view returns (uint256);
+    function basisNumerator() external view returns (uint256 basisNumerator);
 
     function proposalVotingDetails(
-        uint32 proposalId
-    ) external view returns (ProposalVotingDetails memory);
+        uint32 proposalId_
+    )
+        external
+        view
+        returns (ProposalVotingDetails memory proposalVotingDetails);
 
-    function votingAdapters() external view returns (address[] memory);
+    function votingAdapters()
+        external
+        view
+        returns (address[] memory votingAdapters);
 
-    function proposerAdapters() external view returns (address[] memory);
+    function proposerAdapters()
+        external
+        view
+        returns (address[] memory proposerAdapters);
 
-    function isQuorumMet(uint32 _proposalId) external view returns (bool);
+    function isQuorumMet(
+        uint32 proposalId_
+    ) external view returns (bool isQuorumMet);
 
-    function isBasisMet(uint32 _proposalId) external view returns (bool);
+    function isBasisMet(
+        uint32 proposalId_
+    ) external view returns (bool isBasisMet);
 
     function vote(
-        uint32 _proposalId,
-        uint8 _voteType,
-        VotingAdapterVoteData[] calldata votingAdaptersData
+        uint32 proposalId_,
+        uint8 voteType_,
+        VotingAdapterVoteData[] calldata votingAdaptersData_
     ) external;
 
-    function addAuthorizedFreezeVoter(address freezeVoterContract) external;
+    function addAuthorizedFreezeVoter(address freezeVoterContract_) external;
 
-    function removeAuthorizedFreezeVoter(address freezeVoterContract) external;
+    function removeAuthorizedFreezeVoter(address freezeVoterContract_) external;
 
     function isAuthorizedFreezeVoter(
-        address freezeVoterContract
-    ) external view returns (bool);
+        address freezeVoterContract_
+    ) external view returns (bool isAuthorizedFreezeVoter);
 
-    function authorizedFreezeVoters() external view returns (address[] memory);
+    function authorizedFreezeVoters()
+        external
+        view
+        returns (address[] memory authorizedFreezeVoters);
 
-    function votingPeriodEnded(uint32 _proposalId) external view returns (bool);
+    function votingPeriodEnded(
+        uint32 proposalId_
+    ) external view returns (bool votingPeriodEnded);
 
     function validStrategyVote(
         address voter_,

--- a/contracts/interfaces/decent/deployables/IVersion.sol
+++ b/contracts/interfaces/decent/deployables/IVersion.sol
@@ -2,5 +2,5 @@
 pragma solidity ^0.8.30;
 
 interface IVersion {
-    function version() external view returns (uint16);
+    function version() external view returns (uint16 version);
 }

--- a/contracts/interfaces/decent/deployables/IVoterResolverV1.sol
+++ b/contracts/interfaces/decent/deployables/IVoterResolverV1.sol
@@ -2,5 +2,7 @@
 pragma solidity ^0.8.30;
 
 interface IVoterResolverV1 {
-    function voter(address _msgSender) external view returns (address);
+    function voter(
+        address voter_
+    ) external view returns (address resolvedVoter);
 }

--- a/contracts/interfaces/decent/deployables/IVotesERC20LockableV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20LockableV1.sol
@@ -21,11 +21,11 @@ interface IVotesERC20LockableV1 is IVotesERC20V1 {
 
     function lock(bool locked_) external;
 
-    function locked() external view returns (bool);
+    function locked() external view returns (bool isLocked);
 
     function mint(address to_, uint256 amount_) external;
 
-    function maxTotalSupply() external view returns (uint256);
+    function maxTotalSupply() external view returns (uint256 maxTotalSupply);
 
     function setMaxTotalSupply(uint256 newMaxTotalSupply_) external;
 

--- a/contracts/interfaces/decent/deployables/IVotesERC20StakedV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20StakedV1.sol
@@ -46,48 +46,54 @@ interface IVotesERC20StakedV1 {
     error TransferFailed();
 
     function initialize(
-        Metadata calldata metadata,
-        address owner,
-        address _stakedToken,
-        uint256 _minimumStakingPeriod,
-        address[] calldata _rewardsTokens
+        Metadata calldata metadata_,
+        address owner_,
+        address stakedToken_,
+        uint256 minimumStakingPeriod_,
+        address[] calldata rewardsTokens_
     ) external;
 
     function addRewardsTokens(address[] calldata rewardsTokens_) external;
 
     function updateMinimumStakingPeriod(
-        uint256 newMinimumStakingPeriod
+        uint256 newMinimumStakingPeriod_
     ) external;
 
-    function stake(uint256 amount) external;
+    function stake(uint256 amount_) external;
 
-    function unstake(uint256 amount) external;
+    function unstake(uint256 amount_) external;
 
     function distributeRewards() external;
 
-    function distributeRewards(address[] calldata _tokens) external;
+    function distributeRewards(address[] calldata tokens_) external;
 
-    function claimRewards(address _recipient) external;
+    function claimRewards(address recipient_) external;
 
     function claimRewards(
-        address _recipient,
-        address[] memory _tokens
+        address recipient_,
+        address[] calldata tokens_
     ) external;
 
-    function clock() external view returns (uint48);
+    function clock() external view returns (uint48 clock);
 
-    function CLOCK_MODE() external pure returns (string memory);
+    function CLOCK_MODE() external pure returns (string memory CLOCK_MODE);
 
-    function stakedToken() external view returns (address);
+    function stakedToken() external view returns (address stakedToken);
 
-    function minimumStakingPeriod() external view returns (uint256);
+    function minimumStakingPeriod()
+        external
+        view
+        returns (uint256 minimumStakingPeriod);
 
-    function totalStaked() external view returns (uint256);
+    function totalStaked() external view returns (uint256 totalStaked);
 
-    function rewardsTokens() external view returns (address[] memory);
+    function rewardsTokens()
+        external
+        view
+        returns (address[] memory rewardsTokens);
 
     function rewardsTokenData(
-        address token
+        address token_
     )
         external
         view
@@ -97,27 +103,30 @@ interface IVotesERC20StakedV1 {
             uint256 rewardsClaimed
         );
 
-    function distributableRewards() external view returns (uint256[] memory);
+    function distributableRewards()
+        external
+        view
+        returns (uint256[] memory distributableRewards);
 
     function distributableRewards(
         address[] calldata rewardsTokens_
-    ) external view returns (uint256[] memory);
+    ) external view returns (uint256[] memory distributableRewards);
 
     function stakerData(
-        address staker
+        address staker_
     ) external view returns (uint256 stakedAmount, uint256 lastStakeTimestamp);
 
     function stakerRewardsData(
-        address token,
-        address staker
+        address token_,
+        address staker_
     ) external view returns (uint256 rewardRate, uint256 accumulatedRewards);
 
     function claimableRewards(
-        address _staker
-    ) external view returns (uint256[] memory _claimableRewards);
+        address staker_
+    ) external view returns (uint256[] memory claimableRewards);
 
     function claimableRewards(
-        address _staker,
-        address[] memory _tokens
-    ) external view returns (uint256[] memory _claimableRewards);
+        address staker_,
+        address[] calldata tokens_
+    ) external view returns (uint256[] memory claimableRewards);
 }

--- a/contracts/interfaces/decent/deployables/IVotesERC20V1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20V1.sol
@@ -13,12 +13,12 @@ interface IVotesERC20V1 {
     }
 
     function initialize(
-        Metadata calldata _metadata,
-        Allocation[] calldata _allocations,
-        address owner
+        Metadata calldata metadata_,
+        Allocation[] calldata allocations_,
+        address owner_
     ) external;
 
-    function clock() external view returns (uint48);
+    function clock() external view returns (uint48 clock);
 
-    function CLOCK_MODE() external pure returns (string memory);
+    function CLOCK_MODE() external pure returns (string memory CLOCK_MODE);
 }

--- a/contracts/interfaces/decent/singletons/IProxyFactory.sol
+++ b/contracts/interfaces/decent/singletons/IProxyFactory.sol
@@ -5,15 +5,15 @@ interface IProxyFactory {
     event ProxyDeployed(address indexed proxy, address indexed implementation);
 
     function deployProxy(
-        address implementation,
-        bytes calldata initData,
-        bytes32 salt
+        address implementation_,
+        bytes calldata initData_,
+        bytes32 salt_
     ) external returns (address proxy);
 
     function predictProxyAddress(
-        address implementation,
-        bytes calldata initData,
-        bytes32 salt,
-        address deployer
-    ) external view returns (address);
+        address implementation_,
+        bytes calldata initData_,
+        bytes32 salt_,
+        address deployer_
+    ) external view returns (address proxy);
 }

--- a/contracts/interfaces/light-account/ILightAccount.sol
+++ b/contracts/interfaces/light-account/ILightAccount.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 interface ILightAccount {
-    function owner() external view returns (address);
+    function owner() external view returns (address owner);
 
     function execute(
         address target,

--- a/contracts/interfaces/light-account/ILightAccountFactory.sol
+++ b/contracts/interfaces/light-account/ILightAccountFactory.sol
@@ -5,9 +5,9 @@ interface ILightAccountFactory {
     /// @notice Calculate the counterfactual address of this account as it would be returned by `createAccount`.
     /// @param owner The owner of the account to be created.
     /// @param salt A salt, which can be changed to create multiple accounts with the same owner.
-    /// @return The address of the account that would be created with `createAccount`.
+    /// @return account The address of the account that would be created with `createAccount`.
     function getAddress(
         address owner,
         uint256 salt
-    ) external view returns (address);
+    ) external view returns (address account);
 }

--- a/contracts/interfaces/safe/ISafe.sol
+++ b/contracts/interfaces/safe/ISafe.sol
@@ -4,41 +4,41 @@ pragma solidity ^0.8.30;
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 interface ISafe {
-    function nonce() external view returns (uint256);
+    function nonce() external view returns (uint256 nonce);
 
     function setGuard(address _guard) external;
 
     function execTransaction(
-        address _to,
-        uint256 _value,
-        bytes calldata _data,
-        Enum.Operation _operation,
-        uint256 _safeTxGas,
-        uint256 _baseGas,
-        uint256 _gasPrice,
-        address _gasToken,
-        address payable _refundReceiver,
-        bytes memory _signatures
+        address to_,
+        uint256 value_,
+        bytes calldata data_,
+        Enum.Operation operation_,
+        uint256 safeTxGas_,
+        uint256 baseGas_,
+        uint256 gasPrice_,
+        address gasToken_,
+        address payable refundReceiver_,
+        bytes memory signatures_
     ) external payable returns (bool success);
 
     function checkSignatures(
-        bytes32 _dataHash,
-        bytes memory _data,
-        bytes memory _signatures
+        bytes32 dataHash_,
+        bytes memory data_,
+        bytes memory signatures_
     ) external view;
 
     function encodeTransactionData(
-        address _to,
-        uint256 _value,
-        bytes calldata _data,
-        Enum.Operation _operation,
-        uint256 _safeTxGas,
-        uint256 _baseGas,
-        uint256 _gasPrice,
-        address _gasToken,
-        address _refundReceiver,
-        uint256 _nonce
-    ) external view returns (bytes memory);
+        address to_,
+        uint256 value_,
+        bytes calldata data_,
+        Enum.Operation operation_,
+        uint256 safeTxGas_,
+        uint256 baseGas_,
+        uint256 gasPrice_,
+        address gasToken_,
+        address refundReceiver_,
+        uint256 nonce_
+    ) external view returns (bytes memory encodedTransactionData);
 
-    function isOwner(address _owner) external view returns (bool);
+    function isOwner(address owner_) external view returns (bool isOwner);
 }

--- a/contracts/libs/ClockModeLib.sol
+++ b/contracts/libs/ClockModeLib.sol
@@ -16,11 +16,11 @@ library ClockModeLib {
      * @dev Gets the clock mode of a token.
      * Attempts to call CLOCK_MODE() on the token. If it reverts or returns an unexpected value,
      * defaults to BlockNumber.
-     * @param _token The token address.
+     * @param token_ The token address.
      * @return The detected ClockMode.
      */
-    function getClockMode(address _token) internal view returns (ClockMode) {
-        try IERC6372(_token).CLOCK_MODE() returns (string memory mode) {
+    function getClockMode(address token_) internal view returns (ClockMode) {
+        try IERC6372(token_).CLOCK_MODE() returns (string memory mode) {
             if (keccak256(bytes(mode)) == CLOCK_MODE_TIMESTAMP_BYTES32) {
                 return ClockMode.Timestamp;
             }
@@ -32,11 +32,11 @@ library ClockModeLib {
 
     /**
      * @dev Gets the current time point (block number or timestamp) based on the ClockMode.
-     * @param _mode The ClockMode to use.
+     * @param mode_ The ClockMode to use.
      * @return The current time point.
      */
-    function getCurrentPoint(ClockMode _mode) internal view returns (uint256) {
-        if (_mode == ClockMode.Timestamp) {
+    function getCurrentPoint(ClockMode mode_) internal view returns (uint256) {
+        if (mode_ == ClockMode.Timestamp) {
             return block.timestamp;
         } else {
             return block.number;

--- a/contracts/singletons/ProxyFactory.sol
+++ b/contracts/singletons/ProxyFactory.sol
@@ -12,56 +12,56 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
  */
 contract ProxyFactory is IProxyFactory {
     function deployProxy(
-        address implementation,
-        bytes calldata initData,
-        bytes32 salt
-    ) public returns (address proxy) {
+        address implementation_,
+        bytes calldata initData_,
+        bytes32 salt_
+    ) public returns (address) {
         // Validate the implementation address
         require(
-            implementation != address(0),
+            implementation_ != address(0),
             "Implementation cannot be zero address"
         );
         require(
-            implementation.code.length > 0,
+            implementation_.code.length > 0,
             "Implementation must be a contract"
         );
 
         // Create a unique salt based on the sender and provided salt
         // This prevents salt collisions between different callers
-        bytes32 uniqueSalt = keccak256(abi.encodePacked(msg.sender, salt));
+        bytes32 uniqueSalt = keccak256(abi.encodePacked(msg.sender, salt_));
 
         // Deploy the proxy using CREATE2
-        proxy = address(
-            new ERC1967Proxy{salt: uniqueSalt}(implementation, initData)
+        address proxy = address(
+            new ERC1967Proxy{salt: uniqueSalt}(implementation_, initData_)
         );
 
-        emit ProxyDeployed(proxy, implementation);
+        emit ProxyDeployed(proxy, implementation_);
         return proxy;
     }
 
     function predictProxyAddress(
-        address implementation,
-        bytes calldata initData,
-        bytes32 salt,
-        address deployer
+        address implementation_,
+        bytes calldata initData_,
+        bytes32 salt_,
+        address deployer_
     ) public view returns (address) {
         // Validate the implementation address
         require(
-            implementation != address(0),
+            implementation_ != address(0),
             "Implementation cannot be zero address"
         );
         require(
-            implementation.code.length > 0,
+            implementation_.code.length > 0,
             "Implementation must be a contract"
         );
 
         // Create a unique salt based on the deployer and provided salt
-        bytes32 uniqueSalt = keccak256(abi.encodePacked(deployer, salt));
+        bytes32 uniqueSalt = keccak256(abi.encodePacked(deployer_, salt_));
 
         // Calculate the proxy bytecode (implementation address + init data)
         bytes memory proxyConstructorData = abi.encode(
-            implementation,
-            initData
+            implementation_,
+            initData_
         );
         bytes memory bytecode = abi.encodePacked(
             type(ERC1967Proxy).creationCode,

--- a/contracts/utilities/DecentHatsCreationModule.sol
+++ b/contracts/utilities/DecentHatsCreationModule.sol
@@ -57,46 +57,47 @@ contract DecentHatsCreationModule is DecentHatsModuleUtils {
      * the resulting topHatId of the newly created hat can be used to create an admin hat and any other hats needed.
      * We also make use of `KeyValuePairs` to associate the topHatId with the Safe.
      *
-     * @param treeParams The parameters for creating the Hat Tree with Roles
+     * @param treeParams_ The parameters for creating the Hat Tree with Roles
      */
     function createAndDeclareTree(
-        CreateTreeParams calldata treeParams
+        CreateTreeParams calldata treeParams_
     ) external {
         // Create Top Hat
         (uint256 topHatId, address topHatAccount) = _processTopHat(
-            treeParams.hatsProtocol,
-            treeParams.erc6551Registry,
-            treeParams.hatsAccountImplementation,
-            treeParams.keyValuePairs,
-            treeParams.topHat
+            treeParams_.hatsProtocol,
+            treeParams_.erc6551Registry,
+            treeParams_.hatsAccountImplementation,
+            treeParams_.keyValuePairs,
+            treeParams_.topHat
         );
 
         // Create Admin Hat
         uint256 adminHatId = _processAdminHat(
-            treeParams.hatsProtocol,
-            treeParams.erc6551Registry,
-            treeParams.hatsAccountImplementation,
+            treeParams_.hatsProtocol,
+            treeParams_.erc6551Registry,
+            treeParams_.hatsAccountImplementation,
             topHatId,
             topHatAccount,
-            treeParams.proxyFactory,
-            treeParams.decentAutonomousAdminImplementation,
-            treeParams.adminHat
+            treeParams_.proxyFactory,
+            treeParams_.decentAutonomousAdminImplementation,
+            treeParams_.adminHat
         );
 
         // Create Role Hats
         _processRoleHats(
             CreateRoleHatsParams({
-                hatsProtocol: treeParams.hatsProtocol,
-                erc6551Registry: treeParams.erc6551Registry,
-                hatsAccountImplementation: treeParams.hatsAccountImplementation,
+                hatsProtocol: treeParams_.hatsProtocol,
+                erc6551Registry: treeParams_.erc6551Registry,
+                hatsAccountImplementation: treeParams_
+                    .hatsAccountImplementation,
                 topHatId: topHatId,
                 topHatAccount: topHatAccount,
-                hatsModuleFactory: treeParams.hatsModuleFactory,
-                hatsElectionsEligibilityImplementation: treeParams
+                hatsModuleFactory: treeParams_.hatsModuleFactory,
+                hatsElectionsEligibilityImplementation: treeParams_
                     .hatsElectionsEligibilityImplementation,
                 adminHatId: adminHatId,
-                hats: treeParams.hats,
-                keyValuePairs: treeParams.keyValuePairs
+                hats: treeParams_.hats,
+                keyValuePairs: treeParams_.keyValuePairs
             })
         );
     }
@@ -106,38 +107,38 @@ contract DecentHatsCreationModule is DecentHatsModuleUtils {
     ///////////////////////////////////////////////////////////////////////////// */
 
     function _processTopHat(
-        IHats hatsProtocol,
-        IERC6551Registry erc6551Registry,
-        address hatsAccountImplementation,
-        address keyValuePairs,
-        TopHatParams calldata topHat
-    ) internal returns (uint256 topHatId, address topHatAccount) {
+        IHats hatsProtocol_,
+        IERC6551Registry erc6551Registry_,
+        address hatsAccountImplementation_,
+        address keyValuePairs_,
+        TopHatParams calldata topHat_
+    ) internal returns (uint256, address) {
         // Call lastTopHatId() and properly decode the response
-        (bool success, bytes memory data) = address(hatsProtocol).call(
+        (bool success, bytes memory data) = address(hatsProtocol_).call(
             abi.encodeWithSignature("lastTopHatId()")
         );
         require(success, "Failed to get lastTopHatId");
-        topHatId = (abi.decode(data, (uint256)) + 1) << 224;
+        uint256 topHatId = (abi.decode(data, (uint256)) + 1) << 224;
 
         // Mint Top Hat to the Safe
         IAvatar(msg.sender).execTransactionFromModule(
-            address(hatsProtocol),
+            address(hatsProtocol_),
             0,
             abi.encodeWithSignature(
                 "mintTopHat(address,string,string)",
                 msg.sender,
-                topHat.details,
-                topHat.imageURI
+                topHat_.details,
+                topHat_.imageURI
             ),
             Enum.Operation.Call
         );
 
         // Create Top Hat's ERC6551 Account
-        topHatAccount = erc6551Registry.createAccount(
-            hatsAccountImplementation,
+        address topHatAccount = erc6551Registry_.createAccount(
+            hatsAccountImplementation_,
             SALT,
             block.chainid,
-            address(hatsProtocol),
+            address(hatsProtocol_),
             topHatId
         );
 
@@ -147,7 +148,7 @@ contract DecentHatsCreationModule is DecentHatsModuleUtils {
         keys[0] = "topHatId";
         values[0] = Strings.toString(topHatId);
         IAvatar(msg.sender).execTransactionFromModule(
-            keyValuePairs,
+            keyValuePairs_,
             0,
             abi.encodeWithSignature(
                 "updateValues(string[],string[])",
@@ -156,48 +157,50 @@ contract DecentHatsCreationModule is DecentHatsModuleUtils {
             ),
             Enum.Operation.Call
         );
+
+        return (topHatId, topHatAccount);
     }
 
     function _processAdminHat(
-        IHats hatsProtocol,
-        IERC6551Registry erc6551Registry,
-        address hatsAccountImplementation,
-        uint256 topHatId,
-        address topHatAccount,
-        IProxyFactory proxyFactory,
-        address decentAutonomousAdminImplementation,
-        AdminHatParams calldata adminHat
-    ) internal returns (uint256 adminHatId) {
+        IHats hatsProtocol_,
+        IERC6551Registry erc6551Registry_,
+        address hatsAccountImplementation_,
+        uint256 topHatId_,
+        address topHatAccount_,
+        IProxyFactory proxyFactory_,
+        address decentAutonomousAdminImplementation_,
+        AdminHatParams calldata adminHat_
+    ) internal returns (uint256) {
         // Create Admin Hat
-        adminHatId = hatsProtocol.getNextId(topHatId);
+        uint256 adminHatId = hatsProtocol_.getNextId(topHatId_);
         IAvatar(msg.sender).execTransactionFromModule(
-            address(hatsProtocol),
+            address(hatsProtocol_),
             0,
             abi.encodeWithSignature(
                 "createHat(uint256,string,uint32,address,address,bool,string)",
-                topHatId,
-                adminHat.details,
+                topHatId_,
+                adminHat_.details,
                 1, // only one Admin Hat
-                topHatAccount,
-                topHatAccount,
-                adminHat.isMutable,
-                adminHat.imageURI
+                topHatAccount_,
+                topHatAccount_,
+                adminHat_.isMutable,
+                adminHat_.imageURI
             ),
             Enum.Operation.Call
         );
 
         // Create Admin Hat's ERC6551 Account
-        erc6551Registry.createAccount(
-            hatsAccountImplementation,
+        erc6551Registry_.createAccount(
+            hatsAccountImplementation_,
             SALT,
             block.chainid,
-            address(hatsProtocol),
+            address(hatsProtocol_),
             adminHatId
         );
 
         // Deploy Decent Autonomous Admin Module, which will wear the Admin Hat
-        address autonomousAdmin = proxyFactory.deployProxy(
-            decentAutonomousAdminImplementation,
+        address autonomousAdmin = proxyFactory_.deployProxy(
+            decentAutonomousAdminImplementation_,
             abi.encodeWithSignature("initialize(address)", msg.sender),
             keccak256(
                 abi.encodePacked(
@@ -211,7 +214,7 @@ contract DecentHatsCreationModule is DecentHatsModuleUtils {
 
         // Mint Hat to the Decent Autonomous Admin Module
         IAvatar(msg.sender).execTransactionFromModule(
-            address(hatsProtocol),
+            address(hatsProtocol_),
             0,
             abi.encodeWithSignature(
                 "mintHat(uint256,address)",
@@ -220,5 +223,7 @@ contract DecentHatsCreationModule is DecentHatsModuleUtils {
             ),
             Enum.Operation.Call
         );
+
+        return adminHatId;
     }
 }

--- a/contracts/utilities/DecentHatsModificationModule.sol
+++ b/contracts/utilities/DecentHatsModificationModule.sol
@@ -19,11 +19,11 @@ contract DecentHatsModificationModule is DecentHatsModuleUtils {
      * to avoid a race condition where not more than one active proposal to create a new role can exist at a time.
      * See: https://github.com/decentdao/decent-interface/issues/2402
      *
-     * @param roleHatsParams An array of params for each role hat to be created.
+     * @param roleHatsParams_ An array of params for each role hat to be created.
      */
     function createRoleHats(
-        CreateRoleHatsParams calldata roleHatsParams
+        CreateRoleHatsParams calldata roleHatsParams_
     ) external {
-        _processRoleHats(roleHatsParams);
+        _processRoleHats(roleHatsParams_);
     }
 }

--- a/contracts/utilities/DecentHatsModuleUtils.sol
+++ b/contracts/utilities/DecentHatsModuleUtils.sol
@@ -50,36 +50,36 @@ abstract contract DecentHatsModuleUtils {
     }
 
     function _processRoleHats(
-        CreateRoleHatsParams memory roleHatsParams
+        CreateRoleHatsParams memory roleHatsParams_
     ) internal {
-        for (uint256 i = 0; i < roleHatsParams.hats.length; ) {
-            HatParams memory hatParams = roleHatsParams.hats[i];
+        for (uint256 i = 0; i < roleHatsParams_.hats.length; ) {
+            HatParams memory hatParams = roleHatsParams_.hats[i];
 
             // Create eligibility module if needed
             address eligibilityAddress = _createEligibilityModule(
-                roleHatsParams.hatsProtocol,
-                roleHatsParams.hatsModuleFactory,
-                roleHatsParams.hatsElectionsEligibilityImplementation,
-                roleHatsParams.topHatId,
-                roleHatsParams.topHatAccount,
-                roleHatsParams.adminHatId,
+                roleHatsParams_.hatsProtocol,
+                roleHatsParams_.hatsModuleFactory,
+                roleHatsParams_.hatsElectionsEligibilityImplementation,
+                roleHatsParams_.topHatId,
+                roleHatsParams_.topHatAccount,
+                roleHatsParams_.adminHatId,
                 hatParams.termEndDateTs
             );
 
             // Create and Mint the Role Hat
             uint256 hatId = _createAndMintHat(
-                roleHatsParams.hatsProtocol,
-                roleHatsParams.adminHatId,
+                roleHatsParams_.hatsProtocol,
+                roleHatsParams_.adminHatId,
                 hatParams,
                 eligibilityAddress,
-                roleHatsParams.topHatAccount
+                roleHatsParams_.topHatAccount
             );
 
             // Get the stream recipient (based on termed or not)
             address streamRecipient = _setupStreamRecipient(
-                roleHatsParams.erc6551Registry,
-                roleHatsParams.hatsAccountImplementation,
-                address(roleHatsParams.hatsProtocol),
+                roleHatsParams_.erc6551Registry,
+                roleHatsParams_.hatsAccountImplementation,
+                address(roleHatsParams_.hatsProtocol),
                 hatParams.termEndDateTs,
                 hatParams.wearer,
                 hatId
@@ -89,7 +89,7 @@ abstract contract DecentHatsModuleUtils {
             _processSablierStreams(
                 hatParams.sablierStreamsParams,
                 streamRecipient,
-                roleHatsParams.keyValuePairs,
+                roleHatsParams_.keyValuePairs,
                 hatId
             );
 
@@ -100,68 +100,68 @@ abstract contract DecentHatsModuleUtils {
     }
 
     function _createEligibilityModule(
-        IHats hatsProtocol,
-        IHatsModuleFactory hatsModuleFactory,
-        address hatsElectionsEligibilityImplementation,
-        uint256 topHatId,
-        address topHatAccount,
-        uint256 adminHatId,
-        uint128 termEndDateTs
+        IHats hatsProtocol_,
+        IHatsModuleFactory hatsModuleFactory_,
+        address hatsElectionsEligibilityImplementation_,
+        uint256 topHatId_,
+        address topHatAccount_,
+        uint256 adminHatId_,
+        uint128 termEndDateTs_
     ) private returns (address) {
         // If the Hat is termed, create the eligibility module
-        if (termEndDateTs != 0) {
+        if (termEndDateTs_ != 0) {
             return
-                hatsModuleFactory.createHatsModule(
-                    hatsElectionsEligibilityImplementation,
-                    hatsProtocol.getNextId(adminHatId),
-                    abi.encode(topHatId, uint256(0)), // [BALLOT_BOX_ID, ADMIN_HAT_ID]
-                    abi.encode(termEndDateTs),
+                hatsModuleFactory_.createHatsModule(
+                    hatsElectionsEligibilityImplementation_,
+                    hatsProtocol_.getNextId(adminHatId_),
+                    abi.encode(topHatId_, uint256(0)), // [BALLOT_BOX_ID, ADMIN_HAT_ID]
+                    abi.encode(termEndDateTs_),
                     uint256(SALT)
                 );
         }
 
         // Otherwise, return the Top Hat account
-        return topHatAccount;
+        return topHatAccount_;
     }
 
     function _createAndMintHat(
-        IHats hatsProtocol,
-        uint256 adminHatId,
-        HatParams memory hat,
-        address eligibilityAddress,
-        address topHatAccount
+        IHats hatsProtocol_,
+        uint256 adminHatId_,
+        HatParams memory hat_,
+        address eligibilityAddress_,
+        address topHatAccount_
     ) private returns (uint256) {
         // Grab the next Hat ID (before creating it)
-        uint256 hatId = hatsProtocol.getNextId(adminHatId);
+        uint256 hatId = hatsProtocol_.getNextId(adminHatId_);
 
         // Create the new Hat
         IAvatar(msg.sender).execTransactionFromModule(
-            address(hatsProtocol),
+            address(hatsProtocol_),
             0,
             abi.encodeWithSignature(
                 "createHat(uint256,string,uint32,address,address,bool,string)",
-                adminHatId,
-                hat.details,
-                hat.maxSupply,
-                eligibilityAddress,
-                topHatAccount,
-                hat.isMutable,
-                hat.imageURI
+                adminHatId_,
+                hat_.details,
+                hat_.maxSupply,
+                eligibilityAddress_,
+                topHatAccount_,
+                hat_.isMutable,
+                hat_.imageURI
             ),
             Enum.Operation.Call
         );
 
         // If the Hat is termed, nominate the wearer as the eligible member
-        if (hat.termEndDateTs != 0) {
+        if (hat_.termEndDateTs != 0) {
             address[] memory nominatedWearers = new address[](1);
-            nominatedWearers[0] = hat.wearer;
+            nominatedWearers[0] = hat_.wearer;
 
             IAvatar(msg.sender).execTransactionFromModule(
-                eligibilityAddress,
+                eligibilityAddress_,
                 0,
                 abi.encodeWithSignature(
                     "elect(uint128,address[])",
-                    hat.termEndDateTs,
+                    hat_.termEndDateTs,
                     nominatedWearers
                 ),
                 Enum.Operation.Call
@@ -170,12 +170,12 @@ abstract contract DecentHatsModuleUtils {
 
         // Mint the Hat
         IAvatar(msg.sender).execTransactionFromModule(
-            address(hatsProtocol),
+            address(hatsProtocol_),
             0,
             abi.encodeWithSignature(
                 "mintHat(uint256,address)",
                 hatId,
-                hat.wearer
+                hat_.wearer
             ),
             Enum.Operation.Call
         );
@@ -184,37 +184,37 @@ abstract contract DecentHatsModuleUtils {
 
     // Exists to avoid stack too deep errors
     function _setupStreamRecipient(
-        IERC6551Registry erc6551Registry,
-        address hatsAccountImplementation,
-        address hatsProtocol,
-        uint128 termEndDateTs,
-        address wearer,
-        uint256 hatId
+        IERC6551Registry erc6551Registry_,
+        address hatsAccountImplementation_,
+        address hatsProtocol_,
+        uint128 termEndDateTs_,
+        address wearer_,
+        uint256 hatId_
     ) private returns (address) {
         // If the hat is termed, the wearer is the stream recipient
-        if (termEndDateTs != 0) {
-            return wearer;
+        if (termEndDateTs_ != 0) {
+            return wearer_;
         }
 
         // Otherwise, the Hat's smart account is the stream recipient
         return
-            erc6551Registry.createAccount(
-                hatsAccountImplementation,
+            erc6551Registry_.createAccount(
+                hatsAccountImplementation_,
                 SALT,
                 block.chainid,
-                hatsProtocol,
-                hatId
+                hatsProtocol_,
+                hatId_
             );
     }
 
     function _processSablierStreams(
-        SablierStreamParams[] memory streamParams,
-        address streamRecipient,
-        address keyValuePairs,
-        uint256 hatId
+        SablierStreamParams[] memory streamParams_,
+        address streamRecipient_,
+        address keyValuePairs_,
+        uint256 hatId_
     ) private {
-        for (uint256 i = 0; i < streamParams.length; ) {
-            SablierStreamParams memory sablierStreamParams = streamParams[i];
+        for (uint256 i = 0; i < streamParams_.length; ) {
+            SablierStreamParams memory sablierStreamParams = streamParams_[i];
 
             // Approve tokens for Sablier
             IAvatar(msg.sender).execTransactionFromModule(
@@ -239,7 +239,7 @@ abstract contract DecentHatsModuleUtils {
                     "createWithTimestamps((address,address,uint128,address,bool,bool,(uint40,uint40,uint40),(address,uint256)))",
                     LockupLinear.CreateWithTimestamps({
                         sender: sablierStreamParams.sender,
-                        recipient: streamRecipient,
+                        recipient: streamRecipient_,
                         totalAmount: sablierStreamParams.totalAmount,
                         asset: IERC20(sablierStreamParams.asset),
                         cancelable: sablierStreamParams.cancelable,
@@ -257,14 +257,14 @@ abstract contract DecentHatsModuleUtils {
             keys[0] = "hatIdToStreamId";
             values[0] = string(
                 abi.encodePacked(
-                    Strings.toString(hatId),
+                    Strings.toString(hatId_),
                     ":",
                     Strings.toString(streamId)
                 )
             );
 
             IAvatar(msg.sender).execTransactionFromModule(
-                keyValuePairs,
+                keyValuePairs_,
                 0,
                 abi.encodeWithSignature(
                     "updateValues(string[],string[])",

--- a/contracts/utilities/DecentSablierStreamManagementModule.sol
+++ b/contracts/utilities/DecentSablierStreamManagementModule.sol
@@ -8,28 +8,28 @@ import {Lockup} from "../interfaces/sablier/types/DataTypes.sol";
 
 contract DecentSablierStreamManagementModule {
     function withdrawMaxFromStream(
-        ISablierV2Lockup sablier,
-        address recipientHatAccount,
-        uint256 streamId,
-        address to
+        ISablierV2Lockup sablier_,
+        address recipientHatAccount_,
+        uint256 streamId_,
+        address to_
     ) public {
         // Check if there are funds to withdraw
-        if (sablier.withdrawableAmountOf(streamId) == 0) {
+        if (sablier_.withdrawableAmountOf(streamId_) == 0) {
             return;
         }
 
         // Proxy the Sablier withdrawMax call through IAvatar (Safe)
         IAvatar(msg.sender).execTransactionFromModule(
-            recipientHatAccount,
+            recipientHatAccount_,
             0,
             abi.encodeWithSignature(
                 "execute(address,uint256,bytes,uint8)",
-                address(sablier),
+                address(sablier_),
                 0,
                 abi.encodeWithSignature(
                     "withdrawMax(uint256,address)",
-                    streamId,
-                    to
+                    streamId_,
+                    to_
                 ),
                 0
             ),
@@ -37,9 +37,9 @@ contract DecentSablierStreamManagementModule {
         );
     }
 
-    function cancelStream(ISablierV2Lockup sablier, uint256 streamId) public {
+    function cancelStream(ISablierV2Lockup sablier_, uint256 streamId_) public {
         // Check if the stream can be cancelled
-        Lockup.Status streamStatus = sablier.statusOf(streamId);
+        Lockup.Status streamStatus = sablier_.statusOf(streamId_);
         if (
             streamStatus != Lockup.Status.PENDING &&
             streamStatus != Lockup.Status.STREAMING
@@ -48,9 +48,9 @@ contract DecentSablierStreamManagementModule {
         }
 
         IAvatar(msg.sender).execTransactionFromModule(
-            address(sablier),
+            address(sablier_),
             0,
-            abi.encodeWithSignature("cancel(uint256)", streamId),
+            abi.encodeWithSignature("cancel(uint256)", streamId_),
             Enum.Operation.Call
         );
     }

--- a/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
+++ b/test/deployables/freeze-voting/MultisigFreezeVotingV1.test.ts
@@ -446,8 +446,8 @@ describe('MultisigFreezeVotingV1', () => {
 
       // Initial state - user has not voted
       const createdTimestamp = await freezeVoting.freezeProposalCreated();
-      void expect(await freezeVoting.userHasFreezeVoted(createdTimestamp, safeOwner1.address)).to.be
-        .false;
+      void expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address)).to
+        .be.false;
 
       // User votes
       await freezeVoting.connect(safeOwner1).castFreezeVote();
@@ -456,11 +456,11 @@ describe('MultisigFreezeVotingV1', () => {
       const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Updated state - user has voted for the new proposal timestamp
-      void expect(await freezeVoting.userHasFreezeVoted(newCreatedTimestamp, safeOwner1.address)).to
-        .be.true;
+      void expect(await freezeVoting.accountHasFreezeVoted(newCreatedTimestamp, safeOwner1.address))
+        .to.be.true;
       if (createdTimestamp !== newCreatedTimestamp) {
-        void expect(await freezeVoting.userHasFreezeVoted(createdTimestamp, safeOwner1.address)).to
-          .be.false;
+        void expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address))
+          .to.be.false;
       }
     });
 
@@ -475,8 +475,8 @@ describe('MultisigFreezeVotingV1', () => {
       const createdTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Check that user has voted for this proposal timestamp
-      void expect(await freezeVoting.userHasFreezeVoted(createdTimestamp, safeOwner1.address)).to.be
-        .true;
+      void expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address)).to
+        .be.true;
 
       // Owner unfreezes
       await freezeVoting.connect(owner).unfreeze();
@@ -485,18 +485,18 @@ describe('MultisigFreezeVotingV1', () => {
       // but the state for a *new* proposal (which will get a new timestamp) should be clear.
       expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
       // Check for the new (zero) proposal timestamp - should be false
-      void expect(await freezeVoting.userHasFreezeVoted(0, safeOwner1.address)).to.be.false;
+      void expect(await freezeVoting.accountHasFreezeVoted(0, safeOwner1.address)).to.be.false;
 
       // User should be able to vote again (this will create a new proposal timestamp)
       await freezeVoting.connect(safeOwner1).castFreezeVote();
       const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // User has voted on the new proposal
-      void expect(await freezeVoting.userHasFreezeVoted(newCreatedTimestamp, safeOwner1.address)).to
-        .be.true;
+      void expect(await freezeVoting.accountHasFreezeVoted(newCreatedTimestamp, safeOwner1.address))
+        .to.be.true;
       if (createdTimestamp > 0 && createdTimestamp !== newCreatedTimestamp) {
-        void expect(await freezeVoting.userHasFreezeVoted(createdTimestamp, safeOwner1.address)).to
-          .be.true;
+        void expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address))
+          .to.be.true;
       }
     });
   });
@@ -612,7 +612,7 @@ describe('MultisigFreezeVotingV1', () => {
       expect(await freezeVotingSA.freezeProposalVoteCount()).to.equal(1);
       const proposalTimestamp = await freezeVotingSA.freezeProposalCreated();
       void expect(
-        await freezeVotingSA.userHasFreezeVoted(proposalTimestamp, smartAccountOwnerSA.address),
+        await freezeVotingSA.accountHasFreezeVoted(proposalTimestamp, smartAccountOwnerSA.address),
       ).to.be.true;
     });
 

--- a/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
+++ b/test/deployables/strategies/adapters/ERC721VotingAdapterV1.test.ts
@@ -327,7 +327,7 @@ describe('ERC721VotingAdapterV1', () => {
         ['uint256[]'],
         [tokenIdsToVoteWith],
       );
-      const { weight, validTokenIds } = await adapter.weightOfWithValidTokenIds(
+      const [weight, validTokenIds] = await adapter.weightOfWithValidTokenIds(
         user1.address,
         proposalId,
         adapterVoteData,
@@ -343,7 +343,7 @@ describe('ERC721VotingAdapterV1', () => {
         ['uint256[]'],
         [tokenIdsToVoteWith],
       );
-      const { weight, validTokenIds } = await adapter.weightOfWithValidTokenIds(
+      const [weight, validTokenIds] = await adapter.weightOfWithValidTokenIds(
         user1.address,
         proposalId,
         adapterVoteData,
@@ -370,7 +370,7 @@ describe('ERC721VotingAdapterV1', () => {
         ['uint256[]'],
         [tokenIdsForWeightCheck],
       );
-      const { weight, validTokenIds } = await adapter.weightOfWithValidTokenIds(
+      const [weight, validTokenIds] = await adapter.weightOfWithValidTokenIds(
         user1.address,
         proposalId,
         adapterVoteData,
@@ -394,7 +394,7 @@ describe('ERC721VotingAdapterV1', () => {
         ['uint256[]'],
         [[tokenToUse]],
       );
-      const { weight, validTokenIds } = await adapter.weightOfWithValidTokenIds(
+      const [weight, validTokenIds] = await adapter.weightOfWithValidTokenIds(
         user1.address,
         proposalId,
         adapterVoteData,
@@ -409,7 +409,7 @@ describe('ERC721VotingAdapterV1', () => {
         ['uint256[]'],
         [tokenIdsToVoteWith],
       );
-      const { weight, validTokenIds } = await adapter.weightOfWithValidTokenIds(
+      const [weight, validTokenIds] = await adapter.weightOfWithValidTokenIds(
         user1.address,
         proposalId,
         adapterVoteData,
@@ -420,7 +420,7 @@ describe('ERC721VotingAdapterV1', () => {
 
     it('should return 0 weight and empty array if _adapterVoteData is empty or decodes to an empty array', async () => {
       const emptyVoteData = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[]]);
-      const { weight, validTokenIds } = await adapter.weightOfWithValidTokenIds(
+      const [weight, validTokenIds] = await adapter.weightOfWithValidTokenIds(
         user1.address,
         proposalId,
         emptyVoteData,
@@ -435,7 +435,7 @@ describe('ERC721VotingAdapterV1', () => {
         ['uint256[]'],
         [tokenIdsToVoteWith],
       );
-      const { weight, validTokenIds } = await adapter.weightOfWithValidTokenIds(
+      const [weight, validTokenIds] = await adapter.weightOfWithValidTokenIds(
         user1.address, // User1 tries to get weight
         proposalId,
         adapterVoteData,
@@ -459,7 +459,7 @@ describe('ERC721VotingAdapterV1', () => {
         ['uint256[]'],
         [tokenIdsToVoteWith],
       );
-      const { weight, validTokenIds } = await customAdapter.weightOfWithValidTokenIds(
+      const [weight, validTokenIds] = await customAdapter.weightOfWithValidTokenIds(
         user1.address,
         proposalId,
         adapterVoteData,
@@ -487,7 +487,7 @@ describe('ERC721VotingAdapterV1', () => {
         [tokenIdsForWeightCheck],
       );
 
-      const { weight, validTokenIds } = await adapter.weightOfWithValidTokenIds(
+      const [weight, validTokenIds] = await adapter.weightOfWithValidTokenIds(
         user1.address,
         proposalId,
         refinedAdapterVoteData,


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/332

Fixes [ENG-1112](https://linear.app/decent-labs/issue/ENG-1112/standardize-solidity-function-signature-style)

This commit introduces a consistent coding style for function signatures across all Solidity contracts and interfaces to enhance readability and maintainability.

The following changes have been applied codebase-wide:

- **Parameter Naming:** All function parameter names now end with an underscore (e.g., `parameter_`). This convention helps distinguish parameters from local and state variables.
- **Interface Return Values:** Return values in all interface function definitions are now explicitly named. This serves as inline documentation, making the purpose of the return value clear from the interface itself.
- **Contract Return Values:** Named return values have been removed from contract function implementations. This cleans up the code and avoids potential compiler warnings for unused variables, while the interface provides the necessary documentation.