### PR TITLE
refactor: Rename FreezeGuard files for better organization

### DIFF
--- a/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
@@ -2,17 +2,17 @@
 pragma solidity ^0.8.30;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
-import {IAzoriusFreezeGuardV1} from "../../interfaces/decent/deployables/IAzoriusFreezeGuardV1.sol";
+import {IFreezeGuardAzoriusV1} from "../../interfaces/decent/deployables/IFreezeGuardAzoriusV1.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
-import {IBaseFreezeGuardV1} from "../../interfaces/decent/deployables/IBaseFreezeGuardV1.sol";
+import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
-contract AzoriusFreezeGuardV1 is
-    IAzoriusFreezeGuardV1,
+contract FreezeGuardAzoriusV1 is
+    IFreezeGuardAzoriusV1,
     IVersion,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
@@ -72,8 +72,8 @@ contract AzoriusFreezeGuardV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IAzoriusFreezeGuardV1).interfaceId ||
-            interfaceId_ == type(IBaseFreezeGuardV1).interfaceId ||
+            interfaceId_ == type(IFreezeGuardAzoriusV1).interfaceId ||
+            interfaceId_ == type(IFreezeGuardBaseV1).interfaceId ||
             interfaceId_ == type(IGuard).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);

--- a/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.30;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
-import {IMultisigFreezeGuardV1} from "../../interfaces/decent/deployables/IMultisigFreezeGuardV1.sol";
-import {IBaseFreezeGuardV1} from "../../interfaces/decent/deployables/IBaseFreezeGuardV1.sol";
+import {IFreezeGuardMultisigV1} from "../../interfaces/decent/deployables/IFreezeGuardMultisigV1.sol";
+import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
 import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
@@ -12,8 +12,8 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
-contract MultisigFreezeGuardV1 is
-    IMultisigFreezeGuardV1,
+contract FreezeGuardMultisigV1 is
+    IFreezeGuardMultisigV1,
     IVersion,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
@@ -191,8 +191,8 @@ contract MultisigFreezeGuardV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IMultisigFreezeGuardV1).interfaceId ||
-            interfaceId_ == type(IBaseFreezeGuardV1).interfaceId ||
+            interfaceId_ == type(IFreezeGuardMultisigV1).interfaceId ||
+            interfaceId_ == type(IFreezeGuardBaseV1).interfaceId ||
             interfaceId_ == type(IGuard).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);

--- a/contracts/interfaces/decent/deployables/IFreezeGuardAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeGuardAzoriusV1.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IBaseFreezeGuardV1} from "./IBaseFreezeGuardV1.sol";
+import {IFreezeGuardBaseV1} from "./IFreezeGuardBaseV1.sol";
 
-interface IAzoriusFreezeGuardV1 is IBaseFreezeGuardV1 {
+interface IFreezeGuardAzoriusV1 is IFreezeGuardBaseV1 {
     function initialize(address owner_, address freezeVoting_) external;
 }

--- a/contracts/interfaces/decent/deployables/IFreezeGuardBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeGuardBaseV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 
-interface IBaseFreezeGuardV1 is IGuard {
+interface IFreezeGuardBaseV1 is IGuard {
     error DAOFrozen();
 
     function freezeVoting() external view returns (address freezeVoting);

--- a/contracts/interfaces/decent/deployables/IFreezeGuardMultisigV1.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeGuardMultisigV1.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.30;
 
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
-import {IBaseFreezeGuardV1} from "./IBaseFreezeGuardV1.sol";
+import {IFreezeGuardBaseV1} from "./IFreezeGuardBaseV1.sol";
 
-interface IMultisigFreezeGuardV1 is IBaseFreezeGuardV1 {
+interface IFreezeGuardMultisigV1 is IFreezeGuardBaseV1 {
     event TransactionTimelocked(
         address indexed timelocker,
         bytes32 indexed transactionHash,

--- a/test/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
+++ b/test/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
@@ -2,12 +2,12 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  AzoriusFreezeGuardV1,
-  AzoriusFreezeGuardV1__factory,
   ERC1967Proxy__factory,
-  IAzoriusFreezeGuardV1__factory,
-  IBaseFreezeGuardV1__factory,
+  FreezeGuardAzoriusV1,
+  FreezeGuardAzoriusV1__factory,
   IERC165__factory,
+  IFreezeGuardAzoriusV1__factory,
+  IFreezeGuardBaseV1__factory,
   IGuard__factory,
   IVersion__factory,
   MockFreezeVoting,
@@ -22,10 +22,10 @@ async function deployAzoriusFreezeGuardProxy(
   implementation: string,
   owner: SignerWithAddress,
   freezeVoting: string,
-): Promise<AzoriusFreezeGuardV1> {
+): Promise<FreezeGuardAzoriusV1> {
   // Create initialization data with function selector
   const fullInitData =
-    AzoriusFreezeGuardV1__factory.createInterface().getFunction('initialize').selector +
+    FreezeGuardAzoriusV1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(['address', 'address'], [owner.address, freezeVoting])
       .slice(2);
@@ -34,7 +34,7 @@ async function deployAzoriusFreezeGuardProxy(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return AzoriusFreezeGuardV1__factory.connect(await proxy.getAddress(), owner);
+  return FreezeGuardAzoriusV1__factory.connect(await proxy.getAddress(), owner);
 }
 
 describe('AzoriusFreezeGuardV1', () => {
@@ -51,7 +51,7 @@ describe('AzoriusFreezeGuardV1', () => {
 
   // contracts
   let masterCopy: string;
-  let azoriusFreezeGuard: AzoriusFreezeGuardV1;
+  let azoriusFreezeGuard: FreezeGuardAzoriusV1;
   let mockFreezeVoting: MockFreezeVoting;
 
   beforeEach(async () => {
@@ -59,7 +59,7 @@ describe('AzoriusFreezeGuardV1', () => {
     [proxyDeployer, owner, user, nonOwner] = await ethers.getSigners();
 
     // Deploy implementation
-    const implementation = await new AzoriusFreezeGuardV1__factory(proxyDeployer).deploy();
+    const implementation = await new FreezeGuardAzoriusV1__factory(proxyDeployer).deploy();
     masterCopy = await implementation.getAddress();
 
     // Deploy mock contracts
@@ -93,7 +93,7 @@ describe('AzoriusFreezeGuardV1', () => {
     });
 
     it('Should have initialization disabled in the implementation', async function () {
-      const implementationContract = AzoriusFreezeGuardV1__factory.connect(
+      const implementationContract = FreezeGuardAzoriusV1__factory.connect(
         masterCopy,
         proxyDeployer,
       );
@@ -232,21 +232,21 @@ describe('AzoriusFreezeGuardV1', () => {
       ).to.be.true;
     });
 
-    it('Should support IAzoriusFreezeGuardV1 interface', async function () {
+    it('Should support IFreezeGuardAzoriusV1 interface', async function () {
       void expect(
         await azoriusFreezeGuard.supportsInterface(
-          calculateInterfaceId(IAzoriusFreezeGuardV1__factory.createInterface(), [
-            IBaseFreezeGuardV1__factory.createInterface(),
+          calculateInterfaceId(IFreezeGuardAzoriusV1__factory.createInterface(), [
+            IFreezeGuardBaseV1__factory.createInterface(),
             IGuard__factory.createInterface(),
           ]),
         ),
       ).to.be.true;
     });
 
-    it('Should support IBaseFreezeGuardV1 interface', async function () {
+    it('Should support IFreezeGuardBaseV1 interface', async function () {
       void expect(
         await azoriusFreezeGuard.supportsInterface(
-          calculateInterfaceId(IBaseFreezeGuardV1__factory.createInterface(), [
+          calculateInterfaceId(IFreezeGuardBaseV1__factory.createInterface(), [
             IGuard__factory.createInterface(),
           ]),
         ),
@@ -281,7 +281,7 @@ describe('AzoriusFreezeGuardV1', () => {
     runUUPSUpgradeabilityTests({
       getContract: () => azoriusFreezeGuard,
       createNewImplementation: async () => {
-        const newImplementation = await new AzoriusFreezeGuardV1__factory(owner).deploy();
+        const newImplementation = await new FreezeGuardAzoriusV1__factory(owner).deploy();
         return newImplementation;
       },
       owner: () => owner,

--- a/test/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
+++ b/test/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
@@ -4,17 +4,17 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  IBaseFreezeGuardV1__factory,
+  FreezeGuardMultisigV1,
+  FreezeGuardMultisigV1__factory,
   IERC165__factory,
+  IFreezeGuardBaseV1__factory,
+  IFreezeGuardMultisigV1__factory,
   IGuard__factory,
-  IMultisigFreezeGuardV1__factory,
   IVersion__factory,
   MockFreezeVoting,
   MockFreezeVoting__factory,
   MockSafe,
   MockSafe__factory,
-  MultisigFreezeGuardV1,
-  MultisigFreezeGuardV1__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
@@ -28,9 +28,9 @@ async function deployMultisigFreezeGuardProxy(
   executionPeriod: number,
   freezeVoting: string,
   childGnosisSafe: string,
-): Promise<MultisigFreezeGuardV1> {
+): Promise<FreezeGuardMultisigV1> {
   // Create initialization data with function selector
-  const initializeInterface = MultisigFreezeGuardV1__factory.createInterface();
+  const initializeInterface = FreezeGuardMultisigV1__factory.createInterface();
   const fullInitData = initializeInterface.encodeFunctionData('initialize', [
     timelockPeriod,
     executionPeriod,
@@ -43,10 +43,10 @@ async function deployMultisigFreezeGuardProxy(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return MultisigFreezeGuardV1__factory.connect(await proxy.getAddress(), owner);
+  return FreezeGuardMultisigV1__factory.connect(await proxy.getAddress(), owner);
 }
 
-describe('MultisigFreezeGuardV1', () => {
+describe('FreezeGuardMultisigV1', () => {
   const Operation = {
     Call: 0,
     DelegateCall: 1,
@@ -60,7 +60,7 @@ describe('MultisigFreezeGuardV1', () => {
 
   // contracts
   let masterCopy: string;
-  let multisigFreezeGuard: MultisigFreezeGuardV1;
+  let multisigFreezeGuard: FreezeGuardMultisigV1;
   let mockFreezeVoting: MockFreezeVoting;
   let mockSafe: MockSafe;
 
@@ -77,7 +77,7 @@ describe('MultisigFreezeGuardV1', () => {
     [proxyDeployer, owner, user, nonOwner] = await ethers.getSigners();
 
     // Deploy implementation
-    const implementation = await new MultisigFreezeGuardV1__factory(proxyDeployer).deploy();
+    const implementation = await new FreezeGuardMultisigV1__factory(proxyDeployer).deploy();
     masterCopy = await implementation.getAddress();
 
     // Deploy mock contracts
@@ -120,7 +120,7 @@ describe('MultisigFreezeGuardV1', () => {
     });
 
     it('Should have initialization disabled in the implementation', async function () {
-      const implementationContract = MultisigFreezeGuardV1__factory.connect(
+      const implementationContract = FreezeGuardMultisigV1__factory.connect(
         masterCopy,
         proxyDeployer,
       );
@@ -475,21 +475,21 @@ describe('MultisigFreezeGuardV1', () => {
       ).to.be.true;
     });
 
-    it('Should support IMultisigFreezeGuardV1 interface', async function () {
+    it('Should support IFreezeGuardMultisigV1 interface', async function () {
       void expect(
         await multisigFreezeGuard.supportsInterface(
-          calculateInterfaceId(IMultisigFreezeGuardV1__factory.createInterface(), [
-            IBaseFreezeGuardV1__factory.createInterface(),
+          calculateInterfaceId(IFreezeGuardMultisigV1__factory.createInterface(), [
+            IFreezeGuardBaseV1__factory.createInterface(),
             IGuard__factory.createInterface(),
           ]),
         ),
       ).to.be.true;
     });
 
-    it('Should support IBaseFreezeGuardV1 interface', async function () {
+    it('Should support IFreezeGuardBaseV1 interface', async function () {
       void expect(
         await multisigFreezeGuard.supportsInterface(
-          calculateInterfaceId(IBaseFreezeGuardV1__factory.createInterface(), [
+          calculateInterfaceId(IFreezeGuardBaseV1__factory.createInterface(), [
             IGuard__factory.createInterface(),
           ]),
         ),
@@ -513,7 +513,7 @@ describe('MultisigFreezeGuardV1', () => {
     runUUPSUpgradeabilityTests({
       getContract: () => multisigFreezeGuard,
       createNewImplementation: async () => {
-        const newImplementation = await new MultisigFreezeGuardV1__factory(owner).deploy();
+        const newImplementation = await new FreezeGuardMultisigV1__factory(owner).deploy();
         return newImplementation;
       },
       owner: () => owner,


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/336

Fixes [ENG-1116](https://linear.app/decent-labs/issue/ENG-1116/refactor-freezeguard-file-naming-for-consistency)

This commit refactors the naming of all `FreezeGuard` contracts, interfaces, and test files to improve file organization and readability. The `FreezeGuard` prefix is now used at the beginning of the filenames, which groups related files together when sorted alphabetically.

All internal references, imports, and contract/interface declarations have been updated to reflect the new naming convention.

**Key Renames:**
-   `AzoriusFreezeGuardV1.sol` -> `FreezeGuardAzoriusV1.sol`
-   `MultisigFreezeGuardV1.sol` -> `FreezeGuardMultisigV1.sol`
-   `IAzoriusFreezeGuardV1.sol` -> `IFreezeGuardAzoriusV1.sol`
-   `IMultisigFreezeGuardV1.sol` -> `IFreezeGuardMultisigV1.sol`
-   `IBaseFreezeGuardV1.sol` -> `IFreezeGuardBaseV1.sol`
-   `AzoriusFreezeGuardV1.test.ts` -> `FreezeGuardAzoriusV1.test.ts`
-   `MultisigFreezeGuardV1.test.ts` -> `FreezeGuardMultisigV1.test.ts`