### PR TITLE
refactor(voting): Rename initialization functions for consistency

### DIFF
--- a/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
@@ -42,7 +42,7 @@ contract FreezeVotingAzoriusV1 is
         address parentAzorius_,
         address lightAccountFactory_
     ) public virtual override initializer {
-        __BaseFreezeVotingV1_init(
+        __FreezeVotingBaseV1_init(
             owner_,
             freezeProposalPeriod_,
             freezePeriod_,

--- a/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
@@ -27,7 +27,7 @@ abstract contract FreezeVotingBaseV1 is
         _disableInitializers();
     }
 
-    function __BaseFreezeVotingV1_init(
+    function __FreezeVotingBaseV1_init(
         address owner_,
         uint32 freezeProposalPeriod_,
         uint32 freezePeriod_,

--- a/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
@@ -40,7 +40,7 @@ contract FreezeVotingMultisigV1 is
         address parentSafe_,
         address lightAccountFactory_
     ) public virtual override initializer {
-        __BaseFreezeVotingV1_init(
+        __FreezeVotingBaseV1_init(
             owner_,
             freezeProposalPeriod_,
             freezePeriod_,

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterBaseV1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterBaseV1.sol
@@ -36,7 +36,7 @@ abstract contract VotingAdapterBaseV1 is IVotingAdapterBaseV1, Initializable {
         _disableInitializers();
     }
 
-    function __BaseVotingAdapterV1_init(
+    function __VotingAdapterBaseV1_init(
         address strategy_
     ) internal onlyInitializing {
         _strategy = IStrategyV1(strategy_);

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
@@ -43,7 +43,7 @@ contract VotingAdapterERC20V1 is
         address strategy_,
         uint256 weightPerToken_
     ) public virtual override initializer {
-        __BaseVotingAdapterV1_init(strategy_);
+        __VotingAdapterBaseV1_init(strategy_);
         _token = IVotes(token_);
         _weightPerToken = weightPerToken_;
         _tokenClockMode = ClockModeLib.getClockMode(token_);

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
@@ -38,7 +38,7 @@ contract VotingAdapterERC721V1 is
         address strategy_,
         uint256 weightPerToken_
     ) public virtual override initializer {
-        __BaseVotingAdapterV1_init(strategy_);
+        __VotingAdapterBaseV1_init(strategy_);
         _token = IERC721(token_);
         _weightPerToken = weightPerToken_;
     }

--- a/contracts/mocks/concretes/deployables/strategies/adapters/ConcreteVotingAdapterBaseV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/adapters/ConcreteVotingAdapterBaseV1.sol
@@ -10,7 +10,7 @@ contract ConcreteVotingAdapterBaseV1 is VotingAdapterBaseV1 {
     }
 
     function initialize(address strategy_) external initializer {
-        __BaseVotingAdapterV1_init(strategy_);
+        __VotingAdapterBaseV1_init(strategy_);
     }
 
     // Implement IBaseVotingAdapterV1 functions


### PR DESCRIPTION
This commit updates the initialization function names across various voting-related contracts to ensure uniformity and clarity. The changes include renaming `__BaseFreezeVotingV1_init` to `__FreezeVotingBaseV1_init` in `FreezeVotingAzoriusV1` and `FreezeVotingMultisigV1`, as well as renaming `__BaseVotingAdapterV1_init` to `__VotingAdapterBaseV1_init` in the voting adapter contracts. This refactoring aims to enhance code readability and maintainability.