### PR TITLE
refactor(tests): Simplify initialization data encoding in test cases

### DIFF
--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -44,16 +44,11 @@ async function deployDecentPaymasterProxy(
   entryPoint: string,
   lightAccountFactory: string,
 ): Promise<DecentPaymasterV1> {
-  // Encode initialization parameters
-  const initializeParams = ethers.AbiCoder.defaultAbiCoder().encode(
-    ['address', 'address', 'address'],
+  // Create full initialization data with function selector
+  const fullInitData = DecentPaymasterV1__factory.createInterface().encodeFunctionData(
+    'initialize',
     [owner.address, entryPoint, lightAccountFactory],
   );
-
-  // Create full initialization data with function selector
-  const fullInitData =
-    DecentPaymasterV1__factory.createInterface().getFunction('initialize').selector +
-    initializeParams.slice(2);
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);

--- a/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
+++ b/test/deployables/account-abstraction/SmartAccountValidationV1.test.ts
@@ -33,11 +33,10 @@ async function deploySmartAccountValidation(
   mockLightAccountFactoryAddress: string,
 ) {
   // Create full initialization data with function selector
-  const fullInitData =
-    ConcreteSmartAccountValidation__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(['address'], [mockLightAccountFactoryAddress])
-      .slice(2);
+  const fullInitData = ConcreteSmartAccountValidation__factory.createInterface().encodeFunctionData(
+    'initialize',
+    [mockLightAccountFactoryAddress],
+  );
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(deployer).deploy(implementation, fullInitData);

--- a/test/deployables/countersign/Countersign.test.ts
+++ b/test/deployables/countersign/Countersign.test.ts
@@ -2,14 +2,14 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  IERC165__factory,
-  IVersion__factory,
   CountersignV1,
   CountersignV1__factory,
+  ERC1967Proxy__factory,
+  ICountersignV1__factory,
+  IERC165__factory,
+  IVersion__factory,
   MockERC20Votes,
   MockERC20Votes__factory,
-  ICountersignV1__factory,
-  ERC1967Proxy__factory,
 } from '../../../typechain-types';
 import { calculateInterfaceId } from '../../helpers/utils';
 
@@ -24,26 +24,13 @@ async function deployCountersignProxy(
   preExecutionTransactions: any[],
 ): Promise<CountersignV1> {
   // Create initialization data with function selector
-  const fullInitData =
-    CountersignV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(
-        [
-          'string',
-          'address',
-          'uint256',
-          'tuple(address account, bool required, uint256 weight, tuple(address target, uint256 value, bytes data)[] transactions)[]',
-          'tuple(address target, uint256 value, bytes data)[]',
-        ],
-        [
-          agreementUri,
-          verificationContract,
-          minWeight,
-          signerInitializations,
-          preExecutionTransactions,
-        ],
-      )
-      .slice(2);
+  const fullInitData = CountersignV1__factory.createInterface().encodeFunctionData('initialize', [
+    agreementUri,
+    verificationContract,
+    minWeight,
+    signerInitializations,
+    preExecutionTransactions,
+  ]);
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);

--- a/test/deployables/erc20/VotesERC20LockableV1.test.ts
+++ b/test/deployables/erc20/VotesERC20LockableV1.test.ts
@@ -38,22 +38,10 @@ async function deployVotesERC20Lockable(
     symbol,
   };
 
-  const fullInitData =
-    VotesERC20LockableV1__factory.createInterface().getFunction(
-      'initialize((string,string),(address,uint256)[],address,bool,uint256)',
-    ).selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(
-        [
-          'tuple(string name, string symbol)',
-          'tuple(address to, uint256 amount)[]',
-          'address',
-          'bool',
-          'uint256',
-        ],
-        [metadata, allocations, owner.address, locked, maxTotalSupply],
-      )
-      .slice(2);
+  const fullInitData = VotesERC20LockableV1__factory.createInterface().encodeFunctionData(
+    'initialize((string,string),(address,uint256)[],address,bool,uint256)',
+    [metadata, allocations, owner.address, locked, maxTotalSupply],
+  );
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(deployer).deploy(implementation, fullInitData);

--- a/test/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -34,14 +34,10 @@ async function deployVotesERC20StakedProxy(
   };
 
   // Create initialization data with function selector
-  const fullInitData =
-    VotesERC20StakedV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(
-        ['tuple(string name, string symbol)', 'address', 'address', 'uint256', 'address[]'],
-        [metadata, owner.address, stakedToken, minimumStakingPeriod, rewardsTokens],
-      )
-      .slice(2);
+  const fullInitData = VotesERC20StakedV1__factory.createInterface().encodeFunctionData(
+    'initialize',
+    [metadata, owner.address, stakedToken, minimumStakingPeriod, rewardsTokens],
+  );
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);

--- a/test/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/deployables/erc20/VotesERC20V1.test.ts
@@ -38,14 +38,11 @@ async function deployVotesERC20Proxy(
     symbol,
   };
 
-  const fullInitData =
-    VotesERC20V1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(
-        ['tuple(string name, string symbol)', 'tuple(address to, uint256 amount)[]', 'address'],
-        [metadata, allocations, owner.address],
-      )
-      .slice(2);
+  const fullInitData = VotesERC20V1__factory.createInterface().encodeFunctionData('initialize', [
+    metadata,
+    allocations,
+    owner.address,
+  ]);
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);

--- a/test/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
+++ b/test/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
@@ -24,11 +24,10 @@ async function deployAzoriusFreezeGuardProxy(
   freezeVoting: string,
 ): Promise<FreezeGuardAzoriusV1> {
   // Create initialization data with function selector
-  const fullInitData =
-    FreezeGuardAzoriusV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(['address', 'address'], [owner.address, freezeVoting])
-      .slice(2);
+  const fullInitData = FreezeGuardAzoriusV1__factory.createInterface().encodeFunctionData(
+    'initialize',
+    [owner.address, freezeVoting],
+  );
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);

--- a/test/deployables/freeze-voting/FreezeVotingBaseV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingBaseV1.test.ts
@@ -18,14 +18,10 @@ async function deployConcreteBaseFreezeVotingProxy(
   freezePeriod: number,
 ): Promise<ConcreteFreezeVotingBaseV1> {
   // Combine selector and encoded params
-  const fullInitData =
-    ConcreteFreezeVotingBaseV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(
-        ['address', 'uint256', 'uint32', 'uint32'],
-        [owner.address, freezeVotesThreshold, freezeProposalPeriod, freezePeriod],
-      )
-      .slice(2);
+  const fullInitData = ConcreteFreezeVotingBaseV1__factory.createInterface().encodeFunctionData(
+    'initialize',
+    [owner.address, freezeVotesThreshold, freezeProposalPeriod, freezePeriod],
+  );
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);

--- a/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
@@ -31,21 +31,17 @@ async function deployMultisigFreezeVotingProxy(
   lightAccountFactoryAddress: string,
 ): Promise<FreezeVotingMultisigV1> {
   // Combine selector and encoded params
-  const fullInitData =
-    FreezeVotingMultisigV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(
-        ['address', 'uint256', 'uint32', 'uint32', 'address', 'address'],
-        [
-          owner.address,
-          freezeVotesThreshold,
-          freezeProposalPeriod,
-          freezePeriod,
-          await parentGnosisSafe.getAddress(),
-          lightAccountFactoryAddress,
-        ],
-      )
-      .slice(2);
+  const fullInitData = FreezeVotingMultisigV1__factory.createInterface().encodeFunctionData(
+    'initialize',
+    [
+      owner.address,
+      freezeVotesThreshold,
+      freezeProposalPeriod,
+      freezePeriod,
+      await parentGnosisSafe.getAddress(),
+      lightAccountFactoryAddress,
+    ],
+  );
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);

--- a/test/deployables/modules/ModuleAzoriusV1.test.ts
+++ b/test/deployables/modules/ModuleAzoriusV1.test.ts
@@ -32,7 +32,6 @@ async function deployAzoriusProxy(
   executionPeriod: number,
 ): Promise<ModuleAzoriusV1> {
   // Combine selector and encoded params
-
   const fullInitData = ModuleAzoriusV1__factory.createInterface().encodeFunctionData('initialize', [
     owner.address,
     avatar,

--- a/test/deployables/modules/ModuleFractalV1.test.ts
+++ b/test/deployables/modules/ModuleFractalV1.test.ts
@@ -26,11 +26,11 @@ async function deployFractalModuleProxy(
   target: string,
 ): Promise<ModuleFractalV1> {
   // Combine selector and encoded params
-  const fullInitData =
-    ModuleFractalV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder()
-      .encode(['address', 'address', 'address'], [owner.address, avatar, target])
-      .slice(2);
+  const fullInitData = ModuleFractalV1__factory.createInterface().encodeFunctionData('initialize', [
+    owner.address,
+    avatar,
+    target,
+  ]);
 
   // Deploy the proxy with the implementation
   const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);

--- a/test/singletons/ProxyFactory.test.ts
+++ b/test/singletons/ProxyFactory.test.ts
@@ -28,9 +28,10 @@ async function deployConcreteUpgradeableContract(
     : ethers.keccak256(ethers.randomBytes(32));
 
   // Create initialization data with function selector
-  const fullInitData =
-    UpgradeContractV1__factory.createInterface().getFunction('initialize').selector +
-    ethers.AbiCoder.defaultAbiCoder().encode(['string', 'address'], [name, owner.address]).slice(2);
+  const fullInitData = UpgradeContractV1__factory.createInterface().encodeFunctionData(
+    'initialize',
+    [name, owner.address],
+  );
 
   // Deploy using the generic deployProxy method
   await proxyFactory.deployProxy(implementation, fullInitData, salt);
@@ -135,11 +136,10 @@ describe('ProxyFactory', () => {
       // Deploy with a different salt but keep track of the creation parameters
       const DIFFERENT_SALT = 'different-salt';
       const saltHash = ethers.keccak256(ethers.toUtf8Bytes(DIFFERENT_SALT));
-      const initData =
-        UpgradeContractV1__factory.createInterface().getFunction('initialize').selector +
-        ethers.AbiCoder.defaultAbiCoder()
-          .encode(['string', 'address'], [NAME, upgradeableContractOwner.address])
-          .slice(2);
+      const initData = UpgradeContractV1__factory.createInterface().encodeFunctionData(
+        'initialize',
+        [NAME, upgradeableContractOwner.address],
+      );
 
       // Deploy a new contract with these parameters
       await proxyFactory.deployProxy(upgradeableMasterCopy, initData, saltHash);
@@ -182,11 +182,10 @@ describe('ProxyFactory', () => {
       // Setup initialization data
       const PREDICTION_SALT = 'prediction-test-salt';
       const saltHash = ethers.keccak256(ethers.toUtf8Bytes(PREDICTION_SALT));
-      const initData =
-        UpgradeContractV1__factory.createInterface().getFunction('initialize').selector +
-        ethers.AbiCoder.defaultAbiCoder()
-          .encode(['string', 'address'], [NAME, upgradeableContractOwner.address])
-          .slice(2);
+      const initData = UpgradeContractV1__factory.createInterface().encodeFunctionData(
+        'initialize',
+        [NAME, upgradeableContractOwner.address],
+      );
 
       // Get predicted address
       const predictedAddress = await proxyFactory.predictProxyAddress(
@@ -309,9 +308,10 @@ describe('ProxyFactory', () => {
       const newVersion = 2;
 
       // Prepare initialization data for the upgrade
-      const fullInitData =
-        UpgradeContractV2__factory.createInterface().getFunction('initialize(uint16)').selector +
-        ethers.AbiCoder.defaultAbiCoder().encode(['uint16'], [newVersion]).slice(2);
+      const fullInitData = UpgradeContractV2__factory.createInterface().encodeFunctionData(
+        'initialize(uint16)',
+        [newVersion],
+      );
 
       // Upgrade the proxy to the upgraded implementation with initialization data
       await upgradeableContract.upgradeToAndCall(upgradedMasterCopy, fullInitData);
@@ -376,10 +376,11 @@ describe('ProxyFactory', () => {
       const largeString = 'x'.repeat(10000);
 
       // Create initialization data with the large string
-      const iface = MinimalUpgradeableContract__factory.createInterface();
       const largeInitData =
-        iface.getFunction('initializeWithLargeData').selector +
-        ethers.AbiCoder.defaultAbiCoder().encode(['string'], [largeString]).slice(2);
+        MinimalUpgradeableContract__factory.createInterface().encodeFunctionData(
+          'initializeWithLargeData',
+          [largeString],
+        );
 
       // Deploy with large init data
       const salt = ethers.keccak256(ethers.randomBytes(32));
@@ -407,11 +408,10 @@ describe('ProxyFactory', () => {
     it('should not allow initialize to be called twice', async () => {
       // Deploy a contract
       const name = 'InitializerTest';
-      const initData =
-        UpgradeContractV1__factory.createInterface().getFunction('initialize').selector +
-        ethers.AbiCoder.defaultAbiCoder()
-          .encode(['string', 'address'], [name, upgradeableContractOwner.address])
-          .slice(2);
+      const initData = UpgradeContractV1__factory.createInterface().encodeFunctionData(
+        'initialize',
+        [name, upgradeableContractOwner.address],
+      );
 
       const salt = ethers.keccak256(ethers.randomBytes(32));
       await proxyFactory.deployProxy(upgradeV1Implementation, initData, salt);
@@ -437,11 +437,10 @@ describe('ProxyFactory', () => {
     it('should correctly handle reinitializers with proper version increments', async () => {
       // Deploy a contract
       const name = 'ReinitializerTest';
-      const initData =
-        UpgradeContractV1__factory.createInterface().getFunction('initialize').selector +
-        ethers.AbiCoder.defaultAbiCoder()
-          .encode(['string', 'address'], [name, upgradeableContractOwner.address])
-          .slice(2);
+      const initData = UpgradeContractV1__factory.createInterface().encodeFunctionData(
+        'initialize',
+        [name, upgradeableContractOwner.address],
+      );
 
       const salt = ethers.keccak256(ethers.randomBytes(32));
       await proxyFactory.deployProxy(upgradeV1Implementation, initData, salt);
@@ -460,9 +459,10 @@ describe('ProxyFactory', () => {
 
       // Upgrade to V2
       const v2Version = 2;
-      const v2InitData =
-        UpgradeContractV2__factory.createInterface().getFunction('initialize(uint16)').selector +
-        ethers.AbiCoder.defaultAbiCoder().encode(['uint16'], [v2Version]).slice(2);
+      const v2InitData = UpgradeContractV2__factory.createInterface().encodeFunctionData(
+        'initialize(uint16)',
+        [v2Version],
+      );
 
       await contract.upgradeToAndCall(upgradeV2Implementation, v2InitData);
 
@@ -484,9 +484,10 @@ describe('ProxyFactory', () => {
 
       // Upgrade to V3 - should work with reinitializer(3)
       const v3AdditionalValue = 42;
-      const v3InitData =
-        UpgradeContractV3__factory.createInterface().getFunction('initialize(uint256)').selector +
-        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [v3AdditionalValue]).slice(2);
+      const v3InitData = UpgradeContractV3__factory.createInterface().encodeFunctionData(
+        'initialize(uint256)',
+        [v3AdditionalValue],
+      );
 
       await contractV2.upgradeToAndCall(upgradeV3Implementation, v3InitData);
 
@@ -507,11 +508,10 @@ describe('ProxyFactory', () => {
     it('should support upgrading through multiple implementation versions', async () => {
       // Deploy initial contract
       const name = 'MultiStepTest';
-      const initData =
-        UpgradeContractV1__factory.createInterface().getFunction('initialize').selector +
-        ethers.AbiCoder.defaultAbiCoder()
-          .encode(['string', 'address'], [name, upgradeableContractOwner.address])
-          .slice(2);
+      const initData = UpgradeContractV1__factory.createInterface().encodeFunctionData(
+        'initialize',
+        [name, upgradeableContractOwner.address],
+      );
 
       const salt = ethers.keccak256(ethers.randomBytes(32));
       await proxyFactory.deployProxy(upgradeV1Implementation, initData, salt);
@@ -533,9 +533,10 @@ describe('ProxyFactory', () => {
 
       // Upgrade to V2
       const v2Version = 2;
-      const v2InitData =
-        UpgradeContractV2__factory.createInterface().getFunction('initialize(uint16)').selector +
-        ethers.AbiCoder.defaultAbiCoder().encode(['uint16'], [v2Version]).slice(2);
+      const v2InitData = UpgradeContractV2__factory.createInterface().encodeFunctionData(
+        'initialize(uint16)',
+        [v2Version],
+      );
 
       await contractV1.upgradeToAndCall(upgradeV2Implementation, v2InitData);
 
@@ -551,9 +552,10 @@ describe('ProxyFactory', () => {
 
       // Upgrade to V3
       const v3AdditionalValue = 42;
-      const v3InitData =
-        UpgradeContractV3__factory.createInterface().getFunction('initialize(uint256)').selector +
-        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [v3AdditionalValue]).slice(2);
+      const v3InitData = UpgradeContractV3__factory.createInterface().encodeFunctionData(
+        'initialize(uint256)',
+        [v3AdditionalValue],
+      );
 
       await contractV2.upgradeToAndCall(upgradeV3Implementation, v3InitData);
 
@@ -574,11 +576,10 @@ describe('ProxyFactory', () => {
     it('should support complex state transformations during upgrades', async () => {
       // Deploy initial contract
       const name = 'StateMigrationTest';
-      const initData =
-        UpgradeContractV1__factory.createInterface().getFunction('initialize').selector +
-        ethers.AbiCoder.defaultAbiCoder()
-          .encode(['string', 'address'], [name, upgradeableContractOwner.address])
-          .slice(2);
+      const initData = UpgradeContractV1__factory.createInterface().encodeFunctionData(
+        'initialize',
+        [name, upgradeableContractOwner.address],
+      );
 
       const salt = ethers.keccak256(ethers.randomBytes(32));
       await proxyFactory.deployProxy(upgradeV1Implementation, initData, salt);
@@ -591,9 +592,10 @@ describe('ProxyFactory', () => {
 
       // Upgrade to V3 directly (skipping V2)
       const v3AdditionalValue = 100;
-      const v3InitData =
-        UpgradeContractV3__factory.createInterface().getFunction('initialize(uint256)').selector +
-        ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [v3AdditionalValue]).slice(2);
+      const v3InitData = UpgradeContractV3__factory.createInterface().encodeFunctionData(
+        'initialize(uint256)',
+        [v3AdditionalValue],
+      );
 
       const contract = UpgradeContractV1__factory.connect(
         predictedAddress,
@@ -640,9 +642,10 @@ describe('ProxyFactory', () => {
 
     it('should handle initialization functions that revert', async () => {
       // Create initialization data that will cause a revert
-      const initData =
-        FailingInitializerContract__factory.createInterface().getFunction('initialize').selector +
-        ethers.AbiCoder.defaultAbiCoder().encode(['bool'], [true]).slice(2); // true = should fail
+      const initData = FailingInitializerContract__factory.createInterface().encodeFunctionData(
+        'initialize',
+        [true],
+      );
 
       const salt = ethers.keccak256(ethers.randomBytes(32));
 
@@ -655,11 +658,10 @@ describe('ProxyFactory', () => {
     it('should allow detection of incompatible storage layout upgrades', async () => {
       // Deploy initial contract
       const name = 'IncompatibleStorageTest';
-      const initData =
-        UpgradeContractV1__factory.createInterface().getFunction('initialize').selector +
-        ethers.AbiCoder.defaultAbiCoder()
-          .encode(['string', 'address'], [name, upgradeableContractOwner.address])
-          .slice(2);
+      const initData = UpgradeContractV1__factory.createInterface().encodeFunctionData(
+        'initialize',
+        [name, upgradeableContractOwner.address],
+      );
 
       const salt = ethers.keccak256(ethers.randomBytes(32));
       await proxyFactory.deployProxy(upgradeV1Implementation, initData, salt);


### PR DESCRIPTION
This commit refactors multiple test files to streamline the encoding of initialization data by replacing the manual concatenation of function selectors and encoded parameters with the `encodeFunctionData` method. This change enhances code readability and maintainability across various deployable contracts.

**Change Summary:**
- Updated initialization data encoding in `Countersign.test.ts`, `DecentPaymasterV1.test.ts`, `SmartAccountValidationV1.test.ts`, `VotesERC20LockableV1.test.ts`, `VotesERC20StakedV1.test.ts`, `VotesERC20V1.test.ts`, `FreezeGuardAzoriusV1.test.ts`, `FreezeVotingBaseV1.test.ts`, `FreezeVotingMultisigV1.test.ts`, `ModuleAzoriusV1.test.ts`, `ModuleFractalV1.test.ts`, and `ProxyFactory.test.ts` to use `encodeFunctionData` for improved clarity.