### PR TITLE
feat(contracts): Add `hatIdIsWhitelisted` and improve test coverage

### DIFF
--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.sol
@@ -20,7 +20,7 @@ contract ProposerAdapterHatsV1 is
 
     IHats internal _hatsContract;
     uint256[] internal _whitelistedHatIds;
-    mapping(uint256 hatId => bool isWhitelisted) internal _hatIdToIsWhitelisted;
+    mapping(uint256 hatId => bool isWhitelisted) internal _hatIdIsWhitelisted;
 
     // ======================================================================
     // CONSTRUCTOR & INITIALIZERS
@@ -37,7 +37,7 @@ contract ProposerAdapterHatsV1 is
         _hatsContract = IHats(hatsContract_);
         _whitelistedHatIds = whitelistedHatIds_;
         for (uint256 i = 0; i < whitelistedHatIds_.length; ) {
-            _hatIdToIsWhitelisted[whitelistedHatIds_[i]] = true;
+            _hatIdIsWhitelisted[whitelistedHatIds_[i]] = true;
 
             unchecked {
                 ++i;
@@ -65,6 +65,12 @@ contract ProposerAdapterHatsV1 is
         return _whitelistedHatIds;
     }
 
+    function hatIdIsWhitelisted(
+        uint256 hatId_
+    ) public view virtual override returns (bool) {
+        return _hatIdIsWhitelisted[hatId_];
+    }
+
     // ======================================================================
     // IProposerAdapterBaseV1
     // ======================================================================
@@ -77,7 +83,7 @@ contract ProposerAdapterHatsV1 is
     ) public view virtual override returns (bool) {
         uint256 hatId = abi.decode(data_, (uint256));
         return
-            _hatIdToIsWhitelisted[hatId] &&
+            _hatIdIsWhitelisted[hatId] &&
             _hatsContract.isWearerOfHat(proposer_, hatId);
     }
 

--- a/contracts/interfaces/decent/deployables/IProposerAdapterHatsV1.sol
+++ b/contracts/interfaces/decent/deployables/IProposerAdapterHatsV1.sol
@@ -19,4 +19,6 @@ interface IProposerAdapterHatsV1 is IProposerAdapterBaseV1 {
         external
         view
         returns (uint256[] memory whitelistedHatIds);
+
+    function hatIdIsWhitelisted(uint256 hatId_) external view returns (bool);
 }

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
@@ -138,6 +138,72 @@ describe('ProposerAdapterHatsV1', () => {
       );
       void expect(canPropose).to.be.true;
     });
+
+    it('should return false if adapter was initialized with no whitelisted hats', async () => {
+      const localAdapter = await deployHatsProposerAdapterProxy(
+        deployer,
+        await adapterImplementation.getAddress(),
+        await mockHats.getAddress(),
+        [],
+      );
+      await mockHats.setWearerStatus(user1.address, HAT_ID_1, true);
+      const canPropose = await localAdapter.isProposer(
+        user1.address,
+        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_1]),
+      );
+      void expect(canPropose).to.be.false;
+    });
+
+    it('should revert if data is not a valid abi-encoded uint256', async () => {
+      // Empty data
+      await expect(adapter.isProposer(user1.address, '0x')).to.be.reverted;
+
+      // Data too short
+      await expect(adapter.isProposer(user1.address, '0x1234')).to.be.reverted;
+    });
+  });
+
+  describe('IProposerAdapterHatsV1 View Functions', () => {
+    it('hatsContract(): should return the correct hats contract address', async () => {
+      expect(await adapter.hatsContract()).to.equal(await mockHats.getAddress());
+    });
+
+    describe('whitelistedHatIds()', () => {
+      it('should return the list of whitelisted hat IDs', async () => {
+        expect(await adapter.whitelistedHatIds()).to.deep.equal([HAT_ID_1]);
+      });
+
+      it('should return an empty array if initialized with no hats', async () => {
+        const localAdapter = await deployHatsProposerAdapterProxy(
+          deployer,
+          await adapterImplementation.getAddress(),
+          await mockHats.getAddress(),
+          [], // empty array
+        );
+        expect(await localAdapter.whitelistedHatIds()).to.deep.equal([]);
+      });
+    });
+
+    describe('hatIdIsWhitelisted()', () => {
+      it('should return true for a whitelisted hat ID', async () => {
+        void expect(await adapter.hatIdIsWhitelisted(HAT_ID_1)).to.be.true;
+      });
+
+      it('should return false for a non-whitelisted hat ID', async () => {
+        void expect(await adapter.hatIdIsWhitelisted(HAT_ID_2)).to.be.false;
+      });
+
+      it('should return false for any hat ID if initialized with no hats', async () => {
+        const localAdapter = await deployHatsProposerAdapterProxy(
+          deployer,
+          await adapterImplementation.getAddress(),
+          await mockHats.getAddress(),
+          [], // empty array
+        );
+        void expect(await localAdapter.hatIdIsWhitelisted(HAT_ID_1)).to.be.false;
+        void expect(await localAdapter.hatIdIsWhitelisted(HAT_ID_2)).to.be.false;
+      });
+    });
   });
 
   describe('version', () => {


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/342

Fixes [ENG-1122](https://linear.app/decent-labs/issue/ENG-1122/add-hatidiswhitelisted-and-improve-test-coverage-for)

This commit introduces a new view function, `hatIdIsWhitelisted`, to the `ProposerAdapterHatsV1` contract and its corresponding interface. This function allows for checking if a specific hat ID is on the adapter's whitelist. The internal mapping `_hatIdToIsWhitelisted` was also renamed to `_hatIdIsWhitelisted` for consistency.

Additionally, test coverage for `ProposerAdapterHatsV1` has been significantly improved.

- Added `hatIdIsWhitelisted` to `IProposerAdapterHatsV1` and `ProposerAdapterHatsV1`.
- Renamed internal mapping for clarity.
- Added comprehensive tests for all view functions: `hatsContract`, `whitelistedHatIds`, and `hatIdIsWhitelisted`.
- Added edge-case tests for `isProposer`, including handling of invalid `data_` and initialization with no whitelisted hats.