### PR TITLE
refactor: Rename VotingAdapter files for consistency

### DIFF
--- a/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IFreezeVotingAzoriusV1} from "../../interfaces/decent/deployables/IFreezeVotingAzoriusV1.sol";
 import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
-import {IBaseVotingAdapterV1} from "../../interfaces/decent/deployables/IBaseVotingAdapterV1.sol";
+import {IVotingAdapterBaseV1} from "../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {IAzoriusV1} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
@@ -94,7 +94,7 @@ contract FreezeVotingAzoriusV1 is
                 revert InvalidVotingAdapter();
             }
 
-            userVotes += IBaseVotingAdapterV1(adapterAddress).recordFreezeVote(
+            userVotes += IVotingAdapterBaseV1(adapterAddress).recordFreezeVote(
                 voter_,
                 _freezeProposalCreated,
                 votingAdaptersToUse_[i].adapterVoteData

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
-import {IBaseVotingAdapterV1} from "../../interfaces/decent/deployables/IBaseVotingAdapterV1.sol";
+import {IVotingAdapterBaseV1} from "../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {IProposerAdapterV1} from "../../interfaces/decent/deployables/IProposerAdapterV1.sol";
 import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
 import {ISmartAccountValidationV1} from "../../interfaces/decent/deployables/ISmartAccountValidationV1.sol";
@@ -223,7 +223,7 @@ contract StrategyV1 is
                 revert InvalidVotingAdapter();
             }
 
-            totalWeightForThisVoteTransaction += IBaseVotingAdapterV1(
+            totalWeightForThisVoteTransaction += IVotingAdapterBaseV1(
                 votingAdapter
             ).recordVote(
                     resolvedVoter,
@@ -431,7 +431,7 @@ contract StrategyV1 is
                 return false;
             }
 
-            (bool isValid, uint256 votingWeight) = IBaseVotingAdapterV1(
+            (bool isValid, uint256 votingWeight) = IVotingAdapterBaseV1(
                 votingAdapter
             ).validVotingAdapterVote(
                     voter_,

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterBaseV1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterBaseV1.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IBaseVotingAdapterV1} from "../../../interfaces/decent/deployables/IBaseVotingAdapterV1.sol";
-import {IStrategyV1} from "../../../interfaces/decent/deployables/IStrategyV1.sol";
+import {IVotingAdapterBaseV1} from "../../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
+import {IStrategyV1} from "../../../../interfaces/decent/deployables/IStrategyV1.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-abstract contract BaseVotingAdapterV1 is IBaseVotingAdapterV1, Initializable {
+abstract contract VotingAdapterBaseV1 is IVotingAdapterBaseV1, Initializable {
     IStrategyV1 internal _strategy;
 
     modifier onlyStrategy() {

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IERC20VotingAdapterV1} from "../../../interfaces/decent/deployables/IERC20VotingAdapterV1.sol";
-import {IBaseVotingAdapterV1} from "../../../interfaces/decent/deployables/IBaseVotingAdapterV1.sol";
-import {ClockMode} from "../../../interfaces/decent/ClockMode.sol";
-import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
-import {BaseVotingAdapterV1} from "./BaseVotingAdapterV1.sol";
-import {ClockModeLib} from "../../../libs/ClockModeLib.sol";
+import {IVotingAdapterERC20V1} from "../../../../interfaces/decent/deployables/IVotingAdapterERC20V1.sol";
+import {IVotingAdapterBaseV1} from "../../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
+import {ClockMode} from "../../../../interfaces/decent/ClockMode.sol";
+import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
+import {VotingAdapterBaseV1} from "./VotingAdapterBaseV1.sol";
+import {ClockModeLib} from "../../../../libs/ClockModeLib.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {ERC20Votes} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
 
-contract ERC20VotingAdapterV1 is
-    IERC20VotingAdapterV1,
+contract VotingAdapterERC20V1 is
+    IVotingAdapterERC20V1,
     IVersion,
-    BaseVotingAdapterV1,
+    VotingAdapterBaseV1,
     ERC165
 {
     uint16 public constant VERSION = 1;
@@ -176,8 +176,8 @@ contract ERC20VotingAdapterV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IERC20VotingAdapterV1).interfaceId ||
-            interfaceId_ == type(IBaseVotingAdapterV1).interfaceId ||
+            interfaceId_ == type(IVotingAdapterERC20V1).interfaceId ||
+            interfaceId_ == type(IVotingAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IERC721VotingAdapterV1} from "../../../interfaces/decent/deployables/IERC721VotingAdapterV1.sol";
-import {IBaseVotingAdapterV1} from "../../../interfaces/decent/deployables/IBaseVotingAdapterV1.sol";
-import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
-import {BaseVotingAdapterV1} from "./BaseVotingAdapterV1.sol";
+import {IVotingAdapterERC721V1} from "../../../../interfaces/decent/deployables/IVotingAdapterERC721V1.sol";
+import {IVotingAdapterBaseV1} from "../../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
+import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
+import {VotingAdapterBaseV1} from "./VotingAdapterBaseV1.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract ERC721VotingAdapterV1 is
-    IERC721VotingAdapterV1,
+contract VotingAdapterERC721V1 is
+    IVotingAdapterERC721V1,
     IVersion,
-    BaseVotingAdapterV1,
+    VotingAdapterBaseV1,
     ERC165
 {
     uint16 public constant VERSION = 1;
@@ -362,8 +362,8 @@ contract ERC721VotingAdapterV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IERC721VotingAdapterV1).interfaceId ||
-            interfaceId_ == type(IBaseVotingAdapterV1).interfaceId ||
+            interfaceId_ == type(IVotingAdapterERC721V1).interfaceId ||
+            interfaceId_ == type(IVotingAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/contracts/interfaces/decent/deployables/IVotingAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotingAdapterBaseV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-interface IBaseVotingAdapterV1 {
+interface IVotingAdapterBaseV1 {
     error NotStrategy();
     error UnauthorizedFreezeVoter(address caller);
     error NoFreezeVotingWeight();

--- a/contracts/interfaces/decent/deployables/IVotingAdapterERC20V1.sol
+++ b/contracts/interfaces/decent/deployables/IVotingAdapterERC20V1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-interface IERC20VotingAdapterV1 {
+interface IVotingAdapterERC20V1 {
     error ProposalNotReadyForSnapshot();
     error AlreadyVoted();
 

--- a/contracts/interfaces/decent/deployables/IVotingAdapterERC721V1.sol
+++ b/contracts/interfaces/decent/deployables/IVotingAdapterERC721V1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-interface IERC721VotingAdapterV1 {
+interface IVotingAdapterERC721V1 {
     error NoTokenIdsPassed();
     error TokenIdAlreadyUsedForVote(uint256 tokenId);
     error TokenIdNotOwnedByVoter(uint256 tokenId);

--- a/contracts/mocks/MockVotingAdapter.sol
+++ b/contracts/mocks/MockVotingAdapter.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IBaseVotingAdapterV1} from "../interfaces/decent/deployables/IBaseVotingAdapterV1.sol";
+import {IVotingAdapterBaseV1} from "../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 
-contract MockVotingAdapter is IBaseVotingAdapterV1 {
+contract MockVotingAdapter is IVotingAdapterBaseV1 {
     mapping(address => uint256) public weightsToReturn;
     mapping(address => mapping(uint32 => mapping(bytes32 => uint256)))
         public recordedVotesWeight;

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IStrategyV1} from "../interfaces/decent/deployables/IStrategyV1.sol";
-import {IBaseVotingAdapterV1} from "../interfaces/decent/deployables/IBaseVotingAdapterV1.sol";
+import {IVotingAdapterBaseV1} from "../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {VoterResolverV1} from "../deployables/account-abstraction/VoterResolverV1.sol";
 
 contract MockVotingStrategy is IStrategyV1, VoterResolverV1 {
@@ -184,7 +184,7 @@ contract MockVotingStrategy is IStrategyV1, VoterResolverV1 {
         ];
         uint256 totalWeight = 0;
         for (uint i = 0; i < votingAdaptersData.length; i++) {
-            totalWeight += IBaseVotingAdapterV1(
+            totalWeight += IVotingAdapterBaseV1(
                 votingAdaptersData[i].votingAdapter
             ).recordVote(
                     resolvedVoter,

--- a/contracts/mocks/concretes/deployables/strategies/adapters/ConcreteVotingAdapterBaseV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/adapters/ConcreteVotingAdapterBaseV1.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {BaseVotingAdapterV1} from "../../../../../deployables/strategies/adapters/BaseVotingAdapterV1.sol";
+import {VotingAdapterBaseV1} from "../../../../../deployables/strategies/adapters/voting/VotingAdapterBaseV1.sol";
 import {IStrategyV1} from "../../../../../interfaces/decent/deployables/IStrategyV1.sol";
 
-contract ConcreteBaseVotingAdapterV1 is BaseVotingAdapterV1 {
+contract ConcreteVotingAdapterBaseV1 is VotingAdapterBaseV1 {
     constructor() {
         _disableInitializers();
     }

--- a/test/deployables/strategies/adapters/voting/VotingAdapterBaseV1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterBaseV1.test.ts
@@ -3,14 +3,14 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  ConcreteBaseVotingAdapterV1,
-  ConcreteBaseVotingAdapterV1__factory,
+  ConcreteVotingAdapterBaseV1,
+  ConcreteVotingAdapterBaseV1__factory,
   ERC1967Proxy__factory,
   MockVotingStrategy,
   MockVotingStrategy__factory,
-} from '../../../../typechain-types';
+} from '../../../../../typechain-types';
 
-describe('BaseVotingAdapterV1', () => {
+describe('VotingAdapterBaseV1', () => {
   let deployer: SignerWithAddress;
   let eoaStrategySigner: SignerWithAddress; // An EOA that will be designated as the strategy for some tests
   let nonStrategySigner: SignerWithAddress;
@@ -19,7 +19,7 @@ describe('BaseVotingAdapterV1', () => {
 
   async function deployImplementationFixture() {
     const [d, s, ns] = await ethers.getSigners();
-    const factory = new ConcreteBaseVotingAdapterV1__factory(d);
+    const factory = new ConcreteVotingAdapterBaseV1__factory(d);
     const impl = await factory.deploy();
     await impl.waitForDeployment();
     return {
@@ -57,13 +57,13 @@ describe('BaseVotingAdapterV1', () => {
 
   async function deployAdapterProxy(
     strategyAddressToSet: string,
-  ): Promise<ConcreteBaseVotingAdapterV1> {
-    const factory = new ConcreteBaseVotingAdapterV1__factory(deployer);
+  ): Promise<ConcreteVotingAdapterBaseV1> {
+    const factory = new ConcreteVotingAdapterBaseV1__factory(deployer);
     const initData = factory.interface.encodeFunctionData('initialize', [strategyAddressToSet]);
     const proxyFactory = new ERC1967Proxy__factory(deployer);
     const proxy = await proxyFactory.deploy(concreteAdapterImplementationAddress, initData);
     await proxy.waitForDeployment();
-    return ConcreteBaseVotingAdapterV1__factory.connect(await proxy.getAddress(), deployer);
+    return ConcreteVotingAdapterBaseV1__factory.connect(await proxy.getAddress(), deployer);
   }
 
   describe('Initialization', () => {
@@ -81,7 +81,7 @@ describe('BaseVotingAdapterV1', () => {
     });
 
     it('implementation contract should have initializers disabled', async () => {
-      const implContract = ConcreteBaseVotingAdapterV1__factory.connect(
+      const implContract = ConcreteVotingAdapterBaseV1__factory.connect(
         concreteAdapterImplementationAddress,
         deployer,
       );
@@ -99,7 +99,7 @@ describe('BaseVotingAdapterV1', () => {
   });
 
   describe('onlyStrategy modifier', () => {
-    let adapter: ConcreteBaseVotingAdapterV1;
+    let adapter: ConcreteVotingAdapterBaseV1;
 
     beforeEach(async () => {
       // For these tests, the adapter is initialized with the address of the deployed MockVotingStrategy contract
@@ -137,7 +137,7 @@ describe('BaseVotingAdapterV1', () => {
   });
 
   describe('onlyAuthorizedFreezeVoter modifier', () => {
-    let adapter: ConcreteBaseVotingAdapterV1;
+    let adapter: ConcreteVotingAdapterBaseV1;
     let authorizedCaller: SignerWithAddress;
     let unauthorizedCaller: SignerWithAddress;
     const dummyVoterAddress = ethers.Wallet.createRandom().address;

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
@@ -4,18 +4,18 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  ERC20VotingAdapterV1,
-  ERC20VotingAdapterV1__factory,
-  IBaseVotingAdapterV1__factory,
   IERC165__factory,
-  IERC20VotingAdapterV1__factory,
   IVersion__factory,
+  IVotingAdapterBaseV1__factory,
+  IVotingAdapterERC20V1__factory,
   MockERC20Votes,
   MockERC20Votes__factory,
   MockVotingStrategy,
   MockVotingStrategy__factory,
-} from '../../../../typechain-types';
-import { calculateInterfaceId } from '../../../helpers/utils';
+  VotingAdapterERC20V1,
+  VotingAdapterERC20V1__factory,
+} from '../../../../../typechain-types';
+import { calculateInterfaceId } from '../../../../helpers/utils';
 
 // Modified helper function to return deployment tx hash
 async function deployERC20AdapterProxy(
@@ -24,8 +24,8 @@ async function deployERC20AdapterProxy(
   tokenAddress: string,
   strategyAddress: string,
   weightPerToken: bigint,
-): Promise<{ adapter: ERC20VotingAdapterV1 }> {
-  const initData = ERC20VotingAdapterV1__factory.createInterface().encodeFunctionData(
+): Promise<{ adapter: VotingAdapterERC20V1 }> {
+  const initData = VotingAdapterERC20V1__factory.createInterface().encodeFunctionData(
     'initialize',
     [tokenAddress, strategyAddress, weightPerToken],
   );
@@ -33,11 +33,11 @@ async function deployERC20AdapterProxy(
   const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
   await proxy.waitForDeployment();
 
-  const adapter = ERC20VotingAdapterV1__factory.connect(await proxy.getAddress(), proxyDeployer);
+  const adapter = VotingAdapterERC20V1__factory.connect(await proxy.getAddress(), proxyDeployer);
   return { adapter };
 }
 
-describe('ERC20VotingAdapterV1', () => {
+describe('VotingAdapterERC20V1', () => {
   let deployerG: SignerWithAddress;
   let erc20AdapterImplementationAddressG: string;
 
@@ -45,7 +45,7 @@ describe('ERC20VotingAdapterV1', () => {
 
   async function deployGlobalFixture() {
     const [deployer, user1, user2] = await ethers.getSigners();
-    const deployedAdapterImpl = await new ERC20VotingAdapterV1__factory(deployer).deploy();
+    const deployedAdapterImpl = await new VotingAdapterERC20V1__factory(deployer).deploy();
     await deployedAdapterImpl.waitForDeployment();
 
     // Assign to global vars
@@ -141,7 +141,7 @@ describe('ERC20VotingAdapterV1', () => {
     });
 
     it('Should have initialization disabled in the implementation contract', async function () {
-      const implementationContract = ERC20VotingAdapterV1__factory.connect(
+      const implementationContract = VotingAdapterERC20V1__factory.connect(
         erc20AdapterImplementationAddressG,
         deployerG,
       );
@@ -159,7 +159,7 @@ describe('ERC20VotingAdapterV1', () => {
   describe('weightOf', () => {
     const proposalId = 1;
     const mockExtraData = ethers.ZeroHash;
-    let adapter: ERC20VotingAdapterV1;
+    let adapter: VotingAdapterERC20V1;
 
     async function setupAdapterForWeightOf(clockMode: 0 | 1, customWeightPerToken?: bigint) {
       await mockToken.setClockMode(clockMode);
@@ -280,7 +280,7 @@ describe('ERC20VotingAdapterV1', () => {
     const mockExtraData = ethers.ZeroHash;
     const expectedEventAdapterVoteData = '0x';
 
-    let adapter: ERC20VotingAdapterV1;
+    let adapter: VotingAdapterERC20V1;
     let token: MockERC20Votes;
     let strategy: MockVotingStrategy;
     let voter: SignerWithAddress;
@@ -485,7 +485,7 @@ describe('ERC20VotingAdapterV1', () => {
   });
 
   describe('State Getters', () => {
-    let adapter: ERC20VotingAdapterV1;
+    let adapter: VotingAdapterERC20V1;
     let token: MockERC20Votes;
     let strategy: MockVotingStrategy;
     let voter: SignerWithAddress;
@@ -671,7 +671,7 @@ describe('ERC20VotingAdapterV1', () => {
   });
 
   describe('ERC165 supportsInterface', () => {
-    let erc20Adapter: ERC20VotingAdapterV1;
+    let erc20Adapter: VotingAdapterERC20V1;
 
     beforeEach(async () => {
       const { adapter } = await deployERC20AdapterProxy(
@@ -684,18 +684,18 @@ describe('ERC20VotingAdapterV1', () => {
       erc20Adapter = adapter;
     });
 
-    it('should support IERC20VotingAdapterV1', async () => {
+    it('should support IVotingAdapterERC20V1', async () => {
       void expect(
         await erc20Adapter.supportsInterface(
-          calculateInterfaceId(IERC20VotingAdapterV1__factory.createInterface()),
+          calculateInterfaceId(IVotingAdapterERC20V1__factory.createInterface()),
         ),
       ).to.be.true;
     });
 
-    it('should support IBaseVotingAdapterV1', async () => {
+    it('should support IVotingAdapterBaseV1', async () => {
       void expect(
         await erc20Adapter.supportsInterface(
-          calculateInterfaceId(IBaseVotingAdapterV1__factory.createInterface()),
+          calculateInterfaceId(IVotingAdapterBaseV1__factory.createInterface()),
         ),
       ).to.be.true;
     });
@@ -723,7 +723,7 @@ describe('ERC20VotingAdapterV1', () => {
 
   // New Test Suite for Freeze Voting
   describe('Freeze Voting', () => {
-    let adapter: ERC20VotingAdapterV1;
+    let adapter: VotingAdapterERC20V1;
     let token: MockERC20Votes;
     let strategy: MockVotingStrategy;
     let deployerSigner: SignerWithAddress;
@@ -973,7 +973,7 @@ describe('ERC20VotingAdapterV1', () => {
   });
 
   describe('validVotingAdapterVote', () => {
-    let adapter: ERC20VotingAdapterV1;
+    let adapter: VotingAdapterERC20V1;
     let token: MockERC20Votes;
     let strategy: MockVotingStrategy;
     let voter: SignerWithAddress;

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
@@ -4,18 +4,18 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  ERC721VotingAdapterV1,
-  ERC721VotingAdapterV1__factory,
-  IBaseVotingAdapterV1__factory,
   IERC165__factory,
-  IERC721VotingAdapterV1__factory,
   IVersion__factory,
+  IVotingAdapterBaseV1__factory,
+  IVotingAdapterERC721V1__factory,
   MockERC721,
   MockERC721__factory,
   MockVotingStrategy,
   MockVotingStrategy__factory,
-} from '../../../../typechain-types';
-import { calculateInterfaceId } from '../../../helpers/utils';
+  VotingAdapterERC721V1,
+  VotingAdapterERC721V1__factory,
+} from '../../../../../typechain-types';
+import { calculateInterfaceId } from '../../../../helpers/utils';
 
 async function deployERC721AdapterProxy(
   proxyDeployer: SignerWithAddress,
@@ -23,8 +23,8 @@ async function deployERC721AdapterProxy(
   tokenAddress: string,
   strategyAddress: string,
   weightPerNft: bigint,
-): Promise<{ adapter: ERC721VotingAdapterV1 }> {
-  const initData = ERC721VotingAdapterV1__factory.createInterface().encodeFunctionData(
+): Promise<{ adapter: VotingAdapterERC721V1 }> {
+  const initData = VotingAdapterERC721V1__factory.createInterface().encodeFunctionData(
     'initialize',
     [tokenAddress, strategyAddress, weightPerNft],
   );
@@ -32,7 +32,7 @@ async function deployERC721AdapterProxy(
   const proxy = await proxyContractFactory.deploy(implementationAddress, initData);
   await proxy.waitForDeployment();
 
-  const adapterInstance = ERC721VotingAdapterV1__factory.connect(
+  const adapterInstance = VotingAdapterERC721V1__factory.connect(
     await proxy.getAddress(),
     proxyDeployer,
   );
@@ -40,7 +40,7 @@ async function deployERC721AdapterProxy(
   return { adapter: adapterInstance };
 }
 
-describe('ERC721VotingAdapterV1', () => {
+describe('VotingAdapterERC721V1', () => {
   // Globally scoped (from first fixture load in `before`)
   let erc721AdapterImplementationAddressG: string;
 
@@ -49,7 +49,7 @@ describe('ERC721VotingAdapterV1', () => {
 
   async function deployGlobalERC721Fixture() {
     const [deployer] = await ethers.getSigners();
-    const adapterImplFactory = new ERC721VotingAdapterV1__factory(deployer);
+    const adapterImplFactory = new VotingAdapterERC721V1__factory(deployer);
     const deployedAdapterImpl = await adapterImplFactory.deploy();
     await deployedAdapterImpl.waitForDeployment();
     erc721AdapterImplementationAddressG = await deployedAdapterImpl.getAddress();
@@ -156,7 +156,7 @@ describe('ERC721VotingAdapterV1', () => {
         deployer: fixtureDeployer,
         strategyAddress,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
-      const implementationContract = ERC721VotingAdapterV1__factory.connect(
+      const implementationContract = VotingAdapterERC721V1__factory.connect(
         erc721AdapterImplementationAddressG,
         fixtureDeployer,
       );
@@ -171,7 +171,7 @@ describe('ERC721VotingAdapterV1', () => {
   });
 
   describe('weightOf', () => {
-    let adapter: ERC721VotingAdapterV1;
+    let adapter: VotingAdapterERC721V1;
     let mockNft: MockERC721;
     let user1: SignerWithAddress;
     let user1TokenIds: bigint[];
@@ -291,7 +291,7 @@ describe('ERC721VotingAdapterV1', () => {
   });
 
   describe('weightOfWithUnusedTokenIds', () => {
-    let adapter: ERC721VotingAdapterV1;
+    let adapter: VotingAdapterERC721V1;
     let mockNft: MockERC721;
     let user1: SignerWithAddress;
     let user1TokenIds: bigint[];
@@ -499,7 +499,7 @@ describe('ERC721VotingAdapterV1', () => {
   });
 
   describe('recordVote', () => {
-    let adapter: ERC721VotingAdapterV1;
+    let adapter: VotingAdapterERC721V1;
     let mockNft: MockERC721;
     let user1: SignerWithAddress;
     let user1TokenIds: bigint[];
@@ -663,7 +663,7 @@ describe('ERC721VotingAdapterV1', () => {
   });
 
   describe('State Getters', () => {
-    let adapter: ERC721VotingAdapterV1;
+    let adapter: VotingAdapterERC721V1;
     let mockNft: MockERC721;
     let voter1: SignerWithAddress;
     let voter1TokenIds: bigint[];
@@ -855,7 +855,7 @@ describe('ERC721VotingAdapterV1', () => {
   });
 
   describe('ERC165 supportsInterface', () => {
-    let erc721Adapter: ERC721VotingAdapterV1;
+    let erc721Adapter: VotingAdapterERC721V1;
 
     beforeEach(async () => {
       const {
@@ -873,18 +873,18 @@ describe('ERC721VotingAdapterV1', () => {
       erc721Adapter = adapter;
     });
 
-    it('should support IERC721VotingAdapterV1', async () => {
+    it('should support IVotingAdapterERC721V1', async () => {
       void expect(
         await erc721Adapter.supportsInterface(
-          calculateInterfaceId(IERC721VotingAdapterV1__factory.createInterface()),
+          calculateInterfaceId(IVotingAdapterERC721V1__factory.createInterface()),
         ),
       ).to.be.true;
     });
 
-    it('should support IBaseVotingAdapterV1', async () => {
+    it('should support IVotingAdapterBaseV1', async () => {
       void expect(
         await erc721Adapter.supportsInterface(
-          calculateInterfaceId(IBaseVotingAdapterV1__factory.createInterface()),
+          calculateInterfaceId(IVotingAdapterBaseV1__factory.createInterface()),
         ),
       ).to.be.true;
     });
@@ -912,7 +912,7 @@ describe('ERC721VotingAdapterV1', () => {
 
   // New Test Suite for Freeze Voting
   describe('Freeze Voting', () => {
-    let adapter: ERC721VotingAdapterV1;
+    let adapter: VotingAdapterERC721V1;
     let mockNft: MockERC721;
     let mockStrategy: MockVotingStrategy;
     let deployerSigner: SignerWithAddress;
@@ -1345,7 +1345,7 @@ describe('ERC721VotingAdapterV1', () => {
   });
 
   describe('validVotingAdapterVote', () => {
-    let adapter: ERC721VotingAdapterV1;
+    let adapter: VotingAdapterERC721V1;
     let mockNft: MockERC721;
     let user1: SignerWithAddress;
     let user1TokenIds: bigint[];


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/338

Fixes [ENG-1118](https://linear.app/decent-labs/issue/ENG-1118/refactor-voting-adapter-naming-for-consistency)

This commit refactors the naming of all `VotingAdapter` contracts, interfaces, and test files to improve file organization and readability. The `VotingAdapter` prefix is now used at the beginning of the filenames, which groups related files together when sorted alphabetically.

Additionally, the voting adapter contracts and tests have been moved into a new `voting/` subdirectory to better separate them from other types of strategy adapters.

All internal references, imports, and contract/interface declarations have been updated to reflect the new naming convention.

**Key Renames:**
-   `BaseVotingAdapterV1` -> `VotingAdapterBaseV1`
-   `ERC20VotingAdapterV1` -> `VotingAdapterERC20V1`
-   `ERC721VotingAdapterV1` -> `VotingAdapterERC721V1`
-   `IBaseVotingAdapterV1` -> `IVotingAdapterBaseV1`
-   `IERC20VotingAdapterV1` -> `IVotingAdapterERC20V1`
-   `IERC721VotingAdapterV1` -> `IVotingAdapterERC721V1`
-   The corresponding test files and concrete mocks have also been renamed and moved.