### PR TITLE
refactor(key-value-pairs): Improve API safety using KeyValuePair struct

### DIFF
--- a/contracts/interfaces/decent/singletons/IKeyValuePairs.sol
+++ b/contracts/interfaces/decent/singletons/IKeyValuePairs.sol
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-/**
- * A utility contract to log key / value pair events for the calling address.
- */
 interface IKeyValuePairs {
-    /**
-     * Logs the given key / value pairs, along with the caller's address.
-     *
-     * @param _keys the keys
-     * @param _values the values
-     */
-    function updateValues(
-        string[] memory _keys,
-        string[] memory _values
-    ) external;
+    // --- Structs ---
+
+    struct KeyValuePair {
+        string key;
+        string value;
+    }
+
+    // --- Events ---
+
+    event ValueUpdated(address indexed sender, string key, string value);
+
+    // --- State-Changing Functions ---
+
+    function updateValues(KeyValuePair[] memory keyValuePairs_) external;
 }

--- a/contracts/singletons/KeyValuePairs.sol
+++ b/contracts/singletons/KeyValuePairs.sol
@@ -3,26 +3,19 @@ pragma solidity ^0.8.30;
 
 import {IKeyValuePairs} from "../interfaces/decent/singletons/IKeyValuePairs.sol";
 
-/**
- * Implementation of [IKeyValuePairs](./interfaces/IKeyValuePairs.md), a utility
- * contract to log key / value pair events for the calling address.
- */
 contract KeyValuePairs is IKeyValuePairs {
-    event ValueUpdated(address indexed theAddress, string key, string value);
+    // ======================================================================
+    // IKeyValuePairs
+    // ======================================================================
 
-    error IncorrectValueCount();
+    // --- State-Changing Functions ---
 
-    /** @inheritdoc IKeyValuePairs*/
-    function updateValues(
-        string[] memory _keys,
-        string[] memory _values
-    ) external {
-        uint256 keyCount = _keys.length;
+    function updateValues(KeyValuePair[] memory keyValuePairs_) external {
+        for (uint256 i; i < keyValuePairs_.length; ) {
+            KeyValuePair memory keyValuePair = keyValuePairs_[i];
 
-        if (keyCount != _values.length) revert IncorrectValueCount();
+            emit ValueUpdated(msg.sender, keyValuePair.key, keyValuePair.value);
 
-        for (uint256 i; i < keyCount; ) {
-            emit ValueUpdated(msg.sender, _keys[i], _values[i]);
             unchecked {
                 ++i;
             }

--- a/test/singletons/KeyValuePairs.test.ts
+++ b/test/singletons/KeyValuePairs.test.ts
@@ -15,10 +15,13 @@ describe('KeyValuePairs', function () {
 
   describe('updateValues', function () {
     it('should emit ValueUpdated events for each key-value pair', async function () {
-      const keys = ['name', 'age', 'city'];
-      const values = ['Alice', '25', 'New York'];
+      const keyValuePairsData = [
+        { key: 'name', value: 'Alice' },
+        { key: 'age', value: '25' },
+        { key: 'city', value: 'New York' },
+      ];
 
-      await expect(keyValuePairs.connect(user).updateValues(keys, values))
+      await expect(keyValuePairs.connect(user).updateValues(keyValuePairsData))
         .to.emit(keyValuePairs, 'ValueUpdated')
         .withArgs(user.address, 'name', 'Alice')
         .to.emit(keyValuePairs, 'ValueUpdated')
@@ -28,33 +31,17 @@ describe('KeyValuePairs', function () {
     });
 
     it('should work with a single key-value pair', async function () {
-      const keys = ['single'];
-      const values = ['value'];
+      const keyValuePairsData = [{ key: 'single', value: 'value' }];
 
-      await expect(keyValuePairs.connect(user).updateValues(keys, values))
+      await expect(keyValuePairs.connect(user).updateValues(keyValuePairsData))
         .to.emit(keyValuePairs, 'ValueUpdated')
         .withArgs(user.address, 'single', 'value');
     });
 
     it('should work with empty arrays', async function () {
-      const keys: string[] = [];
-      const values: string[] = [];
+      const keyValuePairsData: { key: string; value: string }[] = [];
 
-      await expect(keyValuePairs.connect(user).updateValues(keys, values)).to.not.be.reverted;
-    });
-
-    it('should revert if keys and values arrays have different lengths', async function () {
-      const keys = ['key1', 'key2'];
-      const values = ['value1'];
-
-      await expect(
-        keyValuePairs.connect(user).updateValues(keys, values),
-      ).to.be.revertedWithCustomError(keyValuePairs, 'IncorrectValueCount');
-
-      const moreValues = ['value1', 'value2', 'value3'];
-      await expect(
-        keyValuePairs.connect(user).updateValues(keys, moreValues),
-      ).to.be.revertedWithCustomError(keyValuePairs, 'IncorrectValueCount');
+      await expect(keyValuePairs.connect(user).updateValues(keyValuePairsData)).to.not.be.reverted;
     });
   });
 });


### PR DESCRIPTION
Fixes [ENG-1162](https://linear.app/decent-labs/issue/ENG-1162/refactor-keyvaluepairs-to-use-struct-for-safer-updates)

This commit refactors the `KeyValuePairs` contract and its interface to improve type safety and ease of use.

Previously, the `updateValues` function accepted two parallel arrays for keys and values, which required a runtime check to ensure their lengths matched. This design was prone to caller error.

The function has been updated to accept a single array of `KeyValuePair` structs. This change leverages the type system to guarantee that keys and values are always paired, eliminating the possibility of mismatched array lengths and removing the need for the `IncorrectValueCount` custom error.

This results in a safer, more robust, and developer-friendly API. The interface has also been updated to follow the project's structural guidelines.