### PR TITLE
feat(contracts): Integrate DeploymentBlockV1 across core contracts

### DIFF
--- a/contracts/DeploymentBlockV1NonUpgradeable.sol
+++ b/contracts/DeploymentBlockV1NonUpgradeable.sol
@@ -2,24 +2,19 @@
 pragma solidity ^0.8.30;
 
 import {IDeploymentBlockV1} from "./interfaces/decent/IDeploymentBlockV1.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-abstract contract DeploymentBlockV1 is Initializable, IDeploymentBlockV1 {
+abstract contract DeploymentBlockV1NonUpgradeable is IDeploymentBlockV1 {
     // ======================================================================
     // STATE VARIABLES
     // ======================================================================
 
-    uint256 internal _deploymentBlock;
+    uint256 internal immutable _deploymentBlock;
 
     // ======================================================================
-    // CONSTRUCTOR & INITIALIZERS
+    // CONSTRUCTOR
     // ======================================================================
 
-    function __DeploymentBlockV1_init() internal onlyInitializing {
-        if (_deploymentBlock != 0) {
-            revert DeploymentBlockAlreadySet();
-        }
-
+    constructor() {
         _deploymentBlock = block.number;
     }
 

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -5,8 +5,10 @@ import {IDecentPaymasterV1} from "../../interfaces/decent/deployables/IDecentPay
 import {IFunctionValidator} from "../../interfaces/decent/deployables/IFunctionValidator.sol";
 import {ISmartAccountValidationV1} from "../../interfaces/decent/deployables/ISmartAccountValidationV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
 import {BasePaymasterV1} from "./BasePaymasterV1.sol";
 import {SmartAccountValidationV1} from "./SmartAccountValidationV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -20,6 +22,7 @@ contract DecentPaymasterV1 is
     IVersion,
     BasePaymasterV1,
     SmartAccountValidationV1,
+    DeploymentBlockV1,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
     ERC165
@@ -46,6 +49,7 @@ contract DecentPaymasterV1 is
     ) public virtual override initializer {
         __BasePaymasterV1_init(owner_, IEntryPoint(entryPoint_));
         __SmartAccountValidationV1_init(lightAccountFactory_);
+        __DeploymentBlockV1_init();
     }
 
     // ======================================================================
@@ -189,6 +193,7 @@ contract DecentPaymasterV1 is
             interfaceId_ == type(ISmartAccountValidationV1).interfaceId ||
             interfaceId_ == type(IPaymaster).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/account-abstraction/validators/StrategyV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/StrategyV1ValidatorV1.sol
@@ -4,9 +4,16 @@ pragma solidity ^0.8.30;
 import {IFunctionValidator} from "../../../interfaces/decent/deployables/IFunctionValidator.sol";
 import {IStrategyV1} from "../../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IVersion} from "../../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1NonUpgradeable} from "../../../DeploymentBlockV1NonUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract StrategyV1ValidatorV1 is IFunctionValidator, IVersion, ERC165 {
+contract StrategyV1ValidatorV1 is
+    IFunctionValidator,
+    IVersion,
+    DeploymentBlockV1NonUpgradeable,
+    ERC165
+{
     // ======================================================================
     // IFunctionValidator
     // ======================================================================
@@ -66,6 +73,7 @@ contract StrategyV1ValidatorV1 is IFunctionValidator, IVersion, ERC165 {
         return
             interfaceId_ == type(IFunctionValidator).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -4,13 +4,14 @@ pragma solidity ^0.8.30;
 import {IDecentAutonomousAdminV1} from "../../interfaces/decent/deployables/IDecentAutonomousAdminV1.sol";
 import {IHatsElectionsEligibility} from "../../interfaces/hats/modules/IHatsElectionsEligibility.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract DecentAutonomousAdminV1 is
     IDecentAutonomousAdminV1,
     IVersion,
-    Initializable,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -21,7 +22,9 @@ contract DecentAutonomousAdminV1 is
         _disableInitializers();
     }
 
-    function initialize() public virtual override initializer {}
+    function initialize() public virtual override initializer {
+        __DeploymentBlockV1_init();
+    }
 
     // ======================================================================
     // IDecentAutonomousAdminV1
@@ -72,6 +75,7 @@ contract DecentAutonomousAdminV1 is
         return
             interfaceId_ == type(IDecentAutonomousAdminV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/countersign/CountersignV1.sol
+++ b/contracts/deployables/countersign/CountersignV1.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.30;
 import {IKYCVerifierV1} from "../../interfaces/decent/deployables/IKYCVerifierV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {ICountersignV1} from "../../interfaces/decent/deployables/ICountersignV1.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
-
-contract CountersignV1 is ICountersignV1, IVersion, ERC165, Initializable {
+contract CountersignV1 is ICountersignV1, IVersion, DeploymentBlockV1, ERC165 {
     // ======================================================================
     // STATE VARIABLES
     // ======================================================================
@@ -39,6 +39,7 @@ contract CountersignV1 is ICountersignV1, IVersion, ERC165, Initializable {
         SignerInitialization[] memory signerInitializations_,
         Transaction[] memory preExecutionTransactions_
     ) public virtual override initializer {
+        __DeploymentBlockV1_init();
         _agreementUri = agreementUri_;
         _kycVerifier = kycVerifier_;
         _signingDeadline = signingDeadline_;
@@ -100,13 +101,7 @@ contract CountersignV1 is ICountersignV1, IVersion, ERC165, Initializable {
         return _signingDeadline;
     }
 
-    function executionDeadline()
-        public
-        view
-        virtual
-        override
-        returns (uint48)
-    {
+    function executionDeadline() public view virtual override returns (uint48) {
         return _executionDeadline;
     }
 
@@ -217,6 +212,7 @@ contract CountersignV1 is ICountersignV1, IVersion, ERC165, Initializable {
         return
             interfaceId_ == type(ICountersignV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/countersign/KYCVerifierV1.sol
+++ b/contracts/deployables/countersign/KYCVerifierV1.sol
@@ -4,10 +4,11 @@ pragma solidity ^0.8.30;
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IKYCVerifierV1} from "../../interfaces/decent/deployables/IKYCVerifierV1.sol";
 import {IZKMEVerify} from "../../interfaces/zkme/IZKMEVerify.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
-contract KYCVerifierV1 is IKYCVerifierV1, IVersion, ERC165, Initializable {
+contract KYCVerifierV1 is IKYCVerifierV1, IVersion, DeploymentBlockV1, ERC165 {
     // ======================================================================
     // STATE VARIABLES
     // ======================================================================
@@ -27,6 +28,7 @@ contract KYCVerifierV1 is IKYCVerifierV1, IVersion, ERC165, Initializable {
         address zkMeVerify_,
         address cooperator_
     ) public virtual override initializer {
+        __DeploymentBlockV1_init();
         _zkMeVerify = zkMeVerify_;
         _cooperator = cooperator_;
     }
@@ -73,6 +75,7 @@ contract KYCVerifierV1 is IKYCVerifierV1, IVersion, ERC165, Initializable {
         return
             interfaceId_ == type(IKYCVerifierV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -2,13 +2,15 @@
 pragma solidity ^0.8.30;
 
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {IVotesERC20StakedV1} from "../../interfaces/decent/deployables/IVotesERC20StakedV1.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ERC20VotesUpgradeable, VotesUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
-import {IVotesERC20StakedV1} from "../../interfaces/decent/deployables/IVotesERC20StakedV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract VotesERC20StakedV1 is
@@ -17,6 +19,7 @@ contract VotesERC20StakedV1 is
     ERC20VotesUpgradeable,
     UUPSUpgradeable,
     Ownable2StepUpgradeable,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -58,6 +61,7 @@ contract VotesERC20StakedV1 is
         __ERC20Votes_init();
         __UUPSUpgradeable_init();
         __Ownable_init(owner_);
+        __DeploymentBlockV1_init();
         _stakedToken = IERC20(stakedToken_);
         _updateMinimumStakingPeriod(minimumStakingPeriod_);
         _addRewardsTokens(rewardsTokens_);
@@ -400,6 +404,7 @@ contract VotesERC20StakedV1 is
             interfaceId_ == type(IERC20).interfaceId ||
             interfaceId_ == type(IVotes).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -6,6 +6,8 @@ import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {NoncesUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/NoncesUpgradeable.sol";
@@ -22,6 +24,7 @@ contract VotesERC20V1 is
     ERC20PermitUpgradeable,
     UUPSUpgradeable,
     Ownable2StepUpgradeable,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -42,6 +45,7 @@ contract VotesERC20V1 is
         __ERC20Votes_init();
         __UUPSUpgradeable_init();
         __Ownable_init(owner_);
+        __DeploymentBlockV1_init();
 
         uint256 holderCount = allocations_.length;
         for (uint256 i; i < holderCount; ) {
@@ -147,6 +151,7 @@ contract VotesERC20V1 is
             interfaceId_ == type(IERC20Permit).interfaceId ||
             interfaceId_ == type(IVotes).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
@@ -5,6 +5,8 @@ import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IFreezeGuardAzoriusV1} from "../../interfaces/decent/deployables/IFreezeGuardAzoriusV1.sol";
 import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -16,6 +18,7 @@ contract FreezeGuardAzoriusV1 is
     IVersion,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -38,6 +41,7 @@ contract FreezeGuardAzoriusV1 is
     ) public virtual override initializer {
         __Ownable_init(owner_);
         __UUPSUpgradeable_init();
+        __DeploymentBlockV1_init();
         _freezeVoting = IFreezeVotingBaseV1(freezeVoting_);
     }
 
@@ -109,6 +113,7 @@ contract FreezeGuardAzoriusV1 is
             interfaceId_ == type(IFreezeGuardBaseV1).interfaceId ||
             interfaceId_ == type(IGuard).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
@@ -6,6 +6,8 @@ import {IFreezeGuardMultisigV1} from "../../interfaces/decent/deployables/IFreez
 import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
 import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -17,6 +19,7 @@ contract FreezeGuardMultisigV1 is
     IVersion,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -47,6 +50,7 @@ contract FreezeGuardMultisigV1 is
     ) public virtual override initializer {
         __Ownable_init(owner_);
         __UUPSUpgradeable_init();
+        __DeploymentBlockV1_init();
         _updateTimelockPeriod(timelockPeriod_);
         _updateExecutionPeriod(executionPeriod_);
         _freezeVoting = IFreezeVotingBaseV1(freezeVoting_);
@@ -220,6 +224,7 @@ contract FreezeGuardMultisigV1 is
             interfaceId_ == type(IFreezeGuardBaseV1).interfaceId ||
             interfaceId_ == type(IGuard).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
@@ -8,13 +8,16 @@ import {IModuleAzoriusV1} from "../../interfaces/decent/deployables/IModuleAzori
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
 import {FreezeVotingBaseV1} from "./FreezeVotingBaseV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract FreezeVotingAzoriusV1 is
     IFreezeVotingAzoriusV1,
     IVersion,
     FreezeVotingBaseV1,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -47,6 +50,7 @@ contract FreezeVotingAzoriusV1 is
             freezeVotesThreshold_,
             lightAccountFactory_
         );
+        __DeploymentBlockV1_init();
         _parentAzorius = IModuleAzoriusV1(parentAzorius_);
     }
 
@@ -122,6 +126,7 @@ contract FreezeVotingAzoriusV1 is
             interfaceId_ == type(IFreezeVotingBaseV1).interfaceId ||
             interfaceId_ == type(IVoterResolverV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingBaseV1.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
-import {VoterResolverV1} from "../account-abstraction/VoterResolverV1.sol";
+import {VoterResolverV1} from "../strategies/VoterResolverV1.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 abstract contract FreezeVotingBaseV1 is

--- a/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
@@ -5,14 +5,17 @@ import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVo
 import {IFreezeVotingMultisigV1} from "../../interfaces/decent/deployables/IFreezeVotingMultisigV1.sol";
 import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {FreezeVotingBaseV1} from "./FreezeVotingBaseV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract FreezeVotingMultisigV1 is
     IFreezeVotingMultisigV1,
     IVersion,
     FreezeVotingBaseV1,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -46,6 +49,7 @@ contract FreezeVotingMultisigV1 is
             freezeVotesThreshold_,
             lightAccountFactory_
         );
+        __DeploymentBlockV1_init();
         _parentSafe = ISafe(parentSafe_);
     }
 
@@ -104,6 +108,7 @@ contract FreezeVotingMultisigV1 is
             interfaceId_ == type(IFreezeVotingBaseV1).interfaceId ||
             interfaceId_ == type(IVoterResolverV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/deployables/modules/ModuleAzoriusV1.sol
+++ b/contracts/deployables/modules/ModuleAzoriusV1.sol
@@ -5,6 +5,8 @@ import {IModuleAzoriusV1} from "../../interfaces/decent/deployables/IModuleAzori
 import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {Transaction} from "../../interfaces/decent/Module.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
@@ -15,6 +17,7 @@ contract ModuleAzoriusV1 is
     IModuleAzoriusV1,
     IVersion,
     GuardableModule,
+    DeploymentBlockV1,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
     ERC165
@@ -73,6 +76,7 @@ contract ModuleAzoriusV1 is
     ) public virtual override initializer {
         __UUPSUpgradeable_init();
         __Ownable_init(owner_);
+        __DeploymentBlockV1_init();
 
         // avoids onlyOwner requirement on setAvatar and setTarget
         avatar = avatar_;
@@ -379,6 +383,7 @@ contract ModuleAzoriusV1 is
         return
             interfaceId_ == type(IModuleAzoriusV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/deployables/modules/ModuleFractalV1.sol
+++ b/contracts/deployables/modules/ModuleFractalV1.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.30;
 
 import {IModuleFractalV1} from "../../interfaces/decent/deployables/IModuleFractalV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
 import {Transaction} from "../../interfaces/decent/Module.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -14,6 +16,7 @@ contract ModuleFractalV1 is
     IModuleFractalV1,
     IVersion,
     GuardableModule,
+    DeploymentBlockV1,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
     ERC165
@@ -33,6 +36,7 @@ contract ModuleFractalV1 is
     ) public virtual override initializer {
         __UUPSUpgradeable_init();
         __Ownable_init(owner_);
+        __DeploymentBlockV1_init();
 
         avatar = avatar_;
         target = target_;
@@ -126,6 +130,7 @@ contract ModuleFractalV1 is
         return
             interfaceId_ == type(IModuleFractalV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -7,14 +7,15 @@ import {IProposerAdapterBaseV1} from "../../interfaces/decent/deployables/IPropo
 import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
 import {ISmartAccountValidationV1} from "../../interfaces/decent/deployables/ISmartAccountValidationV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {VoterResolverV1} from "./VoterResolverV1.sol";
+import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {VoterResolverV1} from "../account-abstraction/VoterResolverV1.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract StrategyV1 is
     IStrategyV1,
     IVersion,
-    Initializable,
+    DeploymentBlockV1,
     VoterResolverV1,
     ERC165
 {
@@ -76,6 +77,7 @@ contract StrategyV1 is
         ) revert InvalidBasisNumerator();
 
         __VoterResolverV1_init(lightAccountFactory_);
+        __DeploymentBlockV1_init();
         _votingPeriod = votingPeriod_;
         _quorumThreshold = quorumThreshold_;
         _basisNumerator = basisNumerator_;
@@ -497,6 +499,7 @@ contract StrategyV1 is
             interfaceId_ == type(IVoterResolverV1).interfaceId ||
             interfaceId_ == type(ISmartAccountValidationV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/strategies/VoterResolverV1.sol
+++ b/contracts/deployables/strategies/VoterResolverV1.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IVoterResolverV1} from "../../interfaces/decent/deployables/IVoterResolverV1.sol";
-import {SmartAccountValidationV1} from "./SmartAccountValidationV1.sol";
+import {SmartAccountValidationV1} from "../account-abstraction/SmartAccountValidationV1.sol";
 
 abstract contract VoterResolverV1 is
     IVoterResolverV1,

--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.sol
@@ -4,14 +4,15 @@ pragma solidity ^0.8.30;
 import {IProposerAdapterERC20V1} from "../../../../interfaces/decent/deployables/IProposerAdapterERC20V1.sol";
 import {IProposerAdapterBaseV1} from "../../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../../../DeploymentBlockV1.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract ProposerAdapterERC20V1 is
     IProposerAdapterERC20V1,
     IVersion,
-    Initializable,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -33,6 +34,7 @@ contract ProposerAdapterERC20V1 is
         address token_,
         uint256 proposerThreshold_
     ) public virtual override initializer {
+        __DeploymentBlockV1_init();
         _token = IVotes(token_);
         _proposerThreshold = proposerThreshold_;
     }
@@ -93,6 +95,7 @@ contract ProposerAdapterERC20V1 is
             interfaceId_ == type(IProposerAdapterERC20V1).interfaceId ||
             interfaceId_ == type(IProposerAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.sol
@@ -4,13 +4,14 @@ pragma solidity ^0.8.30;
 import {IProposerAdapterERC721V1} from "../../../../interfaces/decent/deployables/IProposerAdapterERC721V1.sol";
 import {IProposerAdapterBaseV1} from "../../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../../../DeploymentBlockV1.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract ProposerAdapterERC721V1 is
     IProposerAdapterERC721V1,
-    Initializable,
+    DeploymentBlockV1,
     IVersion,
     ERC165
 {
@@ -33,6 +34,7 @@ contract ProposerAdapterERC721V1 is
         address token_,
         uint256 proposerThreshold_
     ) public virtual override initializer {
+        __DeploymentBlockV1_init();
         _token = IERC721(token_);
         _proposerThreshold = proposerThreshold_;
     }
@@ -93,6 +95,7 @@ contract ProposerAdapterERC721V1 is
             interfaceId_ == type(IProposerAdapterERC721V1).interfaceId ||
             interfaceId_ == type(IProposerAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.sol
@@ -5,13 +5,14 @@ import {IProposerAdapterHatsV1} from "../../../../interfaces/decent/deployables/
 import {IProposerAdapterBaseV1} from "../../../../interfaces/decent/deployables/IProposerAdapterBaseV1.sol";
 import {IHats} from "../../../../interfaces/hats/IHats.sol";
 import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IDeploymentBlockV1} from "../../../../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1} from "../../../../DeploymentBlockV1.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 contract ProposerAdapterHatsV1 is
     IProposerAdapterHatsV1,
     IVersion,
-    Initializable,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -34,6 +35,7 @@ contract ProposerAdapterHatsV1 is
         address hatsContract_,
         uint256[] calldata whitelistedHatIds_
     ) public virtual override initializer {
+        __DeploymentBlockV1_init();
         _hatsContract = IHats(hatsContract_);
         _whitelistedHatIds = whitelistedHatIds_;
         for (uint256 i = 0; i < whitelistedHatIds_.length; ) {
@@ -110,6 +112,7 @@ contract ProposerAdapterHatsV1 is
             interfaceId_ == type(IProposerAdapterHatsV1).interfaceId ||
             interfaceId_ == type(IProposerAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
@@ -6,7 +6,9 @@ import {IVotingAdapterBaseV1} from "../../../../interfaces/decent/deployables/IV
 import {IStrategyV1} from "../../../../interfaces/decent/deployables/IStrategyV1.sol";
 import {ClockMode} from "../../../../interfaces/decent/ClockMode.sol";
 import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../../../interfaces/decent/IDeploymentBlockV1.sol";
 import {VotingAdapterBaseV1} from "./VotingAdapterBaseV1.sol";
+import {DeploymentBlockV1} from "../../../../DeploymentBlockV1.sol";
 import {ClockModeLib} from "../../../../libs/ClockModeLib.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -17,6 +19,7 @@ contract VotingAdapterERC20V1 is
     IVotingAdapterERC20V1,
     IVersion,
     VotingAdapterBaseV1,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -45,6 +48,7 @@ contract VotingAdapterERC20V1 is
         uint256 weightPerToken_
     ) public virtual override initializer {
         __VotingAdapterBaseV1_init(strategy_);
+        __DeploymentBlockV1_init();
         _token = IVotes(token_);
         _weightPerToken = weightPerToken_;
         _tokenClockMode = ClockModeLib.getClockMode(token_);
@@ -260,6 +264,7 @@ contract VotingAdapterERC20V1 is
             interfaceId_ == type(IVotingAdapterERC20V1).interfaceId ||
             interfaceId_ == type(IVotingAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
@@ -5,7 +5,9 @@ import {IStrategyV1} from "../../../../interfaces/decent/deployables/IStrategyV1
 import {IVotingAdapterERC721V1} from "../../../../interfaces/decent/deployables/IVotingAdapterERC721V1.sol";
 import {IVotingAdapterBaseV1} from "../../../../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
 import {IVersion} from "../../../../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../../../../interfaces/decent/IDeploymentBlockV1.sol";
 import {VotingAdapterBaseV1} from "./VotingAdapterBaseV1.sol";
+import {DeploymentBlockV1} from "../../../../DeploymentBlockV1.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
@@ -13,6 +15,7 @@ contract VotingAdapterERC721V1 is
     IVotingAdapterERC721V1,
     IVersion,
     VotingAdapterBaseV1,
+    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -40,6 +43,7 @@ contract VotingAdapterERC721V1 is
         uint256 weightPerToken_
     ) public virtual override initializer {
         __VotingAdapterBaseV1_init(strategy_);
+        __DeploymentBlockV1_init();
         _token = IERC721(token_);
         _weightPerToken = weightPerToken_;
     }
@@ -274,6 +278,7 @@ contract VotingAdapterERC721V1 is
             interfaceId_ == type(IVotingAdapterERC721V1).interfaceId ||
             interfaceId_ == type(IVotingAdapterBaseV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/interfaces/decent/IDeploymentBlockV1.sol
+++ b/contracts/interfaces/decent/IDeploymentBlockV1.sol
@@ -2,6 +2,10 @@
 pragma solidity ^0.8.30;
 
 interface IDeploymentBlockV1 {
+    // --- Errors ---
+
+    error DeploymentBlockAlreadySet();
+
     // --- View Functions ---
 
     function deploymentBlock() external view returns (uint256 blockNumber);

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IStrategyV1} from "../interfaces/decent/deployables/IStrategyV1.sol";
 import {IVotingAdapterBaseV1} from "../interfaces/decent/deployables/IVotingAdapterBaseV1.sol";
-import {VoterResolverV1} from "../deployables/account-abstraction/VoterResolverV1.sol";
+import {VoterResolverV1} from "../deployables/strategies/VoterResolverV1.sol";
 
 contract MockVotingStrategy is IStrategyV1, VoterResolverV1 {
     struct TimestampPoints {

--- a/contracts/mocks/concretes/ConcreteDeploymentBlockV1.sol
+++ b/contracts/mocks/concretes/ConcreteDeploymentBlockV1.sol
@@ -11,4 +11,9 @@ contract ConcreteDeploymentBlockV1 is DeploymentBlockV1 {
     function initialize() external initializer {
         __DeploymentBlockV1_init();
     }
+
+    // This should fail if called after initialize
+    function reinitialize() external reinitializer(2) {
+        __DeploymentBlockV1_init();
+    }
 }

--- a/contracts/mocks/concretes/ConcreteDeploymentBlockV1NonUpgradeable.sol
+++ b/contracts/mocks/concretes/ConcreteDeploymentBlockV1NonUpgradeable.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {DeploymentBlockV1NonUpgradeable} from "../../DeploymentBlockV1NonUpgradeable.sol";
+
+// Concrete implementation for testing
+contract ConcreteDeploymentBlockV1NonUpgradeable is
+    DeploymentBlockV1NonUpgradeable
+{
+    constructor() DeploymentBlockV1NonUpgradeable() {}
+}

--- a/contracts/mocks/concretes/deployables/strategies/ConcreteVoterResolverV1.sol
+++ b/contracts/mocks/concretes/deployables/strategies/ConcreteVoterResolverV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {VoterResolverV1} from "../../../../deployables/account-abstraction/VoterResolverV1.sol";
+import {VoterResolverV1} from "../../../../deployables/strategies/VoterResolverV1.sol";
 import {ILightAccountFactory} from "../../../../interfaces/light-account/ILightAccountFactory.sol";
 
 /**

--- a/contracts/singletons/KeyValuePairsV1.sol
+++ b/contracts/singletons/KeyValuePairsV1.sol
@@ -3,9 +3,16 @@ pragma solidity ^0.8.30;
 
 import {IKeyValuePairsV1} from "../interfaces/decent/singletons/IKeyValuePairsV1.sol";
 import {IVersion} from "../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1NonUpgradeable} from "../DeploymentBlockV1NonUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract KeyValuePairsV1 is IKeyValuePairsV1, IVersion, ERC165 {
+contract KeyValuePairsV1 is
+    IKeyValuePairsV1,
+    IVersion,
+    DeploymentBlockV1NonUpgradeable,
+    ERC165
+{
     // ======================================================================
     // IKeyValuePairs
     // ======================================================================
@@ -13,7 +20,7 @@ contract KeyValuePairsV1 is IKeyValuePairsV1, IVersion, ERC165 {
     // --- State-Changing Functions ---
 
     function updateValues(
-        KeyValuePair[] memory keyValuePairs_
+        KeyValuePair[] calldata keyValuePairs_
     ) public virtual override {
         for (uint256 i; i < keyValuePairs_.length; ) {
             KeyValuePair memory keyValuePair = keyValuePairs_[i];
@@ -48,6 +55,7 @@ contract KeyValuePairsV1 is IKeyValuePairsV1, IVersion, ERC165 {
         return
             interfaceId_ == type(IKeyValuePairsV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/singletons/SystemDeployerV1.sol
+++ b/contracts/singletons/SystemDeployerV1.sol
@@ -19,10 +19,17 @@ import {IFreezeGuardMultisigV1} from "../interfaces/decent/deployables/IFreezeGu
 import {IFreezeGuardAzoriusV1} from "../interfaces/decent/deployables/IFreezeGuardAzoriusV1.sol";
 import {ISystemDeployerEventEmitterV1} from "../interfaces/decent/singletons/ISystemDeployerEventEmitterV1.sol";
 import {IVersion} from "../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlockV1} from "../interfaces/decent/IDeploymentBlockV1.sol";
+import {DeploymentBlockV1NonUpgradeable} from "../DeploymentBlockV1NonUpgradeable.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract SystemDeployerV1 is ISystemDeployerV1, IVersion, ERC165 {
+contract SystemDeployerV1 is
+    ISystemDeployerV1,
+    IVersion,
+    DeploymentBlockV1NonUpgradeable,
+    ERC165
+{
     // ======================================================================
     // STATE VARIABLES
     // ======================================================================
@@ -164,6 +171,7 @@ contract SystemDeployerV1 is ISystemDeployerV1, IVersion, ERC165 {
         return
             interfaceId_ == type(ISystemDeployerV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/test/DeploymentBlockV1.test.ts
+++ b/test/DeploymentBlockV1.test.ts
@@ -104,4 +104,35 @@ describe('DeploymentBlockV1', () => {
       expect(block2 - block1).to.be.gte(5);
     });
   });
+
+  describe('Reinitializer Protection', () => {
+    it('should prevent changing deployment block via reinitializer', async () => {
+      // Deploy master copy
+      masterCopy = await (
+        await new ConcreteDeploymentBlockV1__factory(deployer).deploy()
+      ).getAddress();
+
+      // Deploy proxy with initialization
+      const initData =
+        ConcreteDeploymentBlockV1__factory.createInterface().encodeFunctionData('initialize');
+      const proxy = await new ERC1967Proxy__factory(deployer).deploy(masterCopy, initData);
+
+      // Connect to the proxy
+      const contract = ConcreteDeploymentBlockV1__factory.connect(await proxy.getAddress(), owner);
+
+      // Get the initial deployment block
+      const initialDeploymentBlock = await contract.deploymentBlock();
+      expect(initialDeploymentBlock).to.be.gt(0);
+
+      // Try to reinitialize - this should fail with our new protection
+      await expect(contract.reinitialize()).to.be.revertedWithCustomError(
+        contract,
+        'DeploymentBlockAlreadySet',
+      );
+
+      // Verify deployment block hasn't changed
+      const currentDeploymentBlock = await contract.deploymentBlock();
+      expect(currentDeploymentBlock).to.equal(initialDeploymentBlock);
+    });
+  });
 });

--- a/test/DeploymentBlockV1NonUpgradeable.test.ts
+++ b/test/DeploymentBlockV1NonUpgradeable.test.ts
@@ -1,0 +1,85 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteDeploymentBlockV1NonUpgradeable,
+  ConcreteDeploymentBlockV1NonUpgradeable__factory,
+} from '../typechain-types';
+
+describe('DeploymentBlockV1NonUpgradeable', () => {
+  let deployer: SignerWithAddress;
+
+  let concreteDeploymentBlock: ConcreteDeploymentBlockV1NonUpgradeable;
+  let deploymentBlockNumber: bigint;
+
+  beforeEach(async () => {
+    // Get signers
+    [deployer] = await ethers.getSigners();
+
+    // Get the current block number before deployment
+    const currentBlock = await ethers.provider.getBlockNumber();
+
+    // Deploy the contract directly (no proxy needed for non-upgradeable)
+    concreteDeploymentBlock = await new ConcreteDeploymentBlockV1NonUpgradeable__factory(
+      deployer,
+    ).deploy();
+
+    // Store the expected deployment block number (should be currentBlock + 1)
+    deploymentBlockNumber = BigInt(currentBlock + 1);
+  });
+
+  describe('Constructor', () => {
+    it('should set the deployment block correctly during construction', async () => {
+      expect(await concreteDeploymentBlock.deploymentBlock()).to.equal(deploymentBlockNumber);
+    });
+  });
+
+  describe('deploymentBlock', () => {
+    it('should return the correct deployment block number', async () => {
+      const storedBlock = await concreteDeploymentBlock.deploymentBlock();
+      expect(storedBlock).to.equal(deploymentBlockNumber);
+    });
+
+    it('should not change after mining additional blocks', async () => {
+      // Mine some blocks
+      await mine(10);
+
+      // The deployment block should remain the same
+      const storedBlock = await concreteDeploymentBlock.deploymentBlock();
+      expect(storedBlock).to.equal(deploymentBlockNumber);
+    });
+
+    it('should be different for different contract instances', async () => {
+      // Mine some blocks to ensure different deployment blocks
+      await mine(5);
+
+      // Deploy a second instance
+      const concreteDeploymentBlock2 = await new ConcreteDeploymentBlockV1NonUpgradeable__factory(
+        deployer,
+      ).deploy();
+
+      // The deployment blocks should be different
+      const block1 = await concreteDeploymentBlock.deploymentBlock();
+      const block2 = await concreteDeploymentBlock2.deploymentBlock();
+
+      expect(block2).to.be.gt(block1);
+      expect(block2 - block1).to.be.gte(5);
+    });
+
+    it('should use immutable storage for deployment block', async () => {
+      // This test verifies that the deployment block is stored as an immutable variable
+      // by checking that the value is consistent and cannot be changed
+      const block1 = await concreteDeploymentBlock.deploymentBlock();
+
+      // Mine more blocks
+      await mine(100);
+
+      const block2 = await concreteDeploymentBlock.deploymentBlock();
+
+      // The value should remain exactly the same
+      expect(block1).to.equal(block2);
+      expect(block1).to.equal(deploymentBlockNumber);
+    });
+  });
+});

--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -6,6 +6,7 @@ import {
   DecentPaymasterV1__factory,
   ERC1967Proxy__factory,
   IDecentPaymasterV1__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IPaymaster__factory,
   ISmartAccountValidationV1__factory,
@@ -21,6 +22,7 @@ import {
   MockValidator,
   MockValidator__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
@@ -401,6 +403,14 @@ describe('DecentPaymasterV1', function () {
       ).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await decentPaymaster.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('Should not support random interface', async function () {
       const randomInterfaceId = '0x12345678';
       const supported = await decentPaymaster.supportsInterface(randomInterfaceId);
@@ -423,6 +433,12 @@ describe('DecentPaymasterV1', function () {
       },
       owner: () => owner,
       nonOwner: () => nonOwner,
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => decentPaymaster,
     });
   });
 });

--- a/test/deployables/account-abstraction/validators/StrategyV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/StrategyV1ValidatorV1.test.ts
@@ -2,6 +2,7 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IFunctionValidator__factory,
   IStrategyV1,
@@ -12,6 +13,7 @@ import {
   StrategyV1ValidatorV1,
   StrategyV1ValidatorV1__factory,
 } from '../../../../typechain-types';
+import { runDeploymentBlockTests } from '../../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../../helpers/utils';
 
 describe('StrategyV1ValidatorV1', function () {
@@ -229,6 +231,13 @@ describe('StrategyV1ValidatorV1', function () {
       void expect(await validator.supportsInterface(iVersionInterfaceId)).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      const iDeploymentBlockV1InterfaceId = calculateInterfaceId(
+        IDeploymentBlockV1__factory.createInterface(),
+      );
+      void expect(await validator.supportsInterface(iDeploymentBlockV1InterfaceId)).to.be.true;
+    });
+
     it('Should support IERC165 interface', async function () {
       const iERC165InterfaceId = calculateInterfaceId(IERC165__factory.createInterface());
       void expect(await validator.supportsInterface(iERC165InterfaceId)).to.be.true;
@@ -243,6 +252,13 @@ describe('StrategyV1ValidatorV1', function () {
   describe('Version', function () {
     it('Should return correct version', async function () {
       void expect(await validator.version()).to.equal(1);
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => validator,
+      isNonUpgradeable: true,
     });
   });
 });

--- a/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
+++ b/test/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
@@ -6,9 +6,11 @@ import {
   DecentAutonomousAdminV1__factory,
   ERC1967Proxy__factory,
   IDecentAutonomousAdminV1__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IVersion__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 
 // Helper function for deploying DecentAutonomousAdminV1 instances using ERC1967Proxy
@@ -47,37 +49,36 @@ describe('DecentAutonomousAdminV1', function () {
   });
 
   describe('ERC165', function () {
-    let iDecentAutonomousAdminV1InterfaceId: string;
-    let iVersionInterfaceId: string;
-    let iERC165InterfaceId: string;
-
-    beforeEach(async function () {
-      // Dynamically calculate interface IDs
-      const IDecentAutonomousAdminV1Interface = IDecentAutonomousAdminV1__factory.createInterface();
-      iDecentAutonomousAdminV1InterfaceId = calculateInterfaceId(IDecentAutonomousAdminV1Interface);
-
-      const IVersionInterface = IVersion__factory.createInterface();
-      iVersionInterfaceId = calculateInterfaceId(IVersionInterface);
-
-      const IERC165Interface = IERC165__factory.createInterface();
-      iERC165InterfaceId = calculateInterfaceId(IERC165Interface);
-    });
-
     it('Should support IERC165 interface', async function () {
-      const supported = await decentAutonomousAdmin.supportsInterface(iERC165InterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await decentAutonomousAdmin.supportsInterface(
+          calculateInterfaceId(IERC165__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IDecentAutonomousAdminV1 interface', async function () {
-      const supported = await decentAutonomousAdmin.supportsInterface(
-        iDecentAutonomousAdminV1InterfaceId,
-      );
-      void expect(supported).to.be.true;
+      void expect(
+        await decentAutonomousAdmin.supportsInterface(
+          calculateInterfaceId(IDecentAutonomousAdminV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should support IVersion interface', async function () {
-      const supported = await decentAutonomousAdmin.supportsInterface(iVersionInterfaceId);
-      void expect(supported).to.be.true;
+      void expect(
+        await decentAutonomousAdmin.supportsInterface(
+          calculateInterfaceId(IVersion__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await decentAutonomousAdmin.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('should not support random interface', async function () {
@@ -92,6 +93,12 @@ describe('DecentAutonomousAdminV1', function () {
   describe('Version', () => {
     it('should return the correct version number', async () => {
       expect(await decentAutonomousAdmin.version()).to.equal(1);
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => decentAutonomousAdmin,
     });
   });
 });

--- a/test/deployables/countersign/Countersign.test.ts
+++ b/test/deployables/countersign/Countersign.test.ts
@@ -7,6 +7,7 @@ import {
   CountersignV1__factory,
   ERC1967Proxy__factory,
   ICountersignV1__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IVersion__factory,
   MockERC20Votes,
@@ -14,6 +15,7 @@ import {
   MockKYCVerifier,
   MockKYCVerifier__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 
 // Helper function for deploying Countersign instances using ERC1967Proxy
@@ -457,6 +459,14 @@ describe('CountersignV1', () => {
       void expect(supported).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await countersign.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('Should not support random interface', async function () {
       const randomInterfaceId = '0x12345678';
       const supported = await countersign.supportsInterface(randomInterfaceId);
@@ -533,6 +543,12 @@ describe('CountersignV1', () => {
         countersign,
         'InvalidKYCSignature',
       );
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => countersign,
     });
   });
 });

--- a/test/deployables/countersign/KYCVerifier.test.ts
+++ b/test/deployables/countersign/KYCVerifier.test.ts
@@ -2,15 +2,17 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
+  ERC1967Proxy__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
+  IKYCVerifierV1__factory,
   IVersion__factory,
   KYCVerifierV1,
   KYCVerifierV1__factory,
-  IKYCVerifierV1__factory,
-  ERC1967Proxy__factory,
   MockZKMEVerify,
   MockZKMEVerify__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 
 // Helper function for deploying Countersign instances using ERC1967Proxy
@@ -114,6 +116,14 @@ describe('KYCVerifierV1', () => {
       void expect(supported).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await kycVerifier.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('Should not support random interface', async function () {
       const randomInterfaceId = '0x12345678';
       const supported = await kycVerifier.supportsInterface(randomInterfaceId);
@@ -130,6 +140,12 @@ describe('KYCVerifierV1', () => {
     it('should not verify if zkMeVerify has not approved', async () => {
       await mockZKMEVerify.setApproved(false);
       void expect(await kycVerifier.verify(investorAlice.address)).to.be.false;
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => kycVerifier,
     });
   });
 });

--- a/test/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IERC20__factory,
   IVersion__factory,
@@ -14,6 +15,7 @@ import {
   VotesERC20StakedV1,
   VotesERC20StakedV1__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId, executeTxAndCheckBalanceDeltas } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
@@ -314,6 +316,14 @@ describe('VotesERC20StakedV1', () => {
     it('Should support IVotes interface', async function () {
       const supported = await votesERC20Staked.supportsInterface(iVotesInterfaceId);
       void expect(supported).to.be.true;
+    });
+
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await votesERC20Staked.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
     });
 
     it('Should not support random interface', async function () {
@@ -1928,6 +1938,12 @@ describe('VotesERC20StakedV1', () => {
         ethers.parseEther('0'),
         ethers.parseEther('0'),
       ]);
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => votesERC20Staked,
     });
   });
 });

--- a/test/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/deployables/erc20/VotesERC20V1.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IERC20__factory,
   IERC20Permit__factory,
@@ -13,6 +14,7 @@ import {
   VotesERC20V1,
   VotesERC20V1__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
@@ -272,6 +274,14 @@ describe('VotesERC20V1', () => {
       ).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await votesERC20.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('Should not support random interface', async function () {
       const randomInterfaceId = '0x12345678';
       void expect(await votesERC20.supportsInterface(randomInterfaceId)).to.be.false;
@@ -343,6 +353,24 @@ describe('VotesERC20V1', () => {
       },
       owner: () => owner,
       nonOwner: () => nonOwner,
+    });
+  });
+
+  describe('Deployment Block', () => {
+    beforeEach(async function () {
+      votesERC20 = await deployVotesERC20Proxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+        'Test Voting Token',
+        'TVT',
+        [],
+        [],
+      );
+    });
+
+    runDeploymentBlockTests({
+      getContract: () => votesERC20,
     });
   });
 });

--- a/test/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
+++ b/test/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
@@ -5,6 +5,7 @@ import {
   ERC1967Proxy__factory,
   FreezeGuardAzoriusV1,
   FreezeGuardAzoriusV1__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IFreezeGuardAzoriusV1__factory,
   IFreezeGuardBaseV1__factory,
@@ -13,6 +14,7 @@ import {
   MockFreezeVoting,
   MockFreezeVoting__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
@@ -36,7 +38,7 @@ async function deployAzoriusFreezeGuardProxy(
   return FreezeGuardAzoriusV1__factory.connect(await proxy.getAddress(), owner);
 }
 
-describe('AzoriusFreezeGuardV1', () => {
+describe('FreezeGuardAzoriusV1', () => {
   const Operation = {
     Call: 0,
     DelegateCall: 1,
@@ -260,6 +262,14 @@ describe('AzoriusFreezeGuardV1', () => {
       ).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await azoriusFreezeGuard.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('Should not support random interface', async function () {
       void expect(await azoriusFreezeGuard.supportsInterface('0x12345678')).to.be.false;
     });
@@ -285,6 +295,21 @@ describe('AzoriusFreezeGuardV1', () => {
       },
       owner: () => owner,
       nonOwner: () => nonOwner,
+    });
+  });
+
+  describe('Deployment Block', () => {
+    beforeEach(async function () {
+      azoriusFreezeGuard = await deployAzoriusFreezeGuardProxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+        await mockFreezeVoting.getAddress(),
+      );
+    });
+
+    runDeploymentBlockTests({
+      getContract: () => azoriusFreezeGuard,
     });
   });
 });

--- a/test/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
+++ b/test/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
@@ -6,6 +6,7 @@ import {
   ERC1967Proxy__factory,
   FreezeGuardMultisigV1,
   FreezeGuardMultisigV1__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IFreezeGuardBaseV1__factory,
   IFreezeGuardMultisigV1__factory,
@@ -16,6 +17,7 @@ import {
   MockSafe,
   MockSafe__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
@@ -504,6 +506,14 @@ describe('FreezeGuardMultisigV1', () => {
       ).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await multisigFreezeGuard.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('Should not support random interface', async function () {
       void expect(await multisigFreezeGuard.supportsInterface('0x12345678')).to.be.false;
     });
@@ -518,6 +528,12 @@ describe('FreezeGuardMultisigV1', () => {
       },
       owner: () => owner,
       nonOwner: () => nonOwner,
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => multisigFreezeGuard,
     });
   });
 });

--- a/test/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
@@ -6,6 +6,7 @@ import {
   ERC1967Proxy__factory,
   FreezeVotingAzoriusV1,
   FreezeVotingAzoriusV1__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IFreezeVotingAzoriusV1,
   IFreezeVotingAzoriusV1__factory,
@@ -21,6 +22,7 @@ import {
   MockVotingStrategy,
   MockVotingStrategy__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 
 async function deployAzoriusFreezeVotingProxy(
@@ -377,8 +379,21 @@ describe('FreezeVotingAzoriusV1', () => {
         ),
       ).to.be.true;
     });
+    it('should support IDeploymentBlockV1', async () => {
+      void expect(
+        await azoriusFreezeVoting.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
     it('should not support a random interfaceId', async () => {
       void expect(await azoriusFreezeVoting.supportsInterface('0x12345678')).to.be.false;
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => azoriusFreezeVoting,
     });
   });
 });

--- a/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
@@ -6,6 +6,7 @@ import {
   ERC1967Proxy__factory,
   FreezeVotingMultisigV1,
   FreezeVotingMultisigV1__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IFreezeVotingBaseV1__factory,
   IFreezeVotingMultisigV1__factory,
@@ -18,6 +19,7 @@ import {
   MockSafe,
   MockSafe__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 
 // Helper function for deploying MultisigFreezeVotingV1 proxy instances using ERC1967Proxy
@@ -547,6 +549,14 @@ describe('FreezeVotingMultisigV1', () => {
       ).to.be.true;
     });
 
+    it('should support the IDeploymentBlockV1 interface', async () => {
+      void expect(
+        await freezeVoting.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('should not support a random interface', async () => {
       void expect(await freezeVoting.supportsInterface('0x12345678')).to.be.false;
     });
@@ -630,6 +640,12 @@ describe('FreezeVotingMultisigV1', () => {
           .connect(relayerSA)
           .executeFreezeVote(await freezeVotingSA.getAddress(), castVoteCalldata),
       ).to.be.revertedWithCustomError(freezeVotingSA, 'NoVotes');
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => freezeVoting,
     });
   });
 });

--- a/test/deployables/modules/ModuleAzoriusV1.test.ts
+++ b/test/deployables/modules/ModuleAzoriusV1.test.ts
@@ -4,6 +4,8 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IModuleAzoriusV1__factory,
   IVersion__factory,
@@ -17,6 +19,7 @@ import {
   ModuleAzoriusV1__factory,
   UUPSUpgradeable,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
@@ -1536,6 +1539,14 @@ describe('ModuleAzoriusV1', () => {
       ).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await azoriusInstance.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('Should not support random interface', async function () {
       const randomInterfaceId = '0x12345678';
       const supported = await azoriusInstance.supportsInterface(randomInterfaceId);
@@ -1569,6 +1580,27 @@ describe('ModuleAzoriusV1', () => {
       },
       owner: () => owner,
       nonOwner: () => nonOwner,
+    });
+  });
+
+  describe('Deployment Block', () => {
+    let azorius: ModuleAzoriusV1;
+
+    beforeEach(async function () {
+      azorius = await deployAzoriusProxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        mockStrategyAddress,
+        0,
+        0,
+      );
+    });
+
+    runDeploymentBlockTests({
+      getContract: () => azorius as unknown as IDeploymentBlockV1,
     });
   });
 });

--- a/test/deployables/modules/ModuleFractalV1.test.ts
+++ b/test/deployables/modules/ModuleFractalV1.test.ts
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IModuleFractalV1__factory,
   IVersion__factory,
@@ -14,6 +16,7 @@ import {
   ModuleFractalV1__factory,
   UUPSUpgradeable,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 import { runUUPSUpgradeabilityTests } from '../../helpers/uupsUpgradeabilityTests';
 
@@ -72,6 +75,9 @@ describe('ModuleFractalV1', () => {
   // mocks and mastercopies
   let masterCopy: string;
   let mockToken: MockERC20Votes;
+
+  // Shared fractalModule instance for deployment block tests
+  let sharedFractalModule: ModuleFractalV1;
 
   beforeEach(async () => {
     // Get signers
@@ -445,6 +451,14 @@ describe('ModuleFractalV1', () => {
       ).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await fractalModuleInstance.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('Should not support random interface', async function () {
       const randomInterfaceId = '0x12345678';
       const supported = await fractalModuleInstance.supportsInterface(randomInterfaceId);
@@ -464,6 +478,9 @@ describe('ModuleFractalV1', () => {
         ethers.ZeroAddress,
         ethers.ZeroAddress,
       );
+
+      // Set shared instance for deployment block tests
+      sharedFractalModule = fractalModule;
     });
 
     // Run UUPS upgradeability tests
@@ -475,6 +492,12 @@ describe('ModuleFractalV1', () => {
       },
       owner: () => owner,
       nonOwner: () => nonOwner,
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => sharedFractalModule as unknown as IDeploymentBlockV1,
     });
   });
 });

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   ISmartAccountValidationV1__factory,
   IStrategyV1__factory,
@@ -19,6 +20,7 @@ import {
   StrategyV1,
   StrategyV1__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../helpers/utils';
 
 describe('StrategyV1', () => {
@@ -1116,6 +1118,14 @@ describe('StrategyV1', () => {
       ).to.be.true;
     });
 
+    it('Should support IDeploymentBlockV1 interface', async () => {
+      void expect(
+        await strategy.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('Should not support a random interface', async () => {
       const randomInterfaceId = '0x12345678';
       void expect(await strategy.supportsInterface(randomInterfaceId)).to.be.false;
@@ -1829,6 +1839,12 @@ describe('StrategyV1', () => {
       );
 
       void expect(isValid).to.be.false;
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => strategy,
     });
   });
 });

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IProposerAdapterBaseV1__factory,
   IProposerAdapterERC20V1__factory,
@@ -12,6 +13,7 @@ import {
   ProposerAdapterERC20V1,
   ProposerAdapterERC20V1__factory,
 } from '../../../../../typechain-types';
+import { runDeploymentBlockTests } from '../../../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../../../helpers/utils';
 
 async function deployERC20ProposerAdapterProxy(
@@ -172,8 +174,22 @@ describe('ProposerAdapterERC20V1', () => {
       ).to.be.true;
     });
 
+    it('should support IDeploymentBlockV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('should not support a random interfaceId', async () => {
       void expect(await adapter.supportsInterface('0x12345678')).to.be.false;
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => adapter,
     });
   });
 });

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IProposerAdapterBaseV1__factory,
   IProposerAdapterERC721V1__factory,
@@ -12,6 +13,7 @@ import {
   ProposerAdapterERC721V1,
   ProposerAdapterERC721V1__factory,
 } from '../../../../../typechain-types';
+import { runDeploymentBlockTests } from '../../../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../../../helpers/utils';
 
 async function deployERC721ProposerAdapterProxy(
@@ -160,8 +162,22 @@ describe('ProposerAdapterERC721V1', () => {
       ).to.be.true;
     });
 
+    it('should support IDeploymentBlockV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('should not support a random interfaceId', async () => {
       void expect(await adapter.supportsInterface('0x12345678')).to.be.false;
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => adapter,
     });
   });
 });

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IProposerAdapterBaseV1__factory,
   IProposerAdapterHatsV1__factory,
@@ -12,6 +13,7 @@ import {
   ProposerAdapterHatsV1,
   ProposerAdapterHatsV1__factory,
 } from '../../../../../typechain-types';
+import { runDeploymentBlockTests } from '../../../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../../../helpers/utils';
 
 async function deployHatsProposerAdapterProxy(
@@ -243,8 +245,22 @@ describe('ProposerAdapterHatsV1', () => {
       ).to.be.true;
     });
 
+    it('should support IDeploymentBlockV1', async () => {
+      void expect(
+        await adapter.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('should not support a random interfaceId', async () => {
       void expect(await adapter.supportsInterface('0x12345678')).to.be.false;
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => adapter,
     });
   });
 });

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IVersion__factory,
   IVotingAdapterBaseV1__factory,
@@ -15,6 +16,7 @@ import {
   VotingAdapterERC20V1,
   VotingAdapterERC20V1__factory,
 } from '../../../../../typechain-types';
+import { runDeploymentBlockTests } from '../../../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../../../helpers/utils';
 
 // Modified helper function to return deployment tx hash
@@ -717,6 +719,14 @@ describe('VotingAdapterERC20V1', () => {
       ).to.be.true;
     });
 
+    it('should support IDeploymentBlockV1', async () => {
+      void expect(
+        await erc20Adapter.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('should not support a random interfaceId', async () => {
       void expect(await erc20Adapter.supportsInterface('0x12345678')).to.be.false;
     });
@@ -1335,6 +1345,25 @@ describe('VotingAdapterERC20V1', () => {
         void expect(isFinallyValid).to.be.false;
         expect(finalWeight).to.equal(0);
       });
+    });
+  });
+
+  describe('Deployment Block', () => {
+    let adapter: VotingAdapterERC20V1;
+
+    beforeEach(async () => {
+      const { adapter: deployedAdapter } = await deployERC20AdapterProxy(
+        deployer,
+        erc20AdapterImplementationAddressG,
+        await mockToken.getAddress(),
+        await mockStrategy.getAddress(),
+        DEFAULT_WEIGHT_PER_TOKEN,
+      );
+      adapter = deployedAdapter;
+    });
+
+    runDeploymentBlockTests({
+      getContract: () => adapter,
     });
   });
 });

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IDeploymentBlockV1__factory,
   IERC165__factory,
   IVersion__factory,
   IVotingAdapterBaseV1__factory,
@@ -15,6 +16,7 @@ import {
   VotingAdapterERC721V1,
   VotingAdapterERC721V1__factory,
 } from '../../../../../typechain-types';
+import { runDeploymentBlockTests } from '../../../../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../../../../helpers/utils';
 
 async function deployERC721AdapterProxy(
@@ -966,6 +968,14 @@ describe('VotingAdapterERC721V1', () => {
       ).to.be.true;
     });
 
+    it('should support IDeploymentBlockV1', async () => {
+      void expect(
+        await erc721Adapter.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('should not support a random interfaceId', async () => {
       void expect(await erc721Adapter.supportsInterface('0x12345678')).to.be.false;
     });
@@ -1684,6 +1694,33 @@ describe('VotingAdapterERC721V1', () => {
 
       void expect(isValid).to.be.false;
       expect(weight).to.equal(0);
+    });
+  });
+
+  describe('Deployment Block', () => {
+    let adapter: VotingAdapterERC721V1;
+    let mockNft: MockERC721;
+    let deployer: SignerWithAddress;
+    let strategy: MockVotingStrategy;
+
+    beforeEach(async () => {
+      const fixture = await loadFixture(deployMocksAndSignersERC721Fixture);
+      mockNft = fixture.mockNft;
+      deployer = fixture.deployer;
+      strategy = fixture.strategy;
+
+      const { adapter: deployedAdapter } = await deployERC721AdapterProxy(
+        deployer,
+        erc721AdapterImplementationAddressG,
+        await mockNft.getAddress(),
+        await strategy.getAddress(),
+        DEFAULT_WEIGHT_PER_NFT,
+      );
+      adapter = deployedAdapter;
+    });
+
+    runDeploymentBlockTests({
+      getContract: () => adapter,
     });
   });
 });

--- a/test/helpers/deploymentBlockTests.ts
+++ b/test/helpers/deploymentBlockTests.ts
@@ -1,0 +1,105 @@
+import { mine } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { IDeploymentBlockV1 } from '../../typechain-types';
+
+/**
+ * Shared test utilities for testing the DeploymentBlock functionality
+ * Used by all contracts that implement IDeploymentBlockV1
+ */
+
+/**
+ * Parameters for running the DeploymentBlock tests
+ */
+interface DeploymentBlockTestParams {
+  /**
+   * Gets the current contract instance implementing IDeploymentBlockV1
+   */
+  getContract: () => IDeploymentBlockV1;
+
+  /**
+   * Expected deployment block number
+   * If not provided, will be determined automatically during test setup
+   */
+  expectedBlockNumber?: bigint;
+
+  /**
+   * Whether this is a non-upgradeable contract (using immutable storage)
+   * Default is false (assumes upgradeable contract)
+   */
+  isNonUpgradeable?: boolean;
+}
+
+/**
+ * Run all the deployment block tests on the given contract
+ * @param params The test parameters
+ */
+export function runDeploymentBlockTests(params: DeploymentBlockTestParams): void {
+  it('should have deployment block set', async () => {
+    const contract = params.getContract();
+    const deploymentBlock = await contract.deploymentBlock();
+
+    // Check that deployment block is not zero
+    // Zero would indicate that __DeploymentBlockV1_init() was not called
+    expect(deploymentBlock).to.be.gt(
+      0,
+      'Deployment block should not be zero - was __DeploymentBlockV1_init() called?',
+    );
+  });
+
+  it('should return a reasonable deployment block number', async () => {
+    const contract = params.getContract();
+    const deploymentBlock = await contract.deploymentBlock();
+    const currentBlock = await ethers.provider.getBlockNumber();
+
+    // Deployment block should be:
+    // 1. Greater than 0
+    // 2. Less than or equal to current block number
+    expect(deploymentBlock).to.be.gt(0, 'Deployment block should be greater than 0');
+    expect(deploymentBlock).to.be.lte(currentBlock, 'Deployment block should not be in the future');
+
+    // If expectedBlockNumber was provided, check it matches exactly
+    if (params.expectedBlockNumber !== undefined) {
+      expect(deploymentBlock).to.equal(
+        params.expectedBlockNumber,
+        'Deployment block should match expected value',
+      );
+    }
+  });
+
+  it('should not change after mining additional blocks', async () => {
+    const contract = params.getContract();
+    const initialDeploymentBlock = await contract.deploymentBlock();
+
+    // Mine several blocks
+    await mine(10);
+
+    const afterMiningDeploymentBlock = await contract.deploymentBlock();
+
+    // The deployment block should remain the same
+    expect(afterMiningDeploymentBlock).to.equal(
+      initialDeploymentBlock,
+      'Deployment block should not change after mining blocks',
+    );
+  });
+
+  if (params.isNonUpgradeable) {
+    it('should use immutable storage (non-upgradeable contracts)', async () => {
+      // This test is specific to non-upgradeable contracts that use the `immutable` keyword
+      // For upgradeable contracts, the deployment block is stored in proxy storage and
+      // will NOT change during upgrades - the proxy's storage persists across upgrades
+      const contract = params.getContract();
+
+      const calls = await Promise.all([
+        contract.deploymentBlock(),
+        contract.deploymentBlock(),
+        contract.deploymentBlock(),
+      ]);
+
+      // All calls should return the same value
+      expect(calls[0]).to.equal(calls[1]);
+      expect(calls[1]).to.equal(calls[2]);
+      expect(calls[0]).to.be.gt(0);
+    });
+  }
+}

--- a/test/singletons/KeyValuePairsV1.test.ts
+++ b/test/singletons/KeyValuePairsV1.test.ts
@@ -2,11 +2,13 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
+  IDeploymentBlockV1__factory,
   IKeyValuePairsV1__factory,
   IVersion__factory,
   KeyValuePairsV1,
   KeyValuePairsV1__factory,
 } from '../../typechain-types';
+import { runDeploymentBlockTests } from '../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../helpers/utils';
 
 describe('KeyValuePairsV1', function () {
@@ -74,8 +76,23 @@ describe('KeyValuePairsV1', function () {
       ).to.be.true;
     });
 
+    it('should support IDeploymentBlockV1 interface', async function () {
+      void expect(
+        await keyValuePairs.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('should not support a random interfaceId', async function () {
       void expect(await keyValuePairs.supportsInterface('0x12345678')).to.be.false;
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => keyValuePairs,
+      isNonUpgradeable: true,
     });
   });
 });

--- a/test/singletons/SystemDeployerV1.test.ts
+++ b/test/singletons/SystemDeployerV1.test.ts
@@ -10,6 +10,7 @@ import {
   FreezeGuardMultisigV1__factory,
   FreezeVotingAzoriusV1__factory,
   FreezeVotingMultisigV1__factory,
+  IDeploymentBlockV1__factory,
   IncompatibleStorageContract__factory,
   ISystemDeployerV1,
   ISystemDeployerV1__factory,
@@ -46,6 +47,7 @@ import {
   VotingAdapterERC721V1,
   VotingAdapterERC721V1__factory,
 } from '../../typechain-types';
+import { runDeploymentBlockTests } from '../helpers/deploymentBlockTests';
 import { calculateInterfaceId } from '../helpers/utils';
 
 // Helper function to create default setupSafe parameters with optional overrides
@@ -5000,6 +5002,14 @@ describe('SystemDeployerV1', () => {
       ).to.be.true;
     });
 
+    it('should support IDeploymentBlockV1 interface', async () => {
+      void expect(
+        await fixtureData.systemDeployer.supportsInterface(
+          calculateInterfaceId(IDeploymentBlockV1__factory.createInterface()),
+        ),
+      ).to.be.true;
+    });
+
     it('should support ERC165 interface', async () => {
       void expect(
         await fixtureData.systemDeployer.supportsInterface(
@@ -5804,6 +5814,13 @@ describe('SystemDeployerV1', () => {
           }
         });
       });
+    });
+  });
+
+  describe('Deployment Block', () => {
+    runDeploymentBlockTests({
+      getContract: () => fixtureData.systemDeployer,
+      isNonUpgradeable: true,
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/368

Fixes [ENG-1179](https://linear.app/decent-labs/issue/ENG-1179/integrate-deploymentblockv1-into-core-contracts)

feat(contracts): Implement comprehensive DeploymentBlock tracking

This commit introduces a robust, dual-contract system for tracking deployment block numbers across the entire project. This functionality is critical for optimizing frontend and indexing services, allowing them to start event listeners from a precise block number instead of scanning the entire chain history.

To support both upgradeable and non-upgradeable contracts, two distinct base contracts have been created:
1.  **`DeploymentBlockV1`**: For upgradeable contracts, utilizing an initializer. It now includes re-initialization protection to ensure the deployment block cannot be overwritten.
2.  **`DeploymentBlockV1NonUpgradeable`**: A new, gas-efficient version for non-upgradeable contracts that sets the deployment block immutably in the constructor.

### Key Changes:

-   **New Base Contracts:** Introduced `DeploymentBlockV1` (with re-init protection) and `DeploymentBlockV1NonUpgradeable` (with immutable storage).
-   **Widespread Integration:** Integrated the appropriate `DeploymentBlock` contract into all core contracts, including modules, guards, tokens, strategies, and adapters.
-   **Standardized Testing:** Created a new shared test helper, `runDeploymentBlockTests`, to provide consistent and thorough validation of the deployment block functionality across all relevant contracts.
-   **Full Test Coverage:** Added new test files for `DeploymentBlockV1NonUpgradeable` and updated all relevant test suites to use the new test helper, ensuring the feature is correctly implemented everywhere.
-   **Code Organization:** Relocated `VoterResolverV1.sol` to the `contracts/deployables/strategies/` directory for better logical grouping.