### PR TITLE
feat(contracts): implement UUPSUpgradeableExtended for enhanced proxy transparency

### DIFF
--- a/contracts/UUPSUpgradeableExtended.sol
+++ b/contracts/UUPSUpgradeableExtended.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {IUUPSUpgradeableExtended} from "./interfaces/decent/IUUPSUpgradeableExtended.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+
+/**
+ * @title UUPSUpgradeableExtended
+ * @author Decent Labs
+ * @notice Abstract contract extending UUPS upgradeable pattern with implementation address getter
+ * @dev This contract extends OpenZeppelin's UUPSUpgradeable to provide additional functionality
+ * for retrieving the current implementation address. This is useful for verification and
+ * debugging purposes.
+ *
+ * Key features:
+ * - Inherits all UUPS upgrade functionality from OpenZeppelin
+ * - Exposes the current implementation address via a public view function
+ * - Must be inherited by concrete implementations that define _authorizeUpgrade
+ *
+ * @custom:security-contact security@decentlabs.io
+ */
+abstract contract UUPSUpgradeableExtended is
+    UUPSUpgradeable,
+    IUUPSUpgradeableExtended
+{
+    /**
+     * @inheritdoc IUUPSUpgradeableExtended
+     * @dev Uses ERC1967Utils to read the implementation slot defined in EIP-1967
+     */
+    function implementation() public view returns (address) {
+        return ERC1967Utils.getImplementation();
+    }
+}

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -6,9 +6,11 @@ import {IFunctionValidator} from "../../interfaces/decent/services/IFunctionVali
 import {ILightAccountValidatorV1} from "../../interfaces/decent/deployables/ILightAccountValidatorV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {IUUPSUpgradeableExtended} from "../../interfaces/decent/IUUPSUpgradeableExtended.sol";
 import {BasePaymasterV1} from "./BasePaymasterV1.sol";
 import {LightAccountValidatorV1} from "./LightAccountValidatorV1.sol";
 import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
+import {UUPSUpgradeableExtended} from "../../UUPSUpgradeableExtended.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {PackedUserOperation, IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -51,8 +53,8 @@ contract DecentPaymasterV1 is
     BasePaymasterV1,
     LightAccountValidatorV1,
     DeploymentBlockV1,
+    UUPSUpgradeableExtended,
     Ownable2StepUpgradeable,
-    UUPSUpgradeable,
     ERC165
 {
     // ======================================================================
@@ -297,7 +299,7 @@ contract DecentPaymasterV1 is
 
     /**
      * @inheritdoc ERC165
-     * @dev Supports IDecentPaymasterV1, ILightAccountValidatorV1, IPaymaster, IVersion, IDeploymentBlockV1, and IERC165
+     * @dev Supports IDecentPaymasterV1, ILightAccountValidatorV1, IPaymaster, IVersion, IDeploymentBlockV1, IUUPSUpgradeableExtended, and IERC165
      */
     function supportsInterface(
         bytes4 interfaceId_
@@ -308,6 +310,7 @@ contract DecentPaymasterV1 is
             interfaceId_ == type(IPaymaster).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
+            interfaceId_ == type(IUUPSUpgradeableExtended).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.30;
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IVotesERC20StakedV1} from "../../interfaces/decent/deployables/IVotesERC20StakedV1.sol";
 import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {IUUPSUpgradeableExtended} from "../../interfaces/decent/IUUPSUpgradeableExtended.sol";
 import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
+import {UUPSUpgradeableExtended} from "../../UUPSUpgradeableExtended.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -45,10 +47,10 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 contract VotesERC20StakedV1 is
     IVotesERC20StakedV1,
     IVersion,
-    ERC20VotesUpgradeable,
-    UUPSUpgradeable,
-    Ownable2StepUpgradeable,
+    UUPSUpgradeableExtended,
     DeploymentBlockV1,
+    ERC20VotesUpgradeable,
+    Ownable2StepUpgradeable,
     ERC165
 {
     using SafeERC20 for IERC20;
@@ -607,7 +609,7 @@ contract VotesERC20StakedV1 is
     /**
      * @inheritdoc ERC165
      * @dev Supports IVotesERC20StakedV1, IERC20, IVotes, IVersion,
-     * IDeploymentBlockV1, and IERC165
+     * IDeploymentBlockV1, IUUPSUpgradeableExtended, and IERC165
      */
     function supportsInterface(
         bytes4 interfaceId_
@@ -618,6 +620,7 @@ contract VotesERC20StakedV1 is
             interfaceId_ == type(IVotes).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
+            interfaceId_ == type(IUUPSUpgradeableExtended).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -7,7 +7,9 @@ import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {IUUPSUpgradeableExtended} from "../../interfaces/decent/IUUPSUpgradeableExtended.sol";
 import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
+import {UUPSUpgradeableExtended} from "../../UUPSUpgradeableExtended.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
@@ -50,11 +52,11 @@ import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/acce
 contract VotesERC20V1 is
     IVotesERC20V1,
     IVersion,
+    UUPSUpgradeableExtended,
+    DeploymentBlockV1,
     ERC20VotesUpgradeable,
     ERC20PermitUpgradeable,
-    UUPSUpgradeable,
     AccessControlUpgradeable,
-    DeploymentBlockV1,
     ERC165
 {
     // ======================================================================
@@ -387,7 +389,7 @@ contract VotesERC20V1 is
     /**
      * @inheritdoc ERC165
      * @dev Supports IVotesERC20V1, IERC20, IERC20Permit, IVotes, IVersion,
-     * IDeploymentBlockV1, IAccessControl, and IERC165
+     * IDeploymentBlockV1, IAccessControl, IUUPSUpgradeableExtended, and IERC165
      */
     function supportsInterface(
         bytes4 interfaceId_
@@ -406,6 +408,7 @@ contract VotesERC20V1 is
             interfaceId_ == type(IVersion).interfaceId ||
             interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
             interfaceId_ == type(IAccessControl).interfaceId ||
+            interfaceId_ == type(IUUPSUpgradeableExtended).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
@@ -6,7 +6,9 @@ import {IFreezeGuardAzoriusV1} from "../../interfaces/decent/deployables/IFreeze
 import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
 import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {IUUPSUpgradeableExtended} from "../../interfaces/decent/IUUPSUpgradeableExtended.sol";
 import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
+import {UUPSUpgradeableExtended} from "../../UUPSUpgradeableExtended.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -38,9 +40,9 @@ import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/acces
 contract FreezeGuardAzoriusV1 is
     IFreezeGuardAzoriusV1,
     IVersion,
-    Ownable2StepUpgradeable,
-    UUPSUpgradeable,
+    UUPSUpgradeableExtended,
     DeploymentBlockV1,
+    Ownable2StepUpgradeable,
     ERC165
 {
     // ======================================================================
@@ -189,7 +191,7 @@ contract FreezeGuardAzoriusV1 is
 
     /**
      * @inheritdoc ERC165
-     * @dev Supports IFreezeGuardAzoriusV1, IFreezeGuardBaseV1, IGuard, IVersion, IDeploymentBlockV1, and IERC165
+     * @dev Supports IFreezeGuardAzoriusV1, IFreezeGuardBaseV1, IGuard, IVersion, IDeploymentBlockV1, IUUPSUpgradeableExtended, and IERC165
      */
     function supportsInterface(
         bytes4 interfaceId_
@@ -200,6 +202,7 @@ contract FreezeGuardAzoriusV1 is
             interfaceId_ == type(IGuard).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
+            interfaceId_ == type(IUUPSUpgradeableExtended).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
@@ -7,7 +7,9 @@ import {IFreezeGuardBaseV1} from "../../interfaces/decent/deployables/IFreezeGua
 import {IFreezeVotingBaseV1} from "../../interfaces/decent/deployables/IFreezeVotingBaseV1.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {IUUPSUpgradeableExtended} from "../../interfaces/decent/IUUPSUpgradeableExtended.sol";
 import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
+import {UUPSUpgradeableExtended} from "../../UUPSUpgradeableExtended.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -40,8 +42,8 @@ import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/acces
 contract FreezeGuardMultisigV1 is
     IFreezeGuardMultisigV1,
     IVersion,
+    UUPSUpgradeableExtended,
     Ownable2StepUpgradeable,
-    UUPSUpgradeable,
     DeploymentBlockV1,
     ERC165
 {
@@ -359,7 +361,7 @@ contract FreezeGuardMultisigV1 is
 
     /**
      * @inheritdoc ERC165
-     * @dev Supports IFreezeGuardMultisigV1, IFreezeGuardBaseV1, IGuard, IVersion, IDeploymentBlockV1, and IERC165
+     * @dev Supports IFreezeGuardMultisigV1, IFreezeGuardBaseV1, IGuard, IVersion, IDeploymentBlockV1, IUUPSUpgradeableExtended, and IERC165
      */
     function supportsInterface(
         bytes4 interfaceId_
@@ -370,6 +372,7 @@ contract FreezeGuardMultisigV1 is
             interfaceId_ == type(IGuard).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
+            interfaceId_ == type(IUUPSUpgradeableExtended).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/deployables/modules/ModuleAzoriusV1.sol
+++ b/contracts/deployables/modules/ModuleAzoriusV1.sol
@@ -6,7 +6,9 @@ import {IStrategyV1} from "../../interfaces/decent/deployables/IStrategyV1.sol";
 import {Transaction} from "../../interfaces/decent/Module.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
+import {IUUPSUpgradeableExtended} from "../../interfaces/decent/IUUPSUpgradeableExtended.sol";
 import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
+import {UUPSUpgradeableExtended} from "../../UUPSUpgradeableExtended.sol";
 import {GuardableModule} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
@@ -35,10 +37,10 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 contract ModuleAzoriusV1 is
     IModuleAzoriusV1,
     IVersion,
-    GuardableModule,
+    UUPSUpgradeableExtended,
     DeploymentBlockV1,
+    GuardableModule,
     Ownable2StepUpgradeable,
-    UUPSUpgradeable,
     ERC165
 {
     // ======================================================================
@@ -548,7 +550,7 @@ contract ModuleAzoriusV1 is
 
     /**
      * @inheritdoc ERC165
-     * @dev Supports IModuleAzoriusV1, IVersion, IDeploymentBlockV1, and IERC165
+     * @dev Supports IModuleAzoriusV1, IVersion, IDeploymentBlockV1, IUUPSUpgradeableExtended, and IERC165
      */
     function supportsInterface(
         bytes4 interfaceId_
@@ -557,6 +559,7 @@ contract ModuleAzoriusV1 is
             interfaceId_ == type(IModuleAzoriusV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
+            interfaceId_ == type(IUUPSUpgradeableExtended).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 

--- a/contracts/deployables/modules/ModuleFractalV1.sol
+++ b/contracts/deployables/modules/ModuleFractalV1.sol
@@ -5,7 +5,9 @@ import {IModuleFractalV1} from "../../interfaces/decent/deployables/IModuleFract
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IDeploymentBlockV1} from "../../interfaces/decent/IDeploymentBlockV1.sol";
 import {Transaction} from "../../interfaces/decent/Module.sol";
+import {IUUPSUpgradeableExtended} from "../../interfaces/decent/IUUPSUpgradeableExtended.sol";
 import {DeploymentBlockV1} from "../../DeploymentBlockV1.sol";
+import {UUPSUpgradeableExtended} from "../../UUPSUpgradeableExtended.sol";
 import {GuardableModule, Enum} from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -33,10 +35,10 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 contract ModuleFractalV1 is
     IModuleFractalV1,
     IVersion,
-    GuardableModule,
+    UUPSUpgradeableExtended,
     DeploymentBlockV1,
+    GuardableModule,
     Ownable2StepUpgradeable,
-    UUPSUpgradeable,
     ERC165
 {
     // ======================================================================
@@ -173,7 +175,7 @@ contract ModuleFractalV1 is
 
     /**
      * @inheritdoc ERC165
-     * @dev Supports IModuleFractalV1, IVersion, IDeploymentBlockV1, and IERC165
+     * @dev Supports IModuleFractalV1, IVersion, IDeploymentBlockV1, IUUPSUpgradeableExtended, and IERC165
      */
     function supportsInterface(
         bytes4 interfaceId_
@@ -182,6 +184,7 @@ contract ModuleFractalV1 is
             interfaceId_ == type(IModuleFractalV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             interfaceId_ == type(IDeploymentBlockV1).interfaceId ||
+            interfaceId_ == type(IUUPSUpgradeableExtended).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/interfaces/decent/IUUPSUpgradeableExtended.sol
+++ b/contracts/interfaces/decent/IUUPSUpgradeableExtended.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+/**
+ * @title IUUPSUpgradeableExtended
+ * @author Decent Labs
+ * @notice Interface for UUPS upgradeable contracts with implementation address getter
+ * @dev This interface extends the standard UUPS pattern by exposing the implementation
+ * address, which is useful for verification, monitoring, and debugging purposes.
+ *
+ * @custom:security-contact security@decentlabs.io
+ */
+interface IUUPSUpgradeableExtended {
+    /**
+     * @notice Returns the current implementation address of the proxy
+     * @dev This function allows external contracts and tools to query which implementation
+     * a proxy is currently pointing to
+     * @return implementation The address of the current implementation contract
+     */
+    function implementation() external view returns (address implementation);
+}

--- a/contracts/mocks/concretes/ConcreteUUPSUpgradeableExtendedV1.sol
+++ b/contracts/mocks/concretes/ConcreteUUPSUpgradeableExtendedV1.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {UUPSUpgradeableExtended} from "../../UUPSUpgradeableExtended.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+
+/**
+ * @title ConcreteUUPSUpgradeableExtended
+ * @notice Concrete implementation of UUPSUpgradeableExtended for testing
+ * @dev This mock contract provides a minimal implementation of the abstract
+ * UUPSUpgradeableExtended contract for testing purposes.
+ */
+contract ConcreteUUPSUpgradeableExtended is
+    UUPSUpgradeableExtended,
+    Ownable2StepUpgradeable
+{
+    uint256 public testValue;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address owner_) external initializer {
+        __Ownable2Step_init();
+        _transferOwnership(owner_);
+        testValue = 42;
+    }
+
+    function setTestValue(uint256 newValue_) external onlyOwner {
+        testValue = newValue_;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+}

--- a/test/unit/UUPSUpgradeableExtendedV1.test.ts
+++ b/test/unit/UUPSUpgradeableExtendedV1.test.ts
@@ -1,0 +1,150 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  ConcreteUUPSUpgradeableExtended,
+  ConcreteUUPSUpgradeableExtended__factory,
+  ERC1967Proxy__factory,
+} from '../../typechain-types';
+
+// Helper function for deploying ConcreteUUPSUpgradeableExtended instances using ERC1967Proxy
+async function deployConcreteUUPSExtendedProxy(
+  proxyDeployer: SignerWithAddress,
+  implementation: ConcreteUUPSUpgradeableExtended,
+  owner: SignerWithAddress,
+): Promise<ConcreteUUPSUpgradeableExtended> {
+  // Encode the initialize call
+  const initData = ConcreteUUPSUpgradeableExtended__factory.createInterface().encodeFunctionData(
+    'initialize',
+    [owner.address],
+  );
+
+  // Deploy the proxy with the implementation
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    initData,
+  );
+
+  // Return a contract instance connected to the proxy
+  return ConcreteUUPSUpgradeableExtended__factory.connect(await proxy.getAddress(), owner);
+}
+
+describe('UUPSUpgradeableExtended', function () {
+  let owner: SignerWithAddress;
+  let nonOwner: SignerWithAddress;
+  let proxyDeployer: SignerWithAddress;
+  let implementation: ConcreteUUPSUpgradeableExtended;
+  let proxy: ConcreteUUPSUpgradeableExtended;
+
+  beforeEach(async function () {
+    [proxyDeployer, owner, nonOwner] = await ethers.getSigners();
+
+    // Deploy implementation
+    implementation = await new ConcreteUUPSUpgradeableExtended__factory(owner).deploy();
+
+    // Deploy proxy
+    proxy = await deployConcreteUUPSExtendedProxy(proxyDeployer, implementation, owner);
+  });
+
+  describe('Initialization', function () {
+    it('Should initialize with correct owner', async function () {
+      expect(await proxy.owner()).to.equal(owner.address);
+    });
+
+    it('Should initialize with correct test value', async function () {
+      expect(await proxy.testValue()).to.equal(42);
+    });
+
+    it('Should have implementation initialization disabled', async function () {
+      const implContract = ConcreteUUPSUpgradeableExtended__factory.connect(
+        await implementation.getAddress(),
+        owner,
+      );
+
+      await expect(implContract.initialize(owner.address)).to.be.revertedWithCustomError(
+        implContract,
+        'InvalidInitialization',
+      );
+    });
+
+    it('Should not allow reinitialization', async function () {
+      await expect(proxy.initialize(nonOwner.address)).to.be.revertedWithCustomError(
+        proxy,
+        'InvalidInitialization',
+      );
+    });
+  });
+
+  describe('implementation()', function () {
+    it('Should return the correct implementation address', async function () {
+      expect(await proxy.implementation()).to.equal(await implementation.getAddress());
+    });
+
+    it('Should be callable by anyone', async function () {
+      const proxyAsNonOwner = proxy.connect(nonOwner);
+      expect(await proxyAsNonOwner.implementation()).to.equal(await implementation.getAddress());
+    });
+
+    it('Should update after upgrade', async function () {
+      // Deploy new implementation
+      const newImplementation = await new ConcreteUUPSUpgradeableExtended__factory(owner).deploy();
+
+      // Upgrade to new implementation
+      await proxy.upgradeToAndCall(await newImplementation.getAddress(), '0x');
+
+      // Check that implementation() returns the new address
+      expect(await proxy.implementation()).to.equal(await newImplementation.getAddress());
+    });
+  });
+
+  describe('Upgradeability', function () {
+    it('Should allow owner to upgrade', async function () {
+      const newImplementation = await new ConcreteUUPSUpgradeableExtended__factory(owner).deploy();
+
+      await expect(proxy.upgradeToAndCall(await newImplementation.getAddress(), '0x'))
+        .to.emit(proxy, 'Upgraded')
+        .withArgs(await newImplementation.getAddress());
+
+      expect(await proxy.implementation()).to.equal(await newImplementation.getAddress());
+    });
+
+    it('Should not allow non-owner to upgrade', async function () {
+      const newImplementation = await new ConcreteUUPSUpgradeableExtended__factory(owner).deploy();
+
+      const proxyAsNonOwner = proxy.connect(nonOwner);
+      await expect(
+        proxyAsNonOwner.upgradeToAndCall(await newImplementation.getAddress(), '0x'),
+      ).to.be.revertedWithCustomError(proxy, 'OwnableUnauthorizedAccount');
+    });
+
+    it('Should maintain state after upgrade', async function () {
+      // Set a new test value
+      await proxy.setTestValue(123);
+      expect(await proxy.testValue()).to.equal(123);
+
+      // Deploy new implementation
+      const newImplementation = await new ConcreteUUPSUpgradeableExtended__factory(owner).deploy();
+
+      // Upgrade
+      await proxy.upgradeToAndCall(await newImplementation.getAddress(), '0x');
+
+      // Check state is maintained
+      expect(await proxy.testValue()).to.equal(123);
+    });
+  });
+
+  describe('Basic Functionality', function () {
+    it('Should allow owner to set test value', async function () {
+      await proxy.setTestValue(999);
+      expect(await proxy.testValue()).to.equal(999);
+    });
+
+    it('Should not allow non-owner to set test value', async function () {
+      const proxyAsNonOwner = proxy.connect(nonOwner);
+      await expect(proxyAsNonOwner.setTestValue(999)).to.be.revertedWithCustomError(
+        proxy,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+  });
+});

--- a/test/unit/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/unit/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -10,6 +10,7 @@ import {
   IERC165__factory,
   ILightAccountValidatorV1__factory,
   IPaymaster__factory,
+  IUUPSUpgradeableExtended__factory,
   IVersion__factory,
   MockEntryPoint,
   MockEntryPoint__factory,
@@ -41,7 +42,7 @@ interface PackedUserOperation {
 // Helper function for deploying DecentPaymasterV1 instances using ERC1967Proxy
 async function deployDecentPaymasterProxy(
   proxyDeployer: SignerWithAddress,
-  implementation: string,
+  implementation: DecentPaymasterV1,
   owner: SignerWithAddress,
   entryPoint: string,
   lightAccountFactory: string,
@@ -53,7 +54,10 @@ async function deployDecentPaymasterProxy(
   );
 
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    fullInitData,
+  );
 
   // Return a contract instance connected to the proxy
   return DecentPaymasterV1__factory.connect(await proxy.getAddress(), owner);
@@ -114,7 +118,7 @@ describe('DecentPaymasterV1', function () {
     // Deploy DecentPaymaster proxy
     decentPaymaster = await deployDecentPaymasterProxy(
       owner,
-      await masterCopy.getAddress(),
+      masterCopy,
       owner,
       await entryPoint.getAddress(),
       mockLightAccountFactoryAddress,
@@ -372,6 +376,7 @@ describe('DecentPaymasterV1', function () {
         IVersion__factory,
         ILightAccountValidatorV1__factory,
         IDeploymentBlockV1__factory,
+        IUUPSUpgradeableExtended__factory,
       ],
     });
   });
@@ -385,6 +390,7 @@ describe('DecentPaymasterV1', function () {
   describe('UUPS Upgradeability', function () {
     runUUPSUpgradeabilityTests({
       getContract: () => decentPaymaster,
+      getImplementation: () => masterCopy,
       createNewImplementation: async () => {
         const newImplementation = await new DecentPaymasterV1__factory(owner).deploy();
         return newImplementation;

--- a/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -7,6 +7,7 @@ import {
   IDeploymentBlockV1__factory,
   IERC165__factory,
   IERC20__factory,
+  IUUPSUpgradeableExtended__factory,
   IVersion__factory,
   IVotes__factory,
   IVotesERC20StakedV1__factory,
@@ -77,7 +78,7 @@ async function runExecuteTxAndCheckBalanceDeltasTests(
 // Helper function for deploying VotesERC20StakedV1 instances using ERC1967Proxy
 async function deployVotesERC20StakedProxy(
   proxyDeployer: SignerWithAddress,
-  implementation: string,
+  implementation: VotesERC20StakedV1,
   owner: SignerWithAddress,
   name: string,
   symbol: string,
@@ -97,7 +98,10 @@ async function deployVotesERC20StakedProxy(
   );
 
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    fullInitData,
+  );
 
   // Return a contract instance connected to the proxy
   return VotesERC20StakedV1__factory.connect(await proxy.getAddress(), owner);
@@ -115,7 +119,7 @@ describe('VotesERC20StakedV1', () => {
 
   // contracts
   let votesERC20Staked: VotesERC20StakedV1;
-  let masterCopy: string;
+  let masterCopy: VotesERC20StakedV1;
   let stakedToken: MockERC20Votes;
   let rewardsTokenA: MockERC20Votes;
   let rewardsTokenB: MockERC20Votes;
@@ -128,7 +132,7 @@ describe('VotesERC20StakedV1', () => {
     [proxyDeployer, owner, alice, bob, carol, nonOwner, rewardsDistributor] =
       await ethers.getSigners();
 
-    masterCopy = await (await new VotesERC20StakedV1__factory(owner).deploy()).getAddress();
+    masterCopy = await new VotesERC20StakedV1__factory(owner).deploy();
     stakedToken = await new MockERC20Votes__factory(owner).deploy();
     rewardsTokenA = await new MockERC20Votes__factory(owner).deploy();
     rewardsTokenB = await new MockERC20Votes__factory(owner).deploy();
@@ -196,7 +200,10 @@ describe('VotesERC20StakedV1', () => {
     });
 
     it('Should have initialization disabled in the implementation', async function () {
-      const implementationContract = VotesERC20StakedV1__factory.connect(masterCopy, proxyDeployer);
+      const implementationContract = VotesERC20StakedV1__factory.connect(
+        await masterCopy.getAddress(),
+        proxyDeployer,
+      );
 
       await expect(
         implementationContract.initialize(
@@ -335,6 +342,7 @@ describe('VotesERC20StakedV1', () => {
         IERC20__factory,
         IVotes__factory,
         IDeploymentBlockV1__factory,
+        IUUPSUpgradeableExtended__factory,
       ],
     });
   });
@@ -408,6 +416,7 @@ describe('VotesERC20StakedV1', () => {
     // Run UUPS upgradeability tests
     runUUPSUpgradeabilityTests({
       getContract: () => votesERC20Staked,
+      getImplementation: () => masterCopy,
       createNewImplementation: async () => {
         const newImplementation = await new VotesERC20StakedV1__factory(owner).deploy();
         return newImplementation;

--- a/test/unit/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20V1.test.ts
@@ -10,6 +10,7 @@ import {
   IERC165__factory,
   IERC20__factory,
   IERC20Permit__factory,
+  IUUPSUpgradeableExtended__factory,
   IVersion__factory,
   IVotes__factory,
   IVotesERC20V1__factory,
@@ -23,6 +24,7 @@ import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests
 // Helper function for deploying VotesERC20V1 instances using ERC1967Proxy
 async function deployVotesERC20Proxy(
   proxyDeployer: SignerWithAddress,
+  implementation: VotesERC20V1,
   owner: SignerWithAddress,
   locked: boolean,
   maxTotalSupply: bigint,
@@ -51,10 +53,11 @@ async function deployVotesERC20Proxy(
     maxTotalSupply,
   ]);
 
-  const implementation = await new VotesERC20V1__factory(proxyDeployer).deploy();
-
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    fullInitData,
+  );
 
   // Return a contract instance connected to the proxy
   return VotesERC20V1__factory.connect(await proxy.getAddress(), owner);
@@ -63,6 +66,7 @@ async function deployVotesERC20Proxy(
 describe('VotesERC20V1', () => {
   // signers
   let proxyDeployer: SignerWithAddress;
+  let implementation: VotesERC20V1;
   let owner: SignerWithAddress;
   let alice: SignerWithAddress;
   let bob: SignerWithAddress;
@@ -83,12 +87,15 @@ describe('VotesERC20V1', () => {
     // Get signers
     [proxyDeployer, owner, alice, bob, carol, nonOwner, tokenHolder, tokenRecipient, spender] =
       await ethers.getSigners();
+
+    implementation = await new VotesERC20V1__factory(proxyDeployer).deploy();
   });
 
   describe('Initialization', () => {
     it('should initialize with correct name and symbol', async () => {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -112,6 +119,7 @@ describe('VotesERC20V1', () => {
 
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -132,6 +140,7 @@ describe('VotesERC20V1', () => {
     it('should handle empty allocation arrays', async () => {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -147,6 +156,7 @@ describe('VotesERC20V1', () => {
     it('should initialize with locked set to false', async () => {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -162,6 +172,7 @@ describe('VotesERC20V1', () => {
     it('should initialize with locked set to true', async () => {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         true,
         ethers.parseEther('2100'),
@@ -177,6 +188,7 @@ describe('VotesERC20V1', () => {
     it('should initialize with maxTotalSupply set to 2100', async () => {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -192,6 +204,7 @@ describe('VotesERC20V1', () => {
     it('should initialize with DEFAULT_ADMIN_ROLE, MINTER_ROLE, TRANSFER_FROM_ROLE set to owner', async () => {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -209,6 +222,7 @@ describe('VotesERC20V1', () => {
     it('should not allow reinitialization', async () => {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -250,6 +264,7 @@ describe('VotesERC20V1', () => {
       beforeEach(async () => {
         proxy = await deployVotesERC20Proxy(
           proxyDeployer,
+          implementation,
           owner,
           locked,
           ethers.parseEther('2100'),
@@ -304,6 +319,7 @@ describe('VotesERC20V1', () => {
       beforeEach(async () => {
         proxy = await deployVotesERC20Proxy(
           proxyDeployer,
+          implementation,
           owner,
           locked,
           ethers.parseEther('2100'),
@@ -363,6 +379,7 @@ describe('VotesERC20V1', () => {
     beforeEach(async () => {
       proxy = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         locked,
         maxTotalSupply,
@@ -426,6 +443,7 @@ describe('VotesERC20V1', () => {
         beforeEach(async () => {
           proxy = await deployVotesERC20Proxy(
             proxyDeployer,
+            implementation,
             owner,
             locked,
             ethers.parseEther('2100'),
@@ -490,6 +508,7 @@ describe('VotesERC20V1', () => {
         beforeEach(async () => {
           proxy = await deployVotesERC20Proxy(
             proxyDeployer,
+            implementation,
             owner,
             locked,
             ethers.parseEther('2100'),
@@ -549,6 +568,7 @@ describe('VotesERC20V1', () => {
         beforeEach(async () => {
           proxy = await deployVotesERC20Proxy(
             proxyDeployer,
+            implementation,
             owner,
             locked,
             ethers.parseEther('2100'),
@@ -621,6 +641,7 @@ describe('VotesERC20V1', () => {
         beforeEach(async () => {
           proxy = await deployVotesERC20Proxy(
             proxyDeployer,
+            implementation,
             owner,
             locked,
             ethers.parseEther('2100'),
@@ -719,6 +740,7 @@ describe('VotesERC20V1', () => {
       beforeEach(async () => {
         proxy = await deployVotesERC20Proxy(
           proxyDeployer,
+          implementation,
           owner,
           locked,
           maxTotalSupply,
@@ -787,6 +809,7 @@ describe('VotesERC20V1', () => {
       beforeEach(async () => {
         proxy = await deployVotesERC20Proxy(
           proxyDeployer,
+          implementation,
           owner,
           locked,
           ethers.parseEther('2100'),
@@ -846,6 +869,7 @@ describe('VotesERC20V1', () => {
       beforeEach(async () => {
         proxy = await deployVotesERC20Proxy(
           proxyDeployer,
+          implementation,
           owner,
           locked,
           ethers.parseEther('2100'),
@@ -891,6 +915,7 @@ describe('VotesERC20V1', () => {
       beforeEach(async () => {
         proxy = await deployVotesERC20Proxy(
           proxyDeployer,
+          implementation,
           owner,
           locked,
           ethers.parseEther('2100'),
@@ -941,6 +966,7 @@ describe('VotesERC20V1', () => {
     beforeEach(async () => {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -960,6 +986,7 @@ describe('VotesERC20V1', () => {
     beforeEach(async function () {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -981,6 +1008,7 @@ describe('VotesERC20V1', () => {
         IVotes__factory,
         IDeploymentBlockV1__factory,
         IAccessControl__factory,
+        IUUPSUpgradeableExtended__factory,
       ],
     });
   });
@@ -989,6 +1017,7 @@ describe('VotesERC20V1', () => {
     beforeEach(async () => {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -1033,6 +1062,7 @@ describe('VotesERC20V1', () => {
     beforeEach(async function () {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),
@@ -1046,6 +1076,7 @@ describe('VotesERC20V1', () => {
     // Run UUPS upgradeability tests
     runUUPSUpgradeabilityTests({
       getContract: () => votesERC20,
+      getImplementation: () => implementation,
       createNewImplementation: async () => {
         const newImplementation = await new VotesERC20V1__factory(owner).deploy();
         return newImplementation;
@@ -1059,6 +1090,7 @@ describe('VotesERC20V1', () => {
     beforeEach(async function () {
       votesERC20 = await deployVotesERC20Proxy(
         proxyDeployer,
+        implementation,
         owner,
         false,
         ethers.parseEther('2100'),

--- a/test/unit/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
+++ b/test/unit/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
@@ -10,6 +10,7 @@ import {
   IFreezeGuardAzoriusV1__factory,
   IFreezeGuardBaseV1__factory,
   IGuard__factory,
+  IUUPSUpgradeableExtended__factory,
   IVersion__factory,
   MockFreezeVoting,
   MockFreezeVoting__factory,
@@ -21,7 +22,7 @@ import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests
 // Helper function for deploying AzoriusFreezeGuardV1 instances using ERC1967Proxy
 async function deployAzoriusFreezeGuardProxy(
   proxyDeployer: SignerWithAddress,
-  implementation: string,
+  implementation: FreezeGuardAzoriusV1,
   owner: SignerWithAddress,
   freezeVoting: string,
 ): Promise<FreezeGuardAzoriusV1> {
@@ -32,7 +33,10 @@ async function deployAzoriusFreezeGuardProxy(
   );
 
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    fullInitData,
+  );
 
   // Return a contract instance connected to the proxy
   return FreezeGuardAzoriusV1__factory.connect(await proxy.getAddress(), owner);
@@ -51,7 +55,7 @@ describe('FreezeGuardAzoriusV1', () => {
   let nonOwner: SignerWithAddress;
 
   // contracts
-  let masterCopy: string;
+  let masterCopy: FreezeGuardAzoriusV1;
   let azoriusFreezeGuard: FreezeGuardAzoriusV1;
   let mockFreezeVoting: MockFreezeVoting;
 
@@ -60,8 +64,7 @@ describe('FreezeGuardAzoriusV1', () => {
     [proxyDeployer, owner, user, nonOwner] = await ethers.getSigners();
 
     // Deploy implementation
-    const implementation = await new FreezeGuardAzoriusV1__factory(proxyDeployer).deploy();
-    masterCopy = await implementation.getAddress();
+    masterCopy = await new FreezeGuardAzoriusV1__factory(proxyDeployer).deploy();
 
     // Deploy mock contracts
     mockFreezeVoting = await new MockFreezeVoting__factory(owner).deploy();
@@ -95,7 +98,7 @@ describe('FreezeGuardAzoriusV1', () => {
 
     it('Should have initialization disabled in the implementation', async function () {
       const implementationContract = FreezeGuardAzoriusV1__factory.connect(
-        masterCopy,
+        await masterCopy.getAddress(),
         proxyDeployer,
       );
 
@@ -232,6 +235,7 @@ describe('FreezeGuardAzoriusV1', () => {
         },
         IGuard__factory,
         IDeploymentBlockV1__factory,
+        IUUPSUpgradeableExtended__factory,
       ],
     });
   });
@@ -250,6 +254,7 @@ describe('FreezeGuardAzoriusV1', () => {
     // Run UUPS upgradeability tests
     runUUPSUpgradeabilityTests({
       getContract: () => azoriusFreezeGuard,
+      getImplementation: () => masterCopy,
       createNewImplementation: async () => {
         const newImplementation = await new FreezeGuardAzoriusV1__factory(owner).deploy();
         return newImplementation;

--- a/test/unit/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
+++ b/test/unit/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
@@ -11,6 +11,7 @@ import {
   IFreezeGuardBaseV1__factory,
   IFreezeGuardMultisigV1__factory,
   IGuard__factory,
+  IUUPSUpgradeableExtended__factory,
   IVersion__factory,
   MockFreezeVoting,
   MockFreezeVoting__factory,
@@ -24,7 +25,7 @@ import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests
 // Helper function for deploying MultisigFreezeGuardV1 instances using ERC1967Proxy
 async function deployMultisigFreezeGuardProxy(
   proxyDeployer: SignerWithAddress,
-  implementation: string,
+  implementation: FreezeGuardMultisigV1,
   owner: SignerWithAddress,
   timelockPeriod: number,
   executionPeriod: number,
@@ -42,7 +43,10 @@ async function deployMultisigFreezeGuardProxy(
   ]);
 
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    fullInitData,
+  );
 
   // Return a contract instance connected to the proxy
   return FreezeGuardMultisigV1__factory.connect(await proxy.getAddress(), owner);
@@ -61,7 +65,7 @@ describe('FreezeGuardMultisigV1', () => {
   let nonOwner: SignerWithAddress;
 
   // contracts
-  let masterCopy: string;
+  let masterCopy: FreezeGuardMultisigV1;
   let multisigFreezeGuard: FreezeGuardMultisigV1;
   let mockFreezeVoting: MockFreezeVoting;
   let mockSafe: MockSafe;
@@ -79,8 +83,7 @@ describe('FreezeGuardMultisigV1', () => {
     [proxyDeployer, owner, user, nonOwner] = await ethers.getSigners();
 
     // Deploy implementation
-    const implementation = await new FreezeGuardMultisigV1__factory(proxyDeployer).deploy();
-    masterCopy = await implementation.getAddress();
+    masterCopy = await new FreezeGuardMultisigV1__factory(proxyDeployer).deploy();
 
     // Deploy mock contracts
     mockFreezeVoting = await new MockFreezeVoting__factory(owner).deploy();
@@ -123,7 +126,7 @@ describe('FreezeGuardMultisigV1', () => {
 
     it('Should have initialization disabled in the implementation', async function () {
       const implementationContract = FreezeGuardMultisigV1__factory.connect(
-        masterCopy,
+        await masterCopy.getAddress(),
         proxyDeployer,
       );
 
@@ -476,6 +479,7 @@ describe('FreezeGuardMultisigV1', () => {
         },
         IGuard__factory,
         IDeploymentBlockV1__factory,
+        IUUPSUpgradeableExtended__factory,
       ],
     });
   });
@@ -483,6 +487,7 @@ describe('FreezeGuardMultisigV1', () => {
   describe('UUPS Upgradeability', function () {
     runUUPSUpgradeabilityTests({
       getContract: () => multisigFreezeGuard,
+      getImplementation: () => masterCopy,
       createNewImplementation: async () => {
         const newImplementation = await new FreezeGuardMultisigV1__factory(owner).deploy();
         return newImplementation;

--- a/test/unit/deployables/modules/ModuleAzoriusV1.test.ts
+++ b/test/unit/deployables/modules/ModuleAzoriusV1.test.ts
@@ -1,6 +1,7 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
+import type { BaseContract } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
@@ -8,6 +9,7 @@ import {
   IDeploymentBlockV1__factory,
   IERC165__factory,
   IModuleAzoriusV1__factory,
+  IUUPSUpgradeableExtended__factory,
   IVersion__factory,
   MockAvatar,
   MockAvatar__factory,
@@ -17,7 +19,7 @@ import {
   MockVotingStrategy__factory,
   ModuleAzoriusV1,
   ModuleAzoriusV1__factory,
-  UUPSUpgradeable,
+  UUPSUpgradeableExtended,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
@@ -26,7 +28,7 @@ import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests
 // Helper functions for deploying AzoriusV1 instances using ERC1967Proxy
 async function deployAzoriusProxy(
   proxyDeployer: SignerWithAddress,
-  implementation: string,
+  implementation: ModuleAzoriusV1,
   owner: SignerWithAddress,
   avatar: string,
   target: string,
@@ -45,7 +47,10 @@ async function deployAzoriusProxy(
   ]);
 
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    fullInitData,
+  );
 
   // Return a contract instance connected to the proxy
   return ModuleAzoriusV1__factory.connect(await proxy.getAddress(), owner);
@@ -54,7 +59,7 @@ async function deployAzoriusProxy(
 // Helper function for deploying AzoriusV1 using setUp instead of initialize
 async function deployAzoriusProxyWithSetUp(
   proxyDeployer: SignerWithAddress,
-  implementation: string,
+  implementation: ModuleAzoriusV1,
   owner: SignerWithAddress,
   avatar: string,
   target: string,
@@ -71,7 +76,10 @@ async function deployAzoriusProxyWithSetUp(
   ]);
 
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    fullInitData,
+  );
 
   // Return a contract instance connected to the proxy
   return ModuleAzoriusV1__factory.connect(await proxy.getAddress(), owner);
@@ -86,8 +94,7 @@ describe('ModuleAzoriusV1', () => {
   let nonOwner: SignerWithAddress;
 
   // mocks and mastercopies
-  let implementation: ModuleAzoriusV1;
-  let masterCopy: string;
+  let masterCopy: ModuleAzoriusV1;
   let mockStrategy: MockVotingStrategy;
   let mockStrategyAddress: string;
 
@@ -96,8 +103,7 @@ describe('ModuleAzoriusV1', () => {
     [proxyDeployer, owner, proposer, user, nonOwner] = await ethers.getSigners();
 
     // Deploy implementation contract
-    implementation = await new ModuleAzoriusV1__factory(proxyDeployer).deploy();
-    masterCopy = await implementation.getAddress();
+    masterCopy = await new ModuleAzoriusV1__factory(proxyDeployer).deploy();
 
     // Deploy a default mock strategy for use in many tests
     mockStrategy = await new MockVotingStrategy__factory(proxyDeployer).deploy(proposer.address);
@@ -311,7 +317,10 @@ describe('ModuleAzoriusV1', () => {
       });
 
       it('Should have initialization disabled in the implementation', async function () {
-        const implementationContract = ModuleAzoriusV1__factory.connect(masterCopy, proxyDeployer);
+        const implementationContract = ModuleAzoriusV1__factory.connect(
+          await masterCopy.getAddress(),
+          proxyDeployer,
+        );
 
         await expect(
           implementationContract.initialize(
@@ -1522,6 +1531,7 @@ describe('ModuleAzoriusV1', () => {
         IModuleAzoriusV1__factory,
         IVersion__factory,
         IDeploymentBlockV1__factory,
+        IUUPSUpgradeableExtended__factory,
       ],
     });
   });
@@ -1545,10 +1555,11 @@ describe('ModuleAzoriusV1', () => {
 
     // Run UUPS upgradeability tests
     runUUPSUpgradeabilityTests({
-      getContract: () => azorius as unknown as UUPSUpgradeable,
+      getContract: () => azorius as unknown as UUPSUpgradeableExtended,
+      getImplementation: () => masterCopy as unknown as BaseContract,
       createNewImplementation: async () => {
         const newImplementation = await new ModuleAzoriusV1__factory(owner).deploy();
-        return newImplementation as unknown as UUPSUpgradeable;
+        return newImplementation as unknown as UUPSUpgradeableExtended;
       },
       owner: () => owner,
       nonOwner: () => nonOwner,

--- a/test/unit/deployables/modules/ModuleFractalV1.test.ts
+++ b/test/unit/deployables/modules/ModuleFractalV1.test.ts
@@ -1,5 +1,6 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
+import type { BaseContract } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
@@ -7,6 +8,7 @@ import {
   IDeploymentBlockV1__factory,
   IERC165__factory,
   IModuleFractalV1__factory,
+  IUUPSUpgradeableExtended__factory,
   IVersion__factory,
   MockAvatar,
   MockAvatar__factory,
@@ -14,7 +16,7 @@ import {
   MockERC20Votes__factory,
   ModuleFractalV1,
   ModuleFractalV1__factory,
-  UUPSUpgradeable,
+  UUPSUpgradeableExtended,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
@@ -23,7 +25,7 @@ import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests
 // Helper functions for deploying FractalModuleV1 instances using ERC1967Proxy
 async function deployFractalModuleProxy(
   proxyDeployer: SignerWithAddress,
-  implementation: string,
+  implementation: ModuleFractalV1,
   owner: SignerWithAddress,
   avatar: string,
   target: string,
@@ -36,7 +38,10 @@ async function deployFractalModuleProxy(
   ]);
 
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    fullInitData,
+  );
 
   // Return a contract instance connected to the proxy
   return ModuleFractalV1__factory.connect(await proxy.getAddress(), owner);
@@ -45,7 +50,7 @@ async function deployFractalModuleProxy(
 // Helper function for deploying using setUp instead of initialize
 async function deployFractalModuleProxyWithSetUp(
   proxyDeployer: SignerWithAddress,
-  implementation: string,
+  implementation: ModuleFractalV1,
   owner: SignerWithAddress,
   avatar: string,
   target: string,
@@ -59,7 +64,10 @@ async function deployFractalModuleProxyWithSetUp(
   ]);
 
   // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
+  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(
+    await implementation.getAddress(),
+    fullInitData,
+  );
 
   // Return a contract instance connected to the proxy
   return ModuleFractalV1__factory.connect(await proxy.getAddress(), owner);
@@ -73,7 +81,7 @@ describe('ModuleFractalV1', () => {
   let user: SignerWithAddress;
 
   // mocks and mastercopies
-  let masterCopy: string;
+  let masterCopy: ModuleFractalV1;
   let mockToken: MockERC20Votes;
 
   // Shared fractalModule instance for deployment block tests
@@ -84,8 +92,7 @@ describe('ModuleFractalV1', () => {
     [proxyDeployer, owner, nonOwner, user] = await ethers.getSigners();
 
     // Deploy implementation contract
-    const implementation = await new ModuleFractalV1__factory(proxyDeployer).deploy();
-    masterCopy = await implementation.getAddress();
+    masterCopy = await new ModuleFractalV1__factory(proxyDeployer).deploy();
     mockToken = await new MockERC20Votes__factory(proxyDeployer).deploy();
   });
 
@@ -434,6 +441,7 @@ describe('ModuleFractalV1', () => {
         IModuleFractalV1__factory,
         IVersion__factory,
         IDeploymentBlockV1__factory,
+        IUUPSUpgradeableExtended__factory,
       ],
     });
   });
@@ -457,10 +465,11 @@ describe('ModuleFractalV1', () => {
 
     // Run UUPS upgradeability tests
     runUUPSUpgradeabilityTests({
-      getContract: () => fractalModule as unknown as UUPSUpgradeable,
+      getContract: () => fractalModule as unknown as UUPSUpgradeableExtended,
+      getImplementation: () => masterCopy as unknown as BaseContract,
       createNewImplementation: async () => {
         const newImplementation = await new ModuleFractalV1__factory(owner).deploy();
-        return newImplementation as unknown as UUPSUpgradeable;
+        return newImplementation as unknown as UUPSUpgradeableExtended;
       },
       owner: () => owner,
       nonOwner: () => nonOwner,

--- a/test/unit/shared/uupsUpgradeabilityTests.ts
+++ b/test/unit/shared/uupsUpgradeabilityTests.ts
@@ -1,6 +1,10 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
-import { UUPSUpgradeable, UUPSUpgradeable__factory } from '../../../typechain-types';
+import type { BaseContract } from 'ethers';
+import {
+  UUPSUpgradeableExtended,
+  UUPSUpgradeableExtended__factory,
+} from '../../../typechain-types';
 
 /**
  * Shared test utilities for testing the UUPS upgradeability functionality
@@ -12,14 +16,19 @@ import { UUPSUpgradeable, UUPSUpgradeable__factory } from '../../../typechain-ty
  */
 interface UUPSUpgradeabilityTestParams {
   /**
+   * Gets the implementation contract
+   */
+  getImplementation: () => BaseContract;
+
+  /**
    * Gets the current contract instance implementing UUPSUpgradeable
    */
-  getContract: () => UUPSUpgradeable;
+  getContract: () => UUPSUpgradeableExtended;
 
   /**
    * Creates a new implementation of the contract
    */
-  createNewImplementation: () => Promise<UUPSUpgradeable>;
+  createNewImplementation: () => Promise<UUPSUpgradeableExtended>;
 
   /**
    * Owner account that should be allowed to upgrade
@@ -43,6 +52,19 @@ interface UUPSUpgradeabilityTestParams {
  * @param params The test parameters
  */
 export function runUUPSUpgradeabilityTests(params: UUPSUpgradeabilityTestParams): void {
+  it('should return the correct implementation address', async () => {
+    // Get implementation and its address
+    const implementation = params.getImplementation();
+    const implementationAddress = await implementation.getAddress();
+
+    // Get contract and its implementation address
+    const contract = params.getContract();
+    const proxyImplementationAddress = await contract.implementation();
+
+    // Check that the implementation address is the same as the proxy's implementation address
+    expect(proxyImplementationAddress).to.equal(implementationAddress);
+  });
+
   it('should allow the owner to authorize an upgrade', async () => {
     // Deploy a new implementation
     const newImplementation = await params.createNewImplementation();
@@ -51,7 +73,10 @@ export function runUUPSUpgradeabilityTests(params: UUPSUpgradeabilityTestParams)
     // Get contract and connect owner
     const contract = params.getContract();
     const contractAddress = await contract.getAddress();
-    const upgradeableContract = UUPSUpgradeable__factory.connect(contractAddress, params.owner());
+    const upgradeableContract = UUPSUpgradeableExtended__factory.connect(
+      contractAddress,
+      params.owner(),
+    );
 
     // Call with empty bytes for the second parameter
     // We don't check for a specific event since some implementations might emit different events,
@@ -67,7 +92,7 @@ export function runUUPSUpgradeabilityTests(params: UUPSUpgradeabilityTestParams)
     // Get contract and connect non-owner
     const contract = params.getContract();
     const contractAddress = await contract.getAddress();
-    const upgradeableContract = UUPSUpgradeable__factory.connect(
+    const upgradeableContract = UUPSUpgradeableExtended__factory.connect(
       contractAddress,
       params.nonOwner(),
     );


### PR DESCRIPTION
Fixes [ENG-1221](https://linear.app/decent-labs/issue/ENG-1221/add-uupsupgradeableextendedv1-for-enhanced-proxy-transparency)

# WAIT

This code might actually not be needed... Hang tight

## Motivation

This change introduces a new abstract contract `UUPSUpgradeableExtended` that extends OpenZeppelin's standard UUPS pattern with the ability to query the current implementation address. This enhancement improves transparency and debugging capabilities for upgradeable contracts, allowing external tools and contracts to easily verify which implementation a proxy is currently using.

## Change Summary

- Created new abstract contract `UUPSUpgradeableExtended` that adds `implementation()` getter
- Created corresponding interface `IUUPSUpgradeableExtended` defining the extended functionality
- Migrated all UUPS upgradeable contracts to inherit from `UUPSUpgradeableExtended`:
  - `DecentPaymasterV1`
  - `VotesERC20StakedV1`
  - `VotesERC20V1`
  - `FreezeGuardAzoriusV1`
  - `FreezeGuardMultisigV1`
  - `ModuleAzoriusV1`
  - `ModuleFractalV1`
- Updated ERC165 `supportsInterface` functions to include `IUUPSUpgradeableExtended`
- Extended all corresponding test suites to verify interface support
- Added `getImplementation` parameter to UUPS upgradeability test utilities