### PR TITLE
refactor(npm): Migrate package to @decentdao/decent-contracts with new publishing system

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,12 +1,12 @@
 # Security Policy
 
-We at Fractal encourage security researchers to contact us directly and privately to report any potential security vulnerabilities in either our smart contracts or front end code.
+We at Decent encourage security researchers to contact us directly and privately to report any potential security vulnerabilities in either our smart contracts or front end code.
 
-If the issue you are reporting is not a security vulnerability, simply [open a new GitHub issue](https://github.com/decent-dao/fractal-contracts/issues/new/choose).
+If the issue you are reporting is not a security vulnerability, simply [open a new GitHub issue](https://github.com/decentdao/decent-contracts/issues/new).
 
 ## Reporting a Vulnerability
 
-If you would like to disclose a vulnerability in Fractal, please send a new email to [security@decent-dao.org](mailto:security@decent-dao.org).
+If you would like to disclose a vulnerability in Decent, please send a new email to [security@decentlabs.io](mailto:security@decentlabs.io).
 
 Please include the following information in your email:
 
@@ -19,4 +19,4 @@ Please include the following information in your email:
 
 If you prefer secure communication, please use the following GPG key:
 
-https://keys.openpgp.org/search?q=security%40decent-dao.org
+https://keys.openpgp.org/search?q=security%40decentlabs.io

--- a/README.md
+++ b/README.md
@@ -207,23 +207,48 @@ Update natspec doc files after modifying contracts:
 npm run docgen
 ```
 
-## Deploy Contracts to `<network>`
+## Contract Deployment
+
+Before deploying, set your unique CREATE2 salt to ensure deterministic addresses:
 
 ```shell
-npx hardhat deploy --network <network>
+npx hardhat vars set DECENT_CREATE2_SALT 0xUniqueSalt
 ```
 
-Deployed contracts can be verified on Etherscan via the following command:
+Replace `0xUniqueSalt` with your own unique salt value. This salt determines the final contract addresses when using CREATE2.
+
+To deploy all contracts to a specific network using Hardhat Ignition:
 
 ```shell
-npx hardhat verify --network {network name} {contract address}
+npx hardhat ignition deploy ignition/modules/DeployAll.ts --network <network> --strategy create2 --verify
 ```
 
-Currently, this is done manually for each contract deployed, found in `deployments/<network>/XXX.json`
+For example, to deploy to Sepolia:
+
+```shell
+npx hardhat ignition deploy ignition/modules/DeployAll.ts --network sepolia --strategy create2 --verify
+```
+
+This command will:
+
+- Deploy all contracts using CREATE2 for deterministic addresses
+- Automatically verify contracts on Etherscan (or the appropriate block explorer)
+- Store deployment artifacts in `ignition/deployments/chain-<chainId>/`
+
+The `--strategy create2` flag ensures contracts are deployed to the same addresses across all networks when using the same salt.
+
+Individual modules can also be deployed separately if needed:
+
+```shell
+npx hardhat ignition deploy ignition/modules/Deployables.ts --network <network> --strategy create2 --verify
+npx hardhat ignition deploy ignition/modules/Services.ts --network <network> --strategy create2 --verify
+npx hardhat ignition deploy ignition/modules/Singletons.ts --network <network> --strategy create2 --verify
+npx hardhat ignition deploy ignition/modules/Utilities.ts --network <network> --strategy create2 --verify
+```
 
 ## Local Hardhat deployment
 
-To deploy the Fractal contracts to a local node:
+To deploy the Decent contracts to a local node:
 
 ```shell
 npx hardhat node
@@ -236,7 +261,7 @@ The core contracts in this repository are published in an NPM package for easy u
 To install the npm package in your project, run:
 
 ```shell
-npm i @fractal-framework/fractal-contracts
+npm i @decentdao/decent-contracts
 ```
 
 ## Publishing new versions to NPM
@@ -248,7 +273,7 @@ npm i @fractal-framework/fractal-contracts
 
 ## Versioning
 
-Fractal follows a modified style of semantic versioning (https://semver.org/) specific to a smart contract use case.
+Decent follows a modified style of semantic versioning (https://semver.org/) specific to a smart contract use case.
 
 There are three types of releases:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "@fractal-framework/fractal-contracts",
-  "version": "1.4.2",
+  "name": "@decentdao/decent-contracts",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@fractal-framework/fractal-contracts",
-      "version": "1.4.2",
-      "license": "MIT",
+      "name": "@decentdao/decent-contracts",
+      "version": "2.0.0",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@account-abstraction/contracts": "^0.7.0",
         "@gnosis-guild/zodiac": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@fractal-framework/fractal-contracts",
-  "version": "1.4.2",
+  "name": "@decentdao/decent-contracts",
+  "version": "2.0.0",
   "files": [
     "publish",
     "contracts",
-    "!contracts/mock"
+    "!contracts/mocks"
   ],
   "main": "publish/index.js",
   "repository": {
@@ -23,11 +23,11 @@
     "prepublishOnly": "./scripts/prepublish.sh"
   },
   "description": "A Safe Zodiac Module framework",
-  "homepage": "https://github.com/decentdao/fractal-contracts/blob/develop/README.md",
-  "author": "fractal-contributors",
-  "license": "MIT",
+  "homepage": "https://github.com/decentdao/decent-contracts/blob/develop/README.md",
+  "author": "decent-contributors",
+  "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/decentdao/fractal-contracts/issues"
+    "url": "https://github.com/decentdao/decent-contracts/issues"
   },
   "dependencies": {
     "@account-abstraction/contracts": "^0.7.0",

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -1,39 +1,30 @@
 #!/bin/bash
 
+# Exit on error
+set -e
+
+echo "Starting prepublish process..."
+
+# Clean and compile
+echo "Cleaning build artifacts..."
 npm run clean
+
+echo "Compiling contracts..."
 npm run compile
+
+echo "Running tests..."
 npm run test
 
-npx hardhat export --export-all deployments.json
-
+# Remove old publish directory
+echo "Removing old publish directory..."
 rm -rf publish && mkdir publish
 
-# Step 1: Remove the `abi`, `name`, and `chainId` keys
-jq 'walk(if type == "object" then del(.abi, .name, .chainId) else . end)' deployments.json > temp_addresses.json
-# Step 2: Replace array with its single object item
-jq 'to_entries | map({key: .key, value: .value[0]}) | from_entries' temp_addresses.json > temp_flat_addresses.json
-# Step 3: Flatten the structure to remove bottom level objects
-jq 'to_entries | map({key: .key, value: .value.contracts | map_values(.address)}) | from_entries' temp_flat_addresses.json > addresses.json
-# Step 4: Wrap the JSON content in TypeScript format and append "as const;"
-echo "export default $(cat addresses.json) as const;" > publish/addresses.ts
-# Step 5: Cleanup
-rm temp_addresses.json temp_flat_addresses.json addresses.json
+# Process deployment artifacts
+echo "Processing deployment artifacts..."
+npx ts-node scripts/process-deployments.ts
 
+# Compile TypeScript outputs
+echo "Compiling TypeScript files..."
+npx tsc ./publish/index.ts --declaration --outDir ./publish --target es2020 --module commonjs
 
-# Step 1: Extract `abi` values directly under each contract key
-jq '."1"[0].contracts | to_entries | map({key: .key, value: .value.abi}) | from_entries' deployments.json > abis.json
-# Step 2: Wrap the JSON content in TypeScript format and append "as const;"
-echo "export default $(cat abis.json) as const;" > publish/abis.ts
-# Step 3: Cleanup
-rm abis.json
-
-rm deployments.json 
-
-cat << EOF > publish/index.ts
-import abis from "./abis";
-import addresses from "./addresses";
-export { abis, addresses };
-EOF
-
-# Run TypeScript compilation
-npx tsc ./publish/index.ts
+echo "Prepublish complete!"

--- a/scripts/process-deployments.ts
+++ b/scripts/process-deployments.ts
@@ -1,0 +1,478 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Process Deployment Artifacts for NPM Publishing
+ *
+ * This script consolidates deployment artifacts from two sources:
+ * 1. Legacy deployments (hardhat-deploy) - stored in /legacy-deployments/
+ * 2. Current deployments (hardhat-ignition) - stored in /ignition/deployments/
+ *
+ * Key Features:
+ * - Groups current contracts by category (deployables, services, singletons, utilities, etc.)
+ * - Preserves legacy contract names and network-specific addresses
+ * - Validates deployment consistency with different rules for testnets vs mainnets
+ * - Outputs TypeScript files for type-safe contract imports
+ *
+ * Network Validation Rules:
+ * - Sepolia (testnet): Lenient - can have different contracts/addresses than mainnets
+ * - All other networks: Strict - must be identical (treated as mainnet networks)
+ * - Mixed deployments: Mainnet consistency enforced, Sepolia differences logged as info
+ *
+ * Output Structure:
+ * /publish/
+ *   ├── abis.ts          # Current contract ABIs grouped by category
+ *   ├── addresses.ts     # Current contract addresses (same across networks via CREATE2)
+ *   ├── legacy/
+ *   │   ├── abis.ts      # Legacy contract ABIs with original names
+ *   │   ├── addresses.ts # Legacy addresses by network with deployment blocks
+ *   │   └── index.ts     # Legacy export file
+ *   └── index.ts         # Main export file
+ *
+ * Usage: npx ts-node scripts/process-deployments.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface LegacyDeployment {
+  address: string;
+  abi: any[];
+  receipt: {
+    blockNumber: number;
+  };
+}
+
+interface IgnitionArtifact {
+  abi: any[];
+}
+
+interface DeployedAddresses {
+  [key: string]: string;
+}
+
+interface LegacyAddressInfo {
+  address: string;
+  deploymentBlock: number;
+}
+
+interface LegacyAddresses {
+  [network: string]: {
+    [contract: string]: LegacyAddressInfo;
+  };
+}
+
+interface ABIs {
+  [contractName: string]: any[];
+}
+
+interface Addresses {
+  [contractName: string]: string;
+}
+
+// Dynamic types that adapt to whatever categories exist
+type GroupedABIs = Record<string, ABIs>;
+type GroupedAddresses = Record<string, Addresses>;
+
+// Helper function to extract contract name and category from ignition format
+function parseIgnitionKey(ignitionKey: string): { category: string; contractName: string } {
+  // Format: "Module#ContractName" -> { category: "module", contractName: "ContractName" }
+  const parts = ignitionKey.split('#');
+  if (parts.length > 1) {
+    return {
+      category: parts[0].toLowerCase(),
+      contractName: parts[1],
+    };
+  }
+  return {
+    category: 'unknown',
+    contractName: ignitionKey,
+  };
+}
+
+// Process legacy deployments
+function processLegacyDeployments(): { abis: ABIs; addresses: LegacyAddresses } {
+  const legacyPath = path.join(__dirname, '..', 'legacy-deployments');
+  const legacyAbis: ABIs = {};
+  const legacyAddresses: LegacyAddresses = {};
+
+  if (!fs.existsSync(legacyPath)) {
+    console.log('No legacy deployments found');
+    return { abis: legacyAbis, addresses: legacyAddresses };
+  }
+
+  const networks = fs
+    .readdirSync(legacyPath)
+    .filter(dir => fs.statSync(path.join(legacyPath, dir)).isDirectory() && !dir.startsWith('.'));
+
+  for (const network of networks) {
+    const networkPath = path.join(legacyPath, network);
+
+    // Read chain ID from .chainId file
+    const chainIdPath = path.join(networkPath, '.chainId');
+    let chainId: string;
+
+    try {
+      chainId = fs.readFileSync(chainIdPath, 'utf8').trim();
+    } catch (error) {
+      throw new Error(`Missing .chainId file for network ${network}.`);
+    }
+
+    const files = fs
+      .readdirSync(networkPath)
+      .filter(file => file.endsWith('.json') && !file.startsWith('.'));
+
+    legacyAddresses[chainId] = {};
+
+    for (const file of files) {
+      const contractName = path.basename(file, '.json');
+      const filePath = path.join(networkPath, file);
+
+      try {
+        const content: LegacyDeployment = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+        // Store ABI (deduplicated by contract name)
+        if (content.abi && content.abi.length > 0) {
+          legacyAbis[contractName] = content.abi;
+        }
+
+        // Store address and deployment block
+        legacyAddresses[chainId][contractName] = {
+          address: content.address,
+          deploymentBlock: content.receipt?.blockNumber,
+        };
+      } catch (error) {
+        throw new Error(
+          `Failed to process legacy deployment file ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  return { abis: legacyAbis, addresses: legacyAddresses };
+}
+
+// Process ignition deployments
+function processIgnitionDeployments(): {
+  abis: GroupedABIs;
+  addresses: GroupedAddresses;
+  networkIds: number[];
+} {
+  const ignitionPath = path.join(__dirname, '..', 'ignition', 'deployments');
+  const groupedAbis: GroupedABIs = {};
+  const groupedAddresses: GroupedAddresses = {};
+  const networkIds: number[] = [];
+
+  if (!fs.existsSync(ignitionPath)) {
+    console.log('No ignition deployments found');
+    return { abis: groupedAbis, addresses: groupedAddresses, networkIds };
+  }
+
+  // Get all chain directories
+  const chainDirs = fs
+    .readdirSync(ignitionPath)
+    .filter(
+      dir => dir.startsWith('chain-') && fs.statSync(path.join(ignitionPath, dir)).isDirectory(),
+    );
+
+  // Extract network IDs from chain directories
+  for (const chainDir of chainDirs) {
+    const chainId = parseInt(chainDir.replace('chain-', ''), 10);
+    networkIds.push(chainId);
+  }
+
+  // Define network types
+  const SEPOLIA_CHAIN_ID = '11155111';
+
+  // Separate testnet from mainnet deployments
+  // Everything except Sepolia is considered a mainnet network
+  const sepoliaDir = chainDirs.find(dir => dir === `chain-${SEPOLIA_CHAIN_ID}`);
+  const mainnetDirs = chainDirs.filter(dir => dir !== `chain-${SEPOLIA_CHAIN_ID}`);
+
+  // Log deployment information
+  console.log(`Found deployments on ${chainDirs.length} network(s):`);
+  if (sepoliaDir) {
+    console.log(`  - Sepolia (testnet): ${sepoliaDir}`);
+  }
+  if (mainnetDirs.length > 0) {
+    console.log(`  - Mainnet networks: ${mainnetDirs.join(', ')}`);
+  }
+
+  if (mainnetDirs.length > 1) {
+    console.log('  ⚠️  Multiple mainnet networks found - will enforce strict consistency');
+  }
+  if (sepoliaDir && mainnetDirs.length > 0) {
+    console.log('  ℹ️  Sepolia deployments will be checked separately (lenient mode)');
+  }
+
+  // First, collect all contracts from all networks to verify consistency
+  const contractsByNetwork: Map<string, Set<string>> = new Map();
+  const allContracts: Map<
+    string,
+    { category: string; address: string; abi?: any[]; network?: string }
+  > = new Map();
+
+  for (const chainDir of chainDirs) {
+    const chainPath = path.join(ignitionPath, chainDir);
+    const addressesPath = path.join(chainPath, 'deployed_addresses.json');
+
+    if (fs.existsSync(addressesPath)) {
+      const deployedAddresses: DeployedAddresses = JSON.parse(
+        fs.readFileSync(addressesPath, 'utf8'),
+      );
+
+      const contractsInNetwork = new Set<string>();
+
+      for (const [ignitionKey, address] of Object.entries(deployedAddresses)) {
+        const { category, contractName } = parseIgnitionKey(ignitionKey);
+        const fullKey = `${category}#${contractName}`;
+        contractsInNetwork.add(fullKey);
+
+        // Read ABI from artifacts
+        const artifactPath = path.join(chainPath, 'artifacts', `${ignitionKey}.json`);
+        let currentAbi: any[] | undefined;
+
+        if (fs.existsSync(artifactPath)) {
+          try {
+            const artifact: IgnitionArtifact = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+            if (artifact.abi && artifact.abi.length > 0) {
+              currentAbi = artifact.abi;
+            }
+          } catch (error) {
+            throw new Error(
+              `Failed to read artifact file ${artifactPath}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+        }
+
+        // Store contract info if not already stored
+        if (!allContracts.has(fullKey)) {
+          allContracts.set(fullKey, { category, address, abi: currentAbi, network: chainDir });
+        } else {
+          // Verify consistency across networks
+          const existingInfo = allContracts.get(fullKey)!;
+
+          // Check if either network is Sepolia
+          const currentIsSepolia = chainDir === `chain-${SEPOLIA_CHAIN_ID}`;
+          const previousIsSepolia = existingInfo.network === `chain-${SEPOLIA_CHAIN_ID}`;
+          const isSepoliaInvolved = currentIsSepolia || previousIsSepolia;
+
+          // Verify address consistency
+          if (existingInfo.address !== address) {
+            if (isSepoliaInvolved) {
+              // If Sepolia is involved, just warn
+              console.log(
+                `INFO: Contract ${contractName} has different addresses:`,
+                `\n  ${chainDir}: ${address}`,
+                `\n  ${existingInfo.network}: ${existingInfo.address}`,
+                `\n  (This is OK - Sepolia can differ from mainnet)`,
+              );
+            } else {
+              // If only mainnet networks, this is critical
+              throw new Error(
+                `CRITICAL: Contract ${contractName} has different addresses on mainnet networks!` +
+                  `\n  ${chainDir}: ${address}` +
+                  `\n  ${existingInfo.network}: ${existingInfo.address}` +
+                  `\n  All mainnet deployments must use CREATE2 with identical addresses!`,
+              );
+            }
+          }
+
+          // Verify ABI consistency
+          if (currentAbi && existingInfo.abi) {
+            const currentAbiStr = JSON.stringify(currentAbi);
+            const existingAbiStr = JSON.stringify(existingInfo.abi);
+
+            if (currentAbiStr !== existingAbiStr) {
+              if (isSepoliaInvolved) {
+                // If Sepolia is involved, just warn
+                console.log(
+                  `INFO: Contract ${contractName} has different ABIs between networks:`,
+                  `\n  ${chainDir} vs ${existingInfo.network}`,
+                  `\n  (This is OK - Sepolia can have different ABIs from mainnet)`,
+                );
+              } else {
+                // If only mainnet networks, this is critical
+                throw new Error(
+                  `CRITICAL: Contract ${contractName} has different ABIs on mainnet networks!` +
+                    `\n  Networks: ${chainDir} vs ${existingInfo.network}` +
+                    `\n  All mainnet deployments must have identical ABIs!`,
+                );
+              }
+            }
+          }
+
+          // If we don't have an ABI yet but this network does, use it
+          if (!existingInfo.abi && currentAbi) {
+            existingInfo.abi = currentAbi;
+          }
+        }
+      }
+
+      contractsByNetwork.set(chainDir, contractsInNetwork);
+    }
+  }
+
+  // Verify mainnet consistency (strict) and handle Sepolia separately (lenient)
+  if (mainnetDirs.length > 1) {
+    // Check consistency across mainnet networks only
+    const mainnetContractSets = mainnetDirs.map(dir => contractsByNetwork.get(dir)).filter(Boolean);
+
+    if (mainnetContractSets.length > 1) {
+      // Get the first mainnet network as reference
+      const referenceContracts = mainnetContractSets[0]!;
+      const referenceNetwork = mainnetDirs[0];
+
+      // Check all other mainnet networks against the reference
+      for (let i = 1; i < mainnetContractSets.length; i++) {
+        const contracts = mainnetContractSets[i]!;
+        const network = mainnetDirs[i];
+
+        // Check for missing contracts in either direction
+        for (const contract of referenceContracts) {
+          if (!contracts.has(contract)) {
+            throw new Error(
+              `CRITICAL: Contract ${contract} exists on ${referenceNetwork} but is missing on ${network}. ` +
+                `All mainnet deployments must be identical!`,
+            );
+          }
+        }
+
+        for (const contract of contracts) {
+          if (!referenceContracts.has(contract)) {
+            throw new Error(
+              `CRITICAL: Contract ${contract} exists on ${network} but is missing on ${referenceNetwork}. ` +
+                `All mainnet deployments must be identical!`,
+            );
+          }
+        }
+      }
+
+      console.log(
+        `✓ All mainnet networks have identical contracts (${referenceContracts.size} contracts)`,
+      );
+    }
+  }
+
+  // For Sepolia, just log warnings if it differs from mainnet
+  if (sepoliaDir && mainnetDirs.length > 0) {
+    const sepoliaContracts = contractsByNetwork.get(sepoliaDir);
+    const mainnetContracts = contractsByNetwork.get(mainnetDirs[0]);
+
+    if (sepoliaContracts && mainnetContracts) {
+      for (const contract of mainnetContracts) {
+        if (!sepoliaContracts.has(contract)) {
+          console.log(
+            `INFO: Contract ${contract} is on mainnet but not on Sepolia (this is OK for development)`,
+          );
+        }
+      }
+
+      for (const contract of sepoliaContracts) {
+        if (!mainnetContracts.has(contract)) {
+          console.log(
+            `INFO: Contract ${contract} is on Sepolia but not on mainnet (this is OK for prereleases)`,
+          );
+        }
+      }
+    }
+  }
+
+  // Now populate the grouped structures dynamically
+  for (const [fullKey, info] of allContracts.entries()) {
+    const [category, contractName] = fullKey.split('#');
+
+    // Initialize the category if it doesn't exist
+    if (!groupedAddresses[category]) {
+      groupedAddresses[category] = {};
+      groupedAbis[category] = {};
+      console.log(`  📁 Found new category: ${category}`);
+    }
+
+    // Add to the appropriate category
+    groupedAddresses[category][contractName] = info.address;
+    if (info.abi) {
+      groupedAbis[category][contractName] = info.abi;
+    }
+  }
+
+  return { abis: groupedAbis, addresses: groupedAddresses, networkIds };
+}
+
+// Write TypeScript files
+function writeTypeScriptFiles(
+  currentAbis: GroupedABIs,
+  currentAddresses: GroupedAddresses,
+  legacyAbis: ABIs,
+  legacyAddresses: LegacyAddresses,
+  chains: number[],
+): void {
+  const publishPath = path.join(__dirname, '..', 'publish');
+  const legacyPath = path.join(publishPath, 'legacy');
+
+  // Create directories
+  fs.mkdirSync(publishPath, { recursive: true });
+  fs.mkdirSync(legacyPath, { recursive: true });
+
+  // Write current ABIs
+  const currentAbisContent = `export default ${JSON.stringify(currentAbis, null, 2)} as const;`;
+  fs.writeFileSync(path.join(publishPath, 'abis.ts'), currentAbisContent);
+
+  // Write current addresses
+  const currentAddressesContent = `export default ${JSON.stringify(currentAddresses, null, 2)} as const;`;
+  fs.writeFileSync(path.join(publishPath, 'addresses.ts'), currentAddressesContent);
+
+  // Write legacy ABIs
+  const legacyAbisContent = `export default ${JSON.stringify(legacyAbis, null, 2)} as const;`;
+  fs.writeFileSync(path.join(legacyPath, 'abis.ts'), legacyAbisContent);
+
+  // Write legacy addresses
+  const legacyAddressesContent = `export default ${JSON.stringify(legacyAddresses, null, 2)} as const;`;
+  fs.writeFileSync(path.join(legacyPath, 'addresses.ts'), legacyAddressesContent);
+
+  // Write legacy index
+  const legacyIndexContent = `import abis from "./abis";
+import addresses from "./addresses";
+export { abis, addresses };
+`;
+  fs.writeFileSync(path.join(legacyPath, 'index.ts'), legacyIndexContent);
+
+  // Write main index
+  const mainIndexContent = `import abis from "./abis";
+import addresses from "./addresses";
+import * as legacy from "./legacy";
+
+const chains = ${JSON.stringify(chains, null, 2)};
+
+export { chains, abis, addresses, legacy };
+`;
+  fs.writeFileSync(path.join(publishPath, 'index.ts'), mainIndexContent);
+}
+
+// Main function
+function main(): void {
+  console.log('Processing deployments...');
+
+  // Process legacy deployments
+  const { abis: legacyAbis, addresses: legacyAddresses } = processLegacyDeployments();
+  console.log(`Found ${Object.keys(legacyAbis).length} legacy contracts`);
+
+  // Process ignition deployments
+  const {
+    abis: currentAbis,
+    addresses: currentAddresses,
+    networkIds,
+  } = processIgnitionDeployments();
+  const totalCurrentContracts = Object.values(currentAbis).reduce(
+    (sum, categoryAbis) => sum + Object.keys(categoryAbis).length,
+    0,
+  );
+  console.log(`Found ${totalCurrentContracts} current contracts`);
+
+  // Write output files
+  writeTypeScriptFiles(currentAbis, currentAddresses, legacyAbis, legacyAddresses, networkIds);
+
+  console.log('Deployment processing complete!');
+}
+
+// Run the script
+main();


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/402

Fixes [ENG-1229](https://linear.app/decent-labs/issue/ENG-1229/migrate-npm-package-to-decentdaodecent-contracts-with-new-publishing)

## Motivation

Complete the migration from @fractal-framework/fractal-contracts to @decentdao/decent-contracts with a new publishing system that supports both legacy hardhat-deploy and new hardhat-ignition deployment artifacts. This ensures backward compatibility while enabling the new CREATE2 deployment strategy.

## Change Summary

- Renamed npm package from @fractal-framework/fractal-contracts to @decentdao/decent-contracts
- Bumped version to 2.0.0 to reflect the major migration
- Updated security contact from security@decent-dao.org to security@decentlabs.io
- Updated GitHub issue links to new repository structure
- Rewrote prepublish.sh script to use new TypeScript processing pipeline
- Created process-deployments.ts script that:
  - Processes both legacy and ignition deployment artifacts
  - Groups contracts by category dynamically
  - Validates cross-network deployment consistency
  - Outputs typed exports for both current and legacy deployments
- Updated README deployment section with hardhat-ignition commands
- Added documentation for CREATE2 salt configuration

The new system maintains full backward compatibility through the legacy exports while providing a cleaner, category-based structure for new deployments.