### PR TITLE
refactor(governance): Improve naming of voting period state

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -39,8 +39,8 @@ contract StrategyV1 is
     mapping(address freezeVoterContract => bool isAuthorizedFreezeVoter)
         internal _authorizedFreezeVotersMapping;
     address[] internal _authorizedFreezeVotersArray;
-    mapping(uint32 proposalId => bool isVotingPeriodEnded)
-        internal _votingPeriodEnded;
+    mapping(uint32 proposalId => bool voteCastedAfterVotingPeriodEnded)
+        internal _voteCastedAfterVotingPeriodEnded;
 
     // ======================================================================
     // MODIFIERS
@@ -163,10 +163,10 @@ contract StrategyV1 is
         return _proposerAdapters;
     }
 
-    function votingPeriodEnded(
+    function voteCastedAfterVotingPeriodEnded(
         uint32 proposalId_
     ) public view virtual override returns (bool) {
-        return _votingPeriodEnded[proposalId_];
+        return _voteCastedAfterVotingPeriodEnded[proposalId_];
     }
 
     function isQuorumMet(
@@ -287,7 +287,7 @@ contract StrategyV1 is
         }
 
         // Check if voting period has ended
-        if (_votingPeriodEnded[proposalId_]) {
+        if (_voteCastedAfterVotingPeriodEnded[proposalId_]) {
             return false;
         }
 
@@ -373,13 +373,9 @@ contract StrategyV1 is
         }
 
         if (block.timestamp > proposal.votingEndTimestamp) {
-            if (!_votingPeriodEnded[proposalId_]) {
-                _votingPeriodEnded[proposalId_] = true;
-                emit VotingPeriodEnded(
-                    proposalId_,
-                    proposal.votingEndTimestamp,
-                    uint48(block.timestamp)
-                );
+            if (!_voteCastedAfterVotingPeriodEnded[proposalId_]) {
+                _voteCastedAfterVotingPeriodEnded[proposalId_] = true;
+                emit VotingPeriodEnded(proposalId_);
                 return;
             }
             revert ProposalNotActive();

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -58,11 +58,7 @@ interface IStrategyV1 {
         address indexed freezeVoterContract,
         bool isAuthorized
     );
-    event VotingPeriodEnded(
-        uint32 indexed proposalId,
-        uint48 votingEndTimestamp,
-        uint48 currentTimestamp
-    );
+    event VotingPeriodEnded(uint32 indexed proposalId);
 
     // --- Initializer Functions ---
 
@@ -144,9 +140,9 @@ interface IStrategyV1 {
         view
         returns (address[] memory authorizedFreezeVoters);
 
-    function votingPeriodEnded(
+    function voteCastedAfterVotingPeriodEnded(
         uint32 proposalId_
-    ) external view returns (bool votingPeriodEnded);
+    ) external view returns (bool voteCastedAfterVotingPeriodEnded);
 
     function validStrategyVote(
         address voter_,

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -296,7 +296,7 @@ contract MockVotingStrategy is IStrategyV1, VoterResolverV1 {
         return _authorizedFreezeVotersArray;
     }
 
-    function votingPeriodEnded(
+    function voteCastedAfterVotingPeriodEnded(
         uint32 _proposalId
     ) external view override returns (bool) {}
 

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -531,10 +531,7 @@ describe('StrategyV1', () => {
         },
       ]);
 
-      const currentBlockTimestamp = await time.latest();
-      await expect(tx)
-        .to.emit(strategy, 'VotingPeriodEnded')
-        .withArgs(proposalId, proposalDetails.votingEndTimestamp, currentBlockTimestamp);
+      await expect(tx).to.emit(strategy, 'VotingPeriodEnded').withArgs(proposalId);
 
       // Subsequent calls should revert
       await expect(
@@ -559,10 +556,7 @@ describe('StrategyV1', () => {
         },
       ]);
 
-      const blockTimestampAfterVote = await time.latest();
-      await expect(tx)
-        .to.emit(strategy, 'VotingPeriodEnded')
-        .withArgs(proposalId, proposalDetailsBefore.votingEndTimestamp, blockTimestampAfterVote);
+      await expect(tx).to.emit(strategy, 'VotingPeriodEnded').withArgs(proposalId);
 
       // Vote counts should not change as the vote is not processed
       const proposalDetailsAfter = await strategy.proposalVotingDetails(proposalId);
@@ -968,7 +962,7 @@ describe('StrategyV1', () => {
     });
 
     it('should initially return false for any proposal', async () => {
-      const result = await strategy.votingPeriodEnded(PROPOSAL_ID);
+      const result = await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID);
       void expect(result).to.be.false;
     });
 
@@ -976,13 +970,13 @@ describe('StrategyV1', () => {
       await time.increaseTo(
         (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp + 1n,
       );
-      const result = await strategy.votingPeriodEnded(PROPOSAL_ID);
+      const result = await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID);
       void expect(result).to.be.false;
     });
 
     it('should get set to true after casting a vote after voting period ends', async () => {
       // Initially false
-      let result = await strategy.votingPeriodEnded(PROPOSAL_ID);
+      let result = await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID);
       void expect(result).to.be.false;
 
       await time.increaseTo(
@@ -995,7 +989,7 @@ describe('StrategyV1', () => {
         },
       ]);
 
-      result = await strategy.votingPeriodEnded(PROPOSAL_ID);
+      result = await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID);
       void expect(result).to.be.true;
     });
 
@@ -1009,12 +1003,12 @@ describe('StrategyV1', () => {
           adapterVoteData: ethers.ZeroHash,
         },
       ]);
-      void expect(await strategy.votingPeriodEnded(PROPOSAL_ID)).to.be.true;
+      void expect(await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID)).to.be.true;
 
       await time.increaseTo(
         (await strategy.proposalVotingDetails(PROPOSAL_ID_2)).votingEndTimestamp + 1n,
       );
-      void expect(await strategy.votingPeriodEnded(PROPOSAL_ID_2)).to.be.false;
+      void expect(await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID_2)).to.be.false;
     });
 
     it('should not emit VotingPeriodEnded event when casting a vote before voting period ends', async () => {
@@ -1041,11 +1035,7 @@ describe('StrategyV1', () => {
         ]),
       )
         .to.emit(strategy, 'VotingPeriodEnded')
-        .withArgs(
-          PROPOSAL_ID,
-          (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp,
-          await time.latest(),
-        );
+        .withArgs(PROPOSAL_ID);
     });
   });
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/345

Fixes [ENG-1125](https://linear.app/decent-labs/issue/ENG-1125/refactor-clarify-naming-for-voting-period-state)

Renames `votingPeriodEnded` to `voteCastedAfterVotingPeriodEnded` to more accurately reflect its purpose. This state variable is only set to `true` when a vote is cast *after* the voting period has concluded, not simply when the period ends.

This change clarifies the variable's role in the proposal lifecycle and simplifies the `VotingPeriodEnded` event by removing unnecessary timestamp parameters.

- Renamed `votingPeriodEnded` function and state variable to `voteCastedAfterVotingPeriodEnded`.
- Updated the `VotingPeriodEnded` event to only include the `proposalId`.
- Updated all relevant contract logic and tests to reflect these changes.