### PR TITLE
refactor(modules): Align ModuleFractalV1 initialization pattern

### DIFF
--- a/contracts/deployables/modules/ModuleFractalV1.sol
+++ b/contracts/deployables/modules/ModuleFractalV1.sol
@@ -31,13 +31,13 @@ contract ModuleFractalV1 is
         address avatar_,
         address target_
     ) public virtual override initializer {
-        __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
+        __Ownable_init(owner_);
 
-        setAvatar(avatar_);
-        setTarget(target_);
-
-        _transferOwnership(owner_);
+        avatar = avatar_;
+        target = target_;
+        emit AvatarSet(address(0), avatar_);
+        emit TargetSet(address(0), target_);
     }
 
     function setUp(


### PR DESCRIPTION
Fixes [ENG-1161](https://linear.app/decent-labs/issue/ENG-1161/refactor-align-modulefractalv1-initialization-with-moduleazoriusv1)

This commit refactors the `initialize` function in `ModuleFractalV1` to align it with the cleaner, more direct pattern used in `ModuleAzoriusV1`.

The previous implementation granted temporary ownership to the factory contract (`msg.sender`) simply to call the `onlyOwner` protected `setAvatar` and `setTarget` functions, before transferring ownership to the intended owner.

The new approach bypasses this by setting the `avatar` and `target` state variables directly and emitting their corresponding events. This simplifies the initialization logic, makes it more gas-efficient, and avoids the unnecessary two-step ownership transfer. This is a common and robust pattern for initializers that need to set state controlled by `onlyOwner` modifiers.

No functional changes are introduced.