### PR TITLE
refactor: Rename FractalModuleV1 to FractalV1

### DIFF
--- a/contracts/deployables/modules/FractalV1.sol
+++ b/contracts/deployables/modules/FractalV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IFractalModuleV1} from "../../interfaces/decent/deployables/IFractalModuleV1.sol";
+import {IFractalV1} from "../../interfaces/decent/deployables/IFractalV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {Transaction} from "../../interfaces/decent/Module.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
@@ -10,8 +10,8 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract FractalModuleV1 is
-    IFractalModuleV1,
+contract FractalV1 is
+    IFractalV1,
     IVersion,
     GuardableModule,
     Ownable2StepUpgradeable,
@@ -73,7 +73,7 @@ contract FractalModuleV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IFractalModuleV1).interfaceId ||
+            interfaceId_ == type(IFractalV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/contracts/interfaces/decent/deployables/IFractalV1.sol
+++ b/contracts/interfaces/decent/deployables/IFractalV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {Transaction} from "../Module.sol";
 
-interface IFractalModuleV1 {
+interface IFractalV1 {
     error TxFailed();
 
     function initialize(

--- a/test/deployables/modules/FractalV1.test.ts
+++ b/test/deployables/modules/FractalV1.test.ts
@@ -3,10 +3,10 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  FractalModuleV1,
-  FractalModuleV1__factory,
+  FractalV1,
+  FractalV1__factory,
   IERC165__factory,
-  IFractalModuleV1__factory,
+  IFractalV1__factory,
   IVersion__factory,
   MockAvatar,
   MockAvatar__factory,
@@ -24,10 +24,10 @@ async function deployFractalModuleProxy(
   owner: SignerWithAddress,
   avatar: string,
   target: string,
-): Promise<FractalModuleV1> {
+): Promise<FractalV1> {
   // Combine selector and encoded params
   const fullInitData =
-    FractalModuleV1__factory.createInterface().getFunction('initialize').selector +
+    FractalV1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(['address', 'address', 'address'], [owner.address, avatar, target])
       .slice(2);
@@ -36,7 +36,7 @@ async function deployFractalModuleProxy(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return FractalModuleV1__factory.connect(await proxy.getAddress(), owner);
+  return FractalV1__factory.connect(await proxy.getAddress(), owner);
 }
 
 // Helper function for deploying using setUp instead of initialize
@@ -46,9 +46,9 @@ async function deployFractalModuleProxyWithSetUp(
   owner: SignerWithAddress,
   avatar: string,
   target: string,
-): Promise<FractalModuleV1> {
+): Promise<FractalV1> {
   // Create the call to setUp with the encoded parameters
-  const fullInitData = FractalModuleV1__factory.createInterface().encodeFunctionData('setUp', [
+  const fullInitData = FractalV1__factory.createInterface().encodeFunctionData('setUp', [
     ethers.AbiCoder.defaultAbiCoder().encode(
       ['address', 'address', 'address'],
       [owner.address, avatar, target],
@@ -59,10 +59,10 @@ async function deployFractalModuleProxyWithSetUp(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return FractalModuleV1__factory.connect(await proxy.getAddress(), owner);
+  return FractalV1__factory.connect(await proxy.getAddress(), owner);
 }
 
-describe('FractalModuleV1', () => {
+describe('FractalV1', () => {
   // eoas
   let proxyDeployer: SignerWithAddress;
   let owner: SignerWithAddress;
@@ -78,13 +78,13 @@ describe('FractalModuleV1', () => {
     [proxyDeployer, owner, nonOwner, user] = await ethers.getSigners();
 
     // Deploy implementation contract
-    const implementation = await new FractalModuleV1__factory(proxyDeployer).deploy();
+    const implementation = await new FractalV1__factory(proxyDeployer).deploy();
     masterCopy = await implementation.getAddress();
     mockToken = await new MockERC20Votes__factory(proxyDeployer).deploy();
   });
 
   describe('Initialization', () => {
-    let fractalModule: FractalModuleV1;
+    let fractalModule: FractalV1;
     let avatar: MockAvatar;
 
     beforeEach(async () => {
@@ -229,7 +229,7 @@ describe('FractalModuleV1', () => {
   });
 
   describe('Transaction Execution', () => {
-    let fractalModule: FractalModuleV1;
+    let fractalModule: FractalV1;
     let avatar: MockAvatar;
 
     beforeEach(async () => {
@@ -389,7 +389,7 @@ describe('FractalModuleV1', () => {
   });
 
   describe('Version', () => {
-    let fractalModule: FractalModuleV1;
+    let fractalModule: FractalV1;
 
     beforeEach(async () => {
       fractalModule = await deployFractalModuleProxy(
@@ -408,10 +408,7 @@ describe('FractalModuleV1', () => {
   });
 
   describe('ERC165', function () {
-    let fractalModuleInstance: FractalModuleV1;
-    let iFractalModuleV1InterfaceId: string;
-    let iVersionInterfaceId: string;
-    let iERC165InterfaceId: string;
+    let fractalModuleInstance: FractalV1;
 
     beforeEach(async function () {
       // Deploy a new instance for testing
@@ -422,31 +419,30 @@ describe('FractalModuleV1', () => {
         ethers.ZeroAddress,
         ethers.ZeroAddress,
       );
-
-      // Dynamically calculate interface IDs
-      const IFractalModuleV1Interface = IFractalModuleV1__factory.createInterface();
-      iFractalModuleV1InterfaceId = calculateInterfaceId(IFractalModuleV1Interface);
-
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
-
-      const IERC165Interface = IERC165__factory.createInterface();
-      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
     });
 
     it('Should support IERC165 interface', async function () {
-      const supported = await fractalModuleInstance.supportsInterface(iERC165InterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await fractalModuleInstance.supportsInterface(
+          calculateInterfaceId(IERC165__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IFractalModuleV1 interface', async function () {
-      const supported = await fractalModuleInstance.supportsInterface(iFractalModuleV1InterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await fractalModuleInstance.supportsInterface(
+          calculateInterfaceId(IFractalV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IVersion interface', async function () {
-      const supported = await fractalModuleInstance.supportsInterface(iVersionInterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await fractalModuleInstance.supportsInterface(
+          calculateInterfaceId(IVersion__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should not support random interface', async function () {
@@ -457,7 +453,7 @@ describe('FractalModuleV1', () => {
   });
 
   describe('UUPS Upgradeability', function () {
-    let fractalModule: FractalModuleV1;
+    let fractalModule: FractalV1;
 
     beforeEach(async function () {
       // Deploy fractal module proxy
@@ -474,7 +470,7 @@ describe('FractalModuleV1', () => {
     runUUPSUpgradeabilityTests({
       getContract: () => fractalModule as unknown as UUPSUpgradeable,
       createNewImplementation: async () => {
-        const newImplementation = await new FractalModuleV1__factory(owner).deploy();
+        const newImplementation = await new FractalV1__factory(owner).deploy();
         return newImplementation as unknown as UUPSUpgradeable;
       },
       owner: () => owner,


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/334

Fixes [ENG-1114](https://linear.app/decent-labs/issue/ENG-1114/rename-fractalmodulev1-to-fractalv1)

To improve naming conciseness, `FractalModuleV1` and its corresponding interface `IFractalModuleV1` have been renamed to `FractalV1` and `IFractalV1`, respectively. This change removes the "Module" suffix for a more direct and simplified name.

Key changes:
- The `FractalModuleV1` contract is now `FractalV1`.
- The `IFractalModuleV1` interface is now `IFractalV1`.
- The old interface and test files have been removed, and the contract file has been updated to reflect the new naming.