### PR TITLE
feat(contracts): Add deployment block tracking to SystemDeployerEventEmitterV1

### DIFF
--- a/contracts/singletons/SystemDeployerEventEmitterV1.sol
+++ b/contracts/singletons/SystemDeployerEventEmitterV1.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.30;
 
 import {ISystemDeployerEventEmitterV1} from "../interfaces/decent/singletons/ISystemDeployerEventEmitterV1.sol";
 import {IVersion} from "../interfaces/decent/deployables/IVersion.sol";
+import {IDeploymentBlock} from "../interfaces/decent/IDeploymentBlock.sol";
+import {DeploymentBlockNonUpgradeable} from "../DeploymentBlockNonUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -15,6 +17,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  * Implementation details:
  * - Deployed once per chain as a singleton
  * - Non-upgradeable deployment pattern
+ * - Inherits from DeploymentBlockNonUpgradeable to track deployment
  * - Emits events from a consistent address for indexing
  * - Called by SystemDeployerV1 during DAO deployment
  * - Minimal gas overhead for event emission
@@ -30,6 +33,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 contract SystemDeployerEventEmitterV1 is
     ISystemDeployerEventEmitterV1,
     IVersion,
+    DeploymentBlockNonUpgradeable,
     ERC165
 {
     // ======================================================================
@@ -72,7 +76,7 @@ contract SystemDeployerEventEmitterV1 is
 
     /**
      * @inheritdoc ERC165
-     * @dev Supports ISystemDeployerEventEmitterV1, IVersion, and IERC165
+     * @dev Supports ISystemDeployerEventEmitterV1, IVersion, IDeploymentBlock, and IERC165
      */
     function supportsInterface(
         bytes4 interfaceId_
@@ -80,6 +84,7 @@ contract SystemDeployerEventEmitterV1 is
         return
             interfaceId_ == type(ISystemDeployerEventEmitterV1).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
+            interfaceId_ == type(IDeploymentBlock).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/test/unit/singletons/SystemDeployerEventEmitterV1.test.ts
+++ b/test/unit/singletons/SystemDeployerEventEmitterV1.test.ts
@@ -3,11 +3,13 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   ERC165__factory,
+  IDeploymentBlock__factory,
   ISystemDeployerEventEmitterV1__factory,
   IVersion__factory,
   SystemDeployerEventEmitterV1,
   SystemDeployerEventEmitterV1__factory,
 } from '../../../typechain-types';
+import { runDeploymentBlockTests } from '../shared/deploymentBlockTests';
 import { runSupportsInterfaceTests } from '../shared/supportsInterfaceTests';
 
 describe('SystemDeployerEventEmitterV1', function () {
@@ -68,12 +70,20 @@ describe('SystemDeployerEventEmitterV1', function () {
     });
   });
 
+  describe('DeploymentBlock', function () {
+    runDeploymentBlockTests({
+      getContract: () => systemDeployerEventEmitter,
+      isNonUpgradeable: true,
+    });
+  });
+
   describe('ERC165 supportsInterface', function () {
     runSupportsInterfaceTests({
       getContract: () => systemDeployerEventEmitter,
       supportedInterfaceFactories: [
         ISystemDeployerEventEmitterV1__factory,
         IVersion__factory,
+        IDeploymentBlock__factory,
         ERC165__factory,
       ],
     });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/394

Fixes [ENG-1226](https://linear.app/decent-labs/issue/ENG-1226/add-deployment-block-tracking-to-systemdeployereventemitterv1)

## Motivation

SystemDeployerEventEmitterV1 is a singleton contract that needs to track its deployment block for indexing purposes. This information is crucial for off-chain services to know when to start scanning for events emitted by this contract.

## Change Summary

- Add DeploymentBlockNonUpgradeable inheritance to SystemDeployerEventEmitterV1
- Import IDeploymentBlock interface for proper type support
- Update supportsInterface to include IDeploymentBlock interface ID
- Update contract documentation to reflect deployment block tracking capability
- Add comprehensive tests using runDeploymentBlockTests helper
- Update existing supportsInterface tests to verify IDeploymentBlock support