### PR TITLE
feat(governance): Simplify proposal creation signatures

### DIFF
--- a/contracts/deployables/modules/ModuleAzoriusV1.sol
+++ b/contracts/deployables/modules/ModuleAzoriusV1.sol
@@ -274,8 +274,7 @@ contract ModuleAzoriusV1 is
         Transaction[] calldata transactions_,
         string calldata metadata_,
         address proposerAdapter_,
-        bytes calldata proposerAdapterData_,
-        bytes calldata proposalInitializerData_
+        bytes calldata proposerAdapterData_
     ) public virtual override {
         if (
             !_strategy.isProposer(
@@ -299,11 +298,7 @@ contract ModuleAzoriusV1 is
         _proposals[_totalProposalCount].timelockPeriod = _timelockPeriod;
         _proposals[_totalProposalCount].executionPeriod = _executionPeriod;
 
-        _strategy.initializeProposal(
-            _totalProposalCount,
-            txHashes,
-            proposalInitializerData_
-        );
+        _strategy.initializeProposal(_totalProposalCount);
 
         emit ProposalCreated(
             address(_strategy),

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -338,9 +338,7 @@ contract StrategyV1 is
     // --- State-Changing Functions ---
 
     function initializeProposal(
-        uint32 proposalId_,
-        bytes32[] calldata,
-        bytes calldata
+        uint32 proposalId_
     ) public virtual override onlyStrategyAdmin {
         ProposalVotingDetails storage proposal = _proposalVotingDetails[
             proposalId_

--- a/contracts/interfaces/decent/deployables/IModuleAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IModuleAzoriusV1.sol
@@ -124,8 +124,7 @@ interface IModuleAzoriusV1 {
         Transaction[] calldata transactions_,
         string calldata metadata_,
         address proposerAdapter_,
-        bytes calldata proposerAdapterData_,
-        bytes calldata proposalInitializerData_
+        bytes calldata proposerAdapterData_
     ) external;
 
     function executeProposal(

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -157,11 +157,7 @@ interface IStrategyV1 {
 
     // --- State-Changing Functions ---
 
-    function initializeProposal(
-        uint32 proposalId_,
-        bytes32[] calldata txHashes_,
-        bytes calldata proposalInitializerData_
-    ) external;
+    function initializeProposal(uint32 proposalId_) external;
 
     function vote(
         uint32 proposalId_,

--- a/contracts/mocks/MockModuleAzoriusV1.sol
+++ b/contracts/mocks/MockModuleAzoriusV1.sol
@@ -68,7 +68,6 @@ contract MockModuleAzoriusV1 is IModuleAzoriusV1 {
         Transaction[] calldata,
         string calldata,
         address,
-        bytes calldata,
         bytes calldata
     ) external virtual override {}
 

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -152,11 +152,7 @@ contract MockVotingStrategy is IStrategyV1, VoterResolverV1 {
         return votingStartBlocksMap[proposalId];
     }
 
-    function initializeProposal(
-        uint32 proposalId,
-        bytes32[] calldata,
-        bytes calldata
-    ) external virtual override {
+    function initializeProposal(uint32 proposalId) external virtual override {
         ProposalVotingDetails storage proposal = proposalVotingDetailsMap[
             proposalId
         ];

--- a/test/deployables/modules/ModuleAzoriusV1.test.ts
+++ b/test/deployables/modules/ModuleAzoriusV1.test.ts
@@ -430,13 +430,7 @@ describe('ModuleAzoriusV1', () => {
 
         const tx = await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            proposalMetadata,
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], proposalMetadata, ethers.ZeroAddress, ethers.ZeroHash);
 
         const receipt = await tx.wait();
         if (!receipt) throw new Error('Transaction failed to be mined');
@@ -464,13 +458,7 @@ describe('ModuleAzoriusV1', () => {
         await expect(
           azorius
             .connect(user)
-            .submitProposal(
-              [proposalTx],
-              'Test proposal',
-              ethers.ZeroAddress,
-              ethers.ZeroHash,
-              ethers.ZeroHash,
-            ),
+            .submitProposal([proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash),
         ).to.be.revertedWithCustomError(azorius, 'InvalidProposer');
       });
 
@@ -482,13 +470,7 @@ describe('ModuleAzoriusV1', () => {
         await expect(
           azorius
             .connect(proposer)
-            .submitProposal(
-              [],
-              proposalMetadata,
-              ethers.ZeroAddress,
-              ethers.ZeroHash,
-              ethers.ZeroHash,
-            ),
+            .submitProposal([], proposalMetadata, ethers.ZeroAddress, ethers.ZeroHash),
         )
           .to.emit(azorius, 'ProposalCreated')
           .withArgs(mockStrategyAddress, proposalId, proposer.address, [], proposalMetadata);
@@ -544,13 +526,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            'Test proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
         // Now totalProposalCount is 1. Accessing proposalState(1) should revert.
         await expect(azorius.proposalState(1)).to.be.revertedWithCustomError(
           azorius,
@@ -570,13 +546,7 @@ describe('ModuleAzoriusV1', () => {
         // First create a valid proposal
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            'Test proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         // Try to access an invalid tx index
         await expect(azorius.getProposalTxHash(0, 999)).to.be.reverted; // Will revert with array out of bounds
@@ -600,13 +570,7 @@ describe('ModuleAzoriusV1', () => {
         // Submit proposal with multiple transactions
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [tx1, tx2],
-            'Test proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         // Get hashes directly
         const hash1 = await azorius.getTxHash(tx1);
@@ -637,13 +601,7 @@ describe('ModuleAzoriusV1', () => {
         // Submit the proposal
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            metadata,
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], metadata, ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0;
 
         const expectedTxHash = await azorius.getTxHash(proposalTx);
@@ -690,13 +648,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [tx1, tx2],
-            'Partial Exec Test',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([tx1, tx2], 'Partial Exec Test', ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0;
 
         // --- Setup for execution ---
@@ -750,13 +702,7 @@ describe('ModuleAzoriusV1', () => {
         // Submit a proposal
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            'Test proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         proposalId = 0;
 
@@ -961,13 +907,7 @@ describe('ModuleAzoriusV1', () => {
 
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [tx1, tx2],
-            'Test proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         // Set voting to passed and move past timelock on mock strategy
         await mockStrategy.setVotingTimestamps(0, 0, 0);
@@ -1028,13 +968,7 @@ describe('ModuleAzoriusV1', () => {
         // Submit proposal with both transactions (proposalId will be 1 for this new proposal)
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [tx1, tx2],
-            'Test proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         // Get current block number and set up proposal state for the new proposal (ID 1)
         const currentBlockTimestamp = await time.latest();
@@ -1082,13 +1016,7 @@ describe('ModuleAzoriusV1', () => {
           proposalId = Number(await azorius.totalProposalCount());
           await azorius
             .connect(proposer)
-            .submitProposal(
-              [validTx],
-              'Test for Reverts',
-              ethers.ZeroAddress,
-              ethers.ZeroHash,
-              ethers.ZeroHash,
-            );
+            .submitProposal([validTx], 'Test for Reverts', ethers.ZeroAddress, ethers.ZeroHash);
 
           // Setup proposal to be EXECUTABLE for most tests here
           const chainTimeBeforeStrategyUpdate = await time.latest();
@@ -1300,13 +1228,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            'New proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], 'New proposal', ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0; // First proposal
 
         const [, , timelock, ,] = await azorius.getProposal(proposalId);
@@ -1323,13 +1245,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            'Existing proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroAddress, ethers.ZeroHash);
         const existingProposalId = 0;
 
         // Update the timelock period
@@ -1346,7 +1262,6 @@ describe('ModuleAzoriusV1', () => {
             [proposalTx],
             'New proposal post-update',
             ethers.ZeroAddress,
-            ethers.ZeroHash,
             ethers.ZeroHash,
           );
         const newProposalId = 1;
@@ -1382,13 +1297,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            'New proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], 'New proposal', ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0;
 
         const [, , , executionPeriod] = await azorius.getProposal(proposalId);
@@ -1404,13 +1313,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            'Existing proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroAddress, ethers.ZeroHash);
         const existingProposalId = 0;
 
         await azorius.connect(owner).updateExecutionPeriod(NEW_EXECUTION_PERIOD);
@@ -1424,7 +1327,6 @@ describe('ModuleAzoriusV1', () => {
             [proposalTx],
             'New proposal post-update',
             ethers.ZeroAddress,
-            ethers.ZeroHash,
             ethers.ZeroHash,
           );
         const newProposalId = 1;
@@ -1475,13 +1377,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            'New proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], 'New proposal', ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0;
 
         const [strategyAddress, , , ,] = await azorius.getProposal(proposalId);
@@ -1497,13 +1393,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal(
-            [proposalTx],
-            'Existing proposal',
-            ethers.ZeroAddress,
-            ethers.ZeroHash,
-            ethers.ZeroHash,
-          );
+          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroAddress, ethers.ZeroHash);
         const existingProposalId = 0;
 
         await azorius.connect(owner).updateStrategy(newMockStrategyAddress);
@@ -1517,7 +1407,6 @@ describe('ModuleAzoriusV1', () => {
             [proposalTx],
             'New proposal post-update',
             ethers.ZeroAddress,
-            ethers.ZeroHash,
             ethers.ZeroHash,
           );
         const newProposalId = 1;
@@ -1542,7 +1431,6 @@ describe('ModuleAzoriusV1', () => {
             [proposalTx],
             'Existing proposal with mockStrategy',
             ethers.ZeroAddress,
-            ethers.ZeroHash,
             ethers.ZeroHash,
           );
 

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -327,7 +327,7 @@ describe('StrategyV1', () => {
 
     it('should revert if called by a non-strategy admin address', async () => {
       await expect(
-        strategy.connect(nonOwner).initializeProposal(defaultProposalId, [], ethers.ZeroHash),
+        strategy.connect(nonOwner).initializeProposal(defaultProposalId),
       ).to.be.revertedWithCustomError(strategy, 'InvalidStrategyAdmin');
     });
 
@@ -337,9 +337,7 @@ describe('StrategyV1', () => {
       const timestampBefore = blockBefore.timestamp;
       const blockNumberBefore = blockBefore.number;
 
-      await expect(
-        strategy.connect(strategyAdmin).initializeProposal(defaultProposalId, [], ethers.ZeroHash),
-      )
+      await expect(strategy.connect(strategyAdmin).initializeProposal(defaultProposalId))
         .to.emit(strategy, 'ProposalInitialized')
         .withArgs(
           defaultProposalId,
@@ -361,13 +359,9 @@ describe('StrategyV1', () => {
     });
 
     it('should reset vote counts for a re-initialized proposal', async () => {
-      await strategy
-        .connect(strategyAdmin)
-        .initializeProposal(defaultProposalId, [], ethers.ZeroHash);
+      await strategy.connect(strategyAdmin).initializeProposal(defaultProposalId);
 
-      await strategy
-        .connect(strategyAdmin)
-        .initializeProposal(defaultProposalId, [], ethers.ZeroHash); // Re-initialize
+      await strategy.connect(strategyAdmin).initializeProposal(defaultProposalId); // Re-initialize
 
       const proposalDetails = await strategy.proposalVotingDetails(defaultProposalId);
       expect(proposalDetails.yesVotes).to.equal(0);
@@ -461,7 +455,7 @@ describe('StrategyV1', () => {
 
     beforeEach(async () => {
       proposalId = 1;
-      await strategy.connect(strategyAdmin).initializeProposal(proposalId, [], ethers.ZeroHash);
+      await strategy.connect(strategyAdmin).initializeProposal(proposalId);
     });
 
     it('should return correct timestamps and block after proposal initialization', async () => {
@@ -498,7 +492,7 @@ describe('StrategyV1', () => {
 
     beforeEach(async () => {
       proposalId = 1;
-      await strategy.connect(strategyAdmin).initializeProposal(proposalId, [], ethers.ZeroHash);
+      await strategy.connect(strategyAdmin).initializeProposal(proposalId);
 
       adapter1Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[1]]);
       adapter2Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[2]]);
@@ -709,9 +703,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await multiAdapterStrategy
-        .connect(strategyAdmin)
-        .initializeProposal(proposalId, [], ethers.ZeroHash);
+      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(proposalId);
 
       const weight1 = 60;
       const weight2 = 40;
@@ -800,9 +792,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await multiAdapterStrategy
-        .connect(strategyAdmin)
-        .initializeProposal(proposalId, [], ethers.ZeroHash);
+      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(proposalId);
 
       await mockAdapter1.setWeight(user1.address, 10);
       await mockAdapter2.setWeight(user1.address, 20);
@@ -844,7 +834,7 @@ describe('StrategyV1', () => {
   describe('isPassed', () => {
     const PROPOSAL_ID = 1;
     beforeEach(async () => {
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
     });
 
     it('should revert with ProposalNotInitialized if proposal was not initialized', async () => {
@@ -891,9 +881,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await specificStrategy
-        .connect(strategyAdmin)
-        .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await specificStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
       await mockAdapter1.setWeight(voter1.address, 50n);
       await mockAdapter1.setWeight(voter2.address, 50n);
@@ -934,9 +922,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await specificStrategy
-        .connect(strategyAdmin)
-        .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await specificStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
       await mockAdapter1.setWeight(voter1.address, 60n); // YES
       await mockAdapter1.setWeight(voter2.address, 10n); // NO
@@ -967,9 +953,9 @@ describe('StrategyV1', () => {
 
     beforeEach(async () => {
       await mockAdapter1.setWeight(voter1.address, 50n);
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
       await time.increase(1n);
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID_2, [], ethers.ZeroHash);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID_2);
     });
 
     it('should initially return false for any proposal', async () => {
@@ -1107,7 +1093,7 @@ describe('StrategyV1', () => {
     const PROPOSAL_ID = 1;
 
     beforeEach(async () => {
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
     });
 
     describe('isQuorumMet', () => {
@@ -1129,7 +1115,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 40n);
@@ -1159,7 +1145,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 41n); // Exceeds
@@ -1189,7 +1175,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 50n);
         await mockAdapter1.setWeight(voter2.address, 40n); // 90 total, < 100
@@ -1219,7 +1205,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 10n); // Only NO votes
         await qStrategy.connect(voter1).vote(PROPOSAL_ID, 0 /* NO */, [
@@ -1328,7 +1314,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 101n);
         await mockAdapter1.setWeight(voter2.address, 100n);
@@ -1357,7 +1343,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 100n);
@@ -1387,7 +1373,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await bStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
@@ -1410,7 +1396,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 1n);
@@ -1628,7 +1614,7 @@ describe('StrategyV1', () => {
     const ADAPTER_VOTE_DATA = ethers.ZeroHash;
 
     beforeEach(async () => {
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
     });
 
     it('should return true for a valid vote configuration', async () => {
@@ -1736,9 +1722,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await multiAdapterStrategy
-        .connect(strategyAdmin)
-        .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
       await mockAdapter1.setWeight(voter1.address, 50n);
       await mockAdapter2.setWeight(voter1.address, 50n);
@@ -1771,9 +1755,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await multiAdapterStrategy
-        .connect(strategyAdmin)
-        .initializeProposal(PROPOSAL_ID, [], ethers.ZeroHash);
+      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
       await mockAdapter1.setWeight(voter1.address, 50n);
       await mockAdapter2.setValidVote(voter1.address, false, 50n); // This one will be invalid


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/343

Fixes [ENG-1123](https://linear.app/decent-labs/issue/ENG-1123/refactor-simplify-proposal-creation-signatures)

Removes unused parameters from the `submitProposal` and `initializeProposal` functions to simplify the core proposal creation workflow.

The `proposalInitializerData` and `txHashes` parameters were originally included for a more generic strategy mechanism but are not utilized in the current implementation. This change removes them to make the function signatures more explicit and easier to understand, reducing code complexity and improving clarity.

- Updated `IModuleAzoriusV1` and `IStrategyV1` interfaces.
- Simplified function signatures in `ModuleAzoriusV1` and `StrategyV1`.
- Updated mock contracts `MockModuleAzoriusV1` and `MockVotingStrategy`.
- Updated all calls in `ModuleAzoriusV1.test.ts` and `StrategyV1.test.ts` to use the new simplified signatures.