### PR TITLE
refactor(contracts): Rename StrategyV1 vote() to castVote()

### DIFF
--- a/contracts/deployables/account-abstraction/validators/StrategyV1ValidatorV1.sol
+++ b/contracts/deployables/account-abstraction/validators/StrategyV1ValidatorV1.sol
@@ -26,13 +26,13 @@ contract StrategyV1ValidatorV1 is
         address strategy_,
         bytes calldata callData_
     ) public view virtual override returns (bool) {
-        // confirm here that the calldata selector is correct: `vote(uint32,uint8,(address,bytes)[],uint256)`
-        if (bytes4(callData_) != IStrategyV1.vote.selector) {
+        // confirm here that the calldata selector is correct: `castVote(uint32,uint8,(address,bytes)[],uint256)`
+        if (bytes4(callData_) != IStrategyV1.castVote.selector) {
             return false;
         }
 
         // Decode vote parameters from callData
-        // vote(uint32 proposalId_, uint8 voteType_, (tuple(address,bytes))[] votingAdaptersData_, uint256 lightAccountIndex_)
+        // castVote(uint32 proposalId_, uint8 voteType_, (tuple(address,bytes))[] votingAdaptersData_, uint256 lightAccountIndex_)
         (
             uint32 proposalId,
             uint8 voteType,

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -403,7 +403,7 @@ contract StrategyV1 is
         );
     }
 
-    function vote(
+    function castVote(
         uint32 proposalId_,
         uint8 voteType_,
         VotingAdapterVoteData[] calldata votingAdaptersData,

--- a/contracts/interfaces/decent/deployables/IStrategyV1.sol
+++ b/contracts/interfaces/decent/deployables/IStrategyV1.sol
@@ -158,7 +158,7 @@ interface IStrategyV1 {
 
     function initializeProposal(uint32 proposalId_) external;
 
-    function vote(
+    function castVote(
         uint32 proposalId_,
         uint8 voteType_,
         VotingAdapterVoteData[] calldata votingAdaptersData_,

--- a/contracts/mocks/MockLightAccount.sol
+++ b/contracts/mocks/MockLightAccount.sol
@@ -35,7 +35,7 @@ contract MockLightAccount is ILightAccount {
     ) external {
         // msg.sender here is the EOA calling MockLightAccount (e.g., relayer)
         // When strategy.vote is called, msg.sender from StrategyV1's perspective will be address(this)
-        strategy.vote(
+        strategy.castVote(
             proposalId,
             voteType,
             votingAdaptersData,

--- a/contracts/mocks/MockVotingStrategy.sol
+++ b/contracts/mocks/MockVotingStrategy.sol
@@ -180,7 +180,7 @@ contract MockVotingStrategy is IStrategyV1, LightAccountValidatorV1 {
         );
     }
 
-    function vote(
+    function castVote(
         uint32 _proposalId,
         uint8 _voteType,
         IStrategyV1.VotingAdapterVoteData[] calldata votingAdaptersData,

--- a/test/deployables/account-abstraction/validators/StrategyV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/StrategyV1ValidatorV1.test.ts
@@ -66,7 +66,7 @@ describe('StrategyV1ValidatorV1', function () {
     it('Should return true when the underlying strategy vote is valid', async function () {
       await mockStrategy.setValidStrategyVoteResult(true);
 
-      const calldata = mockStrategy.interface.encodeFunctionData('vote', [
+      const calldata = mockStrategy.interface.encodeFunctionData('castVote', [
         proposalId,
         voteType,
         votingAdaptersData,
@@ -86,7 +86,7 @@ describe('StrategyV1ValidatorV1', function () {
     it('Should return false when the underlying strategy vote is invalid', async function () {
       await mockStrategy.setValidStrategyVoteResult(false);
 
-      const calldata = mockStrategy.interface.encodeFunctionData('vote', [
+      const calldata = mockStrategy.interface.encodeFunctionData('castVote', [
         proposalId,
         voteType,
         votingAdaptersData,
@@ -111,7 +111,7 @@ describe('StrategyV1ValidatorV1', function () {
         votingAdaptersData,
       );
 
-      const calldata = mockStrategy.interface.encodeFunctionData('vote', [
+      const calldata = mockStrategy.interface.encodeFunctionData('castVote', [
         proposalId,
         voteType,
         votingAdaptersData,
@@ -147,7 +147,7 @@ describe('StrategyV1ValidatorV1', function () {
       );
 
       // But create calldata with the *wrong* proposalId
-      const calldata = mockStrategy.interface.encodeFunctionData('vote', [
+      const calldata = mockStrategy.interface.encodeFunctionData('castVote', [
         wrongProposalId, // encoded with 999
         voteType,
         votingAdaptersData,
@@ -175,7 +175,7 @@ describe('StrategyV1ValidatorV1', function () {
         votingAdaptersData,
       );
 
-      const calldata = mockStrategy.interface.encodeFunctionData('vote', [
+      const calldata = mockStrategy.interface.encodeFunctionData('castVote', [
         proposalId,
         wrongVoteType, // But encoded with NO (0)
         votingAdaptersData,
@@ -206,7 +206,7 @@ describe('StrategyV1ValidatorV1', function () {
         votingAdaptersData, // Expecting original data
       );
 
-      const calldata = mockStrategy.interface.encodeFunctionData('vote', [
+      const calldata = mockStrategy.interface.encodeFunctionData('castVote', [
         proposalId,
         voteType,
         wrongVotingAdaptersData, // But encoded with different data

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -511,7 +511,7 @@ describe('StrategyV1', () => {
     it('should revert if proposal is not initialized (votingEndTimestamp is 0)', async () => {
       const uninitializedProposalId = 999;
       await expect(
-        strategy.connect(user1).vote(
+        strategy.connect(user1).castVote(
           uninitializedProposalId,
           1,
           [
@@ -530,7 +530,7 @@ describe('StrategyV1', () => {
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
       // First call after period ends should emit event and not revert immediately
-      const tx = await strategy.connect(user1).vote(
+      const tx = await strategy.connect(user1).castVote(
         proposalId,
         1,
         [
@@ -546,7 +546,7 @@ describe('StrategyV1', () => {
 
       // Subsequent calls should revert
       await expect(
-        strategy.connect(user1).vote(
+        strategy.connect(user1).castVote(
           proposalId,
           1,
           [
@@ -565,7 +565,7 @@ describe('StrategyV1', () => {
       await time.increaseTo(proposalDetailsBefore.votingEndTimestamp + 1n);
 
       // First call after voting period ends
-      const tx = await strategy.connect(user1).vote(
+      const tx = await strategy.connect(user1).castVote(
         proposalId,
         1 /* YES */,
         [
@@ -587,7 +587,7 @@ describe('StrategyV1', () => {
 
       // Further calls should revert
       await expect(
-        strategy.connect(user1).vote(
+        strategy.connect(user1).castVote(
           proposalId,
           1 /* YES */,
           [
@@ -604,7 +604,7 @@ describe('StrategyV1', () => {
     it('should revert if single adapter has zero vote weight', async () => {
       await mockAdapter1.setWeight(user1.address, 0);
       await expect(
-        strategy.connect(user1).vote(
+        strategy.connect(user1).castVote(
           proposalId,
           1,
           [
@@ -637,7 +637,7 @@ describe('StrategyV1', () => {
       await mockAdapter2.setWeight(user1.address, 0);
 
       await expect(
-        strategy.connect(user1).vote(
+        strategy.connect(user1).castVote(
           proposalId,
           1,
           [
@@ -661,7 +661,7 @@ describe('StrategyV1', () => {
       const invalidVoteType = 3; // VoteType enum is 0, 1, 2
       await mockAdapter1.setWeight(user1.address, 10);
       await expect(
-        strategy.connect(user1).vote(
+        strategy.connect(user1).castVote(
           proposalId,
           invalidVoteType,
           [
@@ -693,7 +693,7 @@ describe('StrategyV1', () => {
         },
       ];
 
-      await expect(strategy.connect(user1).vote(proposalId, 1 /* YES */, adapterData, 0n))
+      await expect(strategy.connect(user1).castVote(proposalId, 1 /* YES */, adapterData, 0n))
         .to.be.revertedWithCustomError(strategy, 'InvalidVotingAdapter')
         .withArgs(unconfiguredAdapterAddress);
     });
@@ -702,7 +702,7 @@ describe('StrategyV1', () => {
       const voteWeight = 100;
       await mockAdapter1.setWeight(user1.address, voteWeight);
 
-      const tx = await strategy.connect(user1).vote(
+      const tx = await strategy.connect(user1).castVote(
         proposalId,
         1 /* YES */,
         [
@@ -739,7 +739,7 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(user1.address, voteWeight);
 
       await expect(
-        strategy.connect(user1).vote(
+        strategy.connect(user1).castVote(
           proposalId,
           0 /* NO */,
           [
@@ -765,7 +765,7 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(user1.address, voteWeight);
 
       await expect(
-        strategy.connect(user1).vote(
+        strategy.connect(user1).castVote(
           proposalId,
           2 /* ABSTAIN */,
           [
@@ -815,7 +815,7 @@ describe('StrategyV1', () => {
       ];
 
       await expect(
-        multiAdapterStrategy.connect(user1).vote(proposalId, 1 /* YES */, adapterData, 0n),
+        multiAdapterStrategy.connect(user1).castVote(proposalId, 1 /* YES */, adapterData, 0n),
       )
         .to.emit(multiAdapterStrategy, 'Voted')
         .withArgs(user1.address, proposalId, 1 /* YES */, weight1 + weight2);
@@ -872,7 +872,7 @@ describe('StrategyV1', () => {
       await mockAdapter1.setShouldRevertOnRecordVote(true);
 
       await expect(
-        strategy.connect(user1).vote(
+        strategy.connect(user1).castVote(
           proposalId,
           1 /* YES */,
           [
@@ -921,7 +921,7 @@ describe('StrategyV1', () => {
       ];
 
       await expect(
-        multiAdapterStrategy.connect(user1).vote(proposalId, 1 /* YES */, adapterData, 0n),
+        multiAdapterStrategy.connect(user1).castVote(proposalId, 1 /* YES */, adapterData, 0n),
       ).to.be.revertedWith('MockVotingAdapter: recordVote forced revert');
 
       const proposalDetails = await multiAdapterStrategy.proposalVotingDetails(proposalId);
@@ -936,7 +936,7 @@ describe('StrategyV1', () => {
 
     it('should revert if attempting to vote with no voting adapters', async () => {
       await expect(
-        strategy.connect(user1).vote(proposalId, 1 /* YES */, [], 0n),
+        strategy.connect(user1).castVote(proposalId, 1 /* YES */, [], 0n),
       ).to.be.revertedWithCustomError(strategy, 'NoVotingAdapters');
     });
   });
@@ -957,7 +957,7 @@ describe('StrategyV1', () => {
 
     it('should return false if voting period is not over', async () => {
       await mockAdapter1.setWeight(voter1.address, DEFAULT_QUORUM_THRESHOLD + 10n);
-      await strategy.connect(voter1).vote(
+      await strategy.connect(voter1).castVote(
         PROPOSAL_ID,
         1 /* YES */,
         [
@@ -973,7 +973,7 @@ describe('StrategyV1', () => {
 
     it('should return true if quorum and basis are met and voting is over', async () => {
       await mockAdapter1.setWeight(voter1.address, DEFAULT_QUORUM_THRESHOLD + 10n);
-      await strategy.connect(voter1).vote(
+      await strategy.connect(voter1).castVote(
         PROPOSAL_ID,
         1 /* YES */,
         [
@@ -1007,7 +1007,7 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(voter2.address, 50n);
       await mockAdapter1.setWeight(voter3.address, 10n);
 
-      await specificStrategy.connect(voter1).vote(
+      await specificStrategy.connect(voter1).castVote(
         PROPOSAL_ID,
         1 /* YES */,
         [
@@ -1018,7 +1018,7 @@ describe('StrategyV1', () => {
         ],
         0n,
       );
-      await specificStrategy.connect(voter2).vote(
+      await specificStrategy.connect(voter2).castVote(
         PROPOSAL_ID,
         0 /* NO */,
         [
@@ -1029,7 +1029,7 @@ describe('StrategyV1', () => {
         ],
         0n,
       );
-      await specificStrategy.connect(voter3).vote(
+      await specificStrategy.connect(voter3).castVote(
         PROPOSAL_ID,
         2 /* ABSTAIN */,
         [
@@ -1062,7 +1062,7 @@ describe('StrategyV1', () => {
       await mockAdapter1.setWeight(voter1.address, 60n); // YES
       await mockAdapter1.setWeight(voter2.address, 10n); // NO
 
-      await specificStrategy.connect(voter1).vote(
+      await specificStrategy.connect(voter1).castVote(
         PROPOSAL_ID,
         1 /* YES */,
         [
@@ -1073,7 +1073,7 @@ describe('StrategyV1', () => {
         ],
         0n,
       );
-      await specificStrategy.connect(voter2).vote(
+      await specificStrategy.connect(voter2).castVote(
         PROPOSAL_ID,
         0 /* NO */,
         [
@@ -1124,7 +1124,7 @@ describe('StrategyV1', () => {
       await time.increaseTo(
         (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp + 1n,
       );
-      await strategy.connect(voter1).vote(
+      await strategy.connect(voter1).castVote(
         PROPOSAL_ID,
         1 /* YES */,
         [
@@ -1144,7 +1144,7 @@ describe('StrategyV1', () => {
       await time.increaseTo(
         (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp + 1n,
       );
-      await strategy.connect(voter1).vote(
+      await strategy.connect(voter1).castVote(
         PROPOSAL_ID,
         1 /* YES */,
         [
@@ -1165,7 +1165,7 @@ describe('StrategyV1', () => {
 
     it('should not emit VotingPeriodEnded event when casting a vote before voting period ends', async () => {
       await expect(
-        strategy.connect(voter1).vote(
+        strategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1184,7 +1184,7 @@ describe('StrategyV1', () => {
         (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp + 1n,
       );
       await expect(
-        strategy.connect(voter1).vote(
+        strategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1250,7 +1250,7 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 40n);
-        await qStrategy.connect(voter1).vote(
+        await qStrategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1261,7 +1261,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        await qStrategy.connect(voter2).vote(
+        await qStrategy.connect(voter2).castVote(
           PROPOSAL_ID,
           2 /* ABSTAIN */,
           [
@@ -1290,7 +1290,7 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 60n);
         await mockAdapter1.setWeight(voter2.address, 41n); // Exceeds
-        await qStrategy.connect(voter1).vote(
+        await qStrategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1301,7 +1301,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        await qStrategy.connect(voter2).vote(
+        await qStrategy.connect(voter2).castVote(
           PROPOSAL_ID,
           2 /* ABSTAIN */,
           [
@@ -1330,7 +1330,7 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 50n);
         await mockAdapter1.setWeight(voter2.address, 40n); // 90 total, < 100
-        await qStrategy.connect(voter1).vote(
+        await qStrategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1341,7 +1341,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        await qStrategy.connect(voter2).vote(
+        await qStrategy.connect(voter2).castVote(
           PROPOSAL_ID,
           2 /* ABSTAIN */,
           [
@@ -1369,7 +1369,7 @@ describe('StrategyV1', () => {
         await qStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 10n); // Only NO votes
-        await qStrategy.connect(voter1).vote(
+        await qStrategy.connect(voter1).castVote(
           PROPOSAL_ID,
           0 /* NO */,
           [
@@ -1386,7 +1386,7 @@ describe('StrategyV1', () => {
 
       it('should return false if only NO votes are cast and quorum threshold > 0', async () => {
         await mockAdapter1.setWeight(voter1.address, 150n);
-        await strategy.connect(voter1).vote(
+        await strategy.connect(voter1).castVote(
           PROPOSAL_ID,
           0 /* NO */,
           [
@@ -1412,7 +1412,7 @@ describe('StrategyV1', () => {
       it('should return true if basis is met (yes > no for >50% basis)', async () => {
         await mockAdapter1.setWeight(voter1.address, 101n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await strategy.connect(voter1).vote(
+        await strategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1423,7 +1423,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        await strategy.connect(voter2).vote(
+        await strategy.connect(voter2).castVote(
           PROPOSAL_ID,
           0 /* NO */,
           [
@@ -1440,7 +1440,7 @@ describe('StrategyV1', () => {
       it('should return false if basis is not met (yes == no for >50% basis)', async () => {
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await strategy.connect(voter1).vote(
+        await strategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1451,7 +1451,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        await strategy.connect(voter2).vote(
+        await strategy.connect(voter2).castVote(
           PROPOSAL_ID,
           0 /* NO */,
           [
@@ -1468,7 +1468,7 @@ describe('StrategyV1', () => {
       it('should return false if basis is not met (yes < no for >50% basis)', async () => {
         await mockAdapter1.setWeight(voter1.address, 99n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await strategy.connect(voter1).vote(
+        await strategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1479,7 +1479,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        await strategy.connect(voter2).vote(
+        await strategy.connect(voter2).castVote(
           PROPOSAL_ID,
           0 /* NO */,
           [
@@ -1495,7 +1495,7 @@ describe('StrategyV1', () => {
 
       it('should return false if totalYesAndNoVotes is 0 (only abstain)', async () => {
         await mockAdapter1.setWeight(voter1.address, 100n);
-        await strategy.connect(voter1).vote(
+        await strategy.connect(voter1).castVote(
           PROPOSAL_ID,
           2 /* ABSTAIN */,
           [
@@ -1524,7 +1524,7 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 101n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await bStrategy.connect(voter1).vote(
+        await bStrategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1535,7 +1535,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        await bStrategy.connect(voter2).vote(
+        await bStrategy.connect(voter2).castVote(
           PROPOSAL_ID,
           0 /* NO */,
           [
@@ -1563,7 +1563,7 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 100n);
-        await bStrategy.connect(voter1).vote(
+        await bStrategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1574,7 +1574,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        await bStrategy.connect(voter2).vote(
+        await bStrategy.connect(voter2).castVote(
           PROPOSAL_ID,
           0 /* NO */,
           [
@@ -1602,7 +1602,7 @@ describe('StrategyV1', () => {
         await bStrategy.connect(strategyAdmin).initializeProposal(PROPOSAL_ID);
 
         await mockAdapter1.setWeight(voter1.address, 100n);
-        await bStrategy.connect(voter1).vote(
+        await bStrategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1631,7 +1631,7 @@ describe('StrategyV1', () => {
 
         await mockAdapter1.setWeight(voter1.address, 100n);
         await mockAdapter1.setWeight(voter2.address, 1n);
-        await bStrategy.connect(voter1).vote(
+        await bStrategy.connect(voter1).castVote(
           PROPOSAL_ID,
           1 /* YES */,
           [
@@ -1642,7 +1642,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        await bStrategy.connect(voter2).vote(
+        await bStrategy.connect(voter2).castVote(
           PROPOSAL_ID,
           0 /* NO */,
           [
@@ -1888,7 +1888,7 @@ describe('StrategyV1', () => {
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
       // Trigger the end of the voting period
-      await strategy.connect(voter1).vote(
+      await strategy.connect(voter1).castVote(
         PROPOSAL_ID,
         1,
         [

--- a/test/deployables/strategies/adapters/voting/VotingAdapterBaseV1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterBaseV1.test.ts
@@ -113,7 +113,7 @@ describe('VotingAdapterBaseV1', () => {
       const adapterVoteData = ethers.ZeroHash; // Dummy data for the adapter
 
       await expect(
-        mockStrategyContract.connect(nonStrategySigner).vote(
+        mockStrategyContract.connect(nonStrategySigner).castVote(
           proposalId,
           0, // voteType (e.g., YES)
           [

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
@@ -263,7 +263,7 @@ describe('VotingAdapterERC20V1', () => {
         votingStartTimestamp,
         ethers.parseUnits('10', 18),
       );
-      await mockStrategy.connect(user1Signer).vote(
+      await mockStrategy.connect(user1Signer).castVote(
         proposalId,
         0, // voteType
         [
@@ -332,7 +332,7 @@ describe('VotingAdapterERC20V1', () => {
       const expectedWeightCasted = expectedRawVotes * DEFAULT_WEIGHT_PER_TOKEN;
 
       await expect(
-        strategy.connect(voter).vote(
+        strategy.connect(voter).castVote(
           proposalId,
           0, // voteType
           [
@@ -369,7 +369,7 @@ describe('VotingAdapterERC20V1', () => {
       const expectedWeightCasted = expectedRawVotes * customWeight;
 
       await expect(
-        strategy.connect(voter).vote(
+        strategy.connect(voter).castVote(
           proposalId,
           0, // voteType
           [
@@ -394,7 +394,7 @@ describe('VotingAdapterERC20V1', () => {
         votingStartTimestamp,
         votingStartTimestamp + 1000,
       );
-      await strategy.connect(voter).vote(
+      await strategy.connect(voter).castVote(
         proposalId,
         0, // voteType
         [
@@ -406,7 +406,7 @@ describe('VotingAdapterERC20V1', () => {
         0n,
       );
       await expect(
-        strategy.connect(voter).vote(
+        strategy.connect(voter).castVote(
           proposalId,
           0, // voteType
           [
@@ -429,7 +429,7 @@ describe('VotingAdapterERC20V1', () => {
         votingStartTimestamp,
         votingStartTimestamp + 1000,
       );
-      await strategy.connect(voter).vote(
+      await strategy.connect(voter).castVote(
         proposalId,
         0, // voteType
         [
@@ -448,7 +448,7 @@ describe('VotingAdapterERC20V1', () => {
       await setupAdapterForRecordVote(0);
       await strategy.setVotingTimestamps(proposalId, 0, 1000);
       await expect(
-        strategy.connect(voter).vote(
+        strategy.connect(voter).castVote(
           proposalId,
           0, // voteType
           [
@@ -466,7 +466,7 @@ describe('VotingAdapterERC20V1', () => {
       await setupAdapterForRecordVote(1);
       await strategy.setVotingStartBlock(proposalId, 0);
       await expect(
-        strategy.connect(voter).vote(
+        strategy.connect(voter).castVote(
           proposalId,
           0, // voteType
           [
@@ -537,7 +537,7 @@ describe('VotingAdapterERC20V1', () => {
         );
 
         // Record a vote
-        await strategy.connect(voter).vote(
+        await strategy.connect(voter).castVote(
           proposalId,
           0, // voteType
           [
@@ -572,7 +572,7 @@ describe('VotingAdapterERC20V1', () => {
         );
 
         // Record a vote for proposalId/voter
-        await strategy.connect(voter).vote(
+        await strategy.connect(voter).castVote(
           proposalId,
           0, // voteType
           [
@@ -1016,7 +1016,7 @@ describe('VotingAdapterERC20V1', () => {
       expect(initialWeight).to.equal(voteWeight);
 
       // 2. Record a vote
-      await strategy.connect(voter).vote(
+      await strategy.connect(voter).castVote(
         proposalId,
         0, // voteType
         [

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
@@ -229,7 +229,7 @@ describe('VotingAdapterERC721V1', () => {
       );
       await strategy
         .connect(user1)
-        .vote(
+        .castVote(
           proposalId,
           1,
           [{ votingAdapter: adapter, adapterVoteData: initialAdapterVoteData }],
@@ -377,7 +377,7 @@ describe('VotingAdapterERC721V1', () => {
       );
       await strategy
         .connect(user1)
-        .vote(
+        .castVote(
           proposalId,
           1,
           [{ votingAdapter: adapter, adapterVoteData: initialAdapterVoteData }],
@@ -411,7 +411,7 @@ describe('VotingAdapterERC721V1', () => {
       );
       await strategy
         .connect(user1)
-        .vote(
+        .castVote(
           proposalId2,
           1,
           [{ votingAdapter: adapter, adapterVoteData: initialAdapterVoteData }],
@@ -502,7 +502,7 @@ describe('VotingAdapterERC721V1', () => {
 
     it('should return 0 weight and empty array for a mix of invalid (unowned, used) and non-existent tokens', async () => {
       const usedToken = user1TokenIds[0];
-      await strategy.connect(user1).vote(
+      await strategy.connect(user1).castVote(
         proposalId,
         1,
         [
@@ -592,7 +592,7 @@ describe('VotingAdapterERC721V1', () => {
       await expect(
         strategy
           .connect(user1)
-          .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData }], 0n),
+          .castVote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData }], 0n),
       )
         .to.emit(adapter, 'VoteRecorded')
         .withArgs(user1.address, proposalId, expectedWeight, adapterVoteData);
@@ -615,13 +615,18 @@ describe('VotingAdapterERC721V1', () => {
       // First vote
       await strategy
         .connect(user1)
-        .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: voteDataSingle }], 0n);
+        .castVote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: voteDataSingle }], 0n);
 
       // Attempt second vote with same token - should revert
       await expect(
         strategy
           .connect(user1)
-          .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: voteDataSingle }], 0n),
+          .castVote(
+            proposalId,
+            1,
+            [{ votingAdapter: adapter, adapterVoteData: voteDataSingle }],
+            0n,
+          ),
       )
         .to.be.revertedWithCustomError(adapter, 'TokenIdAlreadyUsedForVote')
         .withArgs(tokenToUse);
@@ -632,7 +637,12 @@ describe('VotingAdapterERC721V1', () => {
       await expect(
         strategy
           .connect(user1)
-          .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: emptyVoteData }], 0n),
+          .castVote(
+            proposalId,
+            1,
+            [{ votingAdapter: adapter, adapterVoteData: emptyVoteData }],
+            0n,
+          ),
       )
         .to.emit(adapter, 'VoteRecorded')
         .withArgs(user1.address, proposalId, 0n, emptyVoteData);
@@ -648,7 +658,7 @@ describe('VotingAdapterERC721V1', () => {
       await expect(
         strategy
           .connect(user1)
-          .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData }], 0n),
+          .castVote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData }], 0n),
       )
         .to.be.revertedWithCustomError(adapter, 'TokenIdNotOwnedByVoter')
         .withArgs(tokenIdsNotOwnedByUser1[0]);
@@ -696,7 +706,7 @@ describe('VotingAdapterERC721V1', () => {
       await expect(
         localStrategy
           .connect(localUser1)
-          .vote(proposalId, 1, [{ votingAdapter: customAdapter, adapterVoteData }], 0n),
+          .castVote(proposalId, 1, [{ votingAdapter: customAdapter, adapterVoteData }], 0n),
       )
         .to.emit(customAdapter, 'VoteRecorded')
         .withArgs(localUser1.address, proposalId, expectedWeight, adapterVoteData);
@@ -715,7 +725,7 @@ describe('VotingAdapterERC721V1', () => {
       await expect(
         strategy
           .connect(user1)
-          .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData }], 0n),
+          .castVote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData }], 0n),
       )
         .to.be.revertedWithCustomError(adapter, 'TokenIdAlreadyUsedForVote')
         .withArgs(tokenIdsToVoteWith[0]);
@@ -789,7 +799,7 @@ describe('VotingAdapterERC721V1', () => {
 
         // Vote through the strategy instead of directly calling the adapter
         // Using connect(voter1) because MockVotingStrategy passes msg.sender as the voter
-        await mockStrategy.connect(voter1).vote(
+        await mockStrategy.connect(voter1).castVote(
           proposalId,
           0, // voteType
           [
@@ -818,7 +828,7 @@ describe('VotingAdapterERC721V1', () => {
 
         // Vote through the strategy instead of directly calling the adapter
         // Using connect(voter1) because MockVotingStrategy passes msg.sender as the voter
-        await mockStrategy.connect(voter1).vote(
+        await mockStrategy.connect(voter1).castVote(
           proposalId,
           0, // voteType
           [
@@ -1563,7 +1573,12 @@ describe('VotingAdapterERC721V1', () => {
       );
       await strategy
         .connect(user1)
-        .vote(proposalId, 1, [{ votingAdapter: adapter, adapterVoteData: voteDataForRecord }], 0n);
+        .castVote(
+          proposalId,
+          1,
+          [{ votingAdapter: adapter, adapterVoteData: voteDataForRecord }],
+          0n,
+        );
 
       // 3. Check for FALSE when the used token is included
       const finalAdapterVoteData = ethers.AbiCoder.defaultAbiCoder().encode(


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/384

Fixes [ENG-1210](https://linear.app/decent-labs/issue/ENG-1210/refactor-rename-vote-to-castvote-in-strategyv1)

This commit refactors the `StrategyV1` contract and its related components by renaming the `vote()` function to `castVote()`. This change improves the semantic clarity of the function's name, making it more explicit that the action is to cast a vote in a proposal.

The renaming has been propagated across all relevant files, including:
- The `IStrategyV1` interface.
- The `StrategyV1ValidatorV1` contract.
- All mock contracts (`MockLightAccount`, `MockVotingStrategy`).
- The entire test suite for `StrategyV1` and its dependent voting adapters.

This is purely a naming convention update and introduces no changes to the underlying logic.