### PR TITLE
feat(config): Integrate hardhat-ignition-ethers and configure ignition strategy

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,3 +1,4 @@
+import '@nomicfoundation/hardhat-ignition-ethers';
 import '@nomicfoundation/hardhat-toolbox';
 import '@nomicfoundation/hardhat-verify';
 import { HardhatUserConfig, vars } from 'hardhat/config';
@@ -77,6 +78,16 @@ const config: HardhatUserConfig = {
   },
   docgen: {
     pages: 'files',
+  },
+  ignition: {
+    strategyConfig: {
+      create2: {
+        salt: vars.get(
+          'DECENT_CREATE2_SALT',
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        ),
+      },
+    },
   },
 };
 

--- a/ignition/modules/DeployAll.ts
+++ b/ignition/modules/DeployAll.ts
@@ -1,0 +1,27 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+import DeployablesModule from './deployables/DeployablesModule';
+import ServicesModule from './services/ServicesModule';
+import SingletonsModule from './singletons/SingletonsModule';
+import UtilitiesModule from './utilities/UtilitiesModule';
+
+export default buildModule('DeployAll', m => {
+  // Deploy all singletons
+  const singletons = m.useModule(SingletonsModule);
+
+  // Deploy all deployables
+  const deployables = m.useModule(DeployablesModule);
+
+  // Deploy all utilities
+  const utilities = m.useModule(UtilitiesModule);
+
+  // Deploy all services
+  const services = m.useModule(ServicesModule);
+
+  return {
+    ...singletons,
+    ...deployables,
+    ...utilities,
+    ...services,
+  };
+});

--- a/ignition/modules/deployables/DeployablesModule.ts
+++ b/ignition/modules/deployables/DeployablesModule.ts
@@ -1,0 +1,69 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+export default buildModule('Deployables', m => {
+  // Deploy Modules
+  const moduleAzoriusV1 = m.contract('ModuleAzoriusV1');
+  const moduleFractalV1 = m.contract('ModuleFractalV1');
+
+  // Deploy StrategyV1 implementation
+  const strategyV1 = m.contract('StrategyV1');
+
+  // Deploy Proposer Adapters
+  const proposerAdapterERC20V1 = m.contract('ProposerAdapterERC20V1');
+  const proposerAdapterERC721V1 = m.contract('ProposerAdapterERC721V1');
+  const proposerAdapterHatsV1 = m.contract('ProposerAdapterHatsV1');
+
+  // Deploy Voting Adapters
+  const votingAdapterERC20V1 = m.contract('VotingAdapterERC20V1');
+  const votingAdapterERC721V1 = m.contract('VotingAdapterERC721V1');
+
+  // Deploy Freeze Guards
+  const freezeGuardAzoriusV1 = m.contract('FreezeGuardAzoriusV1');
+  const freezeGuardMultisigV1 = m.contract('FreezeGuardMultisigV1');
+
+  // Deploy Freeze Voting
+  const freezeVotingAzoriusV1 = m.contract('FreezeVotingAzoriusV1');
+  const freezeVotingMultisigV1 = m.contract('FreezeVotingMultisigV1');
+
+  // Deploy VotesERC20 implementations
+  const votesERC20V1 = m.contract('VotesERC20V1');
+  const votesERC20StakedV1 = m.contract('VotesERC20StakedV1');
+
+  // Deploy DecentPaymasterV1 implementation
+  const decentPaymasterV1 = m.contract('DecentPaymasterV1');
+
+  // Deploy DecentAutonomousAdminV1 implementation
+  const decentAutonomousAdminV1 = m.contract('DecentAutonomousAdminV1');
+
+  // Deploy CountersignV1 implementation
+  const countersignV1 = m.contract('CountersignV1');
+
+  return {
+    moduleAzoriusV1,
+    moduleFractalV1,
+
+    strategyV1,
+
+    proposerAdapterERC20V1,
+    proposerAdapterERC721V1,
+    proposerAdapterHatsV1,
+
+    votingAdapterERC20V1,
+    votingAdapterERC721V1,
+
+    freezeGuardAzoriusV1,
+    freezeGuardMultisigV1,
+
+    freezeVotingAzoriusV1,
+    freezeVotingMultisigV1,
+
+    votesERC20V1,
+    votesERC20StakedV1,
+
+    decentPaymasterV1,
+
+    decentAutonomousAdminV1,
+
+    countersignV1,
+  };
+});

--- a/ignition/modules/services/ServicesModule.ts
+++ b/ignition/modules/services/ServicesModule.ts
@@ -1,0 +1,14 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+export default buildModule('Services', m => {
+  // Deploy KYCVerifierV1
+  const kycVerifierV1 = m.contract('KYCVerifierV1');
+
+  // Deploy StrategyV1ValidatorV1
+  const strategyV1ValidatorV1 = m.contract('StrategyV1ValidatorV1');
+
+  return {
+    kycVerifierV1,
+    strategyV1ValidatorV1,
+  };
+});

--- a/ignition/modules/singletons/SingletonsModule.ts
+++ b/ignition/modules/singletons/SingletonsModule.ts
@@ -1,0 +1,18 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+export default buildModule('Singletons', m => {
+  // Deploy SystemDeployerV1
+  const systemDeployerV1 = m.contract('SystemDeployerV1');
+
+  // Deploy SystemDeployerEventEmitterV1
+  const systemDeployerEventEmitterV1 = m.contract('SystemDeployerEventEmitterV1');
+
+  // Deploy KeyValuePairsV1
+  const keyValuePairsV1 = m.contract('KeyValuePairsV1');
+
+  return {
+    systemDeployerV1,
+    systemDeployerEventEmitterV1,
+    keyValuePairsV1,
+  };
+});

--- a/ignition/modules/utilities/UtilitiesModule.ts
+++ b/ignition/modules/utilities/UtilitiesModule.ts
@@ -1,0 +1,10 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+
+export default buildModule('Utilities', m => {
+  // Deploy UtilityRolesManagement utility
+  const utilityRolesManagementModule = m.contract('UtilityRolesManagementV1');
+
+  return {
+    utilityRolesManagementModule,
+  };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@account-abstraction/contracts": "^0.7.0",
         "@gnosis-guild/zodiac": "^4.0.3",
         "@nomicfoundation/hardhat-ethers": "^3.0.9",
+        "@nomicfoundation/hardhat-ignition-ethers": "^0.15.12",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.12",
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
         "@nomicfoundation/hardhat-verify": "^2.0.14",
@@ -1170,16 +1171,18 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-ignition": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.1.tgz",
-      "integrity": "sha512-hWV/W9ZdG9HIqUiQXexrwoBBGP4IrDLghlZPAXXEXETmJ2AVPnBKQG626YmAYgEk2G3vX9ojn16daT+H2i/mFA==",
+      "version": "0.15.11",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.11.tgz",
+      "integrity": "sha512-OXebmK9FCMwwbb4mIeHBbVFFicAGgyGKJT2zrONrpixrROxrVs6KEi1gzsiN25qtQhCQePt8BTjjYrgy86Dfxg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/ignition-core": "^0.15.1",
-        "@nomicfoundation/ignition-ui": "^0.15.1",
+        "@nomicfoundation/ignition-core": "^0.15.11",
+        "@nomicfoundation/ignition-ui": "^0.15.11",
         "chalk": "^4.0.0",
         "debug": "^4.3.2",
         "fs-extra": "^10.0.0",
+        "json5": "^2.2.3",
         "prompts": "^2.4.2"
       },
       "peerDependencies": {
@@ -1188,16 +1191,29 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.1.tgz",
-      "integrity": "sha512-FPeE0EbJ+RcBGro9TxODyDffpSPhnG8ra43nJp7/1H2M0S+UkmJUeZlSjAIVfUut1zMwy+57j+PNn07dOr/YmQ==",
-      "peer": true,
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.12.tgz",
+      "integrity": "sha512-YEqjtrrMkGNXCFJKNrWgqtLmFSiOXDiEWiKup+yqonCzps1B/e9zg4ezRP5feiKUOIxblD6isCDKtQKu7iY6XA==",
+      "license": "MIT",
       "peerDependencies": {
-        "@nomicfoundation/hardhat-ethers": "^3.0.4",
-        "@nomicfoundation/hardhat-ignition": "^0.15.1",
-        "@nomicfoundation/ignition-core": "^0.15.1",
-        "ethers": "^6.7.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.9",
+        "@nomicfoundation/hardhat-ignition": "^0.15.11",
+        "@nomicfoundation/ignition-core": "^0.15.11",
+        "ethers": "^6.14.0",
         "hardhat": "^2.18.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
@@ -1258,9 +1274,10 @@
       }
     },
     "node_modules/@nomicfoundation/ignition-core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.1.tgz",
-      "integrity": "sha512-/AZO0YHRv1+yQSOtSSbg4GEH9YhU8EVePSfByU2PZW2bsAK0SA8GdoLYFbVNl140dogem5lrE+bCKtX0eN/n+A==",
+      "version": "0.15.11",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.11.tgz",
+      "integrity": "sha512-PeYKRlrQ0koT72yRnlyyG66cXMFiv5X/cIB8hBFPl3ekeg5tPXcHAgs/VZhOsgwEox4ejphTtItLESb1IDBw0w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@ethersproject/address": "5.6.1",
@@ -1288,6 +1305,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.2",
@@ -1301,6 +1319,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
       "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "nofilter": "^3.1.0"
@@ -1310,9 +1329,9 @@
       }
     },
     "node_modules/@nomicfoundation/ignition-ui": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.1.tgz",
-      "integrity": "sha512-ecx6M9K4IeF7L0XCcHg0E72zlVaGSOlkhb/9XuWrA2ltfB/e4ZsOhVxXtwDf9xIcaq7tUdMSxyj6Ld0bPAhxAw==",
+      "version": "0.15.11",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.11.tgz",
+      "integrity": "sha512-VPOVl5xqCKhYCyPOQlposx+stjCwqXQ+BCs5lnw/f2YUfgII+G5Ye0JfHiJOfCJGmqyS03WertBslcj9zQg50A==",
       "peer": true
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
@@ -4475,6 +4494,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5354,6 +5374,7 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
       "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -5792,6 +5813,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC",
       "peer": true
     },
     "node_modules/json5": {
@@ -5861,6 +5883,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -6287,6 +6310,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
       "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
@@ -6718,6 +6742,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "kleur": "^3.0.3",
@@ -7304,6 +7329,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/slash": {
@@ -7569,6 +7595,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "readable-stream": "^3.0.0"
@@ -7867,6 +7894,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
       "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "readable-stream": "3"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@account-abstraction/contracts": "^0.7.0",
     "@gnosis-guild/zodiac": "^4.0.3",
     "@nomicfoundation/hardhat-ethers": "^3.0.9",
+    "@nomicfoundation/hardhat-ignition-ethers": "^0.15.12",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.12",
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@nomicfoundation/hardhat-verify": "^2.0.14",


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/401

Fixes [ENG-1228](https://linear.app/decent-labs/issue/ENG-1228/implement-hardhat-ignition-deployment-modules-with-create2-strategy)

## Motivation

Migrate the deployment system from hardhat-deploy to hardhat-ignition to leverage CREATE2 deployments for deterministic contract addresses across all networks. This enables consistent contract addresses regardless of deployment order or network.

## Change Summary

- Added @nomicfoundation/hardhat-ignition-ethers dependency
- Configured Hardhat Ignition with CREATE2 strategy in hardhat.config.ts
- Set default CREATE2 salt with ability to override via DECENT_CREATE2_SALT variable
- Created modular Ignition deployment structure:
  - DeployAll module: Orchestrates deployment of all contracts
  - Deployables module: All DAO-specific deployable contracts (17 contracts)
  - Services module: Stateless service contracts (2 contracts)
  - Singletons module: Chain-wide singleton contracts (3 contracts)
  - Utilities module: Utility contracts for delegatecall operations (1 contract)
- Organized contracts by category matching the codebase structure

This provides a clean, maintainable deployment system with deterministic addresses across all chains when using the same CREATE2 salt.