### PR TITLE
refactor: Rename FreezeVoting files for better organization

### DIFF
--- a/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IFreezeGuardAzoriusV1} from "../../interfaces/decent/deployables/IFreezeGuardAzoriusV1.sol";
-import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
+import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
@@ -20,7 +20,7 @@ contract FreezeGuardAzoriusV1 is
 {
     uint16 private constant VERSION = 1;
 
-    IBaseFreezeVotingV1 internal _freezeVoting;
+    IFreezeVotingBaseV1 internal _freezeVoting;
 
     constructor() {
         _disableInitializers();
@@ -32,7 +32,7 @@ contract FreezeGuardAzoriusV1 is
     ) public virtual override initializer {
         __Ownable_init(owner_);
         __UUPSUpgradeable_init();
-        _freezeVoting = IBaseFreezeVotingV1(freezeVoting_);
+        _freezeVoting = IFreezeVotingBaseV1(freezeVoting_);
     }
 
     function _authorizeUpgrade(

--- a/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IFreezeGuardMultisigV1} from "../../interfaces/decent/deployables/IFreezeGuardMultisigV1.sol";
 import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
-import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
+import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
@@ -21,7 +21,7 @@ contract FreezeGuardMultisigV1 is
 {
     uint16 private constant VERSION = 1;
 
-    IBaseFreezeVotingV1 internal _freezeVoting;
+    IFreezeVotingBaseV1 internal _freezeVoting;
     uint32 internal _timelockPeriod;
     uint32 internal _executionPeriod;
     ISafe internal _childGnosisSafe;
@@ -43,7 +43,7 @@ contract FreezeGuardMultisigV1 is
         __UUPSUpgradeable_init();
         _updateTimelockPeriod(timelockPeriod_);
         _updateExecutionPeriod(executionPeriod_);
-        _freezeVoting = IBaseFreezeVotingV1(freezeVoting_);
+        _freezeVoting = IFreezeVotingBaseV1(freezeVoting_);
         _childGnosisSafe = ISafe(childGnosisSafe_);
     }
 

--- a/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IAzoriusFreezeVotingV1} from "../../interfaces/decent/deployables/IAzoriusFreezeVotingV1.sol";
-import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
+import {IFreezeVotingAzoriusV1} from "../../interfaces/decent/deployables/IFreezeVotingAzoriusV1.sol";
+import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {IBaseVotingAdapterV1} from "../../interfaces/decent/deployables/IBaseVotingAdapterV1.sol";
 import {IAzoriusV1} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
 import {VoterResolverV1} from "../account-abstraction/VoterResolverV1.sol";
-import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
+import {FreezeVotingBaseV1} from "./FreezeVotingBaseV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract AzoriusFreezeVotingV1 is
-    IAzoriusFreezeVotingV1,
+contract FreezeVotingAzoriusV1 is
+    IFreezeVotingAzoriusV1,
     IVersion,
-    BaseFreezeVotingV1,
+    FreezeVotingBaseV1,
     VoterResolverV1,
     ERC165
 {
@@ -121,8 +121,8 @@ contract AzoriusFreezeVotingV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IAzoriusFreezeVotingV1).interfaceId ||
-            interfaceId_ == type(IBaseFreezeVotingV1).interfaceId ||
+            interfaceId_ == type(IFreezeVotingAzoriusV1).interfaceId ||
+            interfaceId_ == type(IFreezeVotingBaseV1).interfaceId ||
             interfaceId_ == type(IVoterResolverV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);

--- a/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
+import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
-abstract contract BaseFreezeVotingV1 is
-    IBaseFreezeVotingV1,
+abstract contract FreezeVotingBaseV1 is
+    IFreezeVotingBaseV1,
     Ownable2StepUpgradeable
 {
     uint48 internal _freezeProposalCreated;

--- a/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IBaseFreezeVotingV1} from "../../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
-import {IMultisigFreezeVotingV1} from "../../interfaces/decent/deployables/IMultisigFreezeVotingV1.sol";
+import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
+import {IFreezeVotingMultisigV1} from "../../interfaces/decent/deployables/IFreezeVotingMultisigV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
-import {BaseFreezeVotingV1} from "./BaseFreezeVotingV1.sol";
+import {FreezeVotingBaseV1} from "./FreezeVotingBaseV1.sol";
 import {VoterResolverV1} from "../account-abstraction/VoterResolverV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract MultisigFreezeVotingV1 is
-    IMultisigFreezeVotingV1,
+contract FreezeVotingMultisigV1 is
+    IFreezeVotingMultisigV1,
     IVersion,
-    BaseFreezeVotingV1,
+    FreezeVotingBaseV1,
     VoterResolverV1,
     ERC165
 {
@@ -93,8 +93,8 @@ contract MultisigFreezeVotingV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IMultisigFreezeVotingV1).interfaceId ||
-            interfaceId_ == type(IBaseFreezeVotingV1).interfaceId ||
+            interfaceId_ == type(IFreezeVotingMultisigV1).interfaceId ||
+            interfaceId_ == type(IFreezeVotingBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/contracts/interfaces/decent/deployables/IFreezeVotingAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeVotingAzoriusV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-interface IAzoriusFreezeVotingV1 {
+interface IFreezeVotingAzoriusV1 {
     error InvalidVotingAdapter();
 
     struct VotingAdapterVoteData {

--- a/contracts/interfaces/decent/deployables/IFreezeVotingBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeVotingBaseV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-interface IBaseFreezeVotingV1 {
+interface IFreezeVotingBaseV1 {
     error NoVotes();
 
     event FreezeVoteCast(address indexed voter_, uint256 votesCast_);

--- a/contracts/interfaces/decent/deployables/IFreezeVotingMultisigV1.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeVotingMultisigV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-interface IMultisigFreezeVotingV1 {
+interface IFreezeVotingMultisigV1 {
     event FreezeProposalCreated(address indexed creator);
 
     function initialize(

--- a/contracts/mocks/MockFreezeVoting.sol
+++ b/contracts/mocks/MockFreezeVoting.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IBaseFreezeVotingV1} from "../interfaces/decent/deployables/IBaseFreezeVotingV1.sol";
+import {IFreezeVotingBaseV1} from "../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 
-contract MockFreezeVoting is IBaseFreezeVotingV1 {
+contract MockFreezeVoting is IFreezeVotingBaseV1 {
     bool private _isFrozen;
     uint256 private _freezeVotesThreshold;
     uint32 private _freezeProposalPeriod;

--- a/contracts/mocks/concretes/deployables/freeze-voting/ConcreteFreezeVotingBaseV1.sol
+++ b/contracts/mocks/concretes/deployables/freeze-voting/ConcreteFreezeVotingBaseV1.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {BaseFreezeVotingV1} from "../../../../deployables/freeze-voting/BaseFreezeVotingV1.sol";
+import {FreezeVotingBaseV1} from "../../../../deployables/freeze-voting/FreezeVotingBaseV1.sol";
 
-contract ConcreteBaseFreezeVotingV1 is BaseFreezeVotingV1 {
+contract ConcreteFreezeVotingBaseV1 is FreezeVotingBaseV1 {
     function initialize(
         address owner_,
         uint256 freezeVotesThreshold_,

--- a/test/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
@@ -3,13 +3,13 @@ import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  AzoriusFreezeVotingV1,
-  AzoriusFreezeVotingV1__factory,
   ERC1967Proxy__factory,
-  IAzoriusFreezeVotingV1,
-  IAzoriusFreezeVotingV1__factory,
-  IBaseFreezeVotingV1__factory,
+  FreezeVotingAzoriusV1,
+  FreezeVotingAzoriusV1__factory,
   IERC165__factory,
+  IFreezeVotingAzoriusV1,
+  IFreezeVotingAzoriusV1__factory,
+  IFreezeVotingBaseV1__factory,
   IVersion__factory,
   IVoterResolverV1__factory,
   MockAzoriusV1,
@@ -32,8 +32,8 @@ async function deployAzoriusFreezeVotingProxy(
   freezePeriod: number,
   parentAzoriusAddress: string,
   lightAccountFactoryAddress: string,
-): Promise<AzoriusFreezeVotingV1> {
-  const initData = AzoriusFreezeVotingV1__factory.createInterface().encodeFunctionData(
+): Promise<FreezeVotingAzoriusV1> {
+  const initData = FreezeVotingAzoriusV1__factory.createInterface().encodeFunctionData(
     'initialize',
     [
       owner,
@@ -49,16 +49,16 @@ async function deployAzoriusFreezeVotingProxy(
     initData,
   );
   await proxy.waitForDeployment();
-  return AzoriusFreezeVotingV1__factory.connect(await proxy.getAddress(), proxyDeployer);
+  return FreezeVotingAzoriusV1__factory.connect(await proxy.getAddress(), proxyDeployer);
 }
 
-describe('AzoriusFreezeVotingV1', () => {
+describe('FreezeVotingAzoriusV1', () => {
   let deployer: SignerWithAddress;
   let owner: SignerWithAddress;
   let voter1: SignerWithAddress;
   let voter2: SignerWithAddress;
 
-  let azoriusFreezeVoting: AzoriusFreezeVotingV1;
+  let azoriusFreezeVoting: FreezeVotingAzoriusV1;
   let mockParentAzorius: MockAzoriusV1;
   let mockStrategy: MockVotingStrategy;
   let mockAdapter1: MockVotingAdapter;
@@ -72,7 +72,7 @@ describe('AzoriusFreezeVotingV1', () => {
   async function fixture() {
     const [d, o, paa, v1, v2] = await ethers.getSigners();
 
-    const implFactory = new AzoriusFreezeVotingV1__factory(d);
+    const implFactory = new FreezeVotingAzoriusV1__factory(d);
     const impl = await implFactory.deploy();
     await impl.waitForDeployment();
     const implAddr = await impl.getAddress();
@@ -168,7 +168,7 @@ describe('AzoriusFreezeVotingV1', () => {
     });
 
     it('implementation contract should have initializers disabled', async () => {
-      const newImpl = AzoriusFreezeVotingV1__factory.connect(
+      const newImpl = FreezeVotingAzoriusV1__factory.connect(
         azoriusFreezeVotingImplementationAddress,
         deployer,
       );
@@ -194,7 +194,7 @@ describe('AzoriusFreezeVotingV1', () => {
   });
 
   describe('castFreezeVote', () => {
-    let votingAdapterData: IAzoriusFreezeVotingV1.VotingAdapterVoteDataStruct[];
+    let votingAdapterData: IFreezeVotingAzoriusV1.VotingAdapterVoteDataStruct[];
     const voteWeightFromAdapter = 50n;
 
     beforeEach(async () => {
@@ -340,19 +340,19 @@ describe('AzoriusFreezeVotingV1', () => {
       void expect(await azoriusFreezeVoting.version()).to.equal(1);
     });
 
-    it('should support IAzoriusFreezeVotingV1', async () => {
+    it('should support IFreezeVotingAzoriusV1', async () => {
       void expect(
         await azoriusFreezeVoting.supportsInterface(
-          calculateInterfaceId(IAzoriusFreezeVotingV1__factory.createInterface(), [
-            IBaseFreezeVotingV1__factory.createInterface(),
+          calculateInterfaceId(IFreezeVotingAzoriusV1__factory.createInterface(), [
+            IFreezeVotingBaseV1__factory.createInterface(),
           ]),
         ),
       ).to.be.true;
     });
-    it('should support IBaseFreezeVotingV1', async () => {
+    it('should support IFreezeVotingBaseV1', async () => {
       void expect(
         await azoriusFreezeVoting.supportsInterface(
-          calculateInterfaceId(IBaseFreezeVotingV1__factory.createInterface()),
+          calculateInterfaceId(IFreezeVotingBaseV1__factory.createInterface()),
         ),
       ).to.be.true;
     });

--- a/test/deployables/freeze-voting/FreezeVotingBaseV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingBaseV1.test.ts
@@ -3,8 +3,8 @@ import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  ConcreteBaseFreezeVotingV1,
-  ConcreteBaseFreezeVotingV1__factory,
+  ConcreteFreezeVotingBaseV1,
+  ConcreteFreezeVotingBaseV1__factory,
   ERC1967Proxy__factory,
 } from '../../../typechain-types';
 
@@ -16,10 +16,10 @@ async function deployConcreteBaseFreezeVotingProxy(
   freezeVotesThreshold: number,
   freezeProposalPeriod: number,
   freezePeriod: number,
-): Promise<ConcreteBaseFreezeVotingV1> {
+): Promise<ConcreteFreezeVotingBaseV1> {
   // Combine selector and encoded params
   const fullInitData =
-    ConcreteBaseFreezeVotingV1__factory.createInterface().getFunction('initialize').selector +
+    ConcreteFreezeVotingBaseV1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(
         ['address', 'uint256', 'uint32', 'uint32'],
@@ -31,10 +31,10 @@ async function deployConcreteBaseFreezeVotingProxy(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return ConcreteBaseFreezeVotingV1__factory.connect(await proxy.getAddress(), owner);
+  return ConcreteFreezeVotingBaseV1__factory.connect(await proxy.getAddress(), owner);
 }
 
-describe('BaseFreezeVotingV1', () => {
+describe('FreezeVotingBaseV1', () => {
   // signers
   let proxyDeployer: SignerWithAddress;
   let owner: SignerWithAddress;
@@ -44,7 +44,7 @@ describe('BaseFreezeVotingV1', () => {
 
   // contracts
   let masterCopy: string;
-  let freezeVoting: ConcreteBaseFreezeVotingV1;
+  let freezeVoting: ConcreteFreezeVotingBaseV1;
 
   // constants
   const FREEZE_VOTES_THRESHOLD = 3;
@@ -56,7 +56,7 @@ describe('BaseFreezeVotingV1', () => {
     [proxyDeployer, owner, voter1, voter2, voter3] = await ethers.getSigners();
 
     // Deploy implementation
-    const implementation = await new ConcreteBaseFreezeVotingV1__factory(proxyDeployer).deploy();
+    const implementation = await new ConcreteFreezeVotingBaseV1__factory(proxyDeployer).deploy();
     masterCopy = await implementation.getAddress();
 
     // Deploy proxy
@@ -90,7 +90,7 @@ describe('BaseFreezeVotingV1', () => {
     });
 
     it('Should have initialization disabled in the implementation', async function () {
-      const implementationContract = ConcreteBaseFreezeVotingV1__factory.connect(
+      const implementationContract = ConcreteFreezeVotingBaseV1__factory.connect(
         masterCopy,
         proxyDeployer,
       ) as any;

--- a/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
@@ -4,9 +4,11 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  IBaseFreezeVotingV1__factory,
+  FreezeVotingMultisigV1,
+  FreezeVotingMultisigV1__factory,
   IERC165__factory,
-  IMultisigFreezeVotingV1__factory,
+  IFreezeVotingBaseV1__factory,
+  IFreezeVotingMultisigV1__factory,
   IVersion__factory,
   MockLightAccount,
   MockLightAccountFactory,
@@ -14,8 +16,6 @@ import {
   MockLightAccount__factory,
   MockSafe,
   MockSafe__factory,
-  MultisigFreezeVotingV1,
-  MultisigFreezeVotingV1__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
 
@@ -29,10 +29,10 @@ async function deployMultisigFreezeVotingProxy(
   freezePeriod: number,
   parentGnosisSafe: MockSafe,
   lightAccountFactoryAddress: string,
-): Promise<MultisigFreezeVotingV1> {
+): Promise<FreezeVotingMultisigV1> {
   // Combine selector and encoded params
   const fullInitData =
-    MultisigFreezeVotingV1__factory.createInterface().getFunction('initialize').selector +
+    FreezeVotingMultisigV1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(
         ['address', 'uint256', 'uint32', 'uint32', 'address', 'address'],
@@ -51,10 +51,10 @@ async function deployMultisigFreezeVotingProxy(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return MultisigFreezeVotingV1__factory.connect(await proxy.getAddress(), owner);
+  return FreezeVotingMultisigV1__factory.connect(await proxy.getAddress(), owner);
 }
 
-describe('MultisigFreezeVotingV1', () => {
+describe('FreezeVotingMultisigV1', () => {
   // signers
   let proxyDeployer: SignerWithAddress;
   let owner: SignerWithAddress;
@@ -64,7 +64,7 @@ describe('MultisigFreezeVotingV1', () => {
 
   // contracts
   let masterCopy: string;
-  let freezeVoting: MultisigFreezeVotingV1;
+  let freezeVoting: FreezeVotingMultisigV1;
   let mockSafe: MockSafe;
   let lightAccountFactoryMock: MockLightAccountFactory;
   let lightAccountFactoryMockAddress: string;
@@ -88,7 +88,7 @@ describe('MultisigFreezeVotingV1', () => {
     lightAccountFactoryMockAddress = lightAccountFactoryMock.target as string;
 
     // Deploy implementation
-    const implementation = await new MultisigFreezeVotingV1__factory(proxyDeployer).deploy();
+    const implementation = await new FreezeVotingMultisigV1__factory(proxyDeployer).deploy();
     masterCopy = await implementation.getAddress();
 
     // Deploy proxy
@@ -128,7 +128,7 @@ describe('MultisigFreezeVotingV1', () => {
     });
 
     it('Should have initialization disabled in the implementation', async function () {
-      const implementationContract = MultisigFreezeVotingV1__factory.connect(
+      const implementationContract = FreezeVotingMultisigV1__factory.connect(
         masterCopy,
         proxyDeployer,
       );
@@ -508,20 +508,20 @@ describe('MultisigFreezeVotingV1', () => {
   });
 
   describe('ERC165', () => {
-    it('should support the IERC721FreezeVotingV1 interface', async () => {
+    it('should support the IFreezeVotingMultisigV1 interface', async () => {
       void expect(
         await freezeVoting.supportsInterface(
-          calculateInterfaceId(IMultisigFreezeVotingV1__factory.createInterface(), [
-            IBaseFreezeVotingV1__factory.createInterface(),
+          calculateInterfaceId(IFreezeVotingMultisigV1__factory.createInterface(), [
+            IFreezeVotingBaseV1__factory.createInterface(),
           ]),
         ),
       ).to.be.true;
     });
 
-    it('should support the IBaseFreezeVotingV1 interface', async () => {
+    it('should support the IFreezeVotingBaseV1 interface', async () => {
       void expect(
         await freezeVoting.supportsInterface(
-          calculateInterfaceId(IBaseFreezeVotingV1__factory.createInterface()),
+          calculateInterfaceId(IFreezeVotingBaseV1__factory.createInterface()),
         ),
       ).to.be.true;
     });
@@ -548,7 +548,7 @@ describe('MultisigFreezeVotingV1', () => {
   });
 
   describe('ERC4337 Smart Account Voting', () => {
-    let freezeVotingSA: MultisigFreezeVotingV1;
+    let freezeVotingSA: FreezeVotingMultisigV1;
     let mockSafeSA: MockSafe;
     let smartAccountOwnerSA: SignerWithAddress;
     let relayerSA: SignerWithAddress;
@@ -581,7 +581,7 @@ describe('MultisigFreezeVotingV1', () => {
       mockSafeSA = await new MockSafe__factory(proxyDeployer).deploy();
       await mockSafeSA.setOwner(smartAccountOwnerSA.address);
 
-      const implementation = await new MultisigFreezeVotingV1__factory(proxyDeployer).deploy();
+      const implementation = await new FreezeVotingMultisigV1__factory(proxyDeployer).deploy();
       const masterCopySA = await implementation.getAddress();
 
       freezeVotingSA = await deployMultisigFreezeVotingProxy(


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/337

Fixes [ENG-1117](https://linear.app/decent-labs/issue/ENG-1117/refactor-freezevoting-file-naming-for-consistency)

This commit refactors the naming of all `FreezeVoting` contracts, interfaces, and test files to improve file organization and readability. The `FreezeVoting` prefix is now used at the beginning of the filenames, which groups related files together when sorted alphabetically.

All internal references, imports, and contract/interface declarations have been updated to reflect the new naming convention.

**Key Renames:**
-   `AzoriusFreezeVotingV1.sol` -> `FreezeVotingAzoriusV1.sol`
-   `MultisigFreezeVotingV1.sol` -> `FreezeVotingMultisigV1.sol`
-   `BaseFreezeVotingV1.sol` -> `FreezeVotingBaseV1.sol`
-   `IAzoriusFreezeVotingV1.sol` -> `IFreezeVotingAzoriusV1.sol`
-   `IMultisigFreezeVotingV1.sol` -> `IFreezeVotingMultisigV1.sol`
-   `IBaseFreezeVotingV1.sol` -> `IFreezeVotingBaseV1.sol`
-   `AzoriusFreezeVotingV1.test.ts` -> `FreezeVotingAzoriusV1.test.ts`
-   `MultisigFreezeVotingV1.test.ts` -> `FreezeVotingMultisigV1.test.ts`
-   `BaseFreezeVotingV1.test.ts` -> `FreezeVotingBaseV1.test.ts`
-   `ConcreteBaseFreezeVotingV1.sol` -> `ConcreteFreezeVotingBaseV1.sol`