### PR TITLE
feat(contracts): Add V1 suffix to concrete utility contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The codebase is organized into four distinct contract categories based on deploy
 - **Purpose**: Handle dynamic logic based on blockchain state at execution time, don't hold any state
 - **Examples**:
   - DecentHatsModuleUtils: Hats Protocol integration
-  - DecentSablierStreamManagementModule: Stream payment management
+  - DecentSablierStreamManagementModuleV1: Stream payment management
 
 ### 4. Services (`contracts/services/`)
 

--- a/contracts/interfaces/decent/utilities/IDecentHatsCreationModuleV1.sol
+++ b/contracts/interfaces/decent/utilities/IDecentHatsCreationModuleV1.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 import {IDecentHatsModuleUtils} from "./IDecentHatsModuleUtils.sol";
 
 /**
- * @title IDecentHatsCreationModule
+ * @title IDecentHatsCreationModuleV1
  * @notice Utility module for creating complete Hats Protocol trees with roles and payment streams
  * @dev This module extends DecentHatsModuleUtils to provide a complete solution for creating
  * organizational structures from scratch. It handles the creation of top hats, admin hats,
@@ -31,7 +31,7 @@ import {IDecentHatsModuleUtils} from "./IDecentHatsModuleUtils.sol";
  * - Setting up compensation structures for contributors
  * - Establishing governance hierarchies
  */
-interface IDecentHatsCreationModule {
+interface IDecentHatsCreationModuleV1 {
     // --- Structs ---
 
     /**

--- a/contracts/interfaces/decent/utilities/IDecentHatsModificationModuleV1.sol
+++ b/contracts/interfaces/decent/utilities/IDecentHatsModificationModuleV1.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 import {DecentHatsModuleUtils} from "../../../utilities/DecentHatsModuleUtils.sol";
 
 /**
- * @title IDecentHatsModificationModule
+ * @title IDecentHatsModificationModuleV1
  * @notice Utility module for adding new roles to an existing Hats Protocol tree
  * @dev This module provides functionality to create additional role hats within an
  * existing organizational structure. Unlike the creation module, this assumes a
@@ -35,7 +35,7 @@ import {DecentHatsModuleUtils} from "../../../utilities/DecentHatsModuleUtils.so
  * - Prevents concurrent role creation proposals
  * - Ensures proper stream recipient setup
  */
-interface IDecentHatsModificationModule {
+interface IDecentHatsModificationModuleV1 {
     // --- State-Changing Functions ---
 
     /**

--- a/contracts/interfaces/decent/utilities/IDecentSablierStreamManagementModuleV1.sol
+++ b/contracts/interfaces/decent/utilities/IDecentSablierStreamManagementModuleV1.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 /**
- * @title IDecentSablierStreamManagementModule
+ * @title IDecentSablierStreamManagementModuleV1
  * @notice Utility module for managing Sablier payment streams
  * @dev This module provides functionality to manage Sablier V2 streams, particularly
  * for withdrawing funds from streams owned by Hat smart accounts and cancelling
@@ -31,7 +31,7 @@ pragma solidity ^0.8.30;
  * - Validates stream status before operations
  * - Temporary module pattern prevents persistent access
  */
-interface IDecentSablierStreamManagementModule {
+interface IDecentSablierStreamManagementModuleV1 {
     // --- State-Changing Functions ---
 
     /**

--- a/contracts/utilities/DecentHatsCreationModuleV1.sol
+++ b/contracts/utilities/DecentHatsCreationModuleV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IDecentHatsCreationModule} from "../interfaces/decent/utilities/IDecentHatsCreationModule.sol";
+import {IDecentHatsCreationModuleV1} from "../interfaces/decent/utilities/IDecentHatsCreationModuleV1.sol";
 import {IDecentAutonomousAdminV1} from "../interfaces/decent/deployables/IDecentAutonomousAdminV1.sol";
 import {ISystemDeployerV1} from "../interfaces/decent/singletons/ISystemDeployerV1.sol";
 import {IKeyValuePairsV1} from "../interfaces/decent/singletons/IKeyValuePairsV1.sol";
@@ -23,10 +23,10 @@ interface IHatsExtended is IHats {
 }
 
 /**
- * @title DecentHatsCreationModule
+ * @title DecentHatsCreationModuleV1
  * @author Decent Labs
  * @notice Implementation of Hats tree creation for DAOs with payment streams
- * @dev This contract implements IDecentHatsCreationModule, providing a complete
+ * @dev This contract implements IDecentHatsCreationModuleV1, providing a complete
  * solution for creating organizational structures from scratch.
  *
  * Implementation details:
@@ -52,18 +52,18 @@ interface IHatsExtended is IHats {
  *
  * @custom:security-contact security@decentlabs.io
  */
-contract DecentHatsCreationModule is
-    IDecentHatsCreationModule,
+contract DecentHatsCreationModuleV1 is
+    IDecentHatsCreationModuleV1,
     DecentHatsModuleUtils
 {
     // ======================================================================
-    // IDecentHatsCreationModule
+    // IDecentHatsCreationModuleV1
     // ======================================================================
 
     // --- State-Changing Functions ---
 
     /**
-     * @inheritdoc IDecentHatsCreationModule
+     * @inheritdoc IDecentHatsCreationModuleV1
      * @dev Creates a complete organizational structure in one transaction.
      * The top hat is minted to the calling Safe, establishing ownership.
      * An autonomous admin is deployed to manage the admin hat for automated operations.

--- a/contracts/utilities/DecentHatsModificationModuleV1.sol
+++ b/contracts/utilities/DecentHatsModificationModuleV1.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IDecentHatsModificationModule} from "../interfaces/decent/utilities/IDecentHatsModificationModule.sol";
+import {IDecentHatsModificationModuleV1} from "../interfaces/decent/utilities/IDecentHatsModificationModuleV1.sol";
 import {DecentHatsModuleUtils} from "./DecentHatsModuleUtils.sol";
 
 /**
- * @title DecentHatsModificationModule
+ * @title DecentHatsModificationModuleV1
  * @author Decent Labs
  * @notice Implementation for adding roles to existing Hats Protocol trees
- * @dev This contract implements IDecentHatsModificationModule, providing
+ * @dev This contract implements IDecentHatsModificationModuleV1, providing
  * functionality to expand existing organizational structures.
  *
  * Implementation details:
@@ -31,18 +31,18 @@ import {DecentHatsModuleUtils} from "./DecentHatsModuleUtils.sol";
  *
  * @custom:security-contact security@decentlabs.io
  */
-contract DecentHatsModificationModule is
-    IDecentHatsModificationModule,
+contract DecentHatsModificationModuleV1 is
+    IDecentHatsModificationModuleV1,
     DecentHatsModuleUtils
 {
     // ======================================================================
-    // IDecentHatsModificationModule
+    // IDecentHatsModificationModuleV1
     // ======================================================================
 
     // --- State-Changing Functions ---
 
     /**
-     * @inheritdoc IDecentHatsModificationModule
+     * @inheritdoc IDecentHatsModificationModuleV1
      * @dev Simply delegates to the inherited _processRoleHats function from
      * DecentHatsModuleUtils, which handles all the complex logic for creating
      * roles with payment streams.

--- a/contracts/utilities/DecentSablierStreamManagementModuleV1.sol
+++ b/contracts/utilities/DecentSablierStreamManagementModuleV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import {IDecentSablierStreamManagementModule} from "../interfaces/decent/utilities/IDecentSablierStreamManagementModule.sol";
+import {IDecentSablierStreamManagementModuleV1} from "../interfaces/decent/utilities/IDecentSablierStreamManagementModuleV1.sol";
 import {Lockup} from "../interfaces/sablier/types/DataTypes.sol";
 import {ISablierV2Lockup} from "../interfaces/sablier/ISablierV2Lockup.sol";
 import {IERC6551Executable} from "../interfaces/erc6551/IERC6551Executable.sol";
@@ -9,10 +9,10 @@ import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IAvatar} from "@gnosis-guild/zodiac/contracts/interfaces/IAvatar.sol";
 
 /**
- * @title DecentSablierStreamManagementModule
+ * @title DecentSablierStreamManagementModuleV1
  * @author Decent Labs
  * @notice Implementation of Sablier stream management utilities
- * @dev This contract implements IDecentSablierStreamManagementModule, providing
+ * @dev This contract implements IDecentSablierStreamManagementModuleV1, providing
  * stream management functionality for DAOs using Sablier V2.
  *
  * Implementation details:
@@ -35,17 +35,17 @@ import {IAvatar} from "@gnosis-guild/zodiac/contracts/interfaces/IAvatar.sol";
  *
  * @custom:security-contact security@decentlabs.io
  */
-contract DecentSablierStreamManagementModule is
-    IDecentSablierStreamManagementModule
+contract DecentSablierStreamManagementModuleV1 is
+    IDecentSablierStreamManagementModuleV1
 {
     // ======================================================================
-    // IDecentSablierStreamManagementModule
+    // IDecentSablierStreamManagementModuleV1
     // ======================================================================
 
     // --- State-Changing Functions ---
 
     /**
-     * @inheritdoc IDecentSablierStreamManagementModule
+     * @inheritdoc IDecentSablierStreamManagementModuleV1
      * @dev Executes a nested call: Safe -> Hat Account -> Sablier.
      * Returns silently if no funds are available to withdraw, preventing
      * proposal failures due to timing issues.
@@ -84,7 +84,7 @@ contract DecentSablierStreamManagementModule is
     }
 
     /**
-     * @inheritdoc IDecentSablierStreamManagementModule
+     * @inheritdoc IDecentSablierStreamManagementModuleV1
      * @dev Only cancels streams in PENDING or STREAMING status.
      * Returns silently for other statuses to prevent proposal failures.
      * The Safe must be the stream sender to cancel.


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/394

Fixes [ENG-1223](https://linear.app/decent-labs/issue/ENG-1223/add-version-suffixes-to-concrete-utility-contracts)

## Motivation
Following the established naming convention where concrete contracts receive version suffixes and abstract contracts do not, this change adds the V1 suffix to all concrete contracts in the utilities directory. This ensures consistency across the codebase and makes it clear which contracts are deployable versus abstract base contracts.

## Change Summary
- Added V1 suffix to concrete utility contracts:
  - `DecentHatsCreationModule` → `DecentHatsCreationModuleV1`
  - `DecentHatsModificationModule` → `DecentHatsModificationModuleV1`
  - `DecentSablierStreamManagementModule` → `DecentSablierStreamManagementModuleV1`
- Updated corresponding interfaces to match:
  - `IDecentHatsCreationModule` → `IDecentHatsCreationModuleV1`
  - `IDecentHatsModificationModule` → `IDecentHatsModificationModuleV1`
  - `IDecentSablierStreamManagementModule` → `IDecentSablierStreamManagementModuleV1`
- Did NOT rename `DecentHatsModuleUtils` as it is an abstract contract
- Updated all import statements and references throughout the codebase
- Updated all @inheritdoc tags and section headers in the contracts