### PR TITLE
feat(contracts): Add DeploymentBlockV1 contract

### DIFF
--- a/contracts/DeploymentBlockV1.sol
+++ b/contracts/DeploymentBlockV1.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IDeploymentBlockV1} from "./interfaces/decent/IDeploymentBlockV1.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+abstract contract DeploymentBlockV1 is Initializable, IDeploymentBlockV1 {
+    // ======================================================================
+    // STATE VARIABLES
+    // ======================================================================
+
+    uint256 internal _deploymentBlock;
+
+    // ======================================================================
+    // CONSTRUCTOR & INITIALIZERS
+    // ======================================================================
+
+    function __DeploymentBlockV1_init() internal onlyInitializing {
+        _deploymentBlock = block.number;
+    }
+
+    // ======================================================================
+    // IDeploymentBlockV1
+    // ======================================================================
+
+    // --- View Functions ---
+
+    function deploymentBlock() public view virtual override returns (uint256) {
+        return _deploymentBlock;
+    }
+}

--- a/contracts/interfaces/decent/IDeploymentBlockV1.sol
+++ b/contracts/interfaces/decent/IDeploymentBlockV1.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+interface IDeploymentBlockV1 {
+    // --- View Functions ---
+
+    function deploymentBlock() external view returns (uint256 blockNumber);
+}

--- a/contracts/mocks/concretes/ConcreteDeploymentBlockV1.sol
+++ b/contracts/mocks/concretes/ConcreteDeploymentBlockV1.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
+
+contract ConcreteDeploymentBlockV1 is DeploymentBlockV1 {
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize() external initializer {
+        __DeploymentBlockV1_init();
+    }
+}

--- a/test/DeploymentBlockV1.test.ts
+++ b/test/DeploymentBlockV1.test.ts
@@ -1,0 +1,107 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteDeploymentBlockV1,
+  ConcreteDeploymentBlockV1__factory,
+  ERC1967Proxy__factory,
+} from '../typechain-types';
+
+describe('DeploymentBlockV1', () => {
+  let deployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+
+  let concreteDeploymentBlock: ConcreteDeploymentBlockV1;
+  let masterCopy: string;
+  let deploymentBlockNumber: bigint;
+
+  beforeEach(async () => {
+    // Get signers
+    [deployer, owner] = await ethers.getSigners();
+
+    // Deploy master copy
+    masterCopy = await (
+      await new ConcreteDeploymentBlockV1__factory(deployer).deploy()
+    ).getAddress();
+
+    // Get the current block number before deployment
+    const currentBlock = await ethers.provider.getBlockNumber();
+
+    // Deploy proxy with initialization
+    const initData =
+      ConcreteDeploymentBlockV1__factory.createInterface().encodeFunctionData('initialize');
+    const proxy = await new ERC1967Proxy__factory(deployer).deploy(masterCopy, initData);
+
+    // Connect to the proxy
+    concreteDeploymentBlock = ConcreteDeploymentBlockV1__factory.connect(
+      await proxy.getAddress(),
+      owner,
+    );
+
+    // Store the expected deployment block number (should be currentBlock + 1)
+    deploymentBlockNumber = BigInt(currentBlock + 1);
+  });
+
+  describe('Initialization', () => {
+    it('should set the deployment block correctly during initialization', async () => {
+      expect(await concreteDeploymentBlock.deploymentBlock()).to.equal(deploymentBlockNumber);
+    });
+
+    it('should not allow reinitialization', async () => {
+      await expect(concreteDeploymentBlock.initialize()).to.be.revertedWithCustomError(
+        concreteDeploymentBlock,
+        'InvalidInitialization',
+      );
+    });
+
+    it('should have initialization disabled in the implementation', async () => {
+      const implementationContract = ConcreteDeploymentBlockV1__factory.connect(
+        masterCopy,
+        deployer,
+      );
+
+      await expect(implementationContract.initialize()).to.be.revertedWithCustomError(
+        implementationContract,
+        'InvalidInitialization',
+      );
+    });
+  });
+
+  describe('deploymentBlock', () => {
+    it('should return the correct deployment block number', async () => {
+      const storedBlock = await concreteDeploymentBlock.deploymentBlock();
+      expect(storedBlock).to.equal(deploymentBlockNumber);
+    });
+
+    it('should not change after mining additional blocks', async () => {
+      // Mine some blocks
+      await mine(10);
+
+      // The deployment block should remain the same
+      const storedBlock = await concreteDeploymentBlock.deploymentBlock();
+      expect(storedBlock).to.equal(deploymentBlockNumber);
+    });
+
+    it('should be different for different contract instances', async () => {
+      // Mine some blocks to ensure different deployment blocks
+      await mine(5);
+
+      // Deploy a second instance
+      const initData =
+        ConcreteDeploymentBlockV1__factory.createInterface().encodeFunctionData('initialize');
+      const proxy2 = await new ERC1967Proxy__factory(deployer).deploy(masterCopy, initData);
+      const concreteDeploymentBlock2 = ConcreteDeploymentBlockV1__factory.connect(
+        await proxy2.getAddress(),
+        owner,
+      );
+
+      // The deployment blocks should be different
+      const block1 = await concreteDeploymentBlock.deploymentBlock();
+      const block2 = await concreteDeploymentBlock2.deploymentBlock();
+
+      expect(block2).to.be.gt(block1);
+      expect(block2 - block1).to.be.gte(5);
+    });
+  });
+});


### PR DESCRIPTION
Fixes [ENG-1168](https://linear.app/decent-labs/issue/ENG-1168/implement-deploymentblockv1-contract)

This commit introduces a new abstract contract, `DeploymentBlockV1`, designed to be inherited by other contracts in the system. Its primary purpose is to store the block number at which a contract is deployed.

This functionality is crucial for optimizing frontend indexers and libraries (like The Graph, Ponder, viem, ethers.js) that listen for contract events. By providing the exact deployment block, these systems can start their log-fetching processes from a precise point, significantly improving efficiency and reducing unnecessary historical scanning.

Change Summary:
-   Introduced the `DeploymentBlockV1` abstract contract, which saves `block.number` in its initializer.
-   Added the `IDeploymentBlockV1` interface.
-   Created `ConcreteDeploymentBlockV1` for testing purposes.
-   Implemented a comprehensive test suite in `DeploymentBlockV1.test.ts` to verify correct initialization, immutability of the deployment block, and behavior across multiple instances.