### PR TITLE
refactor(governance): Make strategy error messages more explicit

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -224,7 +224,7 @@ contract StrategyV1 is
         bytes calldata proposerAdapterData_
     ) public view virtual override returns (bool) {
         if (!_isProposerAdapter[proposerAdapter_]) {
-            revert InvalidProposerAdapter(proposerAdapter_);
+            revert InvalidProposerAdapter();
         }
 
         return
@@ -393,7 +393,7 @@ contract StrategyV1 is
             address votingAdapter = votingAdapterVoteData.votingAdapter;
 
             if (!_isVotingAdapter[votingAdapter]) {
-                revert InvalidVotingAdapter();
+                revert InvalidVotingAdapter(votingAdapter);
             }
 
             totalWeightForThisVoteTransaction += IVotingAdapterBaseV1(

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 interface IStrategyV1 {
     // --- Errors ---
 
-    error InvalidProposerAdapter(address proposerAdapter);
+    error InvalidProposerAdapter();
     error NoVotingAdapters();
     error NoProposerAdapters();
     error InvalidBasisNumerator();
@@ -13,7 +13,7 @@ interface IStrategyV1 {
     error NoVotingWeight();
     error InvalidVoteType();
     error ProposalNotInitialized();
-    error InvalidVotingAdapter();
+    error InvalidVotingAdapter(address votingAdapter);
     error InvalidAddress();
 
     // --- Structs ---

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -448,6 +448,15 @@ describe('StrategyV1', () => {
         await strategy.isProposer(user1.address, mockProposerAdapter1Address, ethers.ZeroHash),
       ).to.be.true;
     });
+
+    it('should revert with InvalidProposerAdapter if the adapter is not configured', async () => {
+      const unconfiguredAdapter = await new MockProposerAdapter__factory(deployer).deploy();
+      await unconfiguredAdapter.waitForDeployment();
+      const unconfiguredAdapterAddress = await unconfiguredAdapter.getAddress();
+      await expect(
+        strategy.isProposer(user1.address, unconfiguredAdapterAddress, ethers.ZeroHash),
+      ).to.be.revertedWithCustomError(strategy, 'InvalidProposerAdapter');
+    });
   });
 
   describe('getVotingTimestamps & getVotingStartBlock', () => {
@@ -615,9 +624,9 @@ describe('StrategyV1', () => {
         },
       ];
 
-      await expect(
-        strategy.connect(user1).vote(proposalId, 1 /* YES */, adapterData),
-      ).to.be.revertedWithCustomError(strategy, 'InvalidVotingAdapter');
+      await expect(strategy.connect(user1).vote(proposalId, 1 /* YES */, adapterData))
+        .to.be.revertedWithCustomError(strategy, 'InvalidVotingAdapter')
+        .withArgs(unconfiguredAdapterAddress);
     });
 
     it('should correctly record a YES vote, update counts, and emit Voted event', async () => {


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/344

Fixes [ENG-1124](https://linear.app/decent-labs/issue/ENG-1124/refactor-improve-specificity-of-strategy-error-messages)

Updates the `InvalidVotingAdapter` and `InvalidProposerAdapter` errors in the `StrategyV1` contract to provide more specific feedback.

The `InvalidVotingAdapter` error now includes the address of the invalid adapter, which is helpful for debugging when multiple adapters can be used. The `InvalidProposerAdapter` error was simplified by removing the address parameter, as only one proposer adapter is used at a time, making the extra information redundant.

- Updated `IStrategyV1` interface with new error signatures.
- Modified `StrategyV1` contract to revert with the updated errors.
- Added a new test case to verify the `InvalidProposerAdapter` revert.
- Updated existing tests to assert the new `InvalidVotingAdapter` error with the correct address.