### PR TITLE
refactor(module-azorius): Decouple strategy from initialization

### DIFF
--- a/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
@@ -42,7 +42,7 @@ contract FreezeVotingAzoriusV1 is
         address parentAzorius_,
         address lightAccountFactory_
     ) public virtual override initializer {
-        __BaseFreezeVotingV1_init(
+        __FreezeVotingBaseV1_init(
             owner_,
             freezeProposalPeriod_,
             freezePeriod_,

--- a/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
@@ -27,7 +27,7 @@ abstract contract FreezeVotingBaseV1 is
         _disableInitializers();
     }
 
-    function __BaseFreezeVotingV1_init(
+    function __FreezeVotingBaseV1_init(
         address owner_,
         uint32 freezeProposalPeriod_,
         uint32 freezePeriod_,

--- a/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
@@ -40,7 +40,7 @@ contract FreezeVotingMultisigV1 is
         address parentSafe_,
         address lightAccountFactory_
     ) public virtual override initializer {
-        __BaseFreezeVotingV1_init(
+        __FreezeVotingBaseV1_init(
             owner_,
             freezeProposalPeriod_,
             freezePeriod_,

--- a/contracts/deployables/modules/ModuleAzoriusV1.sol
+++ b/contracts/deployables/modules/ModuleAzoriusV1.sol
@@ -67,21 +67,20 @@ contract ModuleAzoriusV1 is
         address owner_,
         address avatar_,
         address target_,
-        address strategy_,
         uint32 timelockPeriod_,
         uint32 executionPeriod_
     ) public virtual override initializer {
-        __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
+        __Ownable_init(owner_);
 
-        setAvatar(avatar_);
-        setTarget(target_);
+        // avoids onlyOwner requirement on setAvatar and setTarget
+        avatar = avatar_;
+        target = target_;
+        emit AvatarSet(address(0), avatar_);
+        emit TargetSet(address(0), target_);
 
-        _updateStrategy(strategy_);
         _updateTimelockPeriod(timelockPeriod_);
         _updateExecutionPeriod(executionPeriod_);
-
-        _transferOwnership(owner_);
     }
 
     function setUp(
@@ -91,21 +90,13 @@ contract ModuleAzoriusV1 is
             address owner_,
             address avatar_,
             address target_,
-            address strategy_,
             uint32 timelockPeriod_,
             uint32 executionPeriod_
         ) = abi.decode(
                 initializeParams_,
-                (address, address, address, address, uint32, uint32)
+                (address, address, address, uint32, uint32)
             );
-        initialize(
-            owner_,
-            avatar_,
-            target_,
-            strategy_,
-            timelockPeriod_,
-            executionPeriod_
-        );
+        initialize(owner_, avatar_, target_, timelockPeriod_, executionPeriod_);
     }
 
     // ======================================================================

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -276,6 +276,10 @@ contract StrategyV1 is
         uint8 voteType_,
         VotingAdapterVoteData[] calldata votingAdaptersData_
     ) public view virtual override returns (bool) {
+        if (votingAdaptersData_.length == 0) {
+            return false;
+        }
+
         // get the proposal start and end timestamps to determine if the proposal exists
         ProposalVotingDetails storage details = _proposalVotingDetails[
             proposalId_
@@ -309,6 +313,7 @@ contract StrategyV1 is
                 return false;
             }
 
+            // validVotingAdapterVote should NEVER return (true, 0)
             (bool isValid, uint256 votingWeight) = IVotingAdapterBaseV1(
                 votingAdapter
             ).validVotingAdapterVote(
@@ -328,11 +333,7 @@ contract StrategyV1 is
             }
         }
 
-        if (totalVotingWeight == 0) {
-            return false;
-        }
-
-        return true;
+        return totalVotingWeight > 0;
     }
 
     // --- State-Changing Functions ---
@@ -363,6 +364,10 @@ contract StrategyV1 is
         uint8 voteType_,
         VotingAdapterVoteData[] calldata votingAdaptersData
     ) public virtual override {
+        if (votingAdaptersData.length == 0) {
+            revert NoVotingAdapters();
+        }
+
         address resolvedVoter = voter(msg.sender);
         ProposalVotingDetails storage proposal = _proposalVotingDetails[
             proposalId_
@@ -392,20 +397,23 @@ contract StrategyV1 is
                 revert InvalidVotingAdapter(votingAdapter);
             }
 
-            totalWeightForThisVoteTransaction += IVotingAdapterBaseV1(
-                votingAdapter
-            ).recordVote(
+            uint256 votingWeight = IVotingAdapterBaseV1(votingAdapter)
+                .recordVote(
                     resolvedVoter,
                     proposalId_,
                     votingAdapterVoteData.adapterVoteData
                 );
 
+            if (votingWeight == 0) {
+                revert NoVotingAdapterVotingWeight(votingAdapter);
+            }
+
+            totalWeightForThisVoteTransaction += votingWeight;
+
             unchecked {
                 ++i;
             }
         }
-
-        if (totalWeightForThisVoteTransaction == 0) revert NoVotingWeight();
 
         if (voteType_ == uint8(VoteType.YES)) {
             proposal.yesVotes += totalWeightForThisVoteTransaction;

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterBaseV1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterBaseV1.sol
@@ -36,7 +36,7 @@ abstract contract VotingAdapterBaseV1 is IVotingAdapterBaseV1, Initializable {
         _disableInitializers();
     }
 
-    function __BaseVotingAdapterV1_init(
+    function __VotingAdapterBaseV1_init(
         address strategy_
     ) internal onlyInitializing {
         _strategy = IStrategyV1(strategy_);

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IVotingAdapterERC20V1} from "../../../../interfaces/decent/deployables/IVotingAdapterERC20V1.sol";
 import {IVotingAdapterBaseV1} from "../../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
+import {IStrategyV1} from "../../../../interfaces/decent/deployables/IStrategyV1.sol";
 import {ClockMode} from "../../../../interfaces/decent/ClockMode.sol";
 import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
 import {VotingAdapterBaseV1} from "./VotingAdapterBaseV1.sol";
@@ -121,8 +122,14 @@ contract VotingAdapterERC20V1 is
         // get the number of checkpoints for the voter
         uint32 numCheckpoints = governanceToken.numCheckpoints(voter_);
 
-        (uint48 startTimestamp, uint48 endTimestamp) = _strategy
-            .getVotingTimestamps(proposalId_);
+        IStrategyV1.ProposalVotingDetails memory details = _strategy
+            .proposalVotingDetails(proposalId_);
+
+        if (details.votingEndTimestamp == 0) {
+            return (false, 0); // Proposal not initialized
+        }
+        uint48 startTimestamp = details.votingStartTimestamp;
+        uint48 endTimestamp = details.votingEndTimestamp;
 
         // if there are no checkpoints, user has no voting weight
         if (numCheckpoints == 0) {
@@ -280,7 +287,7 @@ contract VotingAdapterERC20V1 is
             startTimepoint = _strategy.getVotingStartBlock(proposalId_);
         }
 
-        if (startTimepoint == 0) revert ProposalNotReadyForSnapshot();
+        if (startTimepoint == 0) revert ProposalNotInitialized();
         return _calculateWeightAtSnapshot(voter_, startTimepoint);
     }
 }

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
@@ -44,7 +44,7 @@ contract VotingAdapterERC20V1 is
         address strategy_,
         uint256 weightPerToken_
     ) public virtual override initializer {
-        __BaseVotingAdapterV1_init(strategy_);
+        __VotingAdapterBaseV1_init(strategy_);
         _token = IVotes(token_);
         _weightPerToken = weightPerToken_;
         _tokenClockMode = ClockModeLib.getClockMode(token_);

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
+import {IStrategyV1} from "../../../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IVotingAdapterERC721V1} from "../../../../interfaces/decent/deployables/IVotingAdapterERC721V1.sol";
 import {IVotingAdapterBaseV1} from "../../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
@@ -61,6 +62,11 @@ contract VotingAdapterERC721V1 is
         uint32 proposalId_,
         uint256 tokenId_
     ) public view virtual override returns (bool) {
+        if (
+            _strategy.proposalVotingDetails(proposalId_).votingEndTimestamp == 0
+        ) {
+            revert ProposalNotInitialized();
+        }
         return _tokenIdUsedForVote[proposalId_][tokenId_];
     }
 
@@ -126,14 +132,16 @@ contract VotingAdapterERC721V1 is
         uint32 proposalId_,
         bytes calldata adapterVoteData_
     ) public view virtual override returns (bool, uint256) {
-        uint256[] memory allTokenIds = abi.decode(
-            adapterVoteData_,
-            (uint256[])
-        );
+        if (
+            _strategy.proposalVotingDetails(proposalId_).votingEndTimestamp == 0
+        ) {
+            return (false, 0);
+        }
+        uint256[] memory allTokenIds = _decodeTokenIds(adapterVoteData_);
         (
             uint256 votingWeight,
             uint256[] memory validTokenIds
-        ) = _getValidTokenIds(voter_, proposalId_, allTokenIds);
+        ) = _getValidTokenIdsSafe(voter_, proposalId_, allTokenIds);
 
         if (validTokenIds.length != allTokenIds.length || votingWeight == 0) {
             return (false, 0);
@@ -150,13 +158,13 @@ contract VotingAdapterERC721V1 is
         bytes calldata adapterVoteData_
     ) public virtual override onlyAuthorizedFreezeVoter returns (uint256) {
         uint256[] memory tokenIds = _decodeTokenIds(adapterVoteData_);
-        if (tokenIds.length == 0) {
-            revert NoTokenIdsPassed();
+        uint256[] memory uniqueTokenIds = _getUniqueTokenIds(tokenIds);
+        if (uniqueTokenIds.length != tokenIds.length) {
+            revert DuplicateTokenIds();
         }
 
-        uint256 currentWeightCasted = 0;
-        for (uint256 i = 0; i < tokenIds.length; ) {
-            uint256 tokenId = tokenIds[i];
+        for (uint256 i = 0; i < uniqueTokenIds.length; ) {
+            uint256 tokenId = uniqueTokenIds[i];
             if (_token.ownerOf(tokenId) != voter_) {
                 revert TokenIdNotOwnedByVoter(tokenId);
             }
@@ -170,24 +178,26 @@ contract VotingAdapterERC721V1 is
             _tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract[msg.sender][
                 freezeProposalSnapshotAndId_
             ][tokenId] = true;
-            currentWeightCasted += _weightPerToken;
+
             unchecked {
                 ++i;
             }
         }
 
-        if (currentWeightCasted == 0) {
+        uint256 totalWeight = uniqueTokenIds.length * _weightPerToken;
+
+        if (totalWeight == 0) {
             revert NoFreezeVotingWeight();
         }
 
         emit FreezeVoteRecorded(
             voter_,
             freezeProposalSnapshotAndId_,
-            currentWeightCasted,
+            totalWeight,
             adapterVoteData_
         );
 
-        return currentWeightCasted;
+        return totalWeight;
     }
 
     function recordVote(
@@ -195,13 +205,20 @@ contract VotingAdapterERC721V1 is
         uint32 proposalId_,
         bytes calldata adapterVoteData_
     ) public virtual override onlyStrategy returns (uint256) {
-        uint256[] memory tokenIds = _decodeTokenIds(adapterVoteData_);
-        if (tokenIds.length == 0) {
-            revert NoTokenIdsPassed();
+        if (
+            _strategy.proposalVotingDetails(proposalId_).votingEndTimestamp == 0
+        ) {
+            revert ProposalNotInitialized();
         }
 
-        for (uint256 i = 0; i < tokenIds.length; ) {
-            uint256 tokenId = tokenIds[i];
+        uint256[] memory tokenIds = _decodeTokenIds(adapterVoteData_);
+        uint256[] memory uniqueTokenIds = _getUniqueTokenIds(tokenIds);
+        if (uniqueTokenIds.length != tokenIds.length) {
+            revert DuplicateTokenIds();
+        }
+
+        for (uint256 i = 0; i < uniqueTokenIds.length; ) {
+            uint256 tokenId = uniqueTokenIds[i];
             if (_token.ownerOf(tokenId) != voter_) {
                 revert TokenIdNotOwnedByVoter(tokenId);
             }
@@ -215,7 +232,7 @@ contract VotingAdapterERC721V1 is
             }
         }
 
-        uint256 weightCasted = tokenIds.length * _weightPerToken;
+        uint256 weightCasted = uniqueTokenIds.length * _weightPerToken;
 
         emit VoteRecorded(voter_, proposalId_, weightCasted, adapterVoteData_);
 
@@ -407,7 +424,7 @@ contract VotingAdapterERC721V1 is
         return unusedTokenIds;
     }
 
-    function _getValidTokenIds(
+    function _getValidTokenIdsSafe(
         address voter_,
         uint32 proposalId_,
         uint256[] memory allTokenIds_
@@ -423,5 +440,19 @@ contract VotingAdapterERC721V1 is
         );
 
         return (unusedTokenIds.length * _weightPerToken, unusedTokenIds);
+    }
+
+    function _getValidTokenIds(
+        address voter_,
+        uint32 proposalId_,
+        uint256[] memory allTokenIds_
+    ) internal view virtual returns (uint256, uint256[] memory) {
+        if (
+            _strategy.proposalVotingDetails(proposalId_).votingEndTimestamp == 0
+        ) {
+            revert ProposalNotInitialized();
+        }
+
+        return _getValidTokenIdsSafe(voter_, proposalId_, allTokenIds_);
     }
 }

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
@@ -39,7 +39,7 @@ contract VotingAdapterERC721V1 is
         address strategy_,
         uint256 weightPerToken_
     ) public virtual override initializer {
-        __BaseVotingAdapterV1_init(strategy_);
+        __VotingAdapterBaseV1_init(strategy_);
         _token = IERC721(token_);
         _weightPerToken = weightPerToken_;
     }

--- a/contracts/interfaces/decent/deployables/IModuleAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IModuleAzoriusV1.sol
@@ -55,7 +55,6 @@ interface IModuleAzoriusV1 {
         address owner_,
         address avatar_,
         address target_,
-        address strategy_,
         uint32 timelockPeriod_,
         uint32 executionPeriod_
     ) external;

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -10,7 +10,7 @@ interface IStrategyV1 {
     error InvalidBasisNumerator();
     error InvalidStrategyAdmin();
     error ProposalNotActive();
-    error NoVotingWeight();
+    error NoVotingAdapterVotingWeight(address votingAdapter);
     error InvalidVoteType();
     error ProposalNotInitialized();
     error InvalidVotingAdapter(address votingAdapter);

--- a/contracts/interfaces/decent/deployables/IVotingAdapterBaseV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotingAdapterBaseV1.sol
@@ -5,6 +5,7 @@ interface IVotingAdapterBaseV1 {
     // --- Errors ---
 
     error NotStrategy();
+    error ProposalNotInitialized();
     error UnauthorizedFreezeVoter(address caller);
     error NoFreezeVotingWeight();
 

--- a/contracts/interfaces/decent/deployables/IVotingAdapterERC20V1.sol
+++ b/contracts/interfaces/decent/deployables/IVotingAdapterERC20V1.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.30;
 interface IVotingAdapterERC20V1 {
     // --- Errors ---
 
-    error ProposalNotReadyForSnapshot();
     error AlreadyVoted();
 
     // --- Initializer Functions ---

--- a/contracts/interfaces/decent/deployables/IVotingAdapterERC721V1.sol
+++ b/contracts/interfaces/decent/deployables/IVotingAdapterERC721V1.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.30;
 interface IVotingAdapterERC721V1 {
     // --- Errors ---
 
-    error NoTokenIdsPassed();
     error TokenIdAlreadyUsedForVote(uint256 tokenId);
     error TokenIdNotOwnedByVoter(uint256 tokenId);
+    error DuplicateTokenIds();
 
     // --- Initializer Functions ---
 

--- a/contracts/mocks/MockModuleAzoriusV1.sol
+++ b/contracts/mocks/MockModuleAzoriusV1.sol
@@ -17,11 +17,9 @@ contract MockModuleAzoriusV1 is IModuleAzoriusV1 {
         address /* owner_ */,
         address /* avatar_ */,
         address /* target_ */,
-        address strategy_,
         uint32 timelockPeriod_,
         uint32 executionPeriod_
     ) external virtual {
-        currentStrategy = strategy_;
         currentTimelockPeriod = timelockPeriod_;
         currentExecutionPeriod = executionPeriod_;
     }

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -156,11 +156,16 @@ contract MockVotingStrategy is IStrategyV1, VoterResolverV1 {
         ProposalVotingDetails storage proposal = proposalVotingDetailsMap[
             proposalId
         ];
+
         proposal.votingStartTimestamp = uint48(block.timestamp);
         proposal.votingEndTimestamp = uint48(
             block.timestamp + _mockVotingPeriod
         );
         proposal.votingStartBlock = uint32(block.number);
+
+        votingStartTimestampsMap[proposalId] = proposal.votingStartTimestamp;
+        votingEndTimestampsMap[proposalId] = proposal.votingEndTimestamp;
+
         emit ProposalInitialized(
             proposalId,
             proposal.votingStartTimestamp,

--- a/contracts/mocks/concretes/deployables/strategies/adapters/ConcreteVotingAdapterBaseV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/adapters/ConcreteVotingAdapterBaseV1.sol
@@ -10,7 +10,7 @@ contract ConcreteVotingAdapterBaseV1 is VotingAdapterBaseV1 {
     }
 
     function initialize(address strategy_) external initializer {
-        __BaseVotingAdapterV1_init(strategy_);
+        __VotingAdapterBaseV1_init(strategy_);
     }
 
     // Implement IBaseVotingAdapterV1 functions

--- a/test/deployables/modules/ModuleAzoriusV1.test.ts
+++ b/test/deployables/modules/ModuleAzoriusV1.test.ts
@@ -32,20 +32,22 @@ async function deployAzoriusProxy(
   executionPeriod: number,
 ): Promise<ModuleAzoriusV1> {
   // Combine selector and encoded params
-  const fullInitData =
-    ModuleAzoriusV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(
-        ['address', 'address', 'address', 'address', 'uint32', 'uint32'],
-        [owner.address, avatar, target, strategyAddress, timelockPeriod, executionPeriod],
-      )
-      .slice(2);
+
+  const fullInitData = ModuleAzoriusV1__factory.createInterface().encodeFunctionData('initialize', [
+    owner.address,
+    avatar,
+    target,
+    timelockPeriod,
+    executionPeriod,
+  ]);
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return ModuleAzoriusV1__factory.connect(await proxy.getAddress(), owner);
+  const azoriusInstance = ModuleAzoriusV1__factory.connect(await proxy.getAddress(), owner);
+  await azoriusInstance.updateStrategy(strategyAddress);
+  return azoriusInstance;
 }
 
 // Helper function for deploying AzoriusV1 using setUp instead of initialize
@@ -62,8 +64,8 @@ async function deployAzoriusProxyWithSetUp(
   // Create the call to setUp with the encoded parameters
   const fullInitData = ModuleAzoriusV1__factory.createInterface().encodeFunctionData('setUp', [
     ethers.AbiCoder.defaultAbiCoder().encode(
-      ['address', 'address', 'address', 'address', 'uint32', 'uint32'],
-      [owner.address, avatar, target, strategyAddress, timelockPeriod, executionPeriod],
+      ['address', 'address', 'address', 'uint32', 'uint32'],
+      [owner.address, avatar, target, timelockPeriod, executionPeriod],
     ),
   ]);
 
@@ -71,7 +73,9 @@ async function deployAzoriusProxyWithSetUp(
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
 
   // Return a contract instance connected to the proxy
-  return ModuleAzoriusV1__factory.connect(await proxy.getAddress(), owner);
+  const azoriusInstance = ModuleAzoriusV1__factory.connect(await proxy.getAddress(), owner);
+  await azoriusInstance.updateStrategy(strategyAddress);
+  return azoriusInstance;
 }
 
 describe('ModuleAzoriusV1', () => {
@@ -296,14 +300,7 @@ describe('ModuleAzoriusV1', () => {
         );
 
         await expect(
-          azorius.initialize(
-            owner.address,
-            ethers.ZeroAddress,
-            ethers.ZeroAddress,
-            mockStrategyAddress,
-            0,
-            0,
-          ),
+          azorius.initialize(owner.address, ethers.ZeroAddress, ethers.ZeroAddress, 0, 0),
         ).to.be.revertedWithCustomError(azorius, 'InvalidInitialization');
       });
 
@@ -315,7 +312,6 @@ describe('ModuleAzoriusV1', () => {
             owner.address,
             ethers.ZeroAddress,
             ethers.ZeroAddress,
-            mockStrategyAddress,
             0,
             0,
           ),

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -575,7 +575,7 @@ describe('StrategyV1', () => {
       ).to.be.revertedWithCustomError(strategy, 'ProposalNotActive');
     });
 
-    it('should revert if total weight cast is zero (e.g., adapter.recordVote returns 0)', async () => {
+    it('should revert if single adapter has zero vote weight', async () => {
       await mockAdapter1.setWeight(user1.address, 0);
       await expect(
         strategy.connect(user1).vote(proposalId, 1, [
@@ -584,7 +584,41 @@ describe('StrategyV1', () => {
             adapterVoteData: adapter1Data,
           },
         ]),
-      ).to.be.revertedWithCustomError(strategy, 'NoVotingWeight');
+      )
+        .to.be.revertedWithCustomError(strategy, 'NoVotingAdapterVotingWeight')
+        .withArgs(await mockAdapter1.getAddress());
+    });
+
+    it('should revert if one adapter of many has zero vote weight', async () => {
+      strategy = await deployStrategyProxy(
+        strategyAdmin.address,
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        [await mockAdapter1.getAddress(), await mockAdapter2.getAddress()],
+        defaultInitialProposerAdapters,
+        lightAccountFactoryMockAddress,
+      );
+
+      await strategy.connect(strategyAdmin).initializeProposal(proposalId);
+
+      await mockAdapter1.setWeight(user1.address, 50);
+      await mockAdapter2.setWeight(user1.address, 0);
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1, [
+          {
+            votingAdapter: await mockAdapter1.getAddress(),
+            adapterVoteData: adapter1Data,
+          },
+          {
+            votingAdapter: await mockAdapter2.getAddress(),
+            adapterVoteData: adapter2Data,
+          },
+        ]),
+      )
+        .to.be.revertedWithCustomError(strategy, 'NoVotingAdapterVotingWeight')
+        .withArgs(await mockAdapter2.getAddress());
     });
 
     it('should revert on invalid voteType', async () => {
@@ -831,6 +865,12 @@ describe('StrategyV1', () => {
       const dataHashAdapter1 = ethers.keccak256(adapter1DataForVoter1);
       void expect(await mockAdapter1.hasRecordedVote(user1.address, proposalId, dataHashAdapter1))
         .to.be.false;
+    });
+
+    it('should revert if attempting to vote with no voting adapters', async () => {
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1 /* YES */, []),
+      ).to.be.revertedWithCustomError(strategy, 'NoVotingAdapters');
     });
   });
 
@@ -1774,6 +1814,20 @@ describe('StrategyV1', () => {
           },
         ],
       );
+      void expect(isValid).to.be.false;
+    });
+
+    it('should return false if no voting adapters are provided', async () => {
+      // Setup: Ensure the voter WOULD have valid weight if an adapter was passed.
+      await mockAdapter1.setWeight(voter1.address, 100n);
+
+      const isValid = await strategy.validStrategyVote(
+        voter1.address,
+        PROPOSAL_ID,
+        VOTE_TYPE_YES,
+        [], // Empty array is the reason for returning false
+      );
+
       void expect(isValid).to.be.false;
     });
   });

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
@@ -216,10 +216,11 @@ describe('VotingAdapterERC20V1', () => {
       });
 
       it('should revert if strategy returns startTimestamp as 0', async () => {
+        await mockStrategy.initializeProposal(proposalId);
         await mockStrategy.setVotingTimestamps(proposalId, 0, 1000);
         await expect(
           adapter.weightOf(user1Signer.address, proposalId, mockExtraData),
-        ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
+        ).to.be.revertedWithCustomError(adapter, 'ProposalNotInitialized');
       });
     });
 
@@ -243,7 +244,7 @@ describe('VotingAdapterERC20V1', () => {
         await mockStrategy.setVotingStartBlock(proposalId, 0);
         await expect(
           adapter.weightOf(user1Signer.address, proposalId, mockExtraData),
-        ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
+        ).to.be.revertedWithCustomError(adapter, 'ProposalNotInitialized');
       });
     });
 
@@ -435,7 +436,7 @@ describe('VotingAdapterERC20V1', () => {
       expect(weight).to.equal(0);
     });
 
-    it('should revert with ProposalNotReadyForSnapshot if strategy returns startTimestamp as 0 (Timestamp Mode)', async () => {
+    it('should revert with ProposalNotInitialized if strategy returns startTimestamp as 0 (Timestamp Mode)', async () => {
       await setupAdapterForRecordVote(0);
       await strategy.setVotingTimestamps(proposalId, 0, 1000);
       await expect(
@@ -449,10 +450,10 @@ describe('VotingAdapterERC20V1', () => {
             },
           ],
         ),
-      ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
+      ).to.be.revertedWithCustomError(adapter, 'ProposalNotInitialized');
     });
 
-    it('should revert with ProposalNotReadyForSnapshot if strategy returns startBlock as 0 (BlockNumber Mode)', async () => {
+    it('should revert with ProposalNotInitialized if strategy returns startBlock as 0 (BlockNumber Mode)', async () => {
       await setupAdapterForRecordVote(1);
       await strategy.setVotingStartBlock(proposalId, 0);
       await expect(
@@ -466,7 +467,7 @@ describe('VotingAdapterERC20V1', () => {
             },
           ],
         ),
-      ).to.be.revertedWithCustomError(adapter, 'ProposalNotReadyForSnapshot');
+      ).to.be.revertedWithCustomError(adapter, 'ProposalNotInitialized');
     });
   });
 
@@ -848,14 +849,6 @@ describe('VotingAdapterERC20V1', () => {
             ZERO_EXTRA_DATA,
           );
 
-        // Check returned value (Hardhat Chai Matchers V5 syntax for return value needs a bit more setup or direct call)
-        // For simplicity, we can check the event args which already confirm weightCasted.
-        // Alternatively, for a direct check of return value:
-        // const callResult = await adapter.connect(authorizedCaller).recordFreezeVote.staticCall(voter1.address, PROPOSAL_SNAPSHOT_AND_ID_1, ZERO_EXTRA_DATA);
-        // expect(callResult).to.equal(expectedWeightCasted);
-        // And then execute the actual transaction for event and state change checks.
-        // For now, relying on event emission for weightCasted verification is common.
-
         // Verify state change: subsequent call for weightOf for this specific freeze context should indicate voted (hard to check directly without getter)
         // So, we test by trying to vote again, which should fail.
         await expect(
@@ -997,6 +990,20 @@ describe('VotingAdapterERC20V1', () => {
       await strategy.setVotingAdapter(await adapter.getAddress(), true);
     });
 
+    it('should return (false, 0) if the proposal is not initialized', async () => {
+      const uninitializedProposalId = 999;
+      // No setup for this proposal ID in the mock strategy
+
+      const [isValid, weight] = await adapter.validVotingAdapterVote(
+        voter.address,
+        uninitializedProposalId,
+        mockExtraData,
+      );
+
+      void expect(isValid).to.be.false;
+      expect(weight).to.equal(0);
+    });
+
     async function setupValidation(voterAddress: string, startOffset: number, endOffset: number) {
       const currentTimestamp = await time.latest();
       const startTimestamp = currentTimestamp + startOffset;
@@ -1009,9 +1016,19 @@ describe('VotingAdapterERC20V1', () => {
 
     it('should return (false, 0) if user has already voted', async () => {
       const { startTimestamp } = await setupValidation(voter.address, 100, 200);
+      const voteWeight = ethers.parseUnits('10', 18);
+      await token.setCheckpoints(voter.address, [{ _key: startTimestamp, _value: voteWeight }]);
 
-      // Simulate having voted
-      await token.setPastVotes(voter.address, startTimestamp, ethers.parseUnits('10', 18));
+      // 1. Check for TRUE before voting
+      const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
+        voter.address,
+        proposalId,
+        mockExtraData,
+      );
+      void expect(isInitiallyValid).to.be.true;
+      expect(initialWeight).to.equal(voteWeight);
+
+      // 2. Record a vote
       await strategy.connect(voter).vote(
         proposalId,
         0, // voteType
@@ -1023,59 +1040,102 @@ describe('VotingAdapterERC20V1', () => {
         ],
       );
 
-      const [isValid, weight] = await adapter.validVotingAdapterVote(
+      // 3. Check for FALSE after voting
+      const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
         voter.address,
         proposalId,
         mockExtraData,
       );
 
-      void expect(isValid).to.be.false;
-      expect(weight).to.equal(0);
+      void expect(isFinallyValid).to.be.false;
+      expect(finalWeight).to.equal(0);
     });
 
     describe('Checkpoint-based validation', () => {
       it('should return (false, 0) if there are no checkpoints', async () => {
-        await setupValidation(voter.address, 100, 200);
-        await token.setCheckpoints(voter.address, []); // no checkpoints
+        const { startTimestamp } = await setupValidation(voter.address, 100, 200);
 
-        const [isValid, weight] = await adapter.validVotingAdapterVote(
+        // 1. Setup and check for TRUE with a valid checkpoint
+        const validWeight = 100n;
+        await token.setCheckpoints(voter.address, [
+          { _key: startTimestamp - 1, _value: validWeight },
+        ]);
+        const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
           voter.address,
           proposalId,
           mockExtraData,
         );
-        void expect(isValid).to.be.false;
-        expect(weight).to.equal(0);
+        void expect(isInitiallyValid).to.be.true;
+        expect(initialWeight).to.equal(validWeight);
+
+        // 2. Check for FALSE with no checkpoints
+        await token.setCheckpoints(voter.address, []); // no checkpoints
+        const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
+          voter.address,
+          proposalId,
+          mockExtraData,
+        );
+        void expect(isFinallyValid).to.be.false;
+        expect(finalWeight).to.equal(0);
       });
 
       it('should return (false, 0) if all checkpoints are after proposal start', async () => {
         const { startTimestamp } = await setupValidation(voter.address, 100, 200);
 
+        // 1. Setup and check for TRUE with a valid checkpoint
+        const validWeight = 100n;
+        await token.setCheckpoints(voter.address, [
+          { _key: startTimestamp - 1, _value: validWeight },
+        ]);
+        const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
+          voter.address,
+          proposalId,
+          mockExtraData,
+        );
+        void expect(isInitiallyValid).to.be.true;
+        expect(initialWeight).to.equal(validWeight);
+
+        // 2. Check for FALSE with all checkpoints after start
         await token.setCheckpoints(voter.address, [
           { _key: startTimestamp + 1, _value: 100n },
           { _key: startTimestamp + 2, _value: 200n },
         ]);
 
-        const [isValid, weight] = await adapter.validVotingAdapterVote(
+        const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
           voter.address,
           proposalId,
           mockExtraData,
         );
-        void expect(isValid).to.be.false;
-        expect(weight).to.equal(0);
+        void expect(isFinallyValid).to.be.false;
+        expect(finalWeight).to.equal(0);
       });
 
       it('should return (false, 0) if the relevant checkpoint has zero votes', async () => {
         const { startTimestamp } = await setupValidation(voter.address, 100, 200);
 
-        await token.setCheckpoints(voter.address, [{ _key: startTimestamp - 1, _value: 0n }]);
-
-        const [isValid, weight] = await adapter.validVotingAdapterVote(
+        // 1. Setup and check for TRUE with a valid checkpoint
+        const validWeight = 100n;
+        await token.setCheckpoints(voter.address, [
+          { _key: startTimestamp - 1, _value: validWeight },
+        ]);
+        const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
           voter.address,
           proposalId,
           mockExtraData,
         );
-        void expect(isValid).to.be.false;
-        expect(weight).to.equal(0);
+        void expect(isInitiallyValid).to.be.true;
+        expect(initialWeight).to.equal(validWeight);
+
+        // 2. Check for FALSE with a zero-vote checkpoint
+        await token.setCheckpoints(voter.address, [{ _key: startTimestamp - 1, _value: 0n }]);
+
+        const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
+          voter.address,
+          proposalId,
+          mockExtraData,
+        );
+        void expect(isFinallyValid).to.be.false;
+        expect(finalWeight).to.equal(0);
       });
 
       it('should return (true, votingWeight) with a single checkpoint before start timestamp', async () => {
@@ -1131,38 +1191,67 @@ describe('VotingAdapterERC20V1', () => {
 
       it('should ignore checkpoints after proposal start', async () => {
         const { startTimestamp } = await setupValidation(voter.address, 100, 200);
-        const expectedWeight = 0n; // This should be the result
+        const expectedWeight = 100n;
 
+        // 1. Check for TRUE with a valid setup
         await token.setCheckpoints(voter.address, [
           { _key: startTimestamp - 1, _value: expectedWeight },
-          { _key: startTimestamp + 1, _value: 100n },
-          { _key: startTimestamp + 2, _value: 200n },
         ]);
-
-        const [isValid, weight] = await adapter.validVotingAdapterVote(
+        const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
           voter.address,
           proposalId,
           mockExtraData,
         );
-        void expect(isValid).to.be.false;
-        expect(weight).to.equal(0);
+        void expect(isInitiallyValid).to.be.true;
+        expect(initialWeight).to.equal(expectedWeight);
+
+        // 2. Check for FALSE by adding an ignored checkpoint (behavior doesn't change from true)
+        // This test is confirming that later checkpoints are ignored, so the result should still be TRUE
+        // with the weight from the last valid checkpoint.
+        await token.setCheckpoints(voter.address, [
+          { _key: startTimestamp - 1, _value: expectedWeight },
+          { _key: startTimestamp + 1, _value: 200n },
+          { _key: startTimestamp + 2, _value: 300n },
+        ]);
+
+        const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
+          voter.address,
+          proposalId,
+          mockExtraData,
+        );
+        void expect(isFinallyValid).to.be.true;
+        expect(finalWeight).to.equal(expectedWeight);
       });
 
       it('should return (false, 0) if most recent checkpoint is after proposal end', async () => {
         const { startTimestamp, endTimestamp } = await setupValidation(voter.address, 100, 200);
 
+        // 1. Setup and check for TRUE with a valid checkpoint
+        const validWeight = 100n;
+        await token.setCheckpoints(voter.address, [
+          { _key: startTimestamp - 1, _value: validWeight },
+        ]);
+        const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
+          voter.address,
+          proposalId,
+          mockExtraData,
+        );
+        void expect(isInitiallyValid).to.be.true;
+        expect(initialWeight).to.equal(validWeight);
+
+        // 2. Check for FALSE by adding a checkpoint after the end time
         await token.setCheckpoints(voter.address, [
           { _key: startTimestamp - 1, _value: 100n }, // A valid one
           { _key: endTimestamp + 1, _value: 50n }, // But this one is after end time
         ]);
 
-        const [isValid, weight] = await adapter.validVotingAdapterVote(
+        const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
           voter.address,
           proposalId,
           mockExtraData,
         );
-        void expect(isValid).to.be.false;
-        expect(weight).to.equal(0);
+        void expect(isFinallyValid).to.be.false;
+        expect(finalWeight).to.equal(0);
       });
 
       it('should return (true, votingWeight) for happy path with default weightPerToken', async () => {
@@ -1211,6 +1300,22 @@ describe('VotingAdapterERC20V1', () => {
       });
 
       it('should return (false, 0) if weightPerToken is 0', async () => {
+        const { startTimestamp } = await setupValidation(voter.address, 100, 200);
+        const votingWeight = 100n;
+
+        // 1. Check for TRUE with the standard adapter
+        await token.setCheckpoints(voter.address, [
+          { _key: startTimestamp - 1, _value: votingWeight },
+        ]);
+        const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
+          voter.address,
+          proposalId,
+          mockExtraData,
+        );
+        void expect(isInitiallyValid).to.be.true;
+        expect(initialWeight).to.equal(votingWeight * DEFAULT_WEIGHT_PER_TOKEN);
+
+        // 2. Check for FALSE with the zero-weight adapter
         const customWeightPerToken = 0n;
         const { adapter: customAdapter } = await deployERC20AdapterProxy(
           deployer,
@@ -1221,20 +1326,14 @@ describe('VotingAdapterERC20V1', () => {
         );
         await strategy.setVotingAdapter(await customAdapter.getAddress(), true);
 
-        const { startTimestamp } = await setupValidation(voter.address, 100, 200);
-        const votingWeight = 100n;
-        await token.setCheckpoints(voter.address, [
-          { _key: startTimestamp - 1, _value: votingWeight },
-        ]);
-
-        const [isValid, weight] = await customAdapter.validVotingAdapterVote(
+        const [isFinallyValid, finalWeight] = await customAdapter.validVotingAdapterVote(
           voter.address,
           proposalId,
           mockExtraData,
         );
 
-        void expect(isValid).to.be.false;
-        expect(weight).to.equal(0);
+        void expect(isFinallyValid).to.be.false;
+        expect(finalWeight).to.equal(0);
       });
     });
   });

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
@@ -57,7 +57,7 @@ describe('VotingAdapterERC721V1', () => {
   }
 
   async function deployMocksAndSignersERC721Fixture() {
-    const [deployer, user1, user2, strategySigner] = await ethers.getSigners();
+    const [deployer, user1, user2] = await ethers.getSigners();
 
     const mockNftFactory = new MockERC721__factory(deployer);
     const mockNft = await mockNftFactory.deploy();
@@ -92,6 +92,9 @@ describe('VotingAdapterERC721V1', () => {
     user2TokenIds.push(nextTokenId);
     await mockNft.mint(user2.address);
 
+    const mockStrategy = await new MockVotingStrategy__factory(deployer).deploy(deployer);
+    await mockStrategy.waitForDeployment();
+
     return {
       deployer,
       user1Signer: user1,
@@ -99,8 +102,7 @@ describe('VotingAdapterERC721V1', () => {
       mockNft,
       user1TokenIds,
       user2TokenIds,
-      strategyAddress: strategySigner.address,
-      strategySigner,
+      strategy: mockStrategy,
     };
   }
 
@@ -113,14 +115,14 @@ describe('VotingAdapterERC721V1', () => {
       const {
         mockNft,
         deployer: fixtureDeployer,
-        strategyAddress,
+        strategy,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
 
       const { adapter: erc721Adapter } = await deployERC721AdapterProxy(
         fixtureDeployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        strategyAddress,
+        await strategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
 
@@ -132,21 +134,17 @@ describe('VotingAdapterERC721V1', () => {
       const {
         mockNft,
         deployer: fixtureDeployer,
-        strategyAddress,
+        strategy,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
       const { adapter: erc721Adapter } = await deployERC721AdapterProxy(
         fixtureDeployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        strategyAddress,
+        await strategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
       await expect(
-        erc721Adapter.initialize(
-          await mockNft.getAddress(),
-          strategyAddress,
-          DEFAULT_WEIGHT_PER_NFT,
-        ),
+        erc721Adapter.initialize(await mockNft.getAddress(), strategy, DEFAULT_WEIGHT_PER_NFT),
       ).to.be.revertedWithCustomError(erc721Adapter, 'InvalidInitialization');
     });
 
@@ -154,7 +152,7 @@ describe('VotingAdapterERC721V1', () => {
       const {
         mockNft,
         deployer: fixtureDeployer,
-        strategyAddress,
+        strategy,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
       const implementationContract = VotingAdapterERC721V1__factory.connect(
         erc721AdapterImplementationAddressG,
@@ -163,7 +161,7 @@ describe('VotingAdapterERC721V1', () => {
       await expect(
         implementationContract.initialize(
           await mockNft.getAddress(),
-          strategyAddress,
+          strategy,
           DEFAULT_WEIGHT_PER_NFT,
         ),
       ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
@@ -177,7 +175,7 @@ describe('VotingAdapterERC721V1', () => {
     let user1TokenIds: bigint[];
     let user2TokenIds: bigint[];
     let deployer: SignerWithAddress;
-    let strategySigner: SignerWithAddress;
+    let strategy: MockVotingStrategy;
 
     const proposalId = 1;
 
@@ -188,16 +186,17 @@ describe('VotingAdapterERC721V1', () => {
       user1TokenIds = fixture.user1TokenIds;
       user2TokenIds = fixture.user2TokenIds;
       deployer = fixture.deployer;
-      strategySigner = fixture.strategySigner;
+      strategy = fixture.strategy;
 
       const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
         deployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        fixture.strategyAddress,
+        await strategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
       adapter = deployedAdapter;
+      await strategy.initializeProposal(proposalId);
     });
 
     it('should return correct weight if voter owns all provided, unvoted token IDs', async () => {
@@ -226,9 +225,9 @@ describe('VotingAdapterERC721V1', () => {
         ['uint256[]'],
         [[tokenToUse]],
       );
-      await adapter
-        .connect(strategySigner)
-        .recordVote(user1.address, proposalId, initialAdapterVoteData);
+      await strategy
+        .connect(user1)
+        .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: initialAdapterVoteData }]);
 
       // Then, try to get weightOf for the same token
       const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
@@ -276,7 +275,7 @@ describe('VotingAdapterERC721V1', () => {
         deployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        deployer.address,
+        await strategy.getAddress(),
         customWeightPerNft,
       );
 
@@ -288,6 +287,14 @@ describe('VotingAdapterERC721V1', () => {
       const weight = await customAdapter.weightOf(user1.address, proposalId, adapterVoteData);
       expect(weight).to.equal(BigInt(tokenIdsToVoteWith.length) * customWeightPerNft);
     });
+
+    it('should revert with ProposalNotInitialized if proposal does not exist', async () => {
+      const uninitializedProposalId = 999;
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[1]]);
+      await expect(
+        adapter.weightOf(user1.address, uninitializedProposalId, adapterVoteData),
+      ).to.be.revertedWithCustomError(strategy, 'ProposalNotInitialized');
+    });
   });
 
   describe('weightOfWithUnusedTokenIds', () => {
@@ -297,7 +304,7 @@ describe('VotingAdapterERC721V1', () => {
     let user1TokenIds: bigint[];
     let user2TokenIds: bigint[];
     let deployer: SignerWithAddress;
-    let strategySigner: SignerWithAddress;
+    let strategy: MockVotingStrategy;
 
     const proposalId = 1;
     const proposalId2 = 2; // For testing used tokens across different proposals
@@ -309,16 +316,17 @@ describe('VotingAdapterERC721V1', () => {
       user1TokenIds = fixture.user1TokenIds; // User1 owns [0, 1, 2]
       user2TokenIds = fixture.user2TokenIds; // User2 owns [3, 4]
       deployer = fixture.deployer;
-      strategySigner = fixture.strategySigner;
+      strategy = fixture.strategy;
 
       const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
         deployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        fixture.strategyAddress,
+        await fixture.strategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
       adapter = deployedAdapter;
+      await strategy.initializeProposal(proposalId);
     });
 
     it('should return correct weight and token IDs if voter owns all provided, unvoted token IDs', async () => {
@@ -360,9 +368,12 @@ describe('VotingAdapterERC721V1', () => {
         ['uint256[]'],
         [[tokenToUseInitially]],
       );
-      await adapter
-        .connect(strategySigner)
-        .recordVote(user1.address, proposalId, initialAdapterVoteData);
+      await strategy
+        .connect(user1)
+        .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: initialAdapterVoteData }]);
+      // await adapter
+      //   .connect(strategySigner)
+      //   .recordVote(user1.address, proposalId, initialAdapterVoteData);
 
       // Now, try to get weight for [tokenToUseInitially, anotherValidToken]
       const tokenIdsForWeightCheck = [tokenToUseInitially, anotherValidToken];
@@ -380,14 +391,20 @@ describe('VotingAdapterERC721V1', () => {
     });
 
     it('should correctly handle tokens used in a different proposal', async () => {
+      await strategy.initializeProposal(proposalId2);
       const tokenToUse = user1TokenIds[0];
       const initialAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
         ['uint256[]'],
         [[tokenToUse]],
       );
-      await adapter
-        .connect(strategySigner)
-        .recordVote(user1.address, proposalId2, initialAdapterVoteData);
+      await strategy
+        .connect(user1)
+        .vote(proposalId2, 1, [
+          { votingAdapter: adapter, adapterVoteData: initialAdapterVoteData },
+        ]);
+      // await adapter
+      //   .connect(strategySigner)
+      //   .recordVote(user1.address, proposalId2, initialAdapterVoteData);
 
       // Get weight for the same token but for proposalId (different proposal)
       const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
@@ -450,7 +467,7 @@ describe('VotingAdapterERC721V1', () => {
         deployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        deployer.address,
+        await strategy.getAddress(),
         customWeightPerToken,
       );
 
@@ -470,13 +487,19 @@ describe('VotingAdapterERC721V1', () => {
 
     it('should return 0 weight and empty array for a mix of invalid (unowned, used) and non-existent tokens', async () => {
       const usedToken = user1TokenIds[0];
-      await adapter
-        .connect(strategySigner)
-        .recordVote(
-          user1.address,
-          proposalId,
-          ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[usedToken]]),
-        );
+      await strategy.connect(user1).vote(proposalId, 1, [
+        {
+          votingAdapter: adapter,
+          adapterVoteData: ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[usedToken]]),
+        },
+      ]);
+      // await adapter
+      //   .connect(strategySigner)
+      //   .recordVote(
+      //     user1.address,
+      //     proposalId,
+      //     ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[usedToken]]),
+      //   );
 
       const tokenIdsForWeightCheck = [
         user2TokenIds[0], // Valid, existing token, but unowned by user1
@@ -496,6 +519,14 @@ describe('VotingAdapterERC721V1', () => {
       expect(weight).to.equal(0n);
       void expect(validTokenIds).to.be.an('array').that.is.empty;
     });
+
+    it('should revert with ProposalNotInitialized if proposal does not exist', async () => {
+      const uninitializedProposalId = 999;
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[1]]);
+      await expect(
+        adapter.weightOfWithValidTokenIds(user1.address, uninitializedProposalId, adapterVoteData),
+      ).to.be.revertedWithCustomError(strategy, 'ProposalNotInitialized');
+    });
   });
 
   describe('recordVote', () => {
@@ -505,7 +536,7 @@ describe('VotingAdapterERC721V1', () => {
     let user1TokenIds: bigint[];
     let user2TokenIds: bigint[];
     let deployer: SignerWithAddress;
-    let strategySigner: SignerWithAddress;
+    let strategy: MockVotingStrategy;
 
     const proposalId = 1;
 
@@ -516,16 +547,18 @@ describe('VotingAdapterERC721V1', () => {
       user1TokenIds = fixture.user1TokenIds;
       user2TokenIds = fixture.user2TokenIds;
       deployer = fixture.deployer;
-      strategySigner = fixture.strategySigner;
+      strategy = fixture.strategy;
 
       const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
         deployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        fixture.strategyAddress,
+        await strategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
       adapter = deployedAdapter;
+
+      await strategy.initializeProposal(proposalId);
     });
 
     it('should record vote, return casted weight, mark NFTs as used, and emit VoteRecorded event', async () => {
@@ -537,7 +570,7 @@ describe('VotingAdapterERC721V1', () => {
       const expectedWeight = BigInt(tokenIdsToVoteWith.length) * DEFAULT_WEIGHT_PER_NFT;
 
       await expect(
-        adapter.connect(strategySigner).recordVote(user1.address, proposalId, adapterVoteData),
+        strategy.connect(user1).vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData }]),
       )
         .to.emit(adapter, 'VoteRecorded')
         .withArgs(user1.address, proposalId, expectedWeight, adapterVoteData);
@@ -558,21 +591,29 @@ describe('VotingAdapterERC721V1', () => {
         [[tokenToUse]],
       );
       // First vote
-      await adapter.connect(strategySigner).recordVote(user1.address, proposalId, voteDataSingle);
+      await strategy
+        .connect(user1)
+        .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: voteDataSingle }]);
 
       // Attempt second vote with same token - should revert
       await expect(
-        adapter.connect(strategySigner).recordVote(user1.address, proposalId, voteDataSingle),
+        strategy
+          .connect(user1)
+          .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: voteDataSingle }]),
       )
         .to.be.revertedWithCustomError(adapter, 'TokenIdAlreadyUsedForVote')
         .withArgs(tokenToUse);
     });
 
-    it('should not allow voting with no NFTs provided', async () => {
+    it('should emit VoteRecorded event with 0 weight if adapterVoteData is empty', async () => {
       const emptyVoteData = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[]]);
       await expect(
-        adapter.connect(strategySigner).recordVote(user1.address, proposalId, emptyVoteData),
-      ).to.be.revertedWithCustomError(adapter, 'NoTokenIdsPassed');
+        strategy
+          .connect(user1)
+          .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: emptyVoteData }]),
+      )
+        .to.emit(adapter, 'VoteRecorded')
+        .withArgs(user1.address, proposalId, 0n, emptyVoteData);
     });
 
     it('should not allow voting with NFTs not owned by the voter', async () => {
@@ -583,11 +624,7 @@ describe('VotingAdapterERC721V1', () => {
       );
 
       await expect(
-        adapter.connect(strategySigner).recordVote(
-          user1.address, // Voter is user1
-          proposalId,
-          adapterVoteData,
-        ),
+        strategy.connect(user1).vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData }]),
       )
         .to.be.revertedWithCustomError(adapter, 'TokenIdNotOwnedByVoter')
         .withArgs(tokenIdsNotOwnedByUser1[0]);
@@ -603,6 +640,7 @@ describe('VotingAdapterERC721V1', () => {
         mockNft: localMockNft,
         user1Signer: localUser1,
         deployer: localProxyDeployer,
+        strategy: localStrategy,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
 
       // Mint specific tokens for localUser1 on localMockNft
@@ -618,7 +656,7 @@ describe('VotingAdapterERC721V1', () => {
         localProxyDeployer, // Proxy deployer
         erc721AdapterImplementationAddressG,
         await localMockNft.getAddress(),
-        localProxyDeployer.address, // Initialize customAdapter with localProxyDeployer as strategy
+        await localStrategy.getAddress(),
         customWeightPerNft,
       );
 
@@ -629,18 +667,30 @@ describe('VotingAdapterERC721V1', () => {
       );
       const expectedWeight = BigInt(tokenIdsToUseInVote.length) * customWeightPerNft;
 
+      await localStrategy.initializeProposal(proposalId);
+
       await expect(
-        customAdapter.connect(localProxyDeployer).recordVote(
-          localUser1.address, // Actual voter
-          proposalId,
-          adapterVoteData,
-        ),
+        localStrategy
+          .connect(localUser1)
+          .vote(proposalId, 1, [{ votingAdapter: customAdapter, adapterVoteData }]),
       )
         .to.emit(customAdapter, 'VoteRecorded')
         .withArgs(localUser1.address, proposalId, expectedWeight, adapterVoteData);
 
       void expect(await customAdapter.tokenIdUsedForVote(proposalId, tokenIdsToUseInVote[0])).to.be
         .true;
+    });
+
+    it('should revert with DuplicateTokenIds if duplicate token IDs are provided', async () => {
+      const tokenIdsToVoteWith = [user1TokenIds[0], user1TokenIds[0]];
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsToVoteWith],
+      );
+
+      await expect(
+        strategy.connect(user1).vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData }]),
+      ).to.be.revertedWithCustomError(adapter, 'DuplicateTokenIds');
     });
   });
 
@@ -649,13 +699,13 @@ describe('VotingAdapterERC721V1', () => {
       const {
         mockNft,
         deployer: fixtureDeployer,
-        strategyAddress,
+        strategy,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
       const { adapter: erc721Adapter } = await deployERC721AdapterProxy(
         fixtureDeployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        strategyAddress,
+        await strategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
       expect(await erc721Adapter.version()).to.equal(1);
@@ -680,9 +730,9 @@ describe('VotingAdapterERC721V1', () => {
       voter1TokenIds = nftFixture.user1TokenIds;
       mockNft = nftFixture.mockNft;
 
-      const mockStrategyFactory = new MockVotingStrategy__factory(deployerSigner);
-      mockStrategy = await mockStrategyFactory.deploy(deployerSigner.address);
-      await mockStrategy.waitForDeployment();
+      mockStrategy = await new MockVotingStrategy__factory(deployerSigner).deploy(
+        deployerSigner.address,
+      );
 
       const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
         deployerSigner,
@@ -692,7 +742,8 @@ describe('VotingAdapterERC721V1', () => {
         DEFAULT_WEIGHT_PER_NFT,
       );
       adapter = deployedAdapter;
-      await mockStrategy.setVotingAdapter(await adapter.getAddress(), true);
+
+      await mockStrategy.initializeProposal(proposalId);
     });
 
     describe('tokenIdUsedForVote', () => {
@@ -728,6 +779,7 @@ describe('VotingAdapterERC721V1', () => {
 
       it('should only mark the specific proposalId/tokenId combination as used', async () => {
         const anotherProposalId = 2;
+        await mockStrategy.initializeProposal(anotherProposalId);
 
         // Encode the vote data
         const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
@@ -755,6 +807,13 @@ describe('VotingAdapterERC721V1', () => {
         void expect(await adapter.tokenIdUsedForVote(anotherProposalId, voter1TokenIds[0])).to.be
           .false;
         void expect(await adapter.tokenIdUsedForVote(proposalId, voter1TokenIds[1])).to.be.false;
+      });
+
+      it('should revert with ProposalNotInitialized if proposal does not exist', async () => {
+        const uninitializedProposalId = 999;
+        await expect(
+          adapter.tokenIdUsedForVote(uninitializedProposalId, voter1TokenIds[0]),
+        ).to.be.revertedWithCustomError(mockStrategy, 'ProposalNotInitialized');
       });
     });
 
@@ -861,13 +920,13 @@ describe('VotingAdapterERC721V1', () => {
       const {
         mockNft,
         deployer: fixtureDeployer,
-        strategyAddress,
+        strategy,
       } = await loadFixture(deployMocksAndSignersERC721Fixture);
       const { adapter } = await deployERC721AdapterProxy(
         fixtureDeployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        strategyAddress,
+        await strategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
       erc721Adapter = adapter;
@@ -1186,13 +1245,13 @@ describe('VotingAdapterERC721V1', () => {
         expect(weightAfter).to.equal(0n);
       });
 
-      it('should revert with NoTokenIdsPassed if adapterVoteData is empty', async () => {
+      it('should revert with NoFreezeVotingWeight if adapterVoteData is empty', async () => {
         await mockStrategy.addAuthorizedFreezeVoter(authorizedCaller.address);
         await expect(
           adapter
             .connect(authorizedCaller)
             .recordFreezeVote(voter1.address, PROPOSAL_SNAPSHOT_AND_ID_1, ZERO_EXTRA_DATA_BYTES),
-        ).to.be.revertedWithCustomError(adapter, 'NoTokenIdsPassed');
+        ).to.be.revertedWithCustomError(adapter, 'NoFreezeVotingWeight');
       });
 
       it('should revert with NoFreezeVotingWeight if _weightPerToken is 0', async () => {
@@ -1235,27 +1294,6 @@ describe('VotingAdapterERC721V1', () => {
           // Expecting the revert from the ERC721 token itself for a non-existent token
           .to.be.revertedWithCustomError(mockNft, 'ERC721NonexistentToken')
           .withArgs(nonExistentTokenId);
-      });
-
-      it('should revert with TokenIdNotOwnedByVoter if voter does not own an existing token ID', async () => {
-        await mockStrategy.addAuthorizedFreezeVoter(authorizedCaller.address);
-        // Mint a token specifically for another user (voter2)
-        const voter2TokenId = await mockNft.getCurrentTokenId();
-        await mockNft.mint(voter2.address); // voter2 now owns voter2TokenId
-
-        const tokenIdsToUse = [voter2TokenId]; // voter1 attempts to use voter2's token
-        const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['uint256[]'],
-          [tokenIdsToUse],
-        );
-
-        await expect(
-          adapter
-            .connect(authorizedCaller) // Call is authorized
-            .recordFreezeVote(voter1.address, PROPOSAL_SNAPSHOT_AND_ID_1, adapterVoteData),
-        ) // voter1 attempts to vote with voter2's token
-          .to.be.revertedWithCustomError(adapter, 'TokenIdNotOwnedByVoter')
-          .withArgs(voter2TokenId);
       });
 
       describe('Duplicate Vote Prevention for recordFreezeVote', () => {
@@ -1342,6 +1380,50 @@ describe('VotingAdapterERC721V1', () => {
         });
       });
     });
+
+    it('should revert with DuplicateTokenIds if duplicate token IDs are provided', async () => {
+      await mockStrategy.addAuthorizedFreezeVoter(authorizedCaller.address);
+      const tokenIdsToUse = [user1InitialTokenIds[0], user1InitialTokenIds[0]];
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsToUse],
+      );
+      await expect(
+        adapter
+          .connect(authorizedCaller)
+          .recordFreezeVote(voter1.address, PROPOSAL_SNAPSHOT_AND_ID_1, adapterVoteData),
+      ).to.be.revertedWithCustomError(adapter, 'DuplicateTokenIds');
+    });
+
+    it('should revert with TokenIdNotOwnedByVoter if voter does not own an existing token ID', async () => {
+      await mockStrategy.addAuthorizedFreezeVoter(authorizedCaller.address);
+      // Mint a token specifically for another user (voter2)
+      const voter2TokenId = await mockNft.getCurrentTokenId();
+      await mockNft.mint(voter2.address); // voter2 now owns voter2TokenId
+
+      const tokenIdsToUse = [voter2TokenId]; // voter1 attempts to use voter2's token
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsToUse],
+      );
+
+      await expect(
+        adapter
+          .connect(authorizedCaller) // Call is authorized
+          .recordFreezeVote(voter1.address, PROPOSAL_SNAPSHOT_AND_ID_1, adapterVoteData),
+      ) // voter1 attempts to vote with voter2's token
+        .to.be.revertedWithCustomError(adapter, 'TokenIdNotOwnedByVoter')
+        .withArgs(voter2TokenId);
+
+      // Verify token was not marked as used for the freeze vote
+      void expect(
+        await adapter.tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract(
+          authorizedCaller.address,
+          PROPOSAL_SNAPSHOT_AND_ID_1,
+          voter2TokenId,
+        ),
+      ).to.be.false;
+    });
   });
 
   describe('validVotingAdapterVote', () => {
@@ -1351,7 +1433,7 @@ describe('VotingAdapterERC721V1', () => {
     let user1TokenIds: bigint[];
     let user2TokenIds: bigint[];
     let deployer: SignerWithAddress;
-    let strategySigner: SignerWithAddress;
+    let strategy: MockVotingStrategy;
     const proposalId = 1;
 
     beforeEach(async () => {
@@ -1361,16 +1443,18 @@ describe('VotingAdapterERC721V1', () => {
       user1TokenIds = fixture.user1TokenIds;
       user2TokenIds = fixture.user2TokenIds;
       deployer = fixture.deployer;
-      strategySigner = fixture.strategySigner;
+      strategy = fixture.strategy;
 
       const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
         deployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        fixture.strategyAddress,
+        await strategy.getAddress(),
         DEFAULT_WEIGHT_PER_NFT,
       );
       adapter = deployedAdapter;
+
+      await strategy.initializeProposal(proposalId);
     });
 
     it('should return (true, weight) for valid, owned, unused tokens', async () => {
@@ -1392,105 +1476,165 @@ describe('VotingAdapterERC721V1', () => {
     });
 
     it('should return (false, 0) if tokenIds array is empty', async () => {
-      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[]]);
-
-      const [isValid, weight] = await adapter.validVotingAdapterVote(
+      // 1. Check for TRUE with a valid token
+      const validTokenIds = [user1TokenIds[0]];
+      const validAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [validTokenIds],
+      );
+      const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
         user1.address,
         proposalId,
-        adapterVoteData,
+        validAdapterVoteData,
       );
+      void expect(isInitiallyValid).to.be.true;
+      expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
 
-      void expect(isValid).to.be.false;
-      expect(weight).to.equal(0);
+      // 2. Check for FALSE with an empty array
+      const emptyAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[]]);
+      const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
+        user1.address,
+        proposalId,
+        emptyAdapterVoteData,
+      );
+      void expect(isFinallyValid).to.be.false;
+      expect(finalWeight).to.equal(0);
     });
 
     it('should return (false, 0) if one token is not owned by the user', async () => {
-      // user1 owns user1TokenIds[0], but not user2TokenIds[0]
-      const tokenIdsToVoteWith = [user1TokenIds[0], user2TokenIds[0]];
-      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
-        ['uint256[]'],
-        [tokenIdsToVoteWith],
-      );
+      const ownedToken = user1TokenIds[0];
+      const unownedToken = user2TokenIds[0];
 
-      const [isValid, weight] = await adapter.validVotingAdapterVote(
+      // 1. Check for TRUE with only the owned token
+      const initialAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[ownedToken]],
+      );
+      const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
         user1.address,
         proposalId,
-        adapterVoteData,
+        initialAdapterVoteData,
       );
+      void expect(isInitiallyValid).to.be.true;
+      expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
 
-      void expect(isValid).to.be.false;
-      expect(weight).to.equal(0);
+      // 2. Check for FALSE when an unowned token is included
+      const finalAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[ownedToken, unownedToken]],
+      );
+      const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
+        user1.address,
+        proposalId,
+        finalAdapterVoteData,
+      );
+      void expect(isFinallyValid).to.be.false;
+      expect(finalWeight).to.equal(0);
     });
 
     it('should return (false, 0) if one token has already been used for the proposal', async () => {
-      const usedToken = user1TokenIds[0];
       const unusedToken = user1TokenIds[1];
+      const usedToken = user1TokenIds[0];
+
+      // 1. Check for TRUE with only the unused token
+      const initialAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[unusedToken]],
+      );
+      const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
+        user1.address,
+        proposalId,
+        initialAdapterVoteData,
+      );
+      void expect(isInitiallyValid).to.be.true;
+      expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
+
+      // 2. Mark a token as used
       const voteDataForRecord = ethers.AbiCoder.defaultAbiCoder().encode(
         ['uint256[]'],
         [[usedToken]],
       );
+      await strategy
+        .connect(user1)
+        .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: voteDataForRecord }]);
 
-      // Record a vote to mark the token as used
-      await adapter
-        .connect(strategySigner)
-        .recordVote(user1.address, proposalId, voteDataForRecord);
-
-      const tokenIdsToVoteWith = [usedToken, unusedToken];
-      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+      // 3. Check for FALSE when the used token is included
+      const finalAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
         ['uint256[]'],
-        [tokenIdsToVoteWith],
+        [[unusedToken, usedToken]],
       );
-
-      const [isValid, weight] = await adapter.validVotingAdapterVote(
+      const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
         user1.address,
         proposalId,
-        adapterVoteData,
+        finalAdapterVoteData,
       );
-
-      void expect(isValid).to.be.false;
-      expect(weight).to.equal(0);
+      void expect(isFinallyValid).to.be.false;
+      expect(finalWeight).to.equal(0);
     });
 
     it('should return (false, 0) if weightPerToken is 0, resulting in 0 total weight', async () => {
-      const { adapter: zeroWeightAdapter } = await deployERC721AdapterProxy(
-        deployer,
-        erc721AdapterImplementationAddressG,
-        await mockNft.getAddress(),
-        strategySigner.address,
-        0n, // 0 weight per token
-      );
-
       const tokenIdsToVoteWith = [user1TokenIds[0]];
       const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
         ['uint256[]'],
         [tokenIdsToVoteWith],
       );
 
-      const [isValid, weight] = await zeroWeightAdapter.validVotingAdapterVote(
+      // 1. Check for TRUE with the standard adapter
+      const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
+        user1.address,
+        proposalId,
+        adapterVoteData,
+      );
+      void expect(isInitiallyValid).to.be.true;
+      expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
+
+      // 2. Check for FALSE with the zero-weight adapter
+      const { adapter: zeroWeightAdapter } = await deployERC721AdapterProxy(
+        deployer,
+        erc721AdapterImplementationAddressG,
+        await mockNft.getAddress(),
+        await strategy.getAddress(),
+        0n, // 0 weight per token
+      );
+
+      const [isFinallyValid, finalWeight] = await zeroWeightAdapter.validVotingAdapterVote(
         user1.address,
         proposalId,
         adapterVoteData,
       );
 
-      void expect(isValid).to.be.false;
-      expect(weight).to.equal(0);
+      void expect(isFinallyValid).to.be.false;
+      expect(finalWeight).to.equal(0);
     });
 
     it('should return (false, 0) if duplicate token IDs are provided', async () => {
-      const tokenIdsToVoteWith = [user1TokenIds[0], user1TokenIds[0]]; // Duplicate token
-      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
-        ['uint256[]'],
-        [tokenIdsToVoteWith],
-      );
+      const validToken = user1TokenIds[0];
 
-      const [isValid, weight] = await adapter.validVotingAdapterVote(
+      // 1. Check for TRUE with a single valid token
+      const initialAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[validToken]],
+      );
+      const [isInitiallyValid, initialWeight] = await adapter.validVotingAdapterVote(
         user1.address,
         proposalId,
-        adapterVoteData,
+        initialAdapterVoteData,
       );
+      void expect(isInitiallyValid).to.be.true;
+      expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
 
-      void expect(isValid).to.be.false;
-      expect(weight).to.equal(0);
+      // 2. Check for FALSE with duplicate tokens
+      const finalAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [[validToken, validToken]],
+      );
+      const [isFinallyValid, finalWeight] = await adapter.validVotingAdapterVote(
+        user1.address,
+        proposalId,
+        finalAdapterVoteData,
+      );
+      void expect(isFinallyValid).to.be.false;
+      expect(finalWeight).to.equal(0);
     });
 
     it('should correctly apply weightPerToken when it is greater than 1', async () => {
@@ -1499,7 +1643,7 @@ describe('VotingAdapterERC721V1', () => {
         deployer,
         erc721AdapterImplementationAddressG,
         await mockNft.getAddress(),
-        strategySigner.address,
+        await strategy.getAddress(),
         customWeightPerToken,
       );
 
@@ -1517,6 +1661,25 @@ describe('VotingAdapterERC721V1', () => {
 
       void expect(isValid).to.be.true;
       expect(weight).to.equal(BigInt(tokenIdsToVoteWith.length) * customWeightPerToken);
+    });
+
+    it('should return (false, 0) if the proposal is not initialized', async () => {
+      const uninitializedProposalId = 999;
+      const tokenIdsToVoteWith = [user1TokenIds[0]];
+      const adapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(
+        ['uint256[]'],
+        [tokenIdsToVoteWith],
+      );
+
+      // The underlying _getValidTokenIdsSafe call will not revert, so this should return false.
+      const [isValid, weight] = await adapter.validVotingAdapterVote(
+        user1.address,
+        uninitializedProposalId,
+        adapterVoteData,
+      );
+
+      void expect(isValid).to.be.false;
+      expect(weight).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/350

Fixes [ENG-1146](https://linear.app/decent-labs/issue/ENG-1146/refactor-moduleazoriusv1-to-decouple-strategy-from-initialization)

This change refactors the `ModuleAzoriusV1` contract to remove the strategy from its `initialize` and `setUp` functions. The strategy is now intended to be set in a subsequent, separate transaction by calling the `updateStrategy` function.

This decoupling is a critical prerequisite for enabling secure, atomic deployments of the entire Azorius system. By breaking the direct initialization dependency, it allows deployment workflows (using tools like `MultiSend` or a dedicated deployer contract) to configure the module in a more linear, two-step process (`initialize`, then `updateStrategy`). This is particularly important for handling the complex ownership hand-offs required when deploying via a `ProxyFactory`, where the initial owner (`ProxyFactory`) must transfer ownership to an orchestrator contract (e.g., `MultiSend`) which then performs the final configuration.

- Removed the `strategy` parameter from the `initialize` and `setUp` functions in `ModuleAzoriusV1.sol`.
- Updated the `IModuleAzoriusV1` interface to reflect the new `initialize` function signature.
- Aligned the `MockModuleAzoriusV1` contract with the updated interface to ensure test compatibility.
- Reworked the tests for `ModuleAzoriusV1` to use the new two-step configuration flow, first initializing the contract and then calling `updateStrategy`.