### PR TITLE
feat(strategy): Introduce two-step initialization for StrategyV1

### DIFF
--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -60,18 +60,12 @@ contract StrategyV1 is
     }
 
     function initialize(
-        address strategyAdmin_,
         uint32 votingPeriod_,
         uint256 quorumThreshold_,
         uint256 basisNumerator_,
-        address[] calldata votingAdapters_,
         address[] calldata proposerAdapters_,
         address lightAccountFactory_
     ) public virtual override initializer {
-        if (votingAdapters_.length == 0) {
-            revert NoVotingAdapters();
-        }
-
         if (proposerAdapters_.length == 0) {
             revert NoProposerAdapters();
         }
@@ -82,21 +76,32 @@ contract StrategyV1 is
         ) revert InvalidBasisNumerator();
 
         __VoterResolverV1_init(lightAccountFactory_);
-        _strategyAdmin = strategyAdmin_;
         _votingPeriod = votingPeriod_;
         _quorumThreshold = quorumThreshold_;
         _basisNumerator = basisNumerator_;
-        _votingAdapters = votingAdapters_;
         _proposerAdapters = proposerAdapters_;
 
-        for (uint256 i = 0; i < votingAdapters_.length; ) {
-            _isVotingAdapter[votingAdapters_[i]] = true;
+        for (uint256 i = 0; i < proposerAdapters_.length; ) {
+            _isProposerAdapter[proposerAdapters_[i]] = true;
             unchecked {
                 ++i;
             }
         }
-        for (uint256 i = 0; i < proposerAdapters_.length; ) {
-            _isProposerAdapter[proposerAdapters_[i]] = true;
+    }
+
+    function initialize2(
+        address strategyAdmin_,
+        address[] calldata votingAdapters_
+    ) public virtual override reinitializer(2) {
+        if (votingAdapters_.length == 0) {
+            revert NoVotingAdapters();
+        }
+
+        _strategyAdmin = strategyAdmin_;
+        _votingAdapters = votingAdapters_;
+
+        for (uint256 i = 0; i < votingAdapters_.length; ) {
+            _isVotingAdapter[votingAdapters_[i]] = true;
             unchecked {
                 ++i;
             }

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -63,13 +63,16 @@ interface IStrategyV1 {
     // --- Initializer Functions ---
 
     function initialize(
-        address strategyAdmin_,
         uint32 votingPeriod_,
         uint256 quorumThreshold_,
         uint256 basisNumerator_,
-        address[] calldata votingAdapters_,
         address[] calldata proposerAdapters_,
         address lightAccountFactory_
+    ) external;
+
+    function initialize2(
+        address strategyAdmin_,
+        address[] calldata votingAdapters_
     ) external;
 
     // --- View Functions ---

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -41,27 +41,33 @@ contract MockVotingStrategy is IStrategyV1, VoterResolverV1 {
     }
 
     function initialize(
-        address strategyAdmin_,
         uint32 votingPeriod_,
         uint256 quorumThreshold_,
         uint256 basisNumerator_,
-        address[] calldata votingAdapters_,
         address[] calldata proposerAdapters_,
         address lightAccountFactory_
     ) external override {
-        mockStrategyAdmin = strategyAdmin_;
         _mockVotingPeriod = votingPeriod_;
         _mockQuorumThreshold = quorumThreshold_;
         _mockBasisNumerator = basisNumerator_;
-        _mockVotingAdapters = votingAdapters_;
         _mockProposerAdapters = proposerAdapters_;
-        for (uint i = 0; i < votingAdapters_.length; i++) {
-            _isVotingAdapterMap[votingAdapters_[i]] = true;
-        }
+
         for (uint i = 0; i < proposerAdapters_.length; i++) {
             _isProposerAdapterMap[proposerAdapters_[i]] = true;
         }
         __VoterResolverV1_init(lightAccountFactory_);
+    }
+
+    function initialize2(
+        address strategyAdmin_,
+        address[] calldata votingAdapters_
+    ) external override {
+        mockStrategyAdmin = strategyAdmin_;
+        _mockVotingAdapters = votingAdapters_;
+
+        for (uint i = 0; i < votingAdapters_.length; i++) {
+            _isVotingAdapterMap[votingAdapters_[i]] = true;
+        }
     }
 
     function strategyAdmin() external view override returns (address) {

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -56,11 +56,9 @@ describe('StrategyV1', () => {
     lightAccountFactoryAddress: string,
   ): Promise<StrategyV1> {
     const initializeCalldata = strategyImplementation.interface.encodeFunctionData('initialize', [
-      strategyAdminAddress,
       votingPeriod,
       quorumThreshold,
       basisNumerator,
-      initialVotingAdaptersAddresses,
       initialProposerAdaptersAddresses,
       lightAccountFactoryAddress,
     ]);
@@ -68,7 +66,9 @@ describe('StrategyV1', () => {
       await strategyImplementation.getAddress(),
       initializeCalldata,
     );
-    return StrategyV1__factory.connect(await proxy.getAddress(), deployer);
+    const strategyInstance = StrategyV1__factory.connect(await proxy.getAddress(), deployer);
+    await strategyInstance.initialize2(strategyAdminAddress, initialVotingAdaptersAddresses);
+    return strategyInstance;
   }
 
   beforeEach(async () => {


### PR DESCRIPTION
Fixes [ENG-1163](https://linear.app/decent-labs/issue/ENG-1163/implement-two-step-initialization-for-strategyv1-to-resolve-deployment)

This commit introduces a two-step initialization pattern for the `StrategyV1` contract to resolve a circular dependency issue during deployment.

Previously, `StrategyV1` required the addresses of its `VotingAdapter` contracts in its single `initialize` function. However, the `VotingAdapter` contracts themselves require the address of the `StrategyV1` contract for their own initialization. This created a "chicken-and-egg" problem that made it impossible to deploy and link the full governance stack in a single, atomic sequence.

To break this circular dependency, the initialization has been split:
- `initialize`: The primary initializer, now sets up parameters that do not depend on other contracts.
- `initialize2`: A new function using `@reinitializer(2)` is added to set the `strategyAdmin` and the `votingAdapters` after they have been deployed and their addresses are available.

This change enables a flexible deployment process where all components can be created first and then wired together, significantly improving the deployability of the system.