### PR TITLE
refactor(freeze-voting): Consolidate VoterResolverV1 into FreezeVotingBaseV1

### DIFF
--- a/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
@@ -8,7 +8,6 @@ import {IModuleAzoriusV1} from "../../interfaces/decent/deployables/IModuleAzori
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
-import {VoterResolverV1} from "../account-abstraction/VoterResolverV1.sol";
 import {FreezeVotingBaseV1} from "./FreezeVotingBaseV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
@@ -16,7 +15,6 @@ contract FreezeVotingAzoriusV1 is
     IFreezeVotingAzoriusV1,
     IVersion,
     FreezeVotingBaseV1,
-    VoterResolverV1,
     ERC165
 {
     // ======================================================================
@@ -46,9 +44,9 @@ contract FreezeVotingAzoriusV1 is
             owner_,
             freezeProposalPeriod_,
             freezePeriod_,
-            freezeVotesThreshold_
+            freezeVotesThreshold_,
+            lightAccountFactory_
         );
-        __VoterResolverV1_init(lightAccountFactory_);
         _parentAzorius = IModuleAzoriusV1(parentAzorius_);
     }
 

--- a/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
@@ -2,10 +2,12 @@
 pragma solidity ^0.8.30;
 
 import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
+import {VoterResolverV1} from "../account-abstraction/VoterResolverV1.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 abstract contract FreezeVotingBaseV1 is
     IFreezeVotingBaseV1,
+    VoterResolverV1,
     Ownable2StepUpgradeable
 {
     // ======================================================================
@@ -31,12 +33,14 @@ abstract contract FreezeVotingBaseV1 is
         address owner_,
         uint32 freezeProposalPeriod_,
         uint32 freezePeriod_,
-        uint256 freezeVotesThreshold_
+        uint256 freezeVotesThreshold_,
+        address lightAccountFactory_
     ) internal onlyInitializing {
         __Ownable_init(owner_);
         _freezeVotesThreshold = freezeVotesThreshold_;
         _freezeProposalPeriod = freezeProposalPeriod_;
         _freezePeriod = freezePeriod_;
+        __VoterResolverV1_init(lightAccountFactory_);
     }
 
     // ======================================================================

--- a/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
@@ -3,17 +3,16 @@ pragma solidity ^0.8.30;
 
 import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {IFreezeVotingMultisigV1} from "../../interfaces/decent/deployables/IFreezeVotingMultisigV1.sol";
+import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {FreezeVotingBaseV1} from "./FreezeVotingBaseV1.sol";
-import {VoterResolverV1} from "../account-abstraction/VoterResolverV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract FreezeVotingMultisigV1 is
     IFreezeVotingMultisigV1,
     IVersion,
     FreezeVotingBaseV1,
-    VoterResolverV1,
     ERC165
 {
     // ======================================================================
@@ -44,9 +43,9 @@ contract FreezeVotingMultisigV1 is
             owner_,
             freezeProposalPeriod_,
             freezePeriod_,
-            freezeVotesThreshold_
+            freezeVotesThreshold_,
+            lightAccountFactory_
         );
-        __VoterResolverV1_init(lightAccountFactory_);
         _parentSafe = ISafe(parentSafe_);
     }
 
@@ -103,6 +102,7 @@ contract FreezeVotingMultisigV1 is
         return
             interfaceId_ == type(IFreezeVotingMultisigV1).interfaceId ||
             interfaceId_ == type(IFreezeVotingBaseV1).interfaceId ||
+            interfaceId_ == type(IVoterResolverV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             super.supportsInterface(interfaceId_);
     }

--- a/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
@@ -10,6 +10,7 @@ import {
   IFreezeVotingBaseV1__factory,
   IFreezeVotingMultisigV1__factory,
   IVersion__factory,
+  IVoterResolverV1__factory,
   MockLightAccount,
   MockLightAccountFactory,
   MockLightAccountFactory__factory,
@@ -518,6 +519,14 @@ describe('FreezeVotingMultisigV1', () => {
       void expect(
         await freezeVoting.supportsInterface(
           calculateInterfaceId(IFreezeVotingBaseV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('should support the IVoterResolverV1 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IVoterResolverV1__factory.createInterface()),
         ),
       ).to.be.true;
     });


### PR DESCRIPTION
Fixes [ENG-1160](https://linear.app/decent-labs/issue/ENG-1160/refactor-consolidate-voter-resolution-in-freeze-voting-contracts)

This commit refactors the freeze voting contracts by moving the `VoterResolverV1` logic from `FreezeVotingAzoriusV1` and `FreezeVotingMultisigV1` into the shared `FreezeVotingBaseV1` contract.

This change centralizes the voter resolution logic, which handles ERC-4337 smart account voters, into a single base contract. It eliminates code duplication across the different freeze voting implementations, adhering to the DRY (Don't Repeat Yourself) principle.

Key changes include:
- `FreezeVotingBaseV1` now inherits from and initializes `VoterResolverV1`.
- `FreezeVotingAzoriusV1` and `FreezeVotingMultisigV1` now inherit this functionality from the base contract.
- Initializer functions have been updated to pass the `lightAccountFactory` address to the base contract.
- Tests have been updated to reflect the new initialization patterns and to verify continued support for the `IVoterResolverV1` interface.

No functional changes are introduced; this is purely a code cleanup and improvement.