### PR TITLE
feat(governance): Implement future-dated proposals

### DIFF
--- a/contracts/deployables/modules/ModuleAzoriusV1.sol
+++ b/contracts/deployables/modules/ModuleAzoriusV1.sol
@@ -159,11 +159,12 @@ contract ModuleAzoriusV1 is
         Proposal memory _proposal = _proposals[proposalId_];
         IStrategyV1 strategy_ = IStrategyV1(_proposal.strategy);
 
-        (, uint48 votingEndTimestamp) = strategy_.getVotingTimestamps(
-            proposalId_
-        );
+        (uint48 votingStartTimestamp, uint48 votingEndTimestamp) = strategy_
+            .getVotingTimestamps(proposalId_);
 
-        if (block.timestamp <= votingEndTimestamp) {
+        if (block.timestamp < votingStartTimestamp) {
+            return ProposalState.PENDING;
+        } else if (block.timestamp <= votingEndTimestamp) {
             return ProposalState.ACTIVE;
         } else if (!strategy_.isPassed(proposalId_)) {
             return ProposalState.FAILED;
@@ -271,6 +272,7 @@ contract ModuleAzoriusV1 is
     }
 
     function submitProposal(
+        uint48 proposalStartTime_,
         Transaction[] calldata transactions_,
         string calldata metadata_,
         address proposerAdapter_,
@@ -298,7 +300,7 @@ contract ModuleAzoriusV1 is
         _proposals[_totalProposalCount].timelockPeriod = _timelockPeriod;
         _proposals[_totalProposalCount].executionPeriod = _executionPeriod;
 
-        _strategy.initializeProposal(_totalProposalCount);
+        _strategy.initializeProposal(_totalProposalCount, proposalStartTime_);
 
         emit ProposalCreated(
             address(_strategy),

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -39,6 +39,8 @@ contract StrategyV1 is
     mapping(address freezeVoterContract => bool isAuthorizedFreezeVoter)
         internal _authorizedFreezeVotersMapping;
     address[] internal _authorizedFreezeVotersArray;
+    mapping(uint32 proposalId => bool voteCastedBeforeVotingPeriodStarted)
+        internal _voteCastedBeforeVotingPeriodStarted;
     mapping(uint32 proposalId => bool voteCastedAfterVotingPeriodEnded)
         internal _voteCastedAfterVotingPeriodEnded;
 
@@ -163,6 +165,12 @@ contract StrategyV1 is
         return _proposerAdapters;
     }
 
+    function voteCastedBeforeVotingPeriodStarted(
+        uint32 proposalId_
+    ) public view virtual override returns (bool) {
+        return _voteCastedBeforeVotingPeriodStarted[proposalId_];
+    }
+
     function voteCastedAfterVotingPeriodEnded(
         uint32 proposalId_
     ) public view virtual override returns (bool) {
@@ -176,7 +184,7 @@ contract StrategyV1 is
             proposalId_
         ];
 
-        if (proposal.votingEndTimestamp == 0) {
+        if (proposal.votingStartTimestamp == 0) {
             revert ProposalNotInitialized();
         }
 
@@ -191,7 +199,7 @@ contract StrategyV1 is
             _proposalId
         ];
 
-        if (proposal.votingEndTimestamp == 0) {
+        if (proposal.votingStartTimestamp == 0) {
             revert ProposalNotInitialized();
         }
 
@@ -207,7 +215,7 @@ contract StrategyV1 is
             _proposalId
         ];
 
-        if (proposal.votingEndTimestamp == 0) {
+        if (proposal.votingStartTimestamp == 0) {
             revert ProposalNotInitialized();
         }
 
@@ -240,7 +248,7 @@ contract StrategyV1 is
         ProposalVotingDetails storage details = _proposalVotingDetails[
             proposalId_
         ];
-        if (details.votingEndTimestamp == 0) revert ProposalNotInitialized();
+        if (details.votingStartTimestamp == 0) revert ProposalNotInitialized();
         return (details.votingStartTimestamp, details.votingEndTimestamp);
     }
 
@@ -250,7 +258,7 @@ contract StrategyV1 is
         ProposalVotingDetails storage details = _proposalVotingDetails[
             proposalId_
         ];
-        if (details.votingEndTimestamp == 0) revert ProposalNotInitialized();
+        if (details.votingStartTimestamp == 0) revert ProposalNotInitialized();
         return details.votingStartBlock;
     }
 
@@ -276,13 +284,18 @@ contract StrategyV1 is
         uint8 voteType_,
         VotingAdapterVoteData[] calldata votingAdaptersData_
     ) public view virtual override returns (bool) {
-        // get the proposal start and end timestamps to determine if the proposal exists
+        // get the proposal details
         ProposalVotingDetails storage details = _proposalVotingDetails[
             proposalId_
         ];
 
-        // Check if proposal exists (will have non-zero endTimestamp if it exists)
-        if (details.votingEndTimestamp == 0) {
+        // Check if proposal exists (will have non-zero startTimestamp if it exists)
+        if (details.votingStartTimestamp == 0) {
+            return false;
+        }
+
+        // Check if voting period has started
+        if (_voteCastedBeforeVotingPeriodStarted[proposalId_]) {
             return false;
         }
 
@@ -338,13 +351,22 @@ contract StrategyV1 is
     // --- State-Changing Functions ---
 
     function initializeProposal(
-        uint32 proposalId_
+        uint32 proposalId_,
+        uint48 startTime_
     ) public virtual override onlyStrategyAdmin {
+        if (startTime_ != 0 && startTime_ < block.timestamp) {
+            revert InvalidStartTime();
+        }
+
         ProposalVotingDetails storage proposal = _proposalVotingDetails[
             proposalId_
         ];
-        proposal.votingStartTimestamp = uint48(block.timestamp);
-        proposal.votingEndTimestamp = uint48(block.timestamp + _votingPeriod);
+        proposal.votingStartTimestamp = startTime_ == 0
+            ? uint48(block.timestamp)
+            : startTime_;
+        proposal.votingEndTimestamp = uint48(
+            proposal.votingStartTimestamp + _votingPeriod
+        );
         proposal.votingStartBlock = uint32(block.number);
         proposal.yesVotes = 0;
         proposal.noVotes = 0;
@@ -368,8 +390,17 @@ contract StrategyV1 is
             proposalId_
         ];
 
-        if (proposal.votingEndTimestamp == 0) {
+        if (proposal.votingStartTimestamp == 0) {
             revert ProposalNotInitialized();
+        }
+
+        if (block.timestamp < proposal.votingStartTimestamp) {
+            if (!_voteCastedBeforeVotingPeriodStarted[proposalId_]) {
+                _voteCastedBeforeVotingPeriodStarted[proposalId_] = true;
+                emit VotingPeriodNotStarted(proposalId_);
+                return;
+            }
+            revert ProposalNotActive();
         }
 
         if (block.timestamp > proposal.votingEndTimestamp) {

--- a/contracts/interfaces/decent/deployables/IModuleAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IModuleAzoriusV1.sol
@@ -27,6 +27,7 @@ interface IModuleAzoriusV1 {
     // --- Enums ---
 
     enum ProposalState {
+        PENDING,
         ACTIVE,
         TIMELOCKED,
         EXECUTABLE,
@@ -121,6 +122,7 @@ interface IModuleAzoriusV1 {
     function updateStrategy(address strategy_) external;
 
     function submitProposal(
+        uint48 proposalStartTime_,
         Transaction[] calldata transactions_,
         string calldata metadata_,
         address proposerAdapter_,

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 interface IStrategyV1 {
     // --- Errors ---
 
+    error InvalidStartTime();
     error InvalidProposerAdapter();
     error NoVotingAdapters();
     error NoProposerAdapters();
@@ -58,6 +59,7 @@ interface IStrategyV1 {
         address indexed freezeVoterContract,
         bool isAuthorized
     );
+    event VotingPeriodNotStarted(uint32 indexed proposalId);
     event VotingPeriodEnded(uint32 indexed proposalId);
 
     // --- Initializer Functions ---
@@ -140,6 +142,10 @@ interface IStrategyV1 {
         view
         returns (address[] memory authorizedFreezeVoters);
 
+    function voteCastedBeforeVotingPeriodStarted(
+        uint32 proposalId_
+    ) external view returns (bool voteCastedBeforeVotingPeriodStarted);
+
     function voteCastedAfterVotingPeriodEnded(
         uint32 proposalId_
     ) external view returns (bool voteCastedAfterVotingPeriodEnded);
@@ -153,7 +159,7 @@ interface IStrategyV1 {
 
     // --- State-Changing Functions ---
 
-    function initializeProposal(uint32 proposalId_) external;
+    function initializeProposal(uint32 proposalId_, uint48 startTime_) external;
 
     function vote(
         uint32 proposalId_,

--- a/contracts/mocks/MockModuleAzoriusV1.sol
+++ b/contracts/mocks/MockModuleAzoriusV1.sol
@@ -65,6 +65,7 @@ contract MockModuleAzoriusV1 is IModuleAzoriusV1 {
     }
 
     function submitProposal(
+        uint48,
         Transaction[] calldata,
         string calldata,
         address,

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -152,13 +152,18 @@ contract MockVotingStrategy is IStrategyV1, VoterResolverV1 {
         return votingStartBlocksMap[proposalId];
     }
 
-    function initializeProposal(uint32 proposalId) external virtual override {
+    function initializeProposal(
+        uint32 proposalId,
+        uint48 startTime
+    ) external virtual override {
         ProposalVotingDetails storage proposal = proposalVotingDetailsMap[
             proposalId
         ];
-        proposal.votingStartTimestamp = uint48(block.timestamp);
+        proposal.votingStartTimestamp = startTime == 0
+            ? uint48(block.timestamp)
+            : startTime;
         proposal.votingEndTimestamp = uint48(
-            block.timestamp + _mockVotingPeriod
+            uint256(proposal.votingStartTimestamp) + _mockVotingPeriod
         );
         proposal.votingStartBlock = uint32(block.number);
         emit ProposalInitialized(
@@ -295,6 +300,10 @@ contract MockVotingStrategy is IStrategyV1, VoterResolverV1 {
     {
         return _authorizedFreezeVotersArray;
     }
+
+    function voteCastedBeforeVotingPeriodStarted(
+        uint32 _proposalId
+    ) external view override returns (bool) {}
 
     function voteCastedAfterVotingPeriodEnded(
         uint32 _proposalId

--- a/test/deployables/modules/ModuleAzoriusV1.test.ts
+++ b/test/deployables/modules/ModuleAzoriusV1.test.ts
@@ -430,7 +430,7 @@ describe('ModuleAzoriusV1', () => {
 
         const tx = await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], proposalMetadata, ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [proposalTx], proposalMetadata, ethers.ZeroAddress, ethers.ZeroHash);
 
         const receipt = await tx.wait();
         if (!receipt) throw new Error('Transaction failed to be mined');
@@ -458,7 +458,7 @@ describe('ModuleAzoriusV1', () => {
         await expect(
           azorius
             .connect(user)
-            .submitProposal([proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash),
+            .submitProposal(0, [proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash),
         ).to.be.revertedWithCustomError(azorius, 'InvalidProposer');
       });
 
@@ -470,7 +470,7 @@ describe('ModuleAzoriusV1', () => {
         await expect(
           azorius
             .connect(proposer)
-            .submitProposal([], proposalMetadata, ethers.ZeroAddress, ethers.ZeroHash),
+            .submitProposal(0, [], proposalMetadata, ethers.ZeroAddress, ethers.ZeroHash),
         )
           .to.emit(azorius, 'ProposalCreated')
           .withArgs(mockStrategyAddress, proposalId, proposer.address, [], proposalMetadata);
@@ -497,7 +497,7 @@ describe('ModuleAzoriusV1', () => {
         // For a zero-transaction proposal that has passed, the state should directly be EXECUTED
         // regardless of the timelock period, because the condition
         // `_proposal.executionCounter == _proposal.txHashes.length` (0 == 0) is met first.
-        expect(currentState).to.equal(3); // EXECUTED
+        expect(currentState).to.equal(4); // EXECUTED
       });
     });
 
@@ -526,7 +526,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
         // Now totalProposalCount is 1. Accessing proposalState(1) should revert.
         await expect(azorius.proposalState(1)).to.be.revertedWithCustomError(
           azorius,
@@ -546,7 +546,7 @@ describe('ModuleAzoriusV1', () => {
         // First create a valid proposal
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         // Try to access an invalid tx index
         await expect(azorius.getProposalTxHash(0, 999)).to.be.reverted; // Will revert with array out of bounds
@@ -570,7 +570,7 @@ describe('ModuleAzoriusV1', () => {
         // Submit proposal with multiple transactions
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [tx1, tx2], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         // Get hashes directly
         const hash1 = await azorius.getTxHash(tx1);
@@ -601,7 +601,7 @@ describe('ModuleAzoriusV1', () => {
         // Submit the proposal
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], metadata, ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [proposalTx], metadata, ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0;
 
         const expectedTxHash = await azorius.getTxHash(proposalTx);
@@ -648,7 +648,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Partial Exec Test', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [tx1, tx2], 'Partial Exec Test', ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0;
 
         // --- Setup for execution ---
@@ -702,7 +702,7 @@ describe('ModuleAzoriusV1', () => {
         // Submit a proposal
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [proposalTx], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         proposalId = 0;
 
@@ -717,29 +717,40 @@ describe('ModuleAzoriusV1', () => {
         await mockStrategy.setIsPassed(proposalId, true);
       });
 
-      it('should track proposal state correctly', async () => {
-        // Initially active (voting not ended)
-        expect(await azorius.proposalState(proposalId)).to.equal(0); // ACTIVE
+      it('should show PENDING state for a proposal with future start time', async () => {
+        const futureStartTime = (await time.latest()) + 3600;
 
-        const currentBlockTimestamp = await time.latest();
+        const newProposalTx = {
+          to: await mockToken.getAddress(),
+          value: 0,
+          data: mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
+          operation: 0, // Call
+        };
 
-        // End voting immediately on the mock strategy
-        await mockStrategy.setVotingTimestamps(proposalId, 0, currentBlockTimestamp);
+        const newProposalId = await azorius.totalProposalCount();
 
-        // Should be in timelock since we set isPassed to true in beforeEach
-        expect(await azorius.proposalState(proposalId)).to.equal(1); // TIMELOCKED
+        // Manually set the timestamps for the upcoming proposal on the mock strategy
+        await mockStrategy.setVotingTimestamps(
+          Number(newProposalId),
+          futureStartTime,
+          futureStartTime + 100, // some voting period
+        );
 
-        // Move past timelock
-        await time.increase(TIMELOCK_PERIOD);
+        await azorius
+          .connect(proposer)
+          .submitProposal(
+            futureStartTime,
+            [newProposalTx],
+            'Future proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+          );
 
-        // Should be executable
-        expect(await azorius.proposalState(proposalId)).to.equal(2); // EXECUTABLE
+        expect(await azorius.proposalState(newProposalId)).to.equal(0); // PENDING
 
-        // Move past execution period
-        await time.increase(EXECUTION_PERIOD);
+        await time.increaseTo(futureStartTime);
 
-        // Should be expired
-        expect(await azorius.proposalState(proposalId)).to.equal(4); // EXPIRED
+        expect(await azorius.proposalState(newProposalId)).to.equal(1); // ACTIVE
       });
 
       it('should execute proposal transactions when executable', async () => {
@@ -788,70 +799,59 @@ describe('ModuleAzoriusV1', () => {
       });
 
       describe('Timestamp-based proposal state transitions', () => {
+        let futureProposalId: number;
+        let startTime: number;
+        const VOTING_PERIOD = 100;
+        let endTime: number;
+
         beforeEach(async () => {
-          // Setup is already done in the parent beforeEach
-          // Just need to reset the proposal state for our tests
-          const currentTimestamp = await time.latest();
+          startTime = (await time.latest()) + 50;
+          endTime = startTime + VOTING_PERIOD;
+          futureProposalId = Number(await azorius.totalProposalCount());
 
-          // Set a future voting end timestamp on mock strategy
-          await mockStrategy.setVotingTimestamps(
-            proposalId,
-            currentTimestamp,
-            currentTimestamp + 100,
+          await mockStrategy.setVotingTimestamps(futureProposalId, startTime, endTime);
+          await mockStrategy.setIsPassed(futureProposalId, true);
+
+          await azorius.connect(proposer).submitProposal(
+            futureProposalId,
+            [
+              {
+                to: await mockToken.getAddress(),
+                value: 0,
+                data: mockToken.interface.encodeFunctionData('transfer', [user.address, 100]),
+                operation: 0,
+              },
+            ],
+            'Future Timestamps Proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
           );
-          await mockStrategy.setIsPassed(proposalId, true);
-        });
-
-        it('should correctly transition between states based on timestamps', async () => {
-          const currentTimestamp = await time.latest();
-
-          // Initially active
-          expect(await azorius.proposalState(proposalId)).to.equal(0); // ACTIVE
-
-          // Advance time just past voting end
-          await time.increaseTo(currentTimestamp + 101);
-
-          // Verify state changes to TIMELOCKED
-          expect(await azorius.proposalState(proposalId)).to.equal(1); // TIMELOCKED
-
-          // Advance time past timelock period
-          await time.increaseTo(currentTimestamp + 101 + TIMELOCK_PERIOD);
-
-          // Verify state changes to EXECUTABLE
-          expect(await azorius.proposalState(proposalId)).to.equal(2); // EXECUTABLE
-
-          // Advance time past execution period
-          await time.increaseTo(currentTimestamp + 101 + TIMELOCK_PERIOD + EXECUTION_PERIOD);
-
-          // Verify state changes to EXPIRED
-          expect(await azorius.proposalState(proposalId)).to.equal(4); // EXPIRED
         });
 
         it('should handle exact boundary conditions in timestamp transitions', async () => {
-          const currentTimestamp = await time.latest();
+          // At the block before start time, it should be PENDING
+          await time.increaseTo(startTime - 1);
+          expect(await azorius.proposalState(futureProposalId)).to.equal(0); // PENDING
 
-          // Set exact timestamps for voting end on mock strategy
-          await mockStrategy.setVotingTimestamps(
-            proposalId,
-            currentTimestamp,
-            currentTimestamp + 100,
-          );
+          // At exactly the voting start time, should be ACTIVE
+          await time.increaseTo(startTime);
+          expect(await azorius.proposalState(futureProposalId)).to.equal(1); // ACTIVE
 
-          // At exactly the voting end time
-          await time.increaseTo(currentTimestamp + 100);
-          expect(await azorius.proposalState(proposalId)).to.equal(0); // Should still be ACTIVE at exactly the end timestamp
+          // At exactly the voting end time, should be ACTIVE
+          await time.increaseTo(endTime);
+          expect(await azorius.proposalState(futureProposalId)).to.equal(1); // Should still be ACTIVE at exactly the end timestamp
 
-          // One second after voting end
-          await time.increaseTo(currentTimestamp + 101);
-          expect(await azorius.proposalState(proposalId)).to.equal(1); // Should be TIMELOCKED after end timestamp
+          // One second after voting end, should be TIMELOCKED
+          await time.increaseTo(endTime + 1);
+          expect(await azorius.proposalState(futureProposalId)).to.equal(2); // Should be TIMELOCKED after end timestamp
 
           // At exactly the end of timelock period
-          await time.increaseTo(currentTimestamp + 101 + TIMELOCK_PERIOD);
-          expect(await azorius.proposalState(proposalId)).to.equal(2); // Should be EXECUTABLE
+          await time.increaseTo(endTime + 1 + TIMELOCK_PERIOD);
+          expect(await azorius.proposalState(futureProposalId)).to.equal(3); // Should be EXECUTABLE
 
           // At exactly the end of execution period
-          await time.increaseTo(currentTimestamp + 101 + TIMELOCK_PERIOD + EXECUTION_PERIOD);
-          expect(await azorius.proposalState(proposalId)).to.equal(4); // Should be EXPIRED at exactly end of execution period
+          await time.increaseTo(endTime + 1 + TIMELOCK_PERIOD + EXECUTION_PERIOD);
+          expect(await azorius.proposalState(futureProposalId)).to.equal(5); // Should be EXPIRED at exactly end of execution period
         });
       });
 
@@ -871,7 +871,7 @@ describe('ModuleAzoriusV1', () => {
         await time.increaseTo(currentTimestamp + 11);
 
         // Verify state is FAILED
-        expect(await azorius.proposalState(proposalIdToFail)).to.equal(5); // FAILED (Enum.ProposalState.FAILED)
+        expect(await azorius.proposalState(proposalIdToFail)).to.equal(6); // FAILED (Enum.ProposalState.FAILED)
       });
     });
 
@@ -907,7 +907,7 @@ describe('ModuleAzoriusV1', () => {
 
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [tx1, tx2], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         // Set voting to passed and move past timelock on mock strategy
         await mockStrategy.setVotingTimestamps(0, 0, 0);
@@ -960,7 +960,7 @@ describe('ModuleAzoriusV1', () => {
           expect(finalExecutionCounter).to.equal(2);
 
           // Verify proposal state is now EXECUTED
-          expect(await azorius.proposalState(0)).to.equal(3); // EXECUTED
+          expect(await azorius.proposalState(0)).to.equal(4); // EXECUTED
         });
       });
 
@@ -968,7 +968,7 @@ describe('ModuleAzoriusV1', () => {
         // Submit proposal with both transactions (proposalId will be 1 for this new proposal)
         await azorius
           .connect(proposer)
-          .submitProposal([tx1, tx2], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [tx1, tx2], 'Test proposal', ethers.ZeroAddress, ethers.ZeroHash);
 
         // Get current block number and set up proposal state for the new proposal (ID 1)
         const currentBlockTimestamp = await time.latest();
@@ -983,7 +983,7 @@ describe('ModuleAzoriusV1', () => {
         await time.increase(10 + TIMELOCK_PERIOD);
 
         // Verify proposal is executable
-        expect(await azorius.proposalState(1)).to.equal(2); // EXECUTABLE
+        expect(await azorius.proposalState(1)).to.equal(3); // EXECUTABLE
 
         // First execute all transactions
         await azorius.executeProposal(1, [tx1, tx2]);
@@ -1016,7 +1016,7 @@ describe('ModuleAzoriusV1', () => {
           proposalId = Number(await azorius.totalProposalCount());
           await azorius
             .connect(proposer)
-            .submitProposal([validTx], 'Test for Reverts', ethers.ZeroAddress, ethers.ZeroHash);
+            .submitProposal(0, [validTx], 'Test for Reverts', ethers.ZeroAddress, ethers.ZeroHash);
 
           // Setup proposal to be EXECUTABLE for most tests here
           const chainTimeBeforeStrategyUpdate = await time.latest();
@@ -1228,7 +1228,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [proposalTx], 'New proposal', ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0; // First proposal
 
         const [, , timelock, ,] = await azorius.getProposal(proposalId);
@@ -1245,7 +1245,13 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(
+            0,
+            [proposalTx],
+            'Existing proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+          );
         const existingProposalId = 0;
 
         // Update the timelock period
@@ -1259,6 +1265,7 @@ describe('ModuleAzoriusV1', () => {
         await azorius
           .connect(proposer)
           .submitProposal(
+            0,
             [proposalTx],
             'New proposal post-update',
             ethers.ZeroAddress,
@@ -1297,7 +1304,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [proposalTx], 'New proposal', ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0;
 
         const [, , , executionPeriod] = await azorius.getProposal(proposalId);
@@ -1313,7 +1320,13 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(
+            0,
+            [proposalTx],
+            'Existing proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+          );
         const existingProposalId = 0;
 
         await azorius.connect(owner).updateExecutionPeriod(NEW_EXECUTION_PERIOD);
@@ -1324,6 +1337,7 @@ describe('ModuleAzoriusV1', () => {
         await azorius
           .connect(proposer)
           .submitProposal(
+            0,
             [proposalTx],
             'New proposal post-update',
             ethers.ZeroAddress,
@@ -1377,7 +1391,7 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'New proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(0, [proposalTx], 'New proposal', ethers.ZeroAddress, ethers.ZeroHash);
         const proposalId = 0;
 
         const [strategyAddress, , , ,] = await azorius.getProposal(proposalId);
@@ -1393,7 +1407,13 @@ describe('ModuleAzoriusV1', () => {
         };
         await azorius
           .connect(proposer)
-          .submitProposal([proposalTx], 'Existing proposal', ethers.ZeroAddress, ethers.ZeroHash);
+          .submitProposal(
+            0,
+            [proposalTx],
+            'Existing proposal',
+            ethers.ZeroAddress,
+            ethers.ZeroHash,
+          );
         const existingProposalId = 0;
 
         await azorius.connect(owner).updateStrategy(newMockStrategyAddress);
@@ -1404,6 +1424,7 @@ describe('ModuleAzoriusV1', () => {
         await azorius
           .connect(proposer)
           .submitProposal(
+            0,
             [proposalTx],
             'New proposal post-update',
             ethers.ZeroAddress,
@@ -1428,6 +1449,7 @@ describe('ModuleAzoriusV1', () => {
         await azorius
           .connect(proposer)
           .submitProposal(
+            0,
             [proposalTx],
             'Existing proposal with mockStrategy',
             ethers.ZeroAddress,
@@ -1461,14 +1483,14 @@ describe('ModuleAzoriusV1', () => {
         await time.increaseTo(initialVotingEnd + 1);
 
         // 6. Check proposalState. It should be TIMELOCKED because it uses mockStrategy's settings.
-        // ProposalState.TIMELOCKED is 1
-        expect(await azorius.proposalState(existingProposalId)).to.equal(1);
+        // ProposalState.TIMELOCKED is 2
+        expect(await azorius.proposalState(existingProposalId)).to.equal(2);
 
         // 7. Further check: advance past timelock period. Should become EXECUTABLE.
         // INITIAL_TIMELOCK_PERIOD is available from the 'Owner Functions' describe block's scope.
         await time.increase(INITIAL_TIMELOCK_PERIOD);
-        // ProposalState.EXECUTABLE is 2
-        expect(await azorius.proposalState(existingProposalId)).to.equal(2);
+        // ProposalState.EXECUTABLE is 3
+        expect(await azorius.proposalState(existingProposalId)).to.equal(3);
       });
     });
   });

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -327,7 +327,7 @@ describe('StrategyV1', () => {
 
     it('should revert if called by a non-strategy admin address', async () => {
       await expect(
-        strategy.connect(nonOwner).initializeProposal(defaultProposalId),
+        strategy.connect(nonOwner).initializeProposal(defaultProposalId, 0),
       ).to.be.revertedWithCustomError(strategy, 'InvalidStrategyAdmin');
     });
 
@@ -337,7 +337,7 @@ describe('StrategyV1', () => {
       const timestampBefore = blockBefore.timestamp;
       const blockNumberBefore = blockBefore.number;
 
-      await expect(strategy.connect(strategyAdmin).initializeProposal(defaultProposalId))
+      await expect(strategy.connect(strategyAdmin).initializeProposal(defaultProposalId, 0))
         .to.emit(strategy, 'ProposalInitialized')
         .withArgs(
           defaultProposalId,
@@ -358,10 +358,39 @@ describe('StrategyV1', () => {
       expect(proposalDetails.abstainVotes).to.equal(0);
     });
 
-    it('should reset vote counts for a re-initialized proposal', async () => {
-      await strategy.connect(strategyAdmin).initializeProposal(defaultProposalId);
+    it('should correctly initialize a proposal with a future start time', async () => {
+      const futureStartTime = (await time.latest()) + 3600; // 1 hour in the future
+      await expect(
+        strategy.connect(strategyAdmin).initializeProposal(defaultProposalId, futureStartTime),
+      ).to.emit(strategy, 'ProposalInitialized');
 
-      await strategy.connect(strategyAdmin).initializeProposal(defaultProposalId); // Re-initialize
+      const proposalDetails = await strategy.proposalVotingDetails(defaultProposalId);
+      expect(proposalDetails.votingStartTimestamp).to.equal(futureStartTime);
+      expect(proposalDetails.votingEndTimestamp).to.equal(futureStartTime + DEFAULT_VOTING_PERIOD);
+    });
+
+    it('should revert if proposal start time is in the past', async () => {
+      const pastStartTime = (await time.latest()) - 3600; // 1 hour in the past
+      await expect(
+        strategy.connect(strategyAdmin).initializeProposal(defaultProposalId, pastStartTime),
+      ).to.be.revertedWithCustomError(strategy, 'InvalidStartTime');
+    });
+
+    it('should use current timestamp if startTime is 0', async () => {
+      const blockBefore = await ethers.provider.getBlock('latest');
+      if (!blockBefore) throw new Error('Failed to get latest block');
+      const timestampBefore = blockBefore.timestamp;
+
+      await strategy.connect(strategyAdmin).initializeProposal(defaultProposalId, 0);
+
+      const proposalDetails = await strategy.proposalVotingDetails(defaultProposalId);
+      expect(proposalDetails.votingStartTimestamp).to.be.closeTo(timestampBefore + 1, 2);
+    });
+
+    it('should reset vote counts for a re-initialized proposal', async () => {
+      await strategy.connect(strategyAdmin).initializeProposal(defaultProposalId, 0);
+
+      await strategy.connect(strategyAdmin).initializeProposal(defaultProposalId, 0); // Re-initialize
 
       const proposalDetails = await strategy.proposalVotingDetails(defaultProposalId);
       expect(proposalDetails.yesVotes).to.equal(0);
@@ -464,7 +493,7 @@ describe('StrategyV1', () => {
 
     beforeEach(async () => {
       proposalId = 1;
-      await strategy.connect(strategyAdmin).initializeProposal(proposalId);
+      await strategy.connect(strategyAdmin).initializeProposal(proposalId, 0);
     });
 
     it('should return correct timestamps and block after proposal initialization', async () => {
@@ -501,7 +530,7 @@ describe('StrategyV1', () => {
 
     beforeEach(async () => {
       proposalId = 1;
-      await strategy.connect(strategyAdmin).initializeProposal(proposalId);
+      await strategy.connect(strategyAdmin).initializeProposal(proposalId, 0);
 
       adapter1Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[1]]);
       adapter2Data = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[2]]);
@@ -517,6 +546,30 @@ describe('StrategyV1', () => {
           },
         ]),
       ).to.be.revertedWithCustomError(strategy, 'ProposalNotInitialized');
+    });
+
+    it('should revert if proposal is not yet active (pending)', async () => {
+      const futureStartTime = (await time.latest()) + 3600; // 1 hour in the future
+      await strategy.connect(strategyAdmin).initializeProposal(proposalId, futureStartTime);
+
+      // First call after period ends should emit event and not revert immediately
+      const tx = await strategy.connect(user1).vote(proposalId, 1, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: adapter1Data,
+        },
+      ]);
+
+      await expect(tx).to.emit(strategy, 'VotingPeriodNotStarted').withArgs(proposalId);
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]),
+      ).to.be.revertedWithCustomError(strategy, 'ProposalNotActive');
     });
 
     it('should revert if voting period has ended', async () => {
@@ -706,7 +759,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(proposalId);
+      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(proposalId, 0);
 
       const weight1 = 60;
       const weight2 = 40;
@@ -795,7 +848,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(proposalId);
+      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(proposalId, 0);
 
       await mockAdapter1.setWeight(user1.address, 10);
       await mockAdapter2.setWeight(user1.address, 20);
@@ -837,7 +890,7 @@ describe('StrategyV1', () => {
   describe('isPassed', () => {
     const PROPOSAL_ID = 1;
     beforeEach(async () => {
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
     });
 
     it('should revert with ProposalNotInitialized if proposal was not initialized', async () => {
@@ -884,7 +937,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await specificStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+      await specificStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
       await mockAdapter1.setWeight(voter1.address, 50n);
       await mockAdapter1.setWeight(voter2.address, 50n);
@@ -925,7 +978,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await specificStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+      await specificStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
       await mockAdapter1.setWeight(voter1.address, 60n); // YES
       await mockAdapter1.setWeight(voter2.address, 10n); // NO
@@ -950,15 +1003,98 @@ describe('StrategyV1', () => {
     });
   });
 
+  describe('voting period not started', () => {
+    const PROPOSAL_ID = 1;
+    const PROPOSAL_ID_2 = 2;
+
+    beforeEach(async () => {
+      await mockAdapter1.setWeight(voter1.address, 100n);
+      await strategy
+        .connect(strategyAdmin)
+        .initializeProposal(PROPOSAL_ID, (await time.latest()) + 50);
+      await time.increase(1n);
+      await strategy
+        .connect(strategyAdmin)
+        .initializeProposal(PROPOSAL_ID_2, (await time.latest()) + 50);
+    });
+
+    it('should initially return false for any proposal', async () => {
+      const result = await strategy.voteCastedBeforeVotingPeriodStarted(PROPOSAL_ID);
+      void expect(result).to.be.false;
+    });
+
+    it('should still return false if voting period is not started but no vote has been cast', async () => {
+      await time.increaseTo(
+        (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingStartTimestamp + 1n,
+      );
+      const result = await strategy.voteCastedBeforeVotingPeriodStarted(PROPOSAL_ID);
+      void expect(result).to.be.false;
+    });
+
+    it('should get set to true after casting a vote before voting period starts', async () => {
+      // Initially false
+      let result = await strategy.voteCastedBeforeVotingPeriodStarted(PROPOSAL_ID);
+      void expect(result).to.be.false;
+
+      await strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
+
+      result = await strategy.voteCastedBeforeVotingPeriodStarted(PROPOSAL_ID);
+      void expect(result).to.be.true;
+    });
+
+    it('should maintain separate states for different proposal IDs', async () => {
+      await strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ethers.ZeroHash,
+        },
+      ]);
+      void expect(await strategy.voteCastedBeforeVotingPeriodStarted(PROPOSAL_ID)).to.be.true;
+      void expect(await strategy.voteCastedBeforeVotingPeriodStarted(PROPOSAL_ID_2)).to.be.false;
+    });
+
+    it('should not emit VotingPeriodNotStarted event when casting a vote after voting period starts', async () => {
+      await time.increaseTo(
+        (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingStartTimestamp + 1n,
+      );
+      await expect(
+        strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]),
+      ).not.to.emit(strategy, 'VotingPeriodNotStarted');
+    });
+
+    it('should emit VotingPeriodNotStarted event when casting a vote before voting period starts', async () => {
+      await expect(
+        strategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: ethers.ZeroHash,
+          },
+        ]),
+      )
+        .to.emit(strategy, 'VotingPeriodNotStarted')
+        .withArgs(PROPOSAL_ID);
+    });
+  });
+
   describe('voting period ended', () => {
     const PROPOSAL_ID = 1;
     const PROPOSAL_ID_2 = 2;
 
     beforeEach(async () => {
       await mockAdapter1.setWeight(voter1.address, 50n);
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
       await time.increase(1n);
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID_2);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID_2, 0);
     });
 
     it('should initially return false for any proposal', async () => {
@@ -1092,7 +1228,7 @@ describe('StrategyV1', () => {
     const PROPOSAL_ID = 1;
 
     beforeEach(async () => {
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
     });
 
     describe('isQuorumMet', () => {
@@ -1114,7 +1250,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 40n);
@@ -1144,7 +1280,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 41n); // Exceeds
@@ -1174,7 +1310,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
         await mockAdapter1.setWeight(voter1.address, 50n);
         await mockAdapter1.setWeight(voter2.address, 40n); // 90 total, < 100
@@ -1204,7 +1340,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+        await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
         await mockAdapter1.setWeight(voter1.address, 10n); // Only NO votes
         await qStrategy.connect(voter1).vote(PROPOSAL_ID, 0 /* NO */, [
@@ -1313,7 +1449,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
         await mockAdapter1.setWeight(voter1.address, 101n);
         await mockAdapter1.setWeight(voter2.address, 100n);
@@ -1342,7 +1478,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 100n);
@@ -1372,7 +1508,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await bStrategy.connect(voter1).vote(PROPOSAL_ID, 1 /* YES */, [
@@ -1395,7 +1531,7 @@ describe('StrategyV1', () => {
           defaultInitialProposerAdapters,
           lightAccountFactoryMockAddress,
         );
-        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+        await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 1n);
@@ -1613,7 +1749,8 @@ describe('StrategyV1', () => {
     const ADAPTER_VOTE_DATA = ethers.ZeroHash;
 
     beforeEach(async () => {
-      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+      await mockAdapter1.setWeight(voter1.address, 100n);
+      await strategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
     });
 
     it('should return true for a valid vote configuration', async () => {
@@ -1641,12 +1778,33 @@ describe('StrategyV1', () => {
       void expect(isValid).to.be.false;
     });
 
+    it('should return false if the voting period has not started', async () => {
+      // Set the proposal to start in the future
+      await strategy
+        .connect(strategyAdmin)
+        .initializeProposal(PROPOSAL_ID, (await time.latest()) + 50);
+
+      // Trigger the start of the voting period
+      await strategy.connect(voter1).vote(PROPOSAL_ID, VOTE_TYPE_YES, [
+        {
+          votingAdapter: await mockAdapter1.getAddress(),
+          adapterVoteData: ADAPTER_VOTE_DATA,
+        },
+      ]);
+
+      const isValid = await strategy.validStrategyVote(voter1.address, PROPOSAL_ID, VOTE_TYPE_YES, [
+        { votingAdapter: await mockAdapter1.getAddress(), adapterVoteData: ADAPTER_VOTE_DATA },
+      ]);
+
+      void expect(isValid).to.be.false;
+    });
+
     it('should return false if the voting period has ended', async () => {
       const proposalDetails = await strategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
       // Trigger the end of the voting period
-      await strategy.connect(voter1).vote(PROPOSAL_ID, 1, [
+      await strategy.connect(voter1).vote(PROPOSAL_ID, VOTE_TYPE_YES, [
         {
           votingAdapter: await mockAdapter1.getAddress(),
           adapterVoteData: ADAPTER_VOTE_DATA,
@@ -1721,7 +1879,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
       await mockAdapter1.setWeight(voter1.address, 50n);
       await mockAdapter2.setWeight(voter1.address, 50n);
@@ -1754,7 +1912,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters,
         lightAccountFactoryMockAddress,
       );
-      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
+      await multiAdapterStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID, 0);
 
       await mockAdapter1.setWeight(voter1.address, 50n);
       await mockAdapter2.setValidVote(voter1.address, false, 50n); // This one will be invalid


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/346

Fixes [ENG-1126](https://linear.app/decent-labs/issue/ENG-1126/feature-implement-future-dated-proposals)

Adds support for creating proposals with a start time in the future. This allows for proposals to be submitted now but only become active for voting at a specified later time.

This change introduces a `PENDING` state to the proposal lifecycle and a `proposalStartTime` parameter to the proposal creation process. The system now includes robust checks to prevent voting on pending proposals and to handle state transitions correctly.

To support off-chain validation for Account Abstraction, this feature also introduces state tracking for vote attempts made before the voting period begins (`voteCastedBeforeVotingPeriodStarted`). This allows bundlers to simulate and predict the validity of vote transactions without relying on `block.timestamp`.

- Introduced a `PENDING` state in the `ProposalState` enum.
- Added `proposalStartTime` parameter to `submitProposal` and `initializeProposal` functions.
- Implemented logic in `StrategyV1` and `ModuleAzoriusV1` to handle the new `PENDING` state and future start times.
- Added `voteCastedBeforeVotingPeriodStarted` state and `VotingPeriodNotStarted` event for reliable off-chain validation.
- Updated all relevant tests to cover the full lifecycle of future-dated proposals, including state transitions and voting restrictions.