### PR TITLE
refactor: Rename Module files for better organization

### DIFF
--- a/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 import {IFreezeVotingAzoriusV1} from "../../interfaces/decent/deployables/IFreezeVotingAzoriusV1.sol";
 import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {IVotingAdapterBaseV1} from "../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
-import {IAzoriusV1} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
+import {IModuleAzoriusV1} from "../../interfaces/decent/deployables/IModuleAzoriusV1.sol";
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
@@ -21,7 +21,7 @@ contract FreezeVotingAzoriusV1 is
 {
     uint16 public constant VERSION = 1;
 
-    IAzoriusV1 internal _parentAzorius;
+    IModuleAzoriusV1 internal _parentAzorius;
     address internal _freezeProposalStrategy;
 
     constructor() {
@@ -43,7 +43,7 @@ contract FreezeVotingAzoriusV1 is
             freezeVotesThreshold_
         );
         __VoterResolverV1_init(lightAccountFactory_);
-        _parentAzorius = IAzoriusV1(parentAzorius_);
+        _parentAzorius = IModuleAzoriusV1(parentAzorius_);
     }
 
     function parentAzorius() external view virtual override returns (address) {

--- a/contracts/deployables/modules/ModuleAzoriusV1.sol
+++ b/contracts/deployables/modules/ModuleAzoriusV1.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
-import {IAzoriusV1} from "../../interfaces/decent/deployables/IAzoriusV1.sol";
+import {IModuleAzoriusV1} from "../../interfaces/decent/deployables/IModuleAzoriusV1.sol";
 import {Transaction} from "../../interfaces/decent/Module.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
@@ -11,8 +11,8 @@ import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/acces
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract AzoriusV1 is
-    IAzoriusV1,
+contract ModuleAzoriusV1 is
+    IModuleAzoriusV1,
     IVersion,
     GuardableModule,
     Ownable2StepUpgradeable,
@@ -366,7 +366,7 @@ contract AzoriusV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IAzoriusV1).interfaceId ||
+            interfaceId_ == type(IModuleAzoriusV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/contracts/deployables/modules/ModuleFractalV1.sol
+++ b/contracts/deployables/modules/ModuleFractalV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IFractalV1} from "../../interfaces/decent/deployables/IFractalV1.sol";
+import {IModuleFractalV1} from "../../interfaces/decent/deployables/IModuleFractalV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {Transaction} from "../../interfaces/decent/Module.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
@@ -10,8 +10,8 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract FractalV1 is
-    IFractalV1,
+contract ModuleFractalV1 is
+    IModuleFractalV1,
     IVersion,
     GuardableModule,
     Ownable2StepUpgradeable,
@@ -73,7 +73,7 @@ contract FractalV1 is
         bytes4 interfaceId_
     ) public view virtual override returns (bool) {
         return
-            interfaceId_ == type(IFractalV1).interfaceId ||
+            interfaceId_ == type(IModuleFractalV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/contracts/interfaces/decent/deployables/IModuleAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IModuleAzoriusV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {Transaction} from "../Module.sol";
 
-interface IAzoriusV1 {
+interface IModuleAzoriusV1 {
     event ProposalCreated(
         address strategy,
         uint32 proposalId,

--- a/contracts/interfaces/decent/deployables/IModuleFractalV1.sol
+++ b/contracts/interfaces/decent/deployables/IModuleFractalV1.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {Transaction} from "../Module.sol";
 
-interface IFractalV1 {
+interface IModuleFractalV1 {
     error TxFailed();
 
     function initialize(

--- a/contracts/mocks/MockModuleAzoriusV1.sol
+++ b/contracts/mocks/MockModuleAzoriusV1.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IAzoriusV1, Transaction} from "../interfaces/decent/deployables/IAzoriusV1.sol";
+import {IModuleAzoriusV1, Transaction} from "../interfaces/decent/deployables/IModuleAzoriusV1.sol";
 import {Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 
-contract MockAzoriusV1 is IAzoriusV1 {
+contract MockModuleAzoriusV1 is IModuleAzoriusV1 {
     address public currentStrategy;
     uint32 public currentTimelockPeriod;
     uint32 public currentExecutionPeriod;

--- a/test/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
@@ -12,10 +12,10 @@ import {
   IFreezeVotingBaseV1__factory,
   IVersion__factory,
   IVoterResolverV1__factory,
-  MockAzoriusV1,
-  MockAzoriusV1__factory,
   MockLightAccountFactory,
   MockLightAccountFactory__factory,
+  MockModuleAzoriusV1,
+  MockModuleAzoriusV1__factory,
   MockVotingAdapter,
   MockVotingAdapter__factory,
   MockVotingStrategy,
@@ -59,7 +59,7 @@ describe('FreezeVotingAzoriusV1', () => {
   let voter2: SignerWithAddress;
 
   let azoriusFreezeVoting: FreezeVotingAzoriusV1;
-  let mockParentAzorius: MockAzoriusV1;
+  let mockParentAzorius: MockModuleAzoriusV1;
   let mockStrategy: MockVotingStrategy;
   let mockAdapter1: MockVotingAdapter;
   let mockLightAccountFactory: MockLightAccountFactory;
@@ -77,7 +77,7 @@ describe('FreezeVotingAzoriusV1', () => {
     await impl.waitForDeployment();
     const implAddr = await impl.getAddress();
 
-    const mockAzoriusFactory = new MockAzoriusV1__factory(d);
+    const mockAzoriusFactory = new MockModuleAzoriusV1__factory(d);
     const mAzorius = await mockAzoriusFactory.deploy();
     await mAzorius.waitForDeployment();
 

--- a/test/deployables/modules/ModuleAzoriusV1.test.ts
+++ b/test/deployables/modules/ModuleAzoriusV1.test.ts
@@ -3,11 +3,9 @@ import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  AzoriusV1,
-  AzoriusV1__factory,
   ERC1967Proxy__factory,
-  IAzoriusV1__factory,
   IERC165__factory,
+  IModuleAzoriusV1__factory,
   IVersion__factory,
   MockAvatar,
   MockAvatar__factory,
@@ -15,6 +13,8 @@ import {
   MockERC20Votes__factory,
   MockVotingStrategy,
   MockVotingStrategy__factory,
+  ModuleAzoriusV1,
+  ModuleAzoriusV1__factory,
   UUPSUpgradeable,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
@@ -30,10 +30,10 @@ async function deployAzoriusProxy(
   strategyAddress: string,
   timelockPeriod: number,
   executionPeriod: number,
-): Promise<AzoriusV1> {
+): Promise<ModuleAzoriusV1> {
   // Combine selector and encoded params
   const fullInitData =
-    AzoriusV1__factory.createInterface().getFunction('initialize').selector +
+    ModuleAzoriusV1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(
         ['address', 'address', 'address', 'address', 'uint32', 'uint32'],
@@ -45,7 +45,7 @@ async function deployAzoriusProxy(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return AzoriusV1__factory.connect(await proxy.getAddress(), owner);
+  return ModuleAzoriusV1__factory.connect(await proxy.getAddress(), owner);
 }
 
 // Helper function for deploying AzoriusV1 using setUp instead of initialize
@@ -58,9 +58,9 @@ async function deployAzoriusProxyWithSetUp(
   strategyAddress: string,
   timelockPeriod: number,
   executionPeriod: number,
-): Promise<AzoriusV1> {
+): Promise<ModuleAzoriusV1> {
   // Create the call to setUp with the encoded parameters
-  const fullInitData = AzoriusV1__factory.createInterface().encodeFunctionData('setUp', [
+  const fullInitData = ModuleAzoriusV1__factory.createInterface().encodeFunctionData('setUp', [
     ethers.AbiCoder.defaultAbiCoder().encode(
       ['address', 'address', 'address', 'address', 'uint32', 'uint32'],
       [owner.address, avatar, target, strategyAddress, timelockPeriod, executionPeriod],
@@ -71,10 +71,10 @@ async function deployAzoriusProxyWithSetUp(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return AzoriusV1__factory.connect(await proxy.getAddress(), owner);
+  return ModuleAzoriusV1__factory.connect(await proxy.getAddress(), owner);
 }
 
-describe('AzoriusV1', () => {
+describe('ModuleAzoriusV1', () => {
   // eoas
   let proxyDeployer: SignerWithAddress;
   let owner: SignerWithAddress;
@@ -83,7 +83,7 @@ describe('AzoriusV1', () => {
   let nonOwner: SignerWithAddress;
 
   // mocks and mastercopies
-  let implementation: AzoriusV1;
+  let implementation: ModuleAzoriusV1;
   let masterCopy: string;
   let mockStrategy: MockVotingStrategy;
   let mockStrategyAddress: string;
@@ -93,7 +93,7 @@ describe('AzoriusV1', () => {
     [proxyDeployer, owner, proposer, user, nonOwner] = await ethers.getSigners();
 
     // Deploy implementation contract
-    implementation = await new AzoriusV1__factory(proxyDeployer).deploy();
+    implementation = await new ModuleAzoriusV1__factory(proxyDeployer).deploy();
     masterCopy = await implementation.getAddress();
 
     // Deploy a default mock strategy for use in many tests
@@ -102,7 +102,7 @@ describe('AzoriusV1', () => {
   });
 
   describe('Initialization', () => {
-    let azorius: AzoriusV1;
+    let azorius: ModuleAzoriusV1;
     let avatar: MockAvatar;
 
     beforeEach(async () => {
@@ -308,7 +308,7 @@ describe('AzoriusV1', () => {
       });
 
       it('Should have initialization disabled in the implementation', async function () {
-        const implementationContract = AzoriusV1__factory.connect(masterCopy, proxyDeployer);
+        const implementationContract = ModuleAzoriusV1__factory.connect(masterCopy, proxyDeployer);
 
         await expect(
           implementationContract.initialize(
@@ -380,7 +380,7 @@ describe('AzoriusV1', () => {
   });
 
   describe('Proposal Tests', () => {
-    let azorius: AzoriusV1;
+    let azorius: ModuleAzoriusV1;
     let avatar: MockAvatar;
     let mockToken: MockERC20Votes;
 
@@ -1248,7 +1248,7 @@ describe('AzoriusV1', () => {
   });
 
   describe('Owner Functions', () => {
-    let azorius: AzoriusV1;
+    let azorius: ModuleAzoriusV1;
     let avatar: MockAvatar;
 
     const INITIAL_TIMELOCK_PERIOD = 100;
@@ -1586,7 +1586,7 @@ describe('AzoriusV1', () => {
   });
 
   describe('Version', () => {
-    let azorius: AzoriusV1;
+    let azorius: ModuleAzoriusV1;
 
     beforeEach(async () => {
       azorius = await deployAzoriusProxy(
@@ -1608,10 +1608,7 @@ describe('AzoriusV1', () => {
   });
 
   describe('ERC165', function () {
-    let azoriusInstance: AzoriusV1;
-    let iAzoriusV1InterfaceId: string;
-    let iVersionInterfaceId: string;
-    let iERC165InterfaceId: string;
+    let azoriusInstance: ModuleAzoriusV1;
 
     beforeEach(async function () {
       // Deploy a new instance for testing
@@ -1625,31 +1622,30 @@ describe('AzoriusV1', () => {
         0,
         0,
       );
-
-      // Dynamically calculate interface IDs
-      const IAzoriusV1Interface = IAzoriusV1__factory.createInterface();
-      iAzoriusV1InterfaceId = calculateInterfaceId(IAzoriusV1Interface);
-
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
-
-      const IERC165Interface = IERC165__factory.createInterface();
-      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
     });
 
     it('Should support IERC165 interface', async function () {
-      const supported = await azoriusInstance.supportsInterface(iERC165InterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await azoriusInstance.supportsInterface(
+          calculateInterfaceId(IERC165__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
-    it('Should support IAzoriusV1 interface', async function () {
-      const supported = await azoriusInstance.supportsInterface(iAzoriusV1InterfaceId);
-      void expect(supported).to.be.true;
+    it('Should support IModuleAzoriusV1 interface', async function () {
+      void expect(
+        await azoriusInstance.supportsInterface(
+          calculateInterfaceId(IModuleAzoriusV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IVersion interface', async function () {
-      const supported = await azoriusInstance.supportsInterface(iVersionInterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await azoriusInstance.supportsInterface(
+          calculateInterfaceId(IVersion__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should not support random interface', async function () {
@@ -1660,7 +1656,7 @@ describe('AzoriusV1', () => {
   });
 
   describe('UUPS Upgradeability', function () {
-    let azorius: AzoriusV1;
+    let azorius: ModuleAzoriusV1;
 
     beforeEach(async function () {
       // Deploy azorius proxy
@@ -1680,7 +1676,7 @@ describe('AzoriusV1', () => {
     runUUPSUpgradeabilityTests({
       getContract: () => azorius as unknown as UUPSUpgradeable,
       createNewImplementation: async () => {
-        const newImplementation = await new AzoriusV1__factory(owner).deploy();
+        const newImplementation = await new ModuleAzoriusV1__factory(owner).deploy();
         return newImplementation as unknown as UUPSUpgradeable;
       },
       owner: () => owner,

--- a/test/deployables/modules/ModuleFractalV1.test.ts
+++ b/test/deployables/modules/ModuleFractalV1.test.ts
@@ -3,15 +3,15 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  FractalV1,
-  FractalV1__factory,
   IERC165__factory,
-  IFractalV1__factory,
+  IModuleFractalV1__factory,
   IVersion__factory,
   MockAvatar,
   MockAvatar__factory,
   MockERC20Votes,
   MockERC20Votes__factory,
+  ModuleFractalV1,
+  ModuleFractalV1__factory,
   UUPSUpgradeable,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
@@ -24,10 +24,10 @@ async function deployFractalModuleProxy(
   owner: SignerWithAddress,
   avatar: string,
   target: string,
-): Promise<FractalV1> {
+): Promise<ModuleFractalV1> {
   // Combine selector and encoded params
   const fullInitData =
-    FractalV1__factory.createInterface().getFunction('initialize').selector +
+    ModuleFractalV1__factory.createInterface().getFunction('initialize').selector +
     ethers.AbiCoder.defaultAbiCoder()
       .encode(['address', 'address', 'address'], [owner.address, avatar, target])
       .slice(2);
@@ -36,7 +36,7 @@ async function deployFractalModuleProxy(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return FractalV1__factory.connect(await proxy.getAddress(), owner);
+  return ModuleFractalV1__factory.connect(await proxy.getAddress(), owner);
 }
 
 // Helper function for deploying using setUp instead of initialize
@@ -46,9 +46,9 @@ async function deployFractalModuleProxyWithSetUp(
   owner: SignerWithAddress,
   avatar: string,
   target: string,
-): Promise<FractalV1> {
+): Promise<ModuleFractalV1> {
   // Create the call to setUp with the encoded parameters
-  const fullInitData = FractalV1__factory.createInterface().encodeFunctionData('setUp', [
+  const fullInitData = ModuleFractalV1__factory.createInterface().encodeFunctionData('setUp', [
     ethers.AbiCoder.defaultAbiCoder().encode(
       ['address', 'address', 'address'],
       [owner.address, avatar, target],
@@ -59,10 +59,10 @@ async function deployFractalModuleProxyWithSetUp(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return FractalV1__factory.connect(await proxy.getAddress(), owner);
+  return ModuleFractalV1__factory.connect(await proxy.getAddress(), owner);
 }
 
-describe('FractalV1', () => {
+describe('ModuleFractalV1', () => {
   // eoas
   let proxyDeployer: SignerWithAddress;
   let owner: SignerWithAddress;
@@ -78,13 +78,13 @@ describe('FractalV1', () => {
     [proxyDeployer, owner, nonOwner, user] = await ethers.getSigners();
 
     // Deploy implementation contract
-    const implementation = await new FractalV1__factory(proxyDeployer).deploy();
+    const implementation = await new ModuleFractalV1__factory(proxyDeployer).deploy();
     masterCopy = await implementation.getAddress();
     mockToken = await new MockERC20Votes__factory(proxyDeployer).deploy();
   });
 
   describe('Initialization', () => {
-    let fractalModule: FractalV1;
+    let fractalModule: ModuleFractalV1;
     let avatar: MockAvatar;
 
     beforeEach(async () => {
@@ -229,7 +229,7 @@ describe('FractalV1', () => {
   });
 
   describe('Transaction Execution', () => {
-    let fractalModule: FractalV1;
+    let fractalModule: ModuleFractalV1;
     let avatar: MockAvatar;
 
     beforeEach(async () => {
@@ -389,7 +389,7 @@ describe('FractalV1', () => {
   });
 
   describe('Version', () => {
-    let fractalModule: FractalV1;
+    let fractalModule: ModuleFractalV1;
 
     beforeEach(async () => {
       fractalModule = await deployFractalModuleProxy(
@@ -408,7 +408,7 @@ describe('FractalV1', () => {
   });
 
   describe('ERC165', function () {
-    let fractalModuleInstance: FractalV1;
+    let fractalModuleInstance: ModuleFractalV1;
 
     beforeEach(async function () {
       // Deploy a new instance for testing
@@ -429,10 +429,10 @@ describe('FractalV1', () => {
       ).to.be.true;
     });
 
-    it('Should support IFractalModuleV1 interface', async function () {
+    it('Should support IModuleFractalV1 interface', async function () {
       void expect(
         await fractalModuleInstance.supportsInterface(
-          calculateInterfaceId(IFractalV1__factory.createInterface()),
+          calculateInterfaceId(IModuleFractalV1__factory.createInterface()),
         ),
       ).to.be.true;
     });
@@ -453,7 +453,7 @@ describe('FractalV1', () => {
   });
 
   describe('UUPS Upgradeability', function () {
-    let fractalModule: FractalV1;
+    let fractalModule: ModuleFractalV1;
 
     beforeEach(async function () {
       // Deploy fractal module proxy
@@ -470,7 +470,7 @@ describe('FractalV1', () => {
     runUUPSUpgradeabilityTests({
       getContract: () => fractalModule as unknown as UUPSUpgradeable,
       createNewImplementation: async () => {
-        const newImplementation = await new FractalV1__factory(owner).deploy();
+        const newImplementation = await new ModuleFractalV1__factory(owner).deploy();
         return newImplementation as unknown as UUPSUpgradeable;
       },
       owner: () => owner,


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/340

Fixes [ENG-1120](https://linear.app/decent-labs/issue/ENG-1120/refactor-module-file-naming-for-consistency)

This commit refactors the naming of all Module contracts, interfaces, and test files to improve file organization and readability. The `Module` prefix is now used at the beginning of the filenames, which groups related files together when sorted alphabetically.

All internal references, imports, and contract/interface declarations have been updated to reflect the new naming convention.

**Key Renames:**
-   `AzoriusV1.sol` -> `ModuleAzoriusV1.sol`
-   `FractalV1.sol` -> `ModuleFractalV1.sol`
-   `IAzoriusV1.sol` -> `IModuleAzoriusV1.sol`
-   `IFractalV1.sol` -> `IModuleFractalV1.sol`
-   The corresponding test files and mock contracts have also been renamed.