### PR TITLE
refactor: Rename ProposerAdapter files for consistency

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IVotingAdapterBaseV1} from "../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
-import {IProposerAdapterV1} from "../../interfaces/decent/deployables/IProposerAdapterV1.sol";
+import {IProposerAdapterBaseV1} from "../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
 import {ISmartAccountValidationV1} from "../../interfaces/decent/deployables/ISmartAccountValidationV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
@@ -315,7 +315,7 @@ contract StrategyV1 is
         }
 
         return
-            IProposerAdapterV1(proposerAdapter_).isProposer(
+            IProposerAdapterBaseV1(proposerAdapter_).isProposer(
                 address_,
                 proposerAdapterData_
             );

--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IERC20ProposerAdapterV1} from "../../../interfaces/decent/deployables/IERC20ProposerAdapterV1.sol";
-import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
-import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
+import {IProposerAdapterERC20V1} from "../../../../interfaces/decent/deployables/IProposerAdapterERC20V1.sol";
+import {IProposerAdapterBaseV1} from "../../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
+import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract ERC20ProposerAdapterV1 is
-    IERC20ProposerAdapterV1,
+contract ProposerAdapterERC20V1 is
+    IProposerAdapterERC20V1,
     IVersion,
     Initializable,
     ERC165
@@ -60,8 +60,8 @@ contract ERC20ProposerAdapterV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IERC20ProposerAdapterV1).interfaceId ||
-            interfaceId_ == type(IProposerAdapterV1).interfaceId ||
+            interfaceId_ == type(IProposerAdapterERC20V1).interfaceId ||
+            interfaceId_ == type(IProposerAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IERC721ProposerAdapterV1} from "../../../interfaces/decent/deployables/IERC721ProposerAdapterV1.sol";
-import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
-import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
+import {IProposerAdapterERC721V1} from "../../../../interfaces/decent/deployables/IProposerAdapterERC721V1.sol";
+import {IProposerAdapterBaseV1} from "../../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
+import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract ERC721ProposerAdapterV1 is
-    IERC721ProposerAdapterV1,
+contract ProposerAdapterERC721V1 is
+    IProposerAdapterERC721V1,
     Initializable,
     IVersion,
     ERC165
@@ -60,8 +60,8 @@ contract ERC721ProposerAdapterV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IERC721ProposerAdapterV1).interfaceId ||
-            interfaceId_ == type(IProposerAdapterV1).interfaceId ||
+            interfaceId_ == type(IProposerAdapterERC721V1).interfaceId ||
+            interfaceId_ == type(IProposerAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IHatsProposerAdapterV1} from "../../../interfaces/decent/deployables/IHatsProposerAdapterV1.sol";
-import {IProposerAdapterV1} from "../../../interfaces/decent/deployables/IProposerAdapterV1.sol";
-import {IHats} from "../../../interfaces/hats/IHats.sol";
-import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
+import {IProposerAdapterHatsV1} from "../../../../interfaces/decent/deployables/IProposerAdapterHatsV1.sol";
+import {IProposerAdapterBaseV1} from "../../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
+import {IHats} from "../../../../interfaces/hats/IHats.sol";
+import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract HatsProposerAdapterV1 is
-    IHatsProposerAdapterV1,
+contract ProposerAdapterHatsV1 is
+    IProposerAdapterHatsV1,
     IVersion,
     Initializable,
     ERC165
@@ -71,8 +71,8 @@ contract HatsProposerAdapterV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IHatsProposerAdapterV1).interfaceId ||
-            interfaceId_ == type(IProposerAdapterV1).interfaceId ||
+            interfaceId_ == type(IProposerAdapterHatsV1).interfaceId ||
+            interfaceId_ == type(IProposerAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/contracts/interfaces/decent/deployables/IProposerAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IProposerAdapterBaseV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-interface IProposerAdapterV1 {
+interface IProposerAdapterBaseV1 {
     function isProposer(
         address address_,
         bytes calldata data_

--- a/contracts/interfaces/decent/deployables/IProposerAdapterERC20V1.sol
+++ b/contracts/interfaces/decent/deployables/IProposerAdapterERC20V1.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
+import {IProposerAdapterBaseV1} from "./IProposerAdapterBaseV1.sol";
 
-interface IERC20ProposerAdapterV1 is IProposerAdapterV1 {
+interface IProposerAdapterERC20V1 is IProposerAdapterBaseV1 {
     function initialize(address token_, uint256 proposerThreshold_) external;
 
     function token() external view returns (address token);

--- a/contracts/interfaces/decent/deployables/IProposerAdapterERC721V1.sol
+++ b/contracts/interfaces/decent/deployables/IProposerAdapterERC721V1.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
+import {IProposerAdapterBaseV1} from "./IProposerAdapterBaseV1.sol";
 
-interface IERC721ProposerAdapterV1 is IProposerAdapterV1 {
+interface IProposerAdapterERC721V1 is IProposerAdapterBaseV1 {
     function initialize(address token_, uint256 proposerThreshold_) external;
 
     function token() external view returns (address token);

--- a/contracts/interfaces/decent/deployables/IProposerAdapterHatsV1.sol
+++ b/contracts/interfaces/decent/deployables/IProposerAdapterHatsV1.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IProposerAdapterV1} from "./IProposerAdapterV1.sol";
+import {IProposerAdapterBaseV1} from "./IProposerAdapterBaseV1.sol";
 
-interface IHatsProposerAdapterV1 is IProposerAdapterV1 {
+interface IProposerAdapterHatsV1 is IProposerAdapterBaseV1 {
     function initialize(
         address hatsContractAddress_,
         uint256[] calldata whitelistedHats_

--- a/contracts/mocks/MockProposerAdapter.sol
+++ b/contracts/mocks/MockProposerAdapter.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.30;
 
-import {IProposerAdapterV1} from "../interfaces/decent/deployables/IProposerAdapterV1.sol";
+import {IProposerAdapterBaseV1} from "../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 
-contract MockProposerAdapter is IProposerAdapterV1 {
+contract MockProposerAdapter is IProposerAdapterBaseV1 {
     mapping(address => bool) private _isProposer;
 
     function isProposer(

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.test.ts
@@ -3,24 +3,24 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  ERC721ProposerAdapterV1,
-  ERC721ProposerAdapterV1__factory,
   IERC165__factory,
-  IERC721ProposerAdapterV1__factory,
-  IProposerAdapterV1__factory,
+  IProposerAdapterBaseV1__factory,
+  IProposerAdapterERC20V1__factory,
   IVersion__factory,
-  MockERC721,
-  MockERC721__factory,
-} from '../../../../typechain-types';
-import { calculateInterfaceId } from '../../../helpers/utils';
+  MockERC20Votes,
+  MockERC20Votes__factory,
+  ProposerAdapterERC20V1,
+  ProposerAdapterERC20V1__factory,
+} from '../../../../../typechain-types';
+import { calculateInterfaceId } from '../../../../helpers/utils';
 
-async function deployERC721ProposerAdapterProxy(
+async function deployERC20ProposerAdapterProxy(
   deployer: SignerWithAddress,
   implementationAddress: string,
   tokenAddress: string,
   proposerThreshold: bigint,
-): Promise<ERC721ProposerAdapterV1> {
-  const adapterInterface = ERC721ProposerAdapterV1__factory.createInterface();
+): Promise<ProposerAdapterERC20V1> {
+  const adapterInterface = ProposerAdapterERC20V1__factory.createInterface();
   const initializeCalldata = adapterInterface.encodeFunctionData('initialize', [
     tokenAddress,
     proposerThreshold,
@@ -28,96 +28,108 @@ async function deployERC721ProposerAdapterProxy(
   const proxyFactory = new ERC1967Proxy__factory(deployer);
   const proxy = await proxyFactory.deploy(implementationAddress, initializeCalldata);
   await proxy.waitForDeployment();
-  return ERC721ProposerAdapterV1__factory.connect(await proxy.getAddress(), deployer);
+  return ProposerAdapterERC20V1__factory.connect(await proxy.getAddress(), deployer);
 }
 
-describe('ERC721ProposerAdapterV1', () => {
+describe('ProposerAdapterERC20V1', () => {
   let deployer: SignerWithAddress;
   let user1: SignerWithAddress;
 
-  let adapterImplementation: ERC721ProposerAdapterV1;
-  let adapter: ERC721ProposerAdapterV1;
-  let mockNft: MockERC721;
+  let adapterImplementation: ProposerAdapterERC20V1;
+  let adapter: ProposerAdapterERC20V1;
+  let mockToken: MockERC20Votes;
 
-  const DEFAULT_PROPOSER_THRESHOLD = 5n;
+  const DEFAULT_PROPOSER_THRESHOLD = ethers.parseUnits('100', 18);
 
   beforeEach(async () => {
     [deployer, user1] = await ethers.getSigners();
 
-    const mockNftFactory = new MockERC721__factory(deployer);
-    mockNft = await mockNftFactory.deploy();
-    await mockNft.waitForDeployment();
+    const mockTokenFactory = new MockERC20Votes__factory(deployer);
+    mockToken = await mockTokenFactory.deploy();
+    await mockToken.waitForDeployment();
 
     if (!adapterImplementation) {
-      const adapterFactory = new ERC721ProposerAdapterV1__factory(deployer);
+      const adapterFactory = new ProposerAdapterERC20V1__factory(deployer);
       adapterImplementation = await adapterFactory.deploy();
       await adapterImplementation.waitForDeployment();
     }
 
-    adapter = await deployERC721ProposerAdapterProxy(
+    adapter = await deployERC20ProposerAdapterProxy(
       deployer,
       await adapterImplementation.getAddress(),
-      await mockNft.getAddress(),
+      await mockToken.getAddress(),
       DEFAULT_PROPOSER_THRESHOLD,
     );
   });
 
   describe('Initialization (via Proxy)', () => {
     it('should initialize correctly with valid parameters', async () => {
-      expect(await adapter.token()).to.equal(await mockNft.getAddress());
+      expect(await adapter.token()).to.equal(await mockToken.getAddress());
       expect(await adapter.proposerThreshold()).to.equal(DEFAULT_PROPOSER_THRESHOLD);
+    });
+
+    it('should allow proposerThreshold to be zero during proxy initialization', async () => {
+      const localAdapter = await deployERC20ProposerAdapterProxy(
+        deployer,
+        await adapterImplementation.getAddress(),
+        await mockToken.getAddress(),
+        0n,
+      );
+      expect(await localAdapter.proposerThreshold()).to.equal(0n);
     });
 
     it('should prevent reinitialization on proxied adapter', async () => {
       await expect(
-        adapter.initialize(await mockNft.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
+        adapter.initialize(await mockToken.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
       ).to.be.revertedWithCustomError(adapter, 'InvalidInitialization');
     });
 
     it('Implementation contract should remain uninitialized', async () => {
       await expect(
-        adapterImplementation.initialize(await mockNft.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
+        adapterImplementation.initialize(await mockToken.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
       ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidInitialization');
     });
   });
 
   describe('isProposer', () => {
-    it('should return true if user meets the proposer threshold (balance * weight)', async () => {
-      for (let i = 0; i < 5; i++) {
-        await mockNft.connect(deployer).mint(user1.address);
-      }
+    it('should return true if user meets the proposer threshold', async () => {
+      await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
+      await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
 
     it('should return true if user exceeds the proposer threshold', async () => {
-      for (let i = 0; i < 6; i++) {
-        await mockNft.connect(deployer).mint(user1.address);
-      }
+      await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
+      await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
 
     it('should return false if user is below the proposer threshold', async () => {
-      for (let i = 0; i < 4; i++) {
-        await mockNft.connect(deployer).mint(user1.address);
-      }
+      const userVotes = DEFAULT_PROPOSER_THRESHOLD - 1n;
+      await mockToken.connect(deployer).mint(user1.address, userVotes);
+
+      await mockToken.connect(user1).delegate(user1.address);
+
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.false;
     });
 
-    it('should return false if user has no NFTs', async () => {
+    it('should return false if user has no votes (or token balance)', async () => {
+      await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.false;
     });
 
-    it('should return true if proposerThreshold is 0, even with zero NFTs', async () => {
-      const localAdapter = await deployERC721ProposerAdapterProxy(
+    it('should return true if proposerThreshold is 0, even with zero votes', async () => {
+      const localAdapter = await deployERC20ProposerAdapterProxy(
         deployer,
         await adapterImplementation.getAddress(),
-        await mockNft.getAddress(),
+        await mockToken.getAddress(),
         0n,
       );
+      await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await localAdapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
@@ -130,20 +142,20 @@ describe('ERC721ProposerAdapterV1', () => {
   });
 
   describe('ERC165 supportsInterface', () => {
-    it('should support IERC721ProposerAdapterV1', async () => {
+    it('should support IProposerAdapterERC20V1', async () => {
       void expect(
         await adapter.supportsInterface(
-          calculateInterfaceId(IERC721ProposerAdapterV1__factory.createInterface(), [
-            IProposerAdapterV1__factory.createInterface(),
+          calculateInterfaceId(IProposerAdapterERC20V1__factory.createInterface(), [
+            IProposerAdapterBaseV1__factory.createInterface(),
           ]),
         ),
       ).to.be.true;
     });
 
-    it('should support IProposerAdapterV1', async () => {
+    it('should support IProposerAdapterBaseV1', async () => {
       void expect(
         await adapter.supportsInterface(
-          calculateInterfaceId(IProposerAdapterV1__factory.createInterface()),
+          calculateInterfaceId(IProposerAdapterBaseV1__factory.createInterface()),
         ),
       ).to.be.true;
     });

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.test.ts
@@ -3,24 +3,24 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  ERC20ProposerAdapterV1,
-  ERC20ProposerAdapterV1__factory,
   IERC165__factory,
-  IERC20ProposerAdapterV1__factory,
-  IProposerAdapterV1__factory,
+  IProposerAdapterBaseV1__factory,
+  IProposerAdapterERC721V1__factory,
   IVersion__factory,
-  MockERC20Votes,
-  MockERC20Votes__factory,
-} from '../../../../typechain-types';
-import { calculateInterfaceId } from '../../../helpers/utils';
+  MockERC721,
+  MockERC721__factory,
+  ProposerAdapterERC721V1,
+  ProposerAdapterERC721V1__factory,
+} from '../../../../../typechain-types';
+import { calculateInterfaceId } from '../../../../helpers/utils';
 
-async function deployERC20ProposerAdapterProxy(
+async function deployERC721ProposerAdapterProxy(
   deployer: SignerWithAddress,
   implementationAddress: string,
   tokenAddress: string,
   proposerThreshold: bigint,
-): Promise<ERC20ProposerAdapterV1> {
-  const adapterInterface = ERC20ProposerAdapterV1__factory.createInterface();
+): Promise<ProposerAdapterERC721V1> {
+  const adapterInterface = ProposerAdapterERC721V1__factory.createInterface();
   const initializeCalldata = adapterInterface.encodeFunctionData('initialize', [
     tokenAddress,
     proposerThreshold,
@@ -28,108 +28,96 @@ async function deployERC20ProposerAdapterProxy(
   const proxyFactory = new ERC1967Proxy__factory(deployer);
   const proxy = await proxyFactory.deploy(implementationAddress, initializeCalldata);
   await proxy.waitForDeployment();
-  return ERC20ProposerAdapterV1__factory.connect(await proxy.getAddress(), deployer);
+  return ProposerAdapterERC721V1__factory.connect(await proxy.getAddress(), deployer);
 }
 
-describe('ERC20ProposerAdapterV1', () => {
+describe('ProposerAdapterERC721V1', () => {
   let deployer: SignerWithAddress;
   let user1: SignerWithAddress;
 
-  let adapterImplementation: ERC20ProposerAdapterV1;
-  let adapter: ERC20ProposerAdapterV1;
-  let mockToken: MockERC20Votes;
+  let adapterImplementation: ProposerAdapterERC721V1;
+  let adapter: ProposerAdapterERC721V1;
+  let mockNft: MockERC721;
 
-  const DEFAULT_PROPOSER_THRESHOLD = ethers.parseUnits('100', 18);
+  const DEFAULT_PROPOSER_THRESHOLD = 5n;
 
   beforeEach(async () => {
     [deployer, user1] = await ethers.getSigners();
 
-    const mockTokenFactory = new MockERC20Votes__factory(deployer);
-    mockToken = await mockTokenFactory.deploy();
-    await mockToken.waitForDeployment();
+    const mockNftFactory = new MockERC721__factory(deployer);
+    mockNft = await mockNftFactory.deploy();
+    await mockNft.waitForDeployment();
 
     if (!adapterImplementation) {
-      const adapterFactory = new ERC20ProposerAdapterV1__factory(deployer);
+      const adapterFactory = new ProposerAdapterERC721V1__factory(deployer);
       adapterImplementation = await adapterFactory.deploy();
       await adapterImplementation.waitForDeployment();
     }
 
-    adapter = await deployERC20ProposerAdapterProxy(
+    adapter = await deployERC721ProposerAdapterProxy(
       deployer,
       await adapterImplementation.getAddress(),
-      await mockToken.getAddress(),
+      await mockNft.getAddress(),
       DEFAULT_PROPOSER_THRESHOLD,
     );
   });
 
   describe('Initialization (via Proxy)', () => {
     it('should initialize correctly with valid parameters', async () => {
-      expect(await adapter.token()).to.equal(await mockToken.getAddress());
+      expect(await adapter.token()).to.equal(await mockNft.getAddress());
       expect(await adapter.proposerThreshold()).to.equal(DEFAULT_PROPOSER_THRESHOLD);
-    });
-
-    it('should allow proposerThreshold to be zero during proxy initialization', async () => {
-      const localAdapter = await deployERC20ProposerAdapterProxy(
-        deployer,
-        await adapterImplementation.getAddress(),
-        await mockToken.getAddress(),
-        0n,
-      );
-      expect(await localAdapter.proposerThreshold()).to.equal(0n);
     });
 
     it('should prevent reinitialization on proxied adapter', async () => {
       await expect(
-        adapter.initialize(await mockToken.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
+        adapter.initialize(await mockNft.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
       ).to.be.revertedWithCustomError(adapter, 'InvalidInitialization');
     });
 
     it('Implementation contract should remain uninitialized', async () => {
       await expect(
-        adapterImplementation.initialize(await mockToken.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
+        adapterImplementation.initialize(await mockNft.getAddress(), DEFAULT_PROPOSER_THRESHOLD),
       ).to.be.revertedWithCustomError(adapterImplementation, 'InvalidInitialization');
     });
   });
 
   describe('isProposer', () => {
-    it('should return true if user meets the proposer threshold', async () => {
-      await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
-      await mockToken.connect(user1).delegate(user1.address);
+    it('should return true if user meets the proposer threshold (balance * weight)', async () => {
+      for (let i = 0; i < 5; i++) {
+        await mockNft.connect(deployer).mint(user1.address);
+      }
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
 
     it('should return true if user exceeds the proposer threshold', async () => {
-      await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
-      await mockToken.connect(user1).delegate(user1.address);
+      for (let i = 0; i < 6; i++) {
+        await mockNft.connect(deployer).mint(user1.address);
+      }
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
 
     it('should return false if user is below the proposer threshold', async () => {
-      const userVotes = DEFAULT_PROPOSER_THRESHOLD - 1n;
-      await mockToken.connect(deployer).mint(user1.address, userVotes);
-
-      await mockToken.connect(user1).delegate(user1.address);
-
+      for (let i = 0; i < 4; i++) {
+        await mockNft.connect(deployer).mint(user1.address);
+      }
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.false;
     });
 
-    it('should return false if user has no votes (or token balance)', async () => {
-      await mockToken.connect(user1).delegate(user1.address);
+    it('should return false if user has no NFTs', async () => {
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.false;
     });
 
-    it('should return true if proposerThreshold is 0, even with zero votes', async () => {
-      const localAdapter = await deployERC20ProposerAdapterProxy(
+    it('should return true if proposerThreshold is 0, even with zero NFTs', async () => {
+      const localAdapter = await deployERC721ProposerAdapterProxy(
         deployer,
         await adapterImplementation.getAddress(),
-        await mockToken.getAddress(),
+        await mockNft.getAddress(),
         0n,
       );
-      await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await localAdapter.isProposer(user1.address, ethers.ZeroHash);
       void expect(canPropose).to.be.true;
     });
@@ -142,20 +130,20 @@ describe('ERC20ProposerAdapterV1', () => {
   });
 
   describe('ERC165 supportsInterface', () => {
-    it('should support IERC20ProposerAdapterV1', async () => {
+    it('should support IProposerAdapterERC721V1', async () => {
       void expect(
         await adapter.supportsInterface(
-          calculateInterfaceId(IERC20ProposerAdapterV1__factory.createInterface(), [
-            IProposerAdapterV1__factory.createInterface(),
+          calculateInterfaceId(IProposerAdapterERC721V1__factory.createInterface(), [
+            IProposerAdapterBaseV1__factory.createInterface(),
           ]),
         ),
       ).to.be.true;
     });
 
-    it('should support IProposerAdapterV1', async () => {
+    it('should support IProposerAdapterBaseV1', async () => {
       void expect(
         await adapter.supportsInterface(
-          calculateInterfaceId(IProposerAdapterV1__factory.createInterface()),
+          calculateInterfaceId(IProposerAdapterBaseV1__factory.createInterface()),
         ),
       ).to.be.true;
     });

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
@@ -3,24 +3,24 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  HatsProposerAdapterV1,
-  HatsProposerAdapterV1__factory,
   IERC165__factory,
-  IHatsProposerAdapterV1__factory,
-  IProposerAdapterV1__factory,
+  IProposerAdapterBaseV1__factory,
+  IProposerAdapterHatsV1__factory,
   IVersion__factory,
   MockHats,
   MockHats__factory,
-} from '../../../../typechain-types';
-import { calculateInterfaceId } from '../../../helpers/utils';
+  ProposerAdapterHatsV1,
+  ProposerAdapterHatsV1__factory,
+} from '../../../../../typechain-types';
+import { calculateInterfaceId } from '../../../../helpers/utils';
 
 async function deployHatsProposerAdapterProxy(
   deployer: SignerWithAddress,
   implementationAddress: string,
   hatsContractAddress: string,
   initialWhitelistedHats: bigint[],
-): Promise<HatsProposerAdapterV1> {
-  const adapterInterface = HatsProposerAdapterV1__factory.createInterface();
+): Promise<ProposerAdapterHatsV1> {
+  const adapterInterface = ProposerAdapterHatsV1__factory.createInterface();
   const initializeCalldata = adapterInterface.encodeFunctionData('initialize', [
     hatsContractAddress,
     initialWhitelistedHats,
@@ -28,15 +28,15 @@ async function deployHatsProposerAdapterProxy(
   const proxyFactory = new ERC1967Proxy__factory(deployer);
   const proxy = await proxyFactory.deploy(implementationAddress, initializeCalldata);
   await proxy.waitForDeployment();
-  return HatsProposerAdapterV1__factory.connect(await proxy.getAddress(), deployer);
+  return ProposerAdapterHatsV1__factory.connect(await proxy.getAddress(), deployer);
 }
 
-describe('HatsProposerAdapterV1', () => {
+describe('ProposerAdapterHatsV1', () => {
   let deployer: SignerWithAddress;
   let user1: SignerWithAddress;
 
-  let adapterImplementation: HatsProposerAdapterV1;
-  let adapter: HatsProposerAdapterV1;
+  let adapterImplementation: ProposerAdapterHatsV1;
+  let adapter: ProposerAdapterHatsV1;
   let mockHats: MockHats;
 
   const HAT_ID_1 = 111n;
@@ -50,7 +50,7 @@ describe('HatsProposerAdapterV1', () => {
     await mockHats.waitForDeployment();
 
     if (!adapterImplementation) {
-      const adapterFactory = new HatsProposerAdapterV1__factory(deployer);
+      const adapterFactory = new ProposerAdapterHatsV1__factory(deployer);
       adapterImplementation = await adapterFactory.deploy();
       await adapterImplementation.waitForDeployment();
     }
@@ -147,20 +147,20 @@ describe('HatsProposerAdapterV1', () => {
   });
 
   describe('ERC165 supportsInterface', () => {
-    it('should support IHatsProposerAdapterV1', async () => {
+    it('should support IProposerAdapterHatsV1', async () => {
       void expect(
         await adapter.supportsInterface(
-          calculateInterfaceId(IHatsProposerAdapterV1__factory.createInterface(), [
-            IProposerAdapterV1__factory.createInterface(),
+          calculateInterfaceId(IProposerAdapterHatsV1__factory.createInterface(), [
+            IProposerAdapterBaseV1__factory.createInterface(),
           ]),
         ),
       ).to.be.true;
     });
 
-    it('should support IProposerAdapterV1', async () => {
+    it('should support IProposerAdapterBaseV1', async () => {
       void expect(
         await adapter.supportsInterface(
-          calculateInterfaceId(IProposerAdapterV1__factory.createInterface()),
+          calculateInterfaceId(IProposerAdapterBaseV1__factory.createInterface()),
         ),
       ).to.be.true;
     });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/339

Fixes [ENG-1119](https://linear.app/decent-labs/issue/ENG-1119/refactor-proposer-adapter-naming-for-consistency)

This commit refactors the naming of all `ProposerAdapter` contracts, interfaces, and test files to improve file organization and readability. The `ProposerAdapter` prefix is now used at the beginning of the filenames, which groups related files together when sorted alphabetically.

Additionally, the proposer adapter contracts and tests have been moved into a new `proposer/` subdirectory to better separate them from other types of strategy adapters.

All internal references, imports, and contract/interface declarations have been updated to reflect the new naming convention.

**Key Renames:**
-   `IProposerAdapterV1` -> `IProposerAdapterBaseV1`
-   `ERC20ProposerAdapterV1` -> `ProposerAdapterERC20V1`
-   `ERC721ProposerAdapterV1` -> `ProposerAdapterERC721V1`
-   `HatsProposerAdapterV1` -> `ProposerAdapterHatsV1`
-   The corresponding interfaces and test files have also been renamed and moved.