### PR TITLE
chore(eslint): disable no-unused-expressions rule for test files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,5 +40,13 @@
     "@typescript-eslint/no-unused-vars": "warn",
     // class rules
     "@typescript-eslint/lines-between-class-members": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.ts", "test/shared/**/*.ts"],
+      "rules": {
+        "@typescript-eslint/no-unused-expressions": "off"
+      }
+    }
+  ]
 }

--- a/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -186,7 +186,7 @@ describe('DecentPaymasterV1', function () {
         .to.emit(decentPaymaster, 'FunctionValidatorSet')
         .withArgs(await mockTarget.getAddress(), FOO_SELECTOR, await mockValidator.getAddress());
 
-      void expect(
+      expect(
         await decentPaymaster.getFunctionValidator(await mockTarget.getAddress(), FOO_SELECTOR),
       ).to.be.equal(await mockValidator.getAddress());
     });
@@ -197,7 +197,7 @@ describe('DecentPaymasterV1', function () {
         FOO_SELECTOR,
         await mockValidator.getAddress(),
       );
-      void expect(
+      expect(
         await decentPaymaster.getFunctionValidator(await mockTarget.getAddress(), FOO_SELECTOR),
       ).to.be.equal(await mockValidator.getAddress());
 
@@ -207,7 +207,7 @@ describe('DecentPaymasterV1', function () {
         .to.emit(decentPaymaster, 'FunctionValidatorRemoved')
         .withArgs(await mockTarget.getAddress(), FOO_SELECTOR);
 
-      void expect(
+      expect(
         await decentPaymaster.getFunctionValidator(await mockTarget.getAddress(), FOO_SELECTOR),
       ).to.be.equal(ethers.ZeroAddress);
     });

--- a/test/deployables/account-abstraction/LightAccountValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/LightAccountValidatorV1.test.ts
@@ -96,7 +96,7 @@ describe('LightAccountValidatorV1', function () {
             await mockLightAccount.getAddress(),
             0n,
           );
-        void expect(isValid).to.be.true;
+        expect(isValid).to.be.true;
         expect(lightAccountOwner).to.equal(await mockLightAccount.owner());
       });
     });
@@ -109,7 +109,7 @@ describe('LightAccountValidatorV1', function () {
           // Should return false since the address won't have the owner() function
           const [isValid, lightAccountOwner] =
             await concreteLightAccountValidator.validateLightAccountPublic(randomAddress, 0n);
-          void expect(isValid).to.be.false;
+          expect(isValid).to.be.false;
           expect(lightAccountOwner).to.equal(ethers.ZeroAddress);
         });
       });
@@ -124,7 +124,7 @@ describe('LightAccountValidatorV1', function () {
               await mockLightAccount.getAddress(),
               0n,
             );
-          void expect(isValid).to.be.false;
+          expect(isValid).to.be.false;
           expect(lightAccountOwner).to.equal(await mockLightAccount.owner());
         });
 
@@ -135,7 +135,7 @@ describe('LightAccountValidatorV1', function () {
               await mockInvalidLightAccount.getAddress(),
               0n,
             );
-          void expect(isValid).to.be.false;
+          expect(isValid).to.be.false;
           expect(lightAccountOwner).to.equal(ethers.ZeroAddress);
         });
       });
@@ -408,7 +408,7 @@ describe('LightAccountValidatorV1', function () {
             await mockLightAccount.getAddress(),
             0n,
           );
-        void expect(isValid0).to.be.true;
+        expect(isValid0).to.be.true;
         expect(lightAccountOwner0).to.equal(owner.address);
 
         // Validate index 1
@@ -417,7 +417,7 @@ describe('LightAccountValidatorV1', function () {
             await mockLightAccount2.getAddress(),
             1n,
           );
-        void expect(isValid1).to.be.true;
+        expect(isValid1).to.be.true;
         expect(lightAccountOwner1).to.equal(owner.address);
       });
 
@@ -440,7 +440,7 @@ describe('LightAccountValidatorV1', function () {
             await mockLightAccount.getAddress(),
             1n,
           );
-        void expect(isValid).to.be.false;
+        expect(isValid).to.be.false;
         expect(lightAccountOwner).to.equal(owner.address);
       });
     });

--- a/test/deployables/account-abstraction/validators/StrategyV1ValidatorV1.test.ts
+++ b/test/deployables/account-abstraction/validators/StrategyV1ValidatorV1.test.ts
@@ -60,7 +60,7 @@ describe('StrategyV1ValidatorV1', function () {
         await mockStrategy.getAddress(),
         wrongCalldata,
       );
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
 
     it('Should return true when the underlying strategy vote is valid', async function () {
@@ -80,7 +80,7 @@ describe('StrategyV1ValidatorV1', function () {
         calldata,
       );
 
-      void expect(isValid).to.be.true;
+      expect(isValid).to.be.true;
     });
 
     it('Should return false when the underlying strategy vote is invalid', async function () {
@@ -100,7 +100,7 @@ describe('StrategyV1ValidatorV1', function () {
         calldata,
       );
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
 
     it('should correctly decode and pass parameters to the strategy', async function () {
@@ -133,7 +133,7 @@ describe('StrategyV1ValidatorV1', function () {
         await mockStrategy.getAddress(),
         calldata,
       );
-      void expect(isValid).to.be.true;
+      expect(isValid).to.be.true;
     });
 
     it('should cause a revert if the validator decodes and passes the wrong params', async function () {
@@ -238,7 +238,7 @@ describe('StrategyV1ValidatorV1', function () {
 
   describe('Version', function () {
     it('Should return correct version', async function () {
-      void expect(await validator.version()).to.equal(1);
+      expect(await validator.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/countersign/CountersignV1.test.ts
+++ b/test/deployables/countersign/CountersignV1.test.ts
@@ -385,13 +385,13 @@ describe('CountersignV1', () => {
         founderWeight,
         founderTransactions,
       ] = await countersign.signerData(founder.address);
-      void expect(founderIsSigner).to.be.true;
-      void expect(founderRequired).to.be.true;
-      void expect(founderSigned).to.be.false;
-      void expect(founderExecuted).to.be.false;
-      void expect(founderSignedTimestamp).to.equal(0n);
-      void expect(founderWeight).to.equal(0n);
-      void expect(founderTransactions).to.equal(signerTransactions[0].transactions);
+      expect(founderIsSigner).to.be.true;
+      expect(founderRequired).to.be.true;
+      expect(founderSigned).to.be.false;
+      expect(founderExecuted).to.be.false;
+      expect(founderSignedTimestamp).to.equal(0n);
+      expect(founderWeight).to.equal(0n);
+      expect(founderTransactions).to.equal(signerTransactions[0].transactions);
 
       // Alice data: isSigner=true, required=true, signed=false, weight=100, transactions=[2 transactions]
       const [
@@ -403,13 +403,13 @@ describe('CountersignV1', () => {
         aliceWeight,
         aliceTransactions,
       ] = await countersign.signerData(investorAlice.address);
-      void expect(aliceIsSigner).to.be.true;
-      void expect(aliceRequired).to.be.true;
-      void expect(aliceSigned).to.be.false;
-      void expect(aliceExecuted).to.be.false;
-      void expect(aliceBeforeSignedTimestamp).to.equal(0n);
-      void expect(aliceWeight).to.equal(ethers.parseEther('100'));
-      void expect(aliceTransactions).to.equal(signerTransactions[1].transactions);
+      expect(aliceIsSigner).to.be.true;
+      expect(aliceRequired).to.be.true;
+      expect(aliceSigned).to.be.false;
+      expect(aliceExecuted).to.be.false;
+      expect(aliceBeforeSignedTimestamp).to.equal(0n);
+      expect(aliceWeight).to.equal(ethers.parseEther('100'));
+      expect(aliceTransactions).to.equal(signerTransactions[1].transactions);
 
       // Bob data: isSigner=true, required=false, signed=false, weight=50, transactions=[2 transactions]
       const [
@@ -421,13 +421,13 @@ describe('CountersignV1', () => {
         bobWeight,
         bobTransactions,
       ] = await countersign.signerData(investorBob.address);
-      void expect(bobIsSigner).to.be.true;
-      void expect(bobRequired).to.be.false;
-      void expect(bobSigned).to.be.false;
-      void expect(bobExecuted).to.be.false;
-      void expect(bobBeforeSignedTimestamp).to.equal(0n);
-      void expect(bobWeight).to.equal(ethers.parseEther('50'));
-      void expect(bobTransactions).to.equal(signerTransactions[2].transactions);
+      expect(bobIsSigner).to.be.true;
+      expect(bobRequired).to.be.false;
+      expect(bobSigned).to.be.false;
+      expect(bobExecuted).to.be.false;
+      expect(bobBeforeSignedTimestamp).to.equal(0n);
+      expect(bobWeight).to.equal(ethers.parseEther('50'));
+      expect(bobTransactions).to.equal(signerTransactions[2].transactions);
 
       // Carol data: isSigner=true, required=false, signed=false, weight=20, transactions=[2 transactions]
       const [
@@ -439,13 +439,13 @@ describe('CountersignV1', () => {
         carolWeight,
         carolTransactions,
       ] = await countersign.signerData(investorCarol.address);
-      void expect(carolIsSigner).to.be.true;
-      void expect(carolRequired).to.be.false;
-      void expect(carolSigned).to.be.false;
-      void expect(carolExecuted).to.be.false;
-      void expect(carolBeforeSignedTimestamp).to.equal(0n);
-      void expect(carolWeight).to.equal(ethers.parseEther('20'));
-      void expect(carolTransactions).to.equal(signerTransactions[3].transactions);
+      expect(carolIsSigner).to.be.true;
+      expect(carolRequired).to.be.false;
+      expect(carolSigned).to.be.false;
+      expect(carolExecuted).to.be.false;
+      expect(carolBeforeSignedTimestamp).to.equal(0n);
+      expect(carolWeight).to.equal(ethers.parseEther('20'));
+      expect(carolTransactions).to.equal(signerTransactions[3].transactions);
 
       // Invalid signer
       const [
@@ -457,18 +457,18 @@ describe('CountersignV1', () => {
         invalidSignerWeight,
         invalidSignerTransactions,
       ] = await countersign.signerData(anon.address);
-      void expect(invalidSignerIsSigner).to.be.false;
-      void expect(invalidSignerRequired).to.be.false;
-      void expect(invalidSignerSigned).to.be.false;
-      void expect(invalidSignerExecuted).to.be.false;
-      void expect(invalidSignerBeforeSignedTimestamp).to.equal(0n);
-      void expect(invalidSignerWeight).to.equal(0n);
-      void expect(invalidSignerTransactions).to.equal(signerTransactions[0].transactions);
+      expect(invalidSignerIsSigner).to.be.false;
+      expect(invalidSignerRequired).to.be.false;
+      expect(invalidSignerSigned).to.be.false;
+      expect(invalidSignerExecuted).to.be.false;
+      expect(invalidSignerBeforeSignedTimestamp).to.equal(0n);
+      expect(invalidSignerWeight).to.equal(0n);
+      expect(invalidSignerTransactions).to.equal(signerTransactions[0].transactions);
     });
 
     it('should return correct preExecutionTransactions', async () => {
       const returnedPreExecutionTransactions = await countersign.preExecutionTransactions();
-      void expect(returnedPreExecutionTransactions).to.equal(preExecutionTransactions);
+      expect(returnedPreExecutionTransactions).to.equal(preExecutionTransactions);
     });
   });
 
@@ -522,38 +522,38 @@ describe('CountersignV1', () => {
       const [, , aliceBeforeSigned, , aliceBeforeSignedTimestamp, ,] = await countersign.signerData(
         investorAlice.address,
       );
-      void expect(aliceBeforeSigned).to.be.false;
-      void expect(aliceBeforeSignedTimestamp).to.equal(0n);
+      expect(aliceBeforeSigned).to.be.false;
+      expect(aliceBeforeSignedTimestamp).to.equal(0n);
       await countersign.connect(investorAlice).sign();
       const [, , aliceAfterSigned, , aliceAfterSignedTimestamp, ,] = await countersign.signerData(
         investorAlice.address,
       );
-      void expect(aliceAfterSigned).to.be.true;
-      void expect(aliceAfterSignedTimestamp).to.equal(await time.latest());
+      expect(aliceAfterSigned).to.be.true;
+      expect(aliceAfterSignedTimestamp).to.equal(await time.latest());
 
       const [, , bobBeforeSigned, , bobBeforeSignedTimestamp, ,] = await countersign.signerData(
         investorBob.address,
       );
-      void expect(bobBeforeSigned).to.be.false;
-      void expect(bobBeforeSignedTimestamp).to.equal(0n);
+      expect(bobBeforeSigned).to.be.false;
+      expect(bobBeforeSignedTimestamp).to.equal(0n);
       await countersign.connect(investorBob).sign();
       const [, , bobAfterSigned, , bobAfterSignedTimestamp, ,] = await countersign.signerData(
         investorBob.address,
       );
-      void expect(bobAfterSigned).to.be.true;
-      void expect(bobAfterSignedTimestamp).to.equal(await time.latest());
+      expect(bobAfterSigned).to.be.true;
+      expect(bobAfterSignedTimestamp).to.equal(await time.latest());
 
       const [, , carolBeforeSigned, , carolBeforeSignedTimestamp, ,] = await countersign.signerData(
         investorCarol.address,
       );
-      void expect(carolBeforeSigned).to.be.false;
-      void expect(carolBeforeSignedTimestamp).to.equal(0n);
+      expect(carolBeforeSigned).to.be.false;
+      expect(carolBeforeSignedTimestamp).to.equal(0n);
       await countersign.connect(investorCarol).sign();
       const [, , carolAfterSigned, , carolAfterSignedTimestamp, ,] = await countersign.signerData(
         investorCarol.address,
       );
-      void expect(carolAfterSigned).to.be.true;
-      void expect(carolAfterSignedTimestamp).to.equal(await time.latest());
+      expect(carolAfterSigned).to.be.true;
+      expect(carolAfterSignedTimestamp).to.equal(await time.latest());
     });
 
     it('should not allow signers to sign after the signing deadline', async () => {
@@ -712,11 +712,11 @@ describe('CountersignV1', () => {
       // move time to after signing deadline
       await time.increaseTo(signingDeadline + 1n);
 
-      void expect(await countersign.initialExecutionComplete()).to.be.false;
+      expect(await countersign.initialExecutionComplete()).to.be.false;
 
       await countersign.connect(founder).execute();
 
-      void expect(await countersign.initialExecutionComplete()).to.be.true;
+      expect(await countersign.initialExecutionComplete()).to.be.true;
     });
 
     it('should execute even if a non-required signer tx fails', async () => {
@@ -732,7 +732,7 @@ describe('CountersignV1', () => {
       // move time to after signing deadline
       await time.increaseTo(signingDeadline + 1n);
 
-      void expect(await countersign.initialExecutionComplete()).to.be.false;
+      expect(await countersign.initialExecutionComplete()).to.be.false;
 
       // Carol unapproves the USDC transfer from the DAO treasury
       await usdc.connect(investorCarol).approve(await countersign.getAddress(), 0);
@@ -744,12 +744,12 @@ describe('CountersignV1', () => {
       let [, , , bobExecuted, , ,] = await countersign.signerData(investorBob.address);
       let [, , , carolExecuted, , ,] = await countersign.signerData(investorCarol.address);
 
-      void expect(founderExecuted).to.be.false;
-      void expect(aliceExecuted).to.be.true;
-      void expect(bobExecuted).to.be.true;
-      void expect(carolExecuted).to.be.false;
+      expect(founderExecuted).to.be.false;
+      expect(aliceExecuted).to.be.true;
+      expect(bobExecuted).to.be.true;
+      expect(carolExecuted).to.be.false;
 
-      void expect(await countersign.initialExecutionComplete()).to.be.true;
+      expect(await countersign.initialExecutionComplete()).to.be.true;
     });
 
     it('should revert if a required signer tx fails', async () => {
@@ -765,7 +765,7 @@ describe('CountersignV1', () => {
       // move time to after signing deadline
       await time.increaseTo(signingDeadline + 1n);
 
-      void expect(await countersign.initialExecutionComplete()).to.be.false;
+      expect(await countersign.initialExecutionComplete()).to.be.false;
 
       // Alice unapproves the USDC transfer from the DAO treasury
       await usdc.connect(investorAlice).approve(await countersign.getAddress(), 0);
@@ -819,12 +819,12 @@ describe('CountersignV1', () => {
       let [, , , bobExecuted, , ,] = await countersign.signerData(investorBob.address);
       let [, , , carolExecuted, , ,] = await countersign.signerData(investorCarol.address);
 
-      void expect(founderExecuted).to.be.false;
-      void expect(aliceExecuted).to.be.false;
-      void expect(bobExecuted).to.be.false;
-      void expect(carolExecuted).to.be.false;
+      expect(founderExecuted).to.be.false;
+      expect(aliceExecuted).to.be.false;
+      expect(bobExecuted).to.be.false;
+      expect(carolExecuted).to.be.false;
 
-      void expect(await countersign.initialExecutionComplete()).to.be.false;
+      expect(await countersign.initialExecutionComplete()).to.be.false;
 
       await countersign.connect(founder).execute();
 
@@ -845,12 +845,12 @@ describe('CountersignV1', () => {
       [, , , bobExecuted, , ,] = await countersign.signerData(investorBob.address);
       [, , , carolExecuted, , ,] = await countersign.signerData(investorCarol.address);
 
-      void expect(founderExecuted).to.be.false;
-      void expect(aliceExecuted).to.be.true;
-      void expect(bobExecuted).to.be.true;
-      void expect(carolExecuted).to.be.true;
+      expect(founderExecuted).to.be.false;
+      expect(aliceExecuted).to.be.true;
+      expect(bobExecuted).to.be.true;
+      expect(carolExecuted).to.be.true;
 
-      void expect(await countersign.initialExecutionComplete()).to.be.true;
+      expect(await countersign.initialExecutionComplete()).to.be.true;
     });
 
     it('should allow for follow up execution when some non-required signers have not signed', async () => {
@@ -880,12 +880,12 @@ describe('CountersignV1', () => {
       let [, , , bobExecuted, , ,] = await countersign.signerData(investorBob.address);
       let [, , , carolExecuted, , ,] = await countersign.signerData(investorCarol.address);
 
-      void expect(founderExecuted).to.be.false;
-      void expect(aliceExecuted).to.be.false;
-      void expect(bobExecuted).to.be.false;
-      void expect(carolExecuted).to.be.false;
+      expect(founderExecuted).to.be.false;
+      expect(aliceExecuted).to.be.false;
+      expect(bobExecuted).to.be.false;
+      expect(carolExecuted).to.be.false;
 
-      void expect(await countersign.initialExecutionComplete()).to.be.false;
+      expect(await countersign.initialExecutionComplete()).to.be.false;
 
       await countersign.connect(founder).execute();
 
@@ -906,12 +906,12 @@ describe('CountersignV1', () => {
       [, , , bobExecuted, , ,] = await countersign.signerData(investorBob.address);
       [, , , carolExecuted, , ,] = await countersign.signerData(investorCarol.address);
 
-      void expect(founderExecuted).to.be.false;
-      void expect(aliceExecuted).to.be.true;
-      void expect(bobExecuted).to.be.true;
-      void expect(carolExecuted).to.be.false;
+      expect(founderExecuted).to.be.false;
+      expect(aliceExecuted).to.be.true;
+      expect(bobExecuted).to.be.true;
+      expect(carolExecuted).to.be.false;
 
-      void expect(await countersign.initialExecutionComplete()).to.be.true;
+      expect(await countersign.initialExecutionComplete()).to.be.true;
     });
 
     it('should skip non-required signers that have not signed in follow up execution', async () => {
@@ -941,12 +941,12 @@ describe('CountersignV1', () => {
       let [, , , bobExecuted, , ,] = await countersign.signerData(investorBob.address);
       let [, , , carolExecuted, , ,] = await countersign.signerData(investorCarol.address);
 
-      void expect(founderExecuted).to.be.false;
-      void expect(aliceExecuted).to.be.false;
-      void expect(bobExecuted).to.be.false;
-      void expect(carolExecuted).to.be.false;
+      expect(founderExecuted).to.be.false;
+      expect(aliceExecuted).to.be.false;
+      expect(bobExecuted).to.be.false;
+      expect(carolExecuted).to.be.false;
 
-      void expect(await countersign.initialExecutionComplete()).to.be.false;
+      expect(await countersign.initialExecutionComplete()).to.be.false;
 
       await countersign.connect(founder).execute();
 
@@ -967,12 +967,12 @@ describe('CountersignV1', () => {
       [, , , bobExecuted, , ,] = await countersign.signerData(investorBob.address);
       [, , , carolExecuted, , ,] = await countersign.signerData(investorCarol.address);
 
-      void expect(founderExecuted).to.be.false;
-      void expect(aliceExecuted).to.be.true;
-      void expect(bobExecuted).to.be.true;
-      void expect(carolExecuted).to.be.false;
+      expect(founderExecuted).to.be.false;
+      expect(aliceExecuted).to.be.true;
+      expect(bobExecuted).to.be.true;
+      expect(carolExecuted).to.be.false;
 
-      void expect(await countersign.initialExecutionComplete()).to.be.true;
+      expect(await countersign.initialExecutionComplete()).to.be.true;
 
       // execute again, Carol still has not signed
       await countersign.connect(founder).execute();
@@ -994,12 +994,12 @@ describe('CountersignV1', () => {
       [, , , bobExecuted, , ,] = await countersign.signerData(investorBob.address);
       [, , , carolExecuted, , ,] = await countersign.signerData(investorCarol.address);
 
-      void expect(founderExecuted).to.be.false;
-      void expect(aliceExecuted).to.be.true;
-      void expect(bobExecuted).to.be.true;
-      void expect(carolExecuted).to.be.false;
+      expect(founderExecuted).to.be.false;
+      expect(aliceExecuted).to.be.true;
+      expect(bobExecuted).to.be.true;
+      expect(carolExecuted).to.be.false;
 
-      void expect(await countersign.initialExecutionComplete()).to.be.true;
+      expect(await countersign.initialExecutionComplete()).to.be.true;
     });
   });
 

--- a/test/deployables/countersign/KYCVerifierV1.test.ts
+++ b/test/deployables/countersign/KYCVerifierV1.test.ts
@@ -74,7 +74,7 @@ describe('KYCVerifierV1', () => {
 
   describe('Verifications', () => {
     it('should verify', async () => {
-      void expect(await kycVerifier.verify(investorAlice.address)).to.be.true;
+      expect(await kycVerifier.verify(investorAlice.address)).to.be.true;
     });
   });
 

--- a/test/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
@@ -140,18 +140,18 @@ describe('FreezeVotingAzoriusV1', () => {
 
   describe('Initialization', () => {
     it('should initialize with correct parameters', async () => {
-      void expect(await azoriusFreezeVoting.owner()).to.equal(owner.address);
-      void expect(await azoriusFreezeVoting.freezeVotesThreshold()).to.equal(
+      expect(await azoriusFreezeVoting.owner()).to.equal(owner.address);
+      expect(await azoriusFreezeVoting.freezeVotesThreshold()).to.equal(
         DEFAULT_FREEZE_VOTES_THRESHOLD,
       );
-      void expect(await azoriusFreezeVoting.freezeProposalPeriod()).to.equal(
+      expect(await azoriusFreezeVoting.freezeProposalPeriod()).to.equal(
         DEFAULT_FREEZE_PROPOSAL_PERIOD,
       );
-      void expect(await azoriusFreezeVoting.freezePeriod()).to.equal(DEFAULT_FREEZE_PERIOD);
-      void expect(await azoriusFreezeVoting.parentAzorius()).to.equal(
+      expect(await azoriusFreezeVoting.freezePeriod()).to.equal(DEFAULT_FREEZE_PERIOD);
+      expect(await azoriusFreezeVoting.parentAzorius()).to.equal(
         await mockParentAzorius.getAddress(),
       );
-      void expect(await azoriusFreezeVoting.lightAccountFactory()).to.equal(
+      expect(await azoriusFreezeVoting.lightAccountFactory()).to.equal(
         mockLightAccountFactory.target as string,
       );
     });
@@ -189,7 +189,7 @@ describe('FreezeVotingAzoriusV1', () => {
 
   describe('parentAzorius()', () => {
     it('should return the correct parent Azorius contract address', async () => {
-      void expect(await azoriusFreezeVoting.parentAzorius()).to.equal(
+      expect(await azoriusFreezeVoting.parentAzorius()).to.equal(
         await mockParentAzorius.getAddress(),
       );
     });
@@ -223,7 +223,7 @@ describe('FreezeVotingAzoriusV1', () => {
 
     it('should initiate a new freeze proposal period if none active and record a vote', async () => {
       const initialFreezeProposalCreated = await azoriusFreezeVoting.freezeProposalCreated();
-      void expect(initialFreezeProposalCreated).to.equal(0); // Should be 0 before first vote
+      expect(initialFreezeProposalCreated).to.equal(0); // Should be 0 before first vote
 
       const txPromise = azoriusFreezeVoting.connect(voter1).castFreezeVote(votingAdapterData, 0n);
 
@@ -240,19 +240,17 @@ describe('FreezeVotingAzoriusV1', () => {
         .to.emit(azoriusFreezeVoting, 'FreezeVoteCast')
         .withArgs(voter1.address, voteWeightFromAdapter);
 
-      void expect(await azoriusFreezeVoting.freezeProposalCreated()).to.equal(txTimestamp);
-      void expect(await azoriusFreezeVoting.freezeProposalVoteCount()).to.equal(
-        voteWeightFromAdapter,
-      );
-      void expect(await azoriusFreezeVoting.freezeProposalStrategy()).to.equal(
+      expect(await azoriusFreezeVoting.freezeProposalCreated()).to.equal(txTimestamp);
+      expect(await azoriusFreezeVoting.freezeProposalVoteCount()).to.equal(voteWeightFromAdapter);
+      expect(await azoriusFreezeVoting.freezeProposalStrategy()).to.equal(
         await mockStrategy.getAddress(),
       );
 
       // Verify adapter was called correctly
-      void expect(await mockAdapter1.recordVoteCalled()).to.be.true;
-      void expect(await mockAdapter1.lastVoterForRecord()).to.equal(voter1.address);
-      void expect(await mockAdapter1.lastSnapshotAndIdForRecord()).to.equal(txTimestamp);
-      void expect(await mockAdapter1.lastAdapterDataForRecord()).to.equal(
+      expect(await mockAdapter1.recordVoteCalled()).to.be.true;
+      expect(await mockAdapter1.lastVoterForRecord()).to.equal(voter1.address);
+      expect(await mockAdapter1.lastSnapshotAndIdForRecord()).to.equal(txTimestamp);
+      expect(await mockAdapter1.lastAdapterDataForRecord()).to.equal(
         votingAdapterData[0].adapterVoteData,
       );
     });
@@ -277,14 +275,14 @@ describe('FreezeVotingAzoriusV1', () => {
         .to.emit(azoriusFreezeVoting, 'FreezeVoteCast')
         .withArgs(voter2.address, newVoteWeight);
 
-      void expect(await azoriusFreezeVoting.freezeProposalCreated()).to.equal(
+      expect(await azoriusFreezeVoting.freezeProposalCreated()).to.equal(
         firstProposalCreatedTimestamp,
       );
-      void expect(await azoriusFreezeVoting.freezeProposalVoteCount()).to.equal(
+      expect(await azoriusFreezeVoting.freezeProposalVoteCount()).to.equal(
         firstVoteCount + newVoteWeight,
       );
-      void expect(await mockAdapter1.lastVoterForRecord()).to.equal(voter2.address);
-      void expect(await mockAdapter1.lastSnapshotAndIdForRecord()).to.equal(
+      expect(await mockAdapter1.lastVoterForRecord()).to.equal(voter2.address);
+      expect(await mockAdapter1.lastSnapshotAndIdForRecord()).to.equal(
         firstProposalCreatedTimestamp,
       );
     });
@@ -315,9 +313,9 @@ describe('FreezeVotingAzoriusV1', () => {
         .withArgs(voter2.address, newVoteWeight);
 
       const newProposalCreatedTimestamp = await azoriusFreezeVoting.freezeProposalCreated();
-      void expect(newProposalCreatedTimestamp).to.not.equal(firstProposalCreatedTimestamp);
-      void expect(newProposalCreatedTimestamp).to.equal(newTxTimestamp);
-      void expect(await azoriusFreezeVoting.freezeProposalVoteCount()).to.equal(newVoteWeight);
+      expect(newProposalCreatedTimestamp).to.not.equal(firstProposalCreatedTimestamp);
+      expect(newProposalCreatedTimestamp).to.equal(newTxTimestamp);
+      expect(await azoriusFreezeVoting.freezeProposalVoteCount()).to.equal(newVoteWeight);
     });
 
     // Add more tests for reverts and other conditions here
@@ -339,7 +337,7 @@ describe('FreezeVotingAzoriusV1', () => {
 
   describe('Version', () => {
     it('should return the correct version', async () => {
-      void expect(await azoriusFreezeVoting.version()).to.equal(1);
+      expect(await azoriusFreezeVoting.version()).to.equal(1);
     });
   });
 

--- a/test/deployables/freeze-voting/FreezeVotingBaseV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingBaseV1.test.ts
@@ -149,7 +149,7 @@ describe('FreezeVotingBaseV1', () => {
 
   describe('Freeze State', () => {
     it('should not be frozen initially', async () => {
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
     });
 
     it('should not be frozen when below threshold', async () => {
@@ -158,7 +158,7 @@ describe('FreezeVotingBaseV1', () => {
       await freezeVoting.connect(voter2).castFreezeVote();
 
       // Should not be frozen yet
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
     });
 
     it('should be frozen once threshold is met', async () => {
@@ -168,7 +168,7 @@ describe('FreezeVotingBaseV1', () => {
       await freezeVoting.connect(voter3).castFreezeVote();
 
       // Should now be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
     });
 
     it('should automatically unfreeze after freeze period', async () => {
@@ -178,13 +178,13 @@ describe('FreezeVotingBaseV1', () => {
       await freezeVoting.connect(voter3).castFreezeVote();
 
       // Should be frozen initially
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
 
       // Increase time to pass the freeze period
       await time.increase(FREEZE_PERIOD + 1);
 
       // Should no longer be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
     });
 
     it('should allow owner to unfreeze manually', async () => {
@@ -194,13 +194,13 @@ describe('FreezeVotingBaseV1', () => {
       await freezeVoting.connect(voter3).castFreezeVote();
 
       // Should be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
 
       // Owner unfreezes manually
       await freezeVoting.connect(owner).unfreeze();
 
       // Should no longer be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Check that state was reset
       expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
@@ -221,7 +221,7 @@ describe('FreezeVotingBaseV1', () => {
       );
 
       // Should still be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
     });
 
     it('should track freeze status across multiple proposals', async () => {
@@ -231,26 +231,26 @@ describe('FreezeVotingBaseV1', () => {
       await freezeVoting.connect(voter3).castFreezeVote();
 
       // DAO should be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
 
       // Owner unfreezes manually
       await freezeVoting.connect(owner).unfreeze();
 
       // DAO should not be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Start a new proposal with not enough votes
       await freezeVoting.connect(voter1).castFreezeVote();
       await freezeVoting.connect(voter2).castFreezeVote();
 
       // DAO should not be frozen with only 2 votes
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Add the third vote to reach threshold
       await freezeVoting.connect(voter3).castFreezeVote();
 
       // DAO should be frozen again
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
     });
   });
 
@@ -310,7 +310,7 @@ describe('FreezeVotingBaseV1', () => {
       await freezeVoting.connect(voter3).castFreezeVote();
 
       // Should be frozen immediately after threshold is reached
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
 
       // Get the freeze activation timestamp
       const freezeActivated = await freezeVoting.freezeActivated();
@@ -319,19 +319,19 @@ describe('FreezeVotingBaseV1', () => {
       await time.increaseTo(Number(freezeActivated) + FREEZE_PERIOD - 1);
 
       // Should still be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
 
       // Advance time to exactly when freeze period expires
       await time.increaseTo(Number(freezeActivated) + FREEZE_PERIOD);
 
       // Should no longer be frozen at the exact expiry time
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Advance time past freeze period
       await time.increaseTo(Number(freezeActivated) + FREEZE_PERIOD + 1);
 
       // Should no longer be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
     });
 
     it('should handle multiple freeze activation cycles correctly', async () => {

--- a/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
+++ b/test/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
@@ -292,7 +292,7 @@ describe('FreezeVotingMultisigV1', () => {
 
   describe('Freeze State', () => {
     it('should not be frozen initially', async () => {
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
     });
 
     it('should not be frozen when below threshold', async () => {
@@ -303,7 +303,7 @@ describe('FreezeVotingMultisigV1', () => {
       await freezeVoting.connect(safeOwner1).castFreezeVote(0n);
 
       // Total votes: 1, below threshold of 2
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
     });
 
     it('should be frozen once threshold is met', async () => {
@@ -320,7 +320,7 @@ describe('FreezeVotingMultisigV1', () => {
       await freezeVoting.connect(safeOwner2).castFreezeVote(0n);
 
       // Total votes: 2, equal to threshold of 2
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
     });
 
     it('should automatically unfreeze after freeze period', async () => {
@@ -337,13 +337,13 @@ describe('FreezeVotingMultisigV1', () => {
       await freezeVoting.connect(safeOwner2).castFreezeVote(0n);
 
       // Should be frozen initially
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
 
       // Increase time to pass the freeze period
       await time.increase(FREEZE_PERIOD + 1);
 
       // Should no longer be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
     });
 
     it('should allow owner to unfreeze manually', async () => {
@@ -360,13 +360,13 @@ describe('FreezeVotingMultisigV1', () => {
       await freezeVoting.connect(safeOwner2).castFreezeVote(0n);
 
       // Should be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
 
       // Owner unfreezes manually
       await freezeVoting.connect(owner).unfreeze();
 
       // Should no longer be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Check that state was reset
       expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
@@ -393,7 +393,7 @@ describe('FreezeVotingMultisigV1', () => {
       );
 
       // Should still be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
     });
 
     it('should track freeze status across multiple proposals', async () => {
@@ -410,13 +410,13 @@ describe('FreezeVotingMultisigV1', () => {
       await freezeVoting.connect(safeOwner2).castFreezeVote(0n);
 
       // DAO should be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
 
       // Owner unfreezes manually
       await freezeVoting.connect(owner).unfreeze();
 
       // DAO should not be frozen
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Start new proposal
       await mockSafe.setOwner(safeOwner1.address);
@@ -425,14 +425,14 @@ describe('FreezeVotingMultisigV1', () => {
       await freezeVoting.connect(safeOwner1).castFreezeVote(0n);
 
       // DAO should not be frozen with only one vote
-      void expect(await freezeVoting.isFrozen()).to.be.false;
+      expect(await freezeVoting.isFrozen()).to.be.false;
 
       // Second vote to reach threshold
       await mockSafe.setOwner(safeOwner2.address);
       await freezeVoting.connect(safeOwner2).castFreezeVote(0n);
 
       // DAO should be frozen again
-      void expect(await freezeVoting.isFrozen()).to.be.true;
+      expect(await freezeVoting.isFrozen()).to.be.true;
     });
   });
 
@@ -443,8 +443,8 @@ describe('FreezeVotingMultisigV1', () => {
 
       // Initial state - user has not voted
       const createdTimestamp = await freezeVoting.freezeProposalCreated();
-      void expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address)).to
-        .be.false;
+      expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address)).to.be
+        .false;
 
       // User votes
       await freezeVoting.connect(safeOwner1).castFreezeVote(0n);
@@ -453,11 +453,11 @@ describe('FreezeVotingMultisigV1', () => {
       const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Updated state - user has voted for the new proposal timestamp
-      void expect(await freezeVoting.accountHasFreezeVoted(newCreatedTimestamp, safeOwner1.address))
-        .to.be.true;
+      expect(await freezeVoting.accountHasFreezeVoted(newCreatedTimestamp, safeOwner1.address)).to
+        .be.true;
       if (createdTimestamp !== newCreatedTimestamp) {
-        void expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address))
-          .to.be.false;
+        expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address)).to.be
+          .false;
       }
     });
 
@@ -472,8 +472,8 @@ describe('FreezeVotingMultisigV1', () => {
       const createdTimestamp = await freezeVoting.freezeProposalCreated();
 
       // Check that user has voted for this proposal timestamp
-      void expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address)).to
-        .be.true;
+      expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address)).to.be
+        .true;
 
       // Owner unfreezes
       await freezeVoting.connect(owner).unfreeze();
@@ -482,18 +482,18 @@ describe('FreezeVotingMultisigV1', () => {
       // but the state for a *new* proposal (which will get a new timestamp) should be clear.
       expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
       // Check for the new (zero) proposal timestamp - should be false
-      void expect(await freezeVoting.accountHasFreezeVoted(0, safeOwner1.address)).to.be.false;
+      expect(await freezeVoting.accountHasFreezeVoted(0, safeOwner1.address)).to.be.false;
 
       // User should be able to vote again (this will create a new proposal timestamp)
       await freezeVoting.connect(safeOwner1).castFreezeVote(0n);
       const newCreatedTimestamp = await freezeVoting.freezeProposalCreated();
 
       // User has voted on the new proposal
-      void expect(await freezeVoting.accountHasFreezeVoted(newCreatedTimestamp, safeOwner1.address))
-        .to.be.true;
+      expect(await freezeVoting.accountHasFreezeVoted(newCreatedTimestamp, safeOwner1.address)).to
+        .be.true;
       if (createdTimestamp > 0 && createdTimestamp !== newCreatedTimestamp) {
-        void expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address))
-          .to.be.true;
+        expect(await freezeVoting.accountHasFreezeVoted(createdTimestamp, safeOwner1.address)).to.be
+          .true;
       }
     });
   });
@@ -585,7 +585,7 @@ describe('FreezeVotingMultisigV1', () => {
 
       expect(await freezeVotingSA.freezeProposalVoteCount()).to.equal(1);
       const proposalTimestamp = await freezeVotingSA.freezeProposalCreated();
-      void expect(
+      expect(
         await freezeVotingSA.accountHasFreezeVoted(proposalTimestamp, smartAccountOwnerSA.address),
       ).to.be.true;
     });

--- a/test/deployables/modules/ModuleAzoriusV1.test.ts
+++ b/test/deployables/modules/ModuleAzoriusV1.test.ts
@@ -1127,7 +1127,7 @@ describe('ModuleAzoriusV1', () => {
         const hashData = await azorius.generateTxHashData(txParams, nonce);
         expect(hashData).to.be.a('string');
         expect(hashData).to.not.equal('0x');
-        void expect(ethers.isHexString(hashData)).to.be.true;
+        expect(ethers.isHexString(hashData)).to.be.true;
       });
 
       it('should produce different hash data for different nonces', async () => {

--- a/test/deployables/strategies/StrategyV1.test.ts
+++ b/test/deployables/strategies/StrategyV1.test.ts
@@ -268,11 +268,11 @@ describe('StrategyV1', () => {
   describe('isVotingAdapter', () => {
     it('should return true for a configured voting adapter', async () => {
       const configuredAdapter = defaultInitialVotingAdapters[0];
-      void expect(await strategy.isVotingAdapter(configuredAdapter)).to.be.true;
+      expect(await strategy.isVotingAdapter(configuredAdapter)).to.be.true;
     });
 
     it('should return false for an unconfigured address', async () => {
-      void expect(await strategy.isVotingAdapter(nonOwner.address)).to.be.false;
+      expect(await strategy.isVotingAdapter(nonOwner.address)).to.be.false;
     });
 
     it('should return false for a configured proposer adapter that is not a voting adapter', async () => {
@@ -287,7 +287,7 @@ describe('StrategyV1', () => {
         [await proposerOnlyAdapter.getAddress()],
         lightAccountFactoryMockAddress,
       );
-      void expect(await testStrategy.isVotingAdapter(await proposerOnlyAdapter.getAddress())).to.be
+      expect(await testStrategy.isVotingAdapter(await proposerOnlyAdapter.getAddress())).to.be
         .false;
     });
   });
@@ -295,11 +295,11 @@ describe('StrategyV1', () => {
   describe('isProposerAdapter', () => {
     it('should return true for a configured proposer adapter', async () => {
       const configuredAdapter = defaultInitialProposerAdapters[0];
-      void expect(await strategy.isProposerAdapter(configuredAdapter)).to.be.true;
+      expect(await strategy.isProposerAdapter(configuredAdapter)).to.be.true;
     });
 
     it('should return false for an unconfigured address', async () => {
-      void expect(await strategy.isProposerAdapter(nonOwner.address)).to.be.false;
+      expect(await strategy.isProposerAdapter(nonOwner.address)).to.be.false;
     });
 
     it('should return false for a configured voting adapter that is not a proposer adapter', async () => {
@@ -314,7 +314,7 @@ describe('StrategyV1', () => {
         defaultInitialProposerAdapters, // mockProposerAdapter1
         lightAccountFactoryMockAddress,
       );
-      void expect(await testStrategy.isProposerAdapter(await votingOnlyAdapter.getAddress())).to.be
+      expect(await testStrategy.isProposerAdapter(await votingOnlyAdapter.getAddress())).to.be
         .false;
     });
   });
@@ -389,7 +389,7 @@ describe('StrategyV1', () => {
       await mockProposerAdapter2.setProposerStatus(user1.address, true);
 
       // Check against adapter 1 (should be false)
-      void expect(
+      expect(
         await multiProposerStrategy.isProposer(
           user1.address,
           mockProposerAdapter1Address,
@@ -398,7 +398,7 @@ describe('StrategyV1', () => {
       ).to.be.false;
 
       // Check against adapter 2 (should be true)
-      void expect(
+      expect(
         await multiProposerStrategy.isProposer(
           user1.address,
           mockProposerAdapter2Address,
@@ -410,9 +410,8 @@ describe('StrategyV1', () => {
     it('should return false if no configured adapter identifies the address as a proposer', async () => {
       const mockProposerAdapter1Address = await mockProposerAdapter1.getAddress();
       await mockProposerAdapter1.setProposerStatus(user1.address, false);
-      void expect(
-        await strategy.isProposer(user1.address, mockProposerAdapter1Address, ethers.ZeroHash),
-      ).to.be.false;
+      expect(await strategy.isProposer(user1.address, mockProposerAdapter1Address, ethers.ZeroHash))
+        .to.be.false;
 
       const mockProposerAdapter2Address = await mockProposerAdapter2.getAddress();
       const multiProposerStrategy = await deployStrategyProxy(
@@ -426,14 +425,14 @@ describe('StrategyV1', () => {
       );
       await mockProposerAdapter1.setProposerStatus(user1.address, false);
       await mockProposerAdapter2.setProposerStatus(user1.address, false);
-      void expect(
+      expect(
         await multiProposerStrategy.isProposer(
           user1.address,
           mockProposerAdapter1Address,
           ethers.ZeroHash,
         ),
       ).to.be.false;
-      void expect(
+      expect(
         await multiProposerStrategy.isProposer(
           user1.address,
           mockProposerAdapter2Address,
@@ -445,9 +444,8 @@ describe('StrategyV1', () => {
     it('should return true if the first configured adapter identifies the address as a proposer', async () => {
       const mockProposerAdapter1Address = await mockProposerAdapter1.getAddress();
       await mockProposerAdapter1.setProposerStatus(user1.address, true);
-      void expect(
-        await strategy.isProposer(user1.address, mockProposerAdapter1Address, ethers.ZeroHash),
-      ).to.be.true;
+      expect(await strategy.isProposer(user1.address, mockProposerAdapter1Address, ethers.ZeroHash))
+        .to.be.true;
     });
 
     it('should revert with InvalidProposerAdapter if the adapter is not configured', async () => {
@@ -930,8 +928,8 @@ describe('StrategyV1', () => {
       expect(proposalDetails.abstainVotes).to.equal(0);
 
       const dataHashAdapter1 = ethers.keccak256(adapter1DataForVoter1);
-      void expect(await mockAdapter1.hasRecordedVote(user1.address, proposalId, dataHashAdapter1))
-        .to.be.false;
+      expect(await mockAdapter1.hasRecordedVote(user1.address, proposalId, dataHashAdapter1)).to.be
+        .false;
     });
 
     it('should revert if attempting to vote with no voting adapters', async () => {
@@ -968,7 +966,7 @@ describe('StrategyV1', () => {
         ],
         0n,
       );
-      void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.false; // Voting not over
+      expect(await strategy.isPassed(PROPOSAL_ID)).to.be.false; // Voting not over
     });
 
     it('should return true if quorum and basis are met and voting is over', async () => {
@@ -988,7 +986,7 @@ describe('StrategyV1', () => {
       const proposalDetails = await strategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
-      void expect(await strategy.isPassed(PROPOSAL_ID)).to.be.true;
+      expect(await strategy.isPassed(PROPOSAL_ID)).to.be.true;
     });
 
     it('should return false if quorum is met but basis is not, after voting period', async () => {
@@ -1044,7 +1042,7 @@ describe('StrategyV1', () => {
       const proposalDetails = await specificStrategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
-      void expect(await specificStrategy.isPassed(PROPOSAL_ID)).to.be.false;
+      expect(await specificStrategy.isPassed(PROPOSAL_ID)).to.be.false;
     });
 
     it('should return false if basis is met but quorum is not, after voting period', async () => {
@@ -1088,7 +1086,7 @@ describe('StrategyV1', () => {
       const proposalDetails = await specificStrategy.proposalVotingDetails(PROPOSAL_ID);
       await time.increaseTo(proposalDetails.votingEndTimestamp + 1n);
 
-      void expect(await specificStrategy.isPassed(PROPOSAL_ID)).to.be.false;
+      expect(await specificStrategy.isPassed(PROPOSAL_ID)).to.be.false;
     });
   });
 
@@ -1105,7 +1103,7 @@ describe('StrategyV1', () => {
 
     it('should initially return false for any proposal', async () => {
       const result = await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID);
-      void expect(result).to.be.false;
+      expect(result).to.be.false;
     });
 
     it('should still return false if voting period is over but no vote has been cast', async () => {
@@ -1113,13 +1111,13 @@ describe('StrategyV1', () => {
         (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp + 1n,
       );
       const result = await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID);
-      void expect(result).to.be.false;
+      expect(result).to.be.false;
     });
 
     it('should get set to true after casting a vote after voting period ends', async () => {
       // Initially false
       let result = await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID);
-      void expect(result).to.be.false;
+      expect(result).to.be.false;
 
       await time.increaseTo(
         (await strategy.proposalVotingDetails(PROPOSAL_ID)).votingEndTimestamp + 1n,
@@ -1137,7 +1135,7 @@ describe('StrategyV1', () => {
       );
 
       result = await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID);
-      void expect(result).to.be.true;
+      expect(result).to.be.true;
     });
 
     it('should maintain separate states for different proposal IDs', async () => {
@@ -1155,12 +1153,12 @@ describe('StrategyV1', () => {
         ],
         0n,
       );
-      void expect(await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID)).to.be.true;
+      expect(await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID)).to.be.true;
 
       await time.increaseTo(
         (await strategy.proposalVotingDetails(PROPOSAL_ID_2)).votingEndTimestamp + 1n,
       );
-      void expect(await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID_2)).to.be.false;
+      expect(await strategy.voteCastedAfterVotingPeriodEnded(PROPOSAL_ID_2)).to.be.false;
     });
 
     it('should not emit VotingPeriodEnded event when casting a vote before voting period ends', async () => {
@@ -1216,7 +1214,7 @@ describe('StrategyV1', () => {
 
   describe('Version', () => {
     it('should return the correct version', async () => {
-      void expect(await strategy.version()).to.equal(1);
+      expect(await strategy.version()).to.equal(1);
     });
   });
 
@@ -1272,7 +1270,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
+        expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return true if quorum is exceeded (yes + abstain > threshold)', async () => {
@@ -1312,7 +1310,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
+        expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if quorum is not met (yes + abstain < threshold)', async () => {
@@ -1353,7 +1351,7 @@ describe('StrategyV1', () => {
           0n,
         );
 
-        void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
+        expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return true if quorum threshold is 0, even with no votes contributing to quorum count', async () => {
@@ -1381,7 +1379,7 @@ describe('StrategyV1', () => {
           0n,
         );
 
-        void expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
+        expect(await qStrategy.isQuorumMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if only NO votes are cast and quorum threshold > 0', async () => {
@@ -1397,7 +1395,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        void expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
+        expect(await strategy.isQuorumMet(PROPOSAL_ID)).to.be.false;
       });
     });
 
@@ -1434,7 +1432,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.true;
+        expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if basis is not met (yes == no for >50% basis)', async () => {
@@ -1462,7 +1460,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+        expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return false if basis is not met (yes < no for >50% basis)', async () => {
@@ -1490,7 +1488,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+        expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return false if totalYesAndNoVotes is 0 (only abstain)', async () => {
@@ -1507,7 +1505,7 @@ describe('StrategyV1', () => {
           0n,
         );
 
-        void expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+        expect(await strategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return true if basisNumerator is 500,000 (50%) and yes > no', async () => {
@@ -1546,7 +1544,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.true;
+        expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if basisNumerator is 500,000 (50%) and yes == no', async () => {
@@ -1585,7 +1583,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+        expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
 
       it('should return true if basisNumerator is max valid (DENOMINATOR - 1) and yes > 0, no == 0', async () => {
@@ -1613,7 +1611,7 @@ describe('StrategyV1', () => {
           ],
           0n,
         );
-        void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.true;
+        expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.true;
       });
 
       it('should return false if basisNumerator is max valid (DENOMINATOR - 1) and yes > 0, no > 0', async () => {
@@ -1654,7 +1652,7 @@ describe('StrategyV1', () => {
           0n,
         );
 
-        void expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.false;
+        expect(await bStrategy.isBasisMet(PROPOSAL_ID)).to.be.false;
       });
     });
   });
@@ -1677,7 +1675,7 @@ describe('StrategyV1', () => {
         await expect(strategy.connect(strategyAdmin).addAuthorizedFreezeVoter(freezeVoter1.address))
           .to.emit(strategy, 'FreezeVoterAuthorizationChanged')
           .withArgs(freezeVoter1.address, true);
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.true;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.true;
         expect(await strategy.authorizedFreezeVoters()).to.include(freezeVoter1.address);
         expect(await strategy.authorizedFreezeVoters()).to.have.lengthOf(1);
       });
@@ -1687,15 +1685,15 @@ describe('StrategyV1', () => {
         await expect(strategy.connect(strategyAdmin).addAuthorizedFreezeVoter(freezeVoter1.address)) // Second add
           .to.emit(strategy, 'FreezeVoterAuthorizationChanged')
           .withArgs(freezeVoter1.address, true);
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.true;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.true;
         expect(await strategy.authorizedFreezeVoters()).to.have.lengthOf(1); // Length should still be 1
       });
 
       it('should allow adding multiple distinct freeze voters', async () => {
         await strategy.connect(strategyAdmin).addAuthorizedFreezeVoter(freezeVoter1.address);
         await strategy.connect(strategyAdmin).addAuthorizedFreezeVoter(freezeVoter2.address);
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.true;
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter2.address)).to.be.true;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.true;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter2.address)).to.be.true;
         const votersArray = await strategy.authorizedFreezeVoters();
         expect(votersArray).to.include(freezeVoter1.address);
         expect(votersArray).to.include(freezeVoter2.address);
@@ -1726,7 +1724,7 @@ describe('StrategyV1', () => {
           .to.emit(strategy, 'FreezeVoterAuthorizationChanged')
           .withArgs(freezeVoter1.address, false);
 
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false;
         expect(await strategy.authorizedFreezeVoters()).to.have.lengthOf(0);
         expect(await strategy.authorizedFreezeVoters()).to.not.include(freezeVoter1.address);
       });
@@ -1738,8 +1736,8 @@ describe('StrategyV1', () => {
 
         await strategy.connect(strategyAdmin).removeAuthorizedFreezeVoter(freezeVoter1.address);
 
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false;
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter2.address)).to.be.true;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter2.address)).to.be.true;
         const votersArray = await strategy.authorizedFreezeVoters();
         expect(votersArray).to.have.lengthOf(1);
         expect(votersArray).to.include(freezeVoter2.address);
@@ -1747,7 +1745,7 @@ describe('StrategyV1', () => {
       });
 
       it('should emit event even if removing a non-authorized address', async () => {
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false; // Pre-condition
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false; // Pre-condition
         await expect(
           strategy.connect(strategyAdmin).removeAuthorizedFreezeVoter(freezeVoter1.address),
         )
@@ -1773,21 +1771,21 @@ describe('StrategyV1', () => {
     describe('isAuthorizedFreezeVoter', () => {
       it('should return true for an authorized address', async () => {
         await strategy.connect(strategyAdmin).addAuthorizedFreezeVoter(freezeVoter1.address);
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.true;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.true;
       });
 
       it('should return false for a non-authorized address', async () => {
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false;
       });
 
       it('should return false for an address that was removed', async () => {
         await strategy.connect(strategyAdmin).addAuthorizedFreezeVoter(freezeVoter1.address);
         await strategy.connect(strategyAdmin).removeAuthorizedFreezeVoter(freezeVoter1.address);
-        void expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false;
+        expect(await strategy.isAuthorizedFreezeVoter(freezeVoter1.address)).to.be.false;
       });
 
       it('should return false for address(0)', async () => {
-        void expect(await strategy.isAuthorizedFreezeVoter(ethers.ZeroAddress)).to.be.false;
+        expect(await strategy.isAuthorizedFreezeVoter(ethers.ZeroAddress)).to.be.false;
       });
     });
 
@@ -1866,7 +1864,7 @@ describe('StrategyV1', () => {
         { votingAdapter: await mockAdapter1.getAddress(), adapterVoteData: ADAPTER_VOTE_DATA },
       ]);
 
-      void expect(isValid).to.be.true;
+      expect(isValid).to.be.true;
     });
 
     it('should return false if the proposal is not initialized', async () => {
@@ -1880,7 +1878,7 @@ describe('StrategyV1', () => {
         [{ votingAdapter: await mockAdapter1.getAddress(), adapterVoteData: ADAPTER_VOTE_DATA }],
       );
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
 
     it('should return false if the voting period has ended', async () => {
@@ -1904,7 +1902,7 @@ describe('StrategyV1', () => {
         { votingAdapter: await mockAdapter1.getAddress(), adapterVoteData: ADAPTER_VOTE_DATA },
       ]);
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
 
     it('should return false for an invalid vote type', async () => {
@@ -1918,7 +1916,7 @@ describe('StrategyV1', () => {
         [{ votingAdapter: await mockAdapter1.getAddress(), adapterVoteData: ADAPTER_VOTE_DATA }],
       );
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
 
     it('should return false if the voting adapter is not attached to the strategy', async () => {
@@ -1933,7 +1931,7 @@ describe('StrategyV1', () => {
         },
       ]);
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
 
     it('should return false if the adapter considers the vote invalid', async () => {
@@ -1944,7 +1942,7 @@ describe('StrategyV1', () => {
         { votingAdapter: await mockAdapter1.getAddress(), adapterVoteData: ADAPTER_VOTE_DATA },
       ]);
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
 
     it('should return false if total voting weight is zero', async () => {
@@ -1955,7 +1953,7 @@ describe('StrategyV1', () => {
         { votingAdapter: await mockAdapter1.getAddress(), adapterVoteData: ADAPTER_VOTE_DATA },
       ]);
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
 
     it('should return true with multiple valid adapters', async () => {
@@ -1988,7 +1986,7 @@ describe('StrategyV1', () => {
           },
         ],
       );
-      void expect(isValid).to.be.true;
+      expect(isValid).to.be.true;
     });
 
     it('should return false if one of multiple adapters is invalid', async () => {
@@ -2021,7 +2019,7 @@ describe('StrategyV1', () => {
           },
         ],
       );
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
 
     it('should return false if no voting adapters are provided', async () => {
@@ -2035,7 +2033,7 @@ describe('StrategyV1', () => {
         [], // Empty array is the reason for returning false
       );
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
     });
   });
 

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.test.ts
@@ -98,14 +98,14 @@ describe('ProposerAdapterERC20V1', () => {
       await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
       await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.true;
+      expect(canPropose).to.be.true;
     });
 
     it('should return true if user exceeds the proposer threshold', async () => {
       await mockToken.connect(deployer).mint(user1.address, DEFAULT_PROPOSER_THRESHOLD);
       await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.true;
+      expect(canPropose).to.be.true;
     });
 
     it('should return false if user is below the proposer threshold', async () => {
@@ -115,13 +115,13 @@ describe('ProposerAdapterERC20V1', () => {
       await mockToken.connect(user1).delegate(user1.address);
 
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.false;
+      expect(canPropose).to.be.false;
     });
 
     it('should return false if user has no votes (or token balance)', async () => {
       await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.false;
+      expect(canPropose).to.be.false;
     });
 
     it('should return true if proposerThreshold is 0, even with zero votes', async () => {
@@ -133,7 +133,7 @@ describe('ProposerAdapterERC20V1', () => {
       );
       await mockToken.connect(user1).delegate(user1.address);
       const canPropose = await localAdapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.true;
+      expect(canPropose).to.be.true;
     });
   });
 

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.test.ts
@@ -89,7 +89,7 @@ describe('ProposerAdapterERC721V1', () => {
         await mockNft.connect(deployer).mint(user1.address);
       }
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.true;
+      expect(canPropose).to.be.true;
     });
 
     it('should return true if user exceeds the proposer threshold', async () => {
@@ -97,7 +97,7 @@ describe('ProposerAdapterERC721V1', () => {
         await mockNft.connect(deployer).mint(user1.address);
       }
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.true;
+      expect(canPropose).to.be.true;
     });
 
     it('should return false if user is below the proposer threshold', async () => {
@@ -105,12 +105,12 @@ describe('ProposerAdapterERC721V1', () => {
         await mockNft.connect(deployer).mint(user1.address);
       }
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.false;
+      expect(canPropose).to.be.false;
     });
 
     it('should return false if user has no NFTs', async () => {
       const canPropose = await adapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.false;
+      expect(canPropose).to.be.false;
     });
 
     it('should return true if proposerThreshold is 0, even with zero NFTs', async () => {
@@ -121,7 +121,7 @@ describe('ProposerAdapterERC721V1', () => {
         0n,
       );
       const canPropose = await localAdapter.isProposer(user1.address, ethers.ZeroHash);
-      void expect(canPropose).to.be.true;
+      expect(canPropose).to.be.true;
     });
   });
 

--- a/test/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
+++ b/test/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
@@ -95,7 +95,7 @@ describe('ProposerAdapterHatsV1', () => {
         user1.address,
         ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_1]),
       );
-      void expect(canPropose).to.be.true;
+      expect(canPropose).to.be.true;
     });
 
     it('should return false if user does not wear any whitelisted hat', async () => {
@@ -105,7 +105,7 @@ describe('ProposerAdapterHatsV1', () => {
         user1.address,
         ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_1]),
       );
-      void expect(canPropose).to.be.false;
+      expect(canPropose).to.be.false;
     });
 
     it('should return false if user wears a hat that is not whitelisted', async () => {
@@ -114,7 +114,7 @@ describe('ProposerAdapterHatsV1', () => {
         user1.address,
         ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_2]),
       );
-      void expect(canPropose).to.be.false;
+      expect(canPropose).to.be.false;
     });
 
     it('should return false if user wears no hats', async () => {
@@ -122,7 +122,7 @@ describe('ProposerAdapterHatsV1', () => {
         user1.address,
         ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_1]),
       );
-      void expect(canPropose).to.be.false;
+      expect(canPropose).to.be.false;
     });
 
     it('should work with multiple whitelisted hats', async () => {
@@ -138,7 +138,7 @@ describe('ProposerAdapterHatsV1', () => {
         user1.address,
         ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_2]),
       );
-      void expect(canPropose).to.be.true;
+      expect(canPropose).to.be.true;
     });
 
     it('should return false if adapter was initialized with no whitelisted hats', async () => {
@@ -153,7 +153,7 @@ describe('ProposerAdapterHatsV1', () => {
         user1.address,
         ethers.AbiCoder.defaultAbiCoder().encode(['uint256'], [HAT_ID_1]),
       );
-      void expect(canPropose).to.be.false;
+      expect(canPropose).to.be.false;
     });
 
     it('should revert if data is not a valid abi-encoded uint256', async () => {
@@ -188,11 +188,11 @@ describe('ProposerAdapterHatsV1', () => {
 
     describe('hatIdIsWhitelisted()', () => {
       it('should return true for a whitelisted hat ID', async () => {
-        void expect(await adapter.hatIdIsWhitelisted(HAT_ID_1)).to.be.true;
+        expect(await adapter.hatIdIsWhitelisted(HAT_ID_1)).to.be.true;
       });
 
       it('should return false for a non-whitelisted hat ID', async () => {
-        void expect(await adapter.hatIdIsWhitelisted(HAT_ID_2)).to.be.false;
+        expect(await adapter.hatIdIsWhitelisted(HAT_ID_2)).to.be.false;
       });
 
       it('should return false for any hat ID if initialized with no hats', async () => {
@@ -202,8 +202,8 @@ describe('ProposerAdapterHatsV1', () => {
           await mockHats.getAddress(),
           [], // empty array
         );
-        void expect(await localAdapter.hatIdIsWhitelisted(HAT_ID_1)).to.be.false;
-        void expect(await localAdapter.hatIdIsWhitelisted(HAT_ID_2)).to.be.false;
+        expect(await localAdapter.hatIdIsWhitelisted(HAT_ID_1)).to.be.false;
+        expect(await localAdapter.hatIdIsWhitelisted(HAT_ID_2)).to.be.false;
       });
     });
   });

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
@@ -524,7 +524,7 @@ describe('VotingAdapterERC20V1', () => {
     describe('hasCastedVoteForProposal', () => {
       it('should return false initially', async () => {
         const hasVoted = await adapter.hasCastedVoteForProposal(proposalId, voter.address);
-        void expect(hasVoted).to.be.false;
+        expect(hasVoted).to.be.false;
       });
 
       it('should return true after recording a vote', async () => {
@@ -551,7 +551,7 @@ describe('VotingAdapterERC20V1', () => {
 
         // Check the state
         const hasVoted = await adapter.hasCastedVoteForProposal(proposalId, voter.address);
-        void expect(hasVoted).to.be.true;
+        expect(hasVoted).to.be.true;
       });
 
       it('should only mark the specific proposalId/voter combination as voted', async () => {
@@ -585,10 +585,10 @@ describe('VotingAdapterERC20V1', () => {
         );
 
         // Check states
-        void expect(await adapter.hasCastedVoteForProposal(proposalId, voter.address)).to.be.true;
-        void expect(await adapter.hasCastedVoteForProposal(anotherProposalId, voter.address)).to.be
+        expect(await adapter.hasCastedVoteForProposal(proposalId, voter.address)).to.be.true;
+        expect(await adapter.hasCastedVoteForProposal(anotherProposalId, voter.address)).to.be
           .false;
-        void expect(await adapter.hasCastedVoteForProposal(proposalId, anotherVoter.address)).to.be
+        expect(await adapter.hasCastedVoteForProposal(proposalId, anotherVoter.address)).to.be
           .false;
       });
     });
@@ -617,7 +617,7 @@ describe('VotingAdapterERC20V1', () => {
           freezeProposalSnapshotAndId,
           voter.address,
         );
-        void expect(hasVoted).to.be.false;
+        expect(hasVoted).to.be.false;
       });
 
       it('should return true after recording a freeze vote', async () => {
@@ -632,7 +632,7 @@ describe('VotingAdapterERC20V1', () => {
           freezeProposalSnapshotAndId,
           voter.address,
         );
-        void expect(hasVoted).to.be.true;
+        expect(hasVoted).to.be.true;
       });
 
       it('should only mark the specific contract/proposalId/voter combination as voted', async () => {
@@ -648,7 +648,7 @@ describe('VotingAdapterERC20V1', () => {
           .recordFreezeVote(voter.address, freezeProposalSnapshotAndId, ZERO_EXTRA_DATA);
 
         // Check states - same voter, different params
-        void expect(
+        expect(
           await adapter.hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract(
             freezeVoteContract.address,
             freezeProposalSnapshotAndId,
@@ -656,7 +656,7 @@ describe('VotingAdapterERC20V1', () => {
           ),
         ).to.be.true;
 
-        void expect(
+        expect(
           await adapter.hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract(
             anotherFreezeVoteContract.address,
             freezeProposalSnapshotAndId,
@@ -664,7 +664,7 @@ describe('VotingAdapterERC20V1', () => {
           ),
         ).to.be.false;
 
-        void expect(
+        expect(
           await adapter.hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract(
             freezeVoteContract.address,
             anotherSnapshotId,
@@ -672,7 +672,7 @@ describe('VotingAdapterERC20V1', () => {
           ),
         ).to.be.false;
 
-        void expect(
+        expect(
           await adapter.hasCastedVotePerFreezeVoteProposalPerFreezeVoteContract(
             freezeVoteContract.address,
             freezeProposalSnapshotAndId,
@@ -987,7 +987,7 @@ describe('VotingAdapterERC20V1', () => {
         mockExtraData,
       );
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
       expect(weight).to.equal(0);
     });
 
@@ -1012,7 +1012,7 @@ describe('VotingAdapterERC20V1', () => {
         proposalId,
         mockExtraData,
       );
-      void expect(isInitiallyValid).to.be.true;
+      expect(isInitiallyValid).to.be.true;
       expect(initialWeight).to.equal(voteWeight);
 
       // 2. Record a vote
@@ -1035,7 +1035,7 @@ describe('VotingAdapterERC20V1', () => {
         mockExtraData,
       );
 
-      void expect(isFinallyValid).to.be.false;
+      expect(isFinallyValid).to.be.false;
       expect(finalWeight).to.equal(0);
     });
 
@@ -1053,7 +1053,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isInitiallyValid).to.be.true;
+        expect(isInitiallyValid).to.be.true;
         expect(initialWeight).to.equal(validWeight);
 
         // 2. Check for FALSE with no checkpoints
@@ -1063,7 +1063,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isFinallyValid).to.be.false;
+        expect(isFinallyValid).to.be.false;
         expect(finalWeight).to.equal(0);
       });
 
@@ -1080,7 +1080,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isInitiallyValid).to.be.true;
+        expect(isInitiallyValid).to.be.true;
         expect(initialWeight).to.equal(validWeight);
 
         // 2. Check for FALSE with all checkpoints after start
@@ -1094,7 +1094,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isFinallyValid).to.be.false;
+        expect(isFinallyValid).to.be.false;
         expect(finalWeight).to.equal(0);
       });
 
@@ -1111,7 +1111,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isInitiallyValid).to.be.true;
+        expect(isInitiallyValid).to.be.true;
         expect(initialWeight).to.equal(validWeight);
 
         // 2. Check for FALSE with a zero-vote checkpoint
@@ -1122,7 +1122,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isFinallyValid).to.be.false;
+        expect(isFinallyValid).to.be.false;
         expect(finalWeight).to.equal(0);
       });
 
@@ -1139,7 +1139,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isValid).to.be.true;
+        expect(isValid).to.be.true;
         expect(weight).to.equal(votingWeight);
       });
 
@@ -1154,7 +1154,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isValid).to.be.true;
+        expect(isValid).to.be.true;
         expect(weight).to.equal(votingWeight);
       });
 
@@ -1173,7 +1173,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isValid).to.be.true;
+        expect(isValid).to.be.true;
         expect(weight).to.equal(expectedWeight);
       });
 
@@ -1190,7 +1190,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isInitiallyValid).to.be.true;
+        expect(isInitiallyValid).to.be.true;
         expect(initialWeight).to.equal(expectedWeight);
 
         // 2. Check for FALSE by adding an ignored checkpoint (behavior doesn't change from true)
@@ -1207,7 +1207,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isFinallyValid).to.be.true;
+        expect(isFinallyValid).to.be.true;
         expect(finalWeight).to.equal(expectedWeight);
       });
 
@@ -1224,7 +1224,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isInitiallyValid).to.be.true;
+        expect(isInitiallyValid).to.be.true;
         expect(initialWeight).to.equal(validWeight);
 
         // 2. Check for FALSE by adding a checkpoint after the end time
@@ -1238,7 +1238,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isFinallyValid).to.be.false;
+        expect(isFinallyValid).to.be.false;
         expect(finalWeight).to.equal(0);
       });
 
@@ -1256,7 +1256,7 @@ describe('VotingAdapterERC20V1', () => {
           mockExtraData,
         );
 
-        void expect(isValid).to.be.true;
+        expect(isValid).to.be.true;
         expect(weight).to.equal(expectedRawWeight * DEFAULT_WEIGHT_PER_TOKEN);
       });
 
@@ -1283,7 +1283,7 @@ describe('VotingAdapterERC20V1', () => {
           mockExtraData,
         );
 
-        void expect(isValid).to.be.true;
+        expect(isValid).to.be.true;
         expect(weight).to.equal(votingWeight * customWeightPerToken);
       });
 
@@ -1300,7 +1300,7 @@ describe('VotingAdapterERC20V1', () => {
           proposalId,
           mockExtraData,
         );
-        void expect(isInitiallyValid).to.be.true;
+        expect(isInitiallyValid).to.be.true;
         expect(initialWeight).to.equal(votingWeight * DEFAULT_WEIGHT_PER_TOKEN);
 
         // 2. Check for FALSE with the zero-weight adapter
@@ -1320,7 +1320,7 @@ describe('VotingAdapterERC20V1', () => {
           mockExtraData,
         );
 
-        void expect(isFinallyValid).to.be.false;
+        expect(isFinallyValid).to.be.false;
         expect(finalWeight).to.equal(0);
       });
     });

--- a/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
+++ b/test/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
@@ -458,7 +458,7 @@ describe('VotingAdapterERC721V1', () => {
         emptyVoteData,
       );
       expect(weight).to.equal(0n);
-      void expect(validTokenIds).to.be.an('array').that.is.empty;
+      expect(validTokenIds).to.be.an('array').that.is.empty;
     });
 
     it('should return 0 weight and empty array if voter owns none of the valid provided token IDs', async () => {
@@ -473,7 +473,7 @@ describe('VotingAdapterERC721V1', () => {
         adapterVoteData,
       );
       expect(weight).to.equal(0n);
-      void expect(validTokenIds).to.be.an('array').that.is.empty;
+      expect(validTokenIds).to.be.an('array').that.is.empty;
     });
 
     it('should correctly apply weightPerToken > 1', async () => {
@@ -537,7 +537,7 @@ describe('VotingAdapterERC721V1', () => {
       );
 
       expect(weight).to.equal(0n);
-      void expect(validTokenIds).to.be.an('array').that.is.empty;
+      expect(validTokenIds).to.be.an('array').that.is.empty;
     });
 
     it('should revert with ProposalNotInitialized if proposal does not exist', async () => {
@@ -597,10 +597,10 @@ describe('VotingAdapterERC721V1', () => {
         .to.emit(adapter, 'VoteRecorded')
         .withArgs(user1.address, proposalId, expectedWeight, adapterVoteData);
 
-      void expect(await adapter.tokenIdUsedForVote(proposalId, user1TokenIds[0])).to.be.true;
-      void expect(await adapter.tokenIdUsedForVote(proposalId, user1TokenIds[1])).to.be.true;
+      expect(await adapter.tokenIdUsedForVote(proposalId, user1TokenIds[0])).to.be.true;
+      expect(await adapter.tokenIdUsedForVote(proposalId, user1TokenIds[1])).to.be.true;
       if (user1TokenIds.length > 2) {
-        void expect(await adapter.tokenIdUsedForVote(proposalId, user1TokenIds[2])).to.be.false;
+        expect(await adapter.tokenIdUsedForVote(proposalId, user1TokenIds[2])).to.be.false;
       }
       const weightAfter = await adapter.weightOf(user1.address, proposalId, adapterVoteData);
       expect(weightAfter).to.equal(0n);
@@ -664,7 +664,7 @@ describe('VotingAdapterERC721V1', () => {
         .withArgs(tokenIdsNotOwnedByUser1[0]);
 
       // Verify token was not marked as used
-      void expect(await adapter.tokenIdUsedForVote(proposalId, user2TokenIds[0])).to.be.false;
+      expect(await adapter.tokenIdUsedForVote(proposalId, user2TokenIds[0])).to.be.false;
     });
 
     it('should correctly apply custom weightPerNft on recordVote and emit event', async () => {
@@ -711,8 +711,7 @@ describe('VotingAdapterERC721V1', () => {
         .to.emit(customAdapter, 'VoteRecorded')
         .withArgs(localUser1.address, proposalId, expectedWeight, adapterVoteData);
 
-      void expect(await customAdapter.tokenIdUsedForVote(proposalId, tokenIdsToUseInVote[0])).to.be
-        .true;
+      expect(await customAdapter.tokenIdUsedForVote(proposalId, tokenIdsToUseInVote[0])).to.be.true;
     });
 
     it('should revert with DuplicateTokenIds if duplicate token IDs are provided', async () => {
@@ -787,7 +786,7 @@ describe('VotingAdapterERC721V1', () => {
     describe('tokenIdUsedForVote', () => {
       it('should return false initially', async () => {
         const isUsed = await adapter.tokenIdUsedForVote(proposalId, voter1TokenIds[0]);
-        void expect(isUsed).to.be.false;
+        expect(isUsed).to.be.false;
       });
 
       it('should return true after a token ID is used to vote', async () => {
@@ -813,7 +812,7 @@ describe('VotingAdapterERC721V1', () => {
 
         // Check the state
         const isUsed = await adapter.tokenIdUsedForVote(proposalId, voter1TokenIds[0]);
-        void expect(isUsed).to.be.true;
+        expect(isUsed).to.be.true;
       });
 
       it('should only mark the specific proposalId/tokenId combination as used', async () => {
@@ -841,12 +840,11 @@ describe('VotingAdapterERC721V1', () => {
         );
 
         // Check the original proposal/token ID
-        void expect(await adapter.tokenIdUsedForVote(proposalId, voter1TokenIds[0])).to.be.true;
+        expect(await adapter.tokenIdUsedForVote(proposalId, voter1TokenIds[0])).to.be.true;
 
         // Check different combinations
-        void expect(await adapter.tokenIdUsedForVote(anotherProposalId, voter1TokenIds[0])).to.be
-          .false;
-        void expect(await adapter.tokenIdUsedForVote(proposalId, voter1TokenIds[1])).to.be.false;
+        expect(await adapter.tokenIdUsedForVote(anotherProposalId, voter1TokenIds[0])).to.be.false;
+        expect(await adapter.tokenIdUsedForVote(proposalId, voter1TokenIds[1])).to.be.false;
       });
 
       it('should revert with ProposalNotInitialized if proposal does not exist', async () => {
@@ -876,7 +874,7 @@ describe('VotingAdapterERC721V1', () => {
           PROPOSAL_SNAPSHOT_AND_ID,
           voter1TokenIds[0],
         );
-        void expect(isUsed).to.be.false;
+        expect(isUsed).to.be.false;
       });
 
       it('should return true after a token ID is used for a freeze vote', async () => {
@@ -897,7 +895,7 @@ describe('VotingAdapterERC721V1', () => {
           PROPOSAL_SNAPSHOT_AND_ID,
           voter1TokenIds[0],
         );
-        void expect(isUsed).to.be.true;
+        expect(isUsed).to.be.true;
       });
 
       it('should only mark the specific contract/proposalId/tokenId combination as used', async () => {
@@ -917,7 +915,7 @@ describe('VotingAdapterERC721V1', () => {
           .recordFreezeVote(voter1.address, PROPOSAL_SNAPSHOT_AND_ID, adapterVoteData);
 
         // Check the original contract/proposal/token ID
-        void expect(
+        expect(
           await adapter.tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract(
             freezeVoteContract.address,
             PROPOSAL_SNAPSHOT_AND_ID,
@@ -926,7 +924,7 @@ describe('VotingAdapterERC721V1', () => {
         ).to.be.true;
 
         // Check different combinations
-        void expect(
+        expect(
           await adapter.tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract(
             anotherFreezeVoteContract.address,
             PROPOSAL_SNAPSHOT_AND_ID,
@@ -934,7 +932,7 @@ describe('VotingAdapterERC721V1', () => {
           ),
         ).to.be.false;
 
-        void expect(
+        expect(
           await adapter.tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract(
             freezeVoteContract.address,
             anotherSnapshotId,
@@ -942,7 +940,7 @@ describe('VotingAdapterERC721V1', () => {
           ),
         ).to.be.false;
 
-        void expect(
+        expect(
           await adapter.tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract(
             freezeVoteContract.address,
             PROPOSAL_SNAPSHOT_AND_ID,
@@ -1433,7 +1431,7 @@ describe('VotingAdapterERC721V1', () => {
         .withArgs(voter2TokenId);
 
       // Verify token was not marked as used for the freeze vote
-      void expect(
+      expect(
         await adapter.tokenIdUsedPerFreezeVoteProposalPerFreezeVoteContract(
           authorizedCaller.address,
           PROPOSAL_SNAPSHOT_AND_ID_1,
@@ -1488,7 +1486,7 @@ describe('VotingAdapterERC721V1', () => {
         adapterVoteData,
       );
 
-      void expect(isValid).to.be.true;
+      expect(isValid).to.be.true;
       expect(weight).to.equal(expectedWeight);
     });
 
@@ -1504,7 +1502,7 @@ describe('VotingAdapterERC721V1', () => {
         proposalId,
         validAdapterVoteData,
       );
-      void expect(isInitiallyValid).to.be.true;
+      expect(isInitiallyValid).to.be.true;
       expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
 
       // 2. Check for FALSE with an empty array
@@ -1514,7 +1512,7 @@ describe('VotingAdapterERC721V1', () => {
         proposalId,
         emptyAdapterVoteData,
       );
-      void expect(isFinallyValid).to.be.false;
+      expect(isFinallyValid).to.be.false;
       expect(finalWeight).to.equal(0);
     });
 
@@ -1532,7 +1530,7 @@ describe('VotingAdapterERC721V1', () => {
         proposalId,
         initialAdapterVoteData,
       );
-      void expect(isInitiallyValid).to.be.true;
+      expect(isInitiallyValid).to.be.true;
       expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
 
       // 2. Check for FALSE when an unowned token is included
@@ -1545,7 +1543,7 @@ describe('VotingAdapterERC721V1', () => {
         proposalId,
         finalAdapterVoteData,
       );
-      void expect(isFinallyValid).to.be.false;
+      expect(isFinallyValid).to.be.false;
       expect(finalWeight).to.equal(0);
     });
 
@@ -1563,7 +1561,7 @@ describe('VotingAdapterERC721V1', () => {
         proposalId,
         initialAdapterVoteData,
       );
-      void expect(isInitiallyValid).to.be.true;
+      expect(isInitiallyValid).to.be.true;
       expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
 
       // 2. Mark a token as used
@@ -1590,7 +1588,7 @@ describe('VotingAdapterERC721V1', () => {
         proposalId,
         finalAdapterVoteData,
       );
-      void expect(isFinallyValid).to.be.false;
+      expect(isFinallyValid).to.be.false;
       expect(finalWeight).to.equal(0);
     });
 
@@ -1607,7 +1605,7 @@ describe('VotingAdapterERC721V1', () => {
         proposalId,
         adapterVoteData,
       );
-      void expect(isInitiallyValid).to.be.true;
+      expect(isInitiallyValid).to.be.true;
       expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
 
       // 2. Check for FALSE with the zero-weight adapter
@@ -1625,7 +1623,7 @@ describe('VotingAdapterERC721V1', () => {
         adapterVoteData,
       );
 
-      void expect(isFinallyValid).to.be.false;
+      expect(isFinallyValid).to.be.false;
       expect(finalWeight).to.equal(0);
     });
 
@@ -1642,7 +1640,7 @@ describe('VotingAdapterERC721V1', () => {
         proposalId,
         initialAdapterVoteData,
       );
-      void expect(isInitiallyValid).to.be.true;
+      expect(isInitiallyValid).to.be.true;
       expect(initialWeight).to.equal(DEFAULT_WEIGHT_PER_NFT);
 
       // 2. Check for FALSE with duplicate tokens
@@ -1655,7 +1653,7 @@ describe('VotingAdapterERC721V1', () => {
         proposalId,
         finalAdapterVoteData,
       );
-      void expect(isFinallyValid).to.be.false;
+      expect(isFinallyValid).to.be.false;
       expect(finalWeight).to.equal(0);
     });
 
@@ -1681,7 +1679,7 @@ describe('VotingAdapterERC721V1', () => {
         adapterVoteData,
       );
 
-      void expect(isValid).to.be.true;
+      expect(isValid).to.be.true;
       expect(weight).to.equal(BigInt(tokenIdsToVoteWith.length) * customWeightPerToken);
     });
 
@@ -1700,7 +1698,7 @@ describe('VotingAdapterERC721V1', () => {
         adapterVoteData,
       );
 
-      void expect(isValid).to.be.false;
+      expect(isValid).to.be.false;
       expect(weight).to.equal(0);
     });
   });

--- a/test/shared/supportsInterfaceTests.ts
+++ b/test/shared/supportsInterfaceTests.ts
@@ -127,7 +127,7 @@ export function runSupportsInterfaceTests(params: SupportsInterfaceTestParams): 
           )
         : calculateInterfaceId(factory.createInterface());
 
-      void expect(await contract.supportsInterface(interfaceId)).to.be.true;
+      expect(await contract.supportsInterface(interfaceId)).to.be.true;
     });
   });
 
@@ -135,6 +135,6 @@ export function runSupportsInterfaceTests(params: SupportsInterfaceTestParams): 
     const contract = params.getContract();
     const randomInterfaceId = '0x12345678';
 
-    void expect(await contract.supportsInterface(randomInterfaceId)).to.be.false;
+    expect(await contract.supportsInterface(randomInterfaceId)).to.be.false;
   });
 }

--- a/test/singletons/KeyValuePairsV1.test.ts
+++ b/test/singletons/KeyValuePairsV1.test.ts
@@ -55,7 +55,7 @@ describe('KeyValuePairsV1', function () {
 
   describe('version', function () {
     it('should return the correct version', async function () {
-      void expect(await keyValuePairs.version()).to.equal(1);
+      expect(await keyValuePairs.version()).to.equal(1);
     });
   });
 

--- a/test/singletons/SystemDeployerV1.test.ts
+++ b/test/singletons/SystemDeployerV1.test.ts
@@ -275,7 +275,7 @@ async function verifySafeConfiguration(params: {
     }
   });
 
-  void expect(proxyCreationEvent).to.not.be.undefined;
+  expect(proxyCreationEvent).to.not.be.undefined;
 
   if (!proxyCreationEvent) {
     throw new Error('Proxy creation event not found');
@@ -417,12 +417,12 @@ async function findAndVerifyVotesERC20V1s(params: {
 
     expect(await votesERC20V1Proxy.name()).to.equal(votesERC20V1Data.metadata.name);
     expect(await votesERC20V1Proxy.symbol()).to.equal(votesERC20V1Data.metadata.symbol);
-    void expect(
+    expect(
       await votesERC20V1Proxy.hasRole(await votesERC20V1Proxy.DEFAULT_ADMIN_ROLE(), safeAddress),
     ).to.be.true;
-    void expect(await votesERC20V1Proxy.hasRole(await votesERC20V1Proxy.MINTER_ROLE(), safeAddress))
-      .to.be.true;
-    void expect(
+    expect(await votesERC20V1Proxy.hasRole(await votesERC20V1Proxy.MINTER_ROLE(), safeAddress)).to
+      .be.true;
+    expect(
       await votesERC20V1Proxy.hasRole(await votesERC20V1Proxy.TRANSFER_FROM_ROLE(), safeAddress),
     ).to.be.true;
     expect(await votesERC20V1Proxy.locked()).to.equal(votesERC20V1Data.locked);
@@ -457,7 +457,7 @@ async function findAndVerifyModuleFractalV1(params: {
   // Verify the module is enabled on the Safe
   const safeProxy = Safe__factory.connect(safeAddress, fixtureData.deployer);
   const isModuleEnabled = await safeProxy.isModuleEnabled(moduleFractalAddress);
-  void expect(isModuleEnabled).to.be.true;
+  expect(isModuleEnabled).to.be.true;
 
   // Connect to the deployed ModuleFractal proxy
   const moduleFractalProxy = ModuleFractalV1__factory.connect(
@@ -507,7 +507,7 @@ async function findAndVerifyModuleAzoriusV1(params: {
   // Verify the module is enabled on the Safe
   const safeProxy = Safe__factory.connect(safeAddress, fixtureData.deployer);
   const isModuleEnabled = await safeProxy.isModuleEnabled(azoriusAddress);
-  void expect(isModuleEnabled).to.be.true;
+  expect(isModuleEnabled).to.be.true;
 
   const azoriusProxy = ModuleAzoriusV1__factory.connect(azoriusAddress, fixtureData.deployer);
 
@@ -859,7 +859,7 @@ async function findAndVerifyFreezeGuardMultisigV1(params: {
       ethers.keccak256(ethers.toUtf8Bytes('guard_manager.guard.address')),
     ),
   )[0];
-  void expect(guardAddress).to.equal(freezeGuardMultisigAddress);
+  expect(guardAddress).to.equal(freezeGuardMultisigAddress);
 
   // Connect to the deployed FreezeGuardMultisig proxy
   const freezeGuardMultisigProxy = FreezeGuardMultisigV1__factory.connect(
@@ -902,7 +902,7 @@ async function findAndVerifyFreezeGuardAzoriusV1(params: {
     fixtureData.deployer,
   );
   const guard = await azoriusModule.getGuard();
-  void expect(guard).to.equal(freezeGuardAzoriusAddress);
+  expect(guard).to.equal(freezeGuardAzoriusAddress);
 
   // Connect to the deployed FreezeGuardAzorius proxy
   const freezeGuardAzoriusProxy = FreezeGuardAzoriusV1__factory.connect(
@@ -1056,7 +1056,7 @@ async function findAndVerifySystemDeployedEvent(params: {
     }
   });
 
-  void expect(systemDeployedEvent).to.not.be.undefined;
+  expect(systemDeployedEvent).to.not.be.undefined;
 
   if (!systemDeployedEvent) {
     throw new Error('SystemDeployed event not found');
@@ -1101,7 +1101,7 @@ async function findAndVerifySystemDeployedEventEmitterEvent(params: {
     }
   });
 
-  void expect(systemDeployedEventEmitterEvent).to.not.be.undefined;
+  expect(systemDeployedEventEmitterEvent).to.not.be.undefined;
 
   if (!systemDeployedEventEmitterEvent) {
     throw new Error('SystemDeployed event emitter event not found');
@@ -4263,7 +4263,7 @@ describe('SystemDeployerV1', () => {
             fixtureData.upgradeableContractOwner,
           );
 
-          void expect(await minimalContract.isInitialized()).to.be.true;
+          expect(await minimalContract.isInitialized()).to.be.true;
         });
 
         it('should handle very large initialization data', async () => {
@@ -4299,7 +4299,7 @@ describe('SystemDeployerV1', () => {
             fixtureData.upgradeableContractOwner,
           );
 
-          void expect(await minimalContract.isInitialized()).to.be.true;
+          expect(await minimalContract.isInitialized()).to.be.true;
           expect(await minimalContract.largeData()).to.equal(largeString);
         });
       });
@@ -4537,7 +4537,7 @@ describe('SystemDeployerV1', () => {
           await contractV3.migrateState();
 
           // Verify migration was successful
-          void expect(await contractV3.migrationPerformed()).to.be.true;
+          expect(await contractV3.migrationPerformed()).to.be.true;
         });
       });
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/385

Fixes [ENG-1211](https://linear.app/decent-labs/issue/ENG-1211/remove-void-prefix-requirement-from-chai-expect-statements-in-test)

**Motivation:**
The ESLint rule `@typescript-eslint/no-unused-expressions` was requiring the use of `void` prefix before Chai expect statements ending with `.to.be.true`, `.to.be.false`, or `.to.be.undefined` in test files. This made the test code unnecessarily verbose and less readable.

**Change Summary:**
- Disabled `@typescript-eslint/no-unused-expressions` rule for test files (*.test.ts) and test shared files via ESLint overrides configuration
- Removed all `void` prefixes from expect statements across the test suite (17 test files, 650+ changes)
- Maintained the `@typescript-eslint/no-floating-promises` rule as "error" since it wasn't the cause of the issue
- Updated test helper files in test/shared directory to also benefit from the rule override