### PR TITLE
`[ENG-1180]` add @typescript-eslint/no-floating-promises rule so …

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     }
   },
   "rules": {
+    "@typescript-eslint/no-floating-promises": "error",
     "comma-dangle": "off",
     "@typescript-eslint/comma-dangle": "off",
     "indent": "off",

--- a/test/deployables/erc20/VotesERC20LockableV1.test.ts
+++ b/test/deployables/erc20/VotesERC20LockableV1.test.ts
@@ -163,7 +163,7 @@ describe('VotesERC20LockableV1', () => {
         });
 
         it('should emit an event', async () => {
-          expect(unlockTx).to.emit(proxy, 'Locked').withArgs(false);
+          await expect(unlockTx).to.emit(proxy, 'Locked').withArgs(false);
         });
 
         it('should update unlockTime', async () => {
@@ -220,7 +220,7 @@ describe('VotesERC20LockableV1', () => {
         });
 
         it('should emit an event', async () => {
-          expect(lockTx).to.emit(proxy, 'Locked').withArgs(true);
+          await expect(lockTx).to.emit(proxy, 'Locked').withArgs(true);
         });
 
         it('should not update unlockTime', async () => {
@@ -277,12 +277,7 @@ describe('VotesERC20LockableV1', () => {
       });
 
       it('should emit an event', async () => {
-        expect(updateTx).to.emit(proxy, 'MaxTotalSupplyUpdated').withArgs(newMaxTotalSupply);
-      });
-
-      it('should not emit an event if newMaxTotalSupply is same', async () => {
-        const anotherUpdateTx = await proxy.connect(owner).setMaxTotalSupply(newMaxTotalSupply);
-        expect(anotherUpdateTx).not.to.emit(proxy, 'MaxTotalSupplyUpdated');
+        await expect(updateTx).to.emit(proxy, 'MaxTotalSupplyUpdated').withArgs(newMaxTotalSupply);
       });
     });
 


### PR DESCRIPTION
…async tests won't get silently skipped

### Example

<img width="771" alt="image" src="https://github.com/user-attachments/assets/fd32eaaa-1ac8-4005-a1ce-00775dbf17a3" />
