### PR TITLE
feat(contracts): Add InitializerEventEmitter for transparent initialization tracking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,7 +45,8 @@
     {
       "files": ["test/**/*.ts"],
       "rules": {
-        "@typescript-eslint/no-unused-expressions": "off"
+        "@typescript-eslint/no-unused-expressions": "off",
+        "@typescript-eslint/return-await": "off"
       }
     },
     {

--- a/contracts/InitializerEventEmitter.sol
+++ b/contracts/InitializerEventEmitter.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/**
+ * @title InitializerEventEmitter
+ * @author Decent Labs
+ * @notice Abstract contract for emitting initialization data during contract deployment
+ * @dev This abstract contract provides a standardized way to emit initialization
+ * data for initializable contracts in the Decent ecosystem.
+ *
+ * Implementation details:
+ * - Designed to be inherited by upgradeable contracts
+ * - Emits raw initialization data for transparency and auditability
+ * - Minimal gas overhead with single event emission
+ * - Follows OpenZeppelin's initializer pattern
+ * - Uses `onlyInitializing` modifier for security
+ *
+ * Usage:
+ * - Inherit this contract in your upgradeable contract
+ * - Call `__InitializerEventEmitter_init()` in your initializer function
+ * - Pass the encoded initialization parameters as bytes
+ *
+ * Example:
+ * ```solidity
+ * contract MyContract is InitializerEventEmitter, OtherContracts {
+ *     function initialize(address owner_, uint256 value_) public initializer {
+ *         bytes memory initData = abi.encode(owner_, value_);
+ *         __InitializerEventEmitter_init(initData);
+ *         // ... rest of initialization
+ *     }
+ * }
+ * ```
+ *
+ * @custom:security-contact security@decentlabs.io
+ */
+abstract contract InitializerEventEmitter is Initializable {
+    // ======================================================================
+    // ERRORS
+    // ======================================================================
+
+    /**
+     * @notice Thrown when attempting to initialize after already initialized
+     * @dev Prevents reinitialization attacks on upgradeable contracts
+     */
+    error InitializeDataAlreadyEmitted();
+
+    // ======================================================================
+    // EVENTS
+    // ======================================================================
+
+    /**
+     * @notice Emitted when a contract is initialized with data
+     * @dev This event provides transparency for all initialization parameters
+     * @param initData The raw initialization data passed to the contract
+     */
+    event InitializeData(bytes initData);
+
+    // ======================================================================
+    // STATE VARIABLES
+    // ======================================================================
+
+    /**
+     * @notice Storage struct for InitializerEventEmitter following EIP-7201
+     * @dev Tracks whether initialization data has been emitted
+     * @custom:storage-location erc7201:Decent.InitializerEventEmitter.main
+     */
+    struct InitializerEventEmitterStorage {
+        /** @notice Whether the initialization data has been emitted */
+        bool initialized;
+    }
+
+    /**
+     * @dev Storage slot for InitializerEventEmitterStorage calculated using EIP-7201 formula:
+     * keccak256(abi.encode(uint256(keccak256("Decent.InitializerEventEmitter.main")) - 1)) & ~bytes32(uint256(0xff))
+     */
+    bytes32 internal constant INITIALIZER_EVENT_EMITTER_STORAGE_LOCATION =
+        0xf7464a9b8e299d18ec8976df251e878e5204887b642c36b9e3e606b459323300;
+
+    /**
+     * @dev Returns the storage struct for InitializerEventEmitter
+     * Following the EIP-7201 namespaced storage pattern to avoid storage collisions
+     * @return $ The storage struct for InitializerEventEmitter
+     */
+    function _getInitializerEventEmitterStorage()
+        internal
+        pure
+        returns (InitializerEventEmitterStorage storage $)
+    {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            $.slot := INITIALIZER_EVENT_EMITTER_STORAGE_LOCATION
+        }
+    }
+
+    // ======================================================================
+    // INITIALIZERS
+    // ======================================================================
+
+    /**
+     * @notice Initializes the event emitter and emits the initialization data
+     * @dev Must be called by inheriting contracts in their initializer function.
+     * Can only be called once - subsequent calls will revert.
+     * @param initData The initialization data to emit
+     * @custom:throws InitializeDataAlreadyEmitted if already initialized
+     */
+    function __InitializerEventEmitter_init(
+        // solhint-disable-previous-line func-name-mixedcase
+        bytes memory initData
+    ) internal onlyInitializing {
+        InitializerEventEmitterStorage
+            storage $ = _getInitializerEventEmitterStorage();
+
+        if ($.initialized) {
+            revert InitializeDataAlreadyEmitted();
+        }
+
+        $.initialized = true;
+        emit InitializeData(initData);
+    }
+}

--- a/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
+++ b/contracts/deployables/account-abstraction/DecentPaymasterV1.sol
@@ -15,6 +15,7 @@ import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {BasePaymaster} from "./BasePaymaster.sol";
 import {LightAccountValidator} from "./LightAccountValidator.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {
     IEntryPoint
 } from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
@@ -68,6 +69,7 @@ contract DecentPaymasterV1 is
     BasePaymaster,
     LightAccountValidator,
     DeploymentBlock,
+    InitializerEventEmitter,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
     ERC165
@@ -127,6 +129,9 @@ contract DecentPaymasterV1 is
         address entryPoint_,
         address lightAccountFactory_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(
+            abi.encode(owner_, entryPoint_, lightAccountFactory_)
+        );
         __BasePaymaster_init(owner_, IEntryPoint(entryPoint_));
         __LightAccountValidator_init(lightAccountFactory_);
         __DeploymentBlock_init();

--- a/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
+++ b/contracts/deployables/autonomous-admin/DecentAutonomousAdminV1.sol
@@ -10,6 +10,7 @@ import {
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -44,6 +45,7 @@ contract DecentAutonomousAdminV1 is
     IDecentAutonomousAdminV1,
     IVersion,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -58,6 +60,7 @@ contract DecentAutonomousAdminV1 is
      * @inheritdoc IDecentAutonomousAdminV1
      */
     function initialize() public virtual override initializer {
+        __InitializerEventEmitter_init(abi.encode());
         __DeploymentBlock_init();
     }
 

--- a/contracts/deployables/countersign/CountersignV1.sol
+++ b/contracts/deployables/countersign/CountersignV1.sol
@@ -11,6 +11,7 @@ import {
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {IMultisend} from "../../interfaces/safe/IMultiSend.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {
     Ownable2StepUpgradeable
@@ -51,6 +52,7 @@ contract CountersignV1 is
     ICountersignV1,
     IVersion,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165,
     Ownable2StepUpgradeable
 {
@@ -137,6 +139,19 @@ contract CountersignV1 is
         bytes memory preExecutionTransactions_,
         SignerInitialization[] memory signerInitializations_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(
+            abi.encode(
+                owner_,
+                agreementUri_,
+                kycVerifier_,
+                signingDeadline_,
+                executionDeadline_,
+                multisend_,
+                minWeight_,
+                preExecutionTransactions_,
+                signerInitializations_
+            )
+        );
         __Ownable_init(owner_);
         __DeploymentBlock_init();
 

--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -7,6 +7,7 @@ import {
 } from "../../interfaces/decent/deployables/IVotesERC20StakedV1.sol";
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {
@@ -63,6 +64,7 @@ contract VotesERC20StakedV1 is
     UUPSUpgradeable,
     Ownable2StepUpgradeable,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     using SafeERC20 for IERC20;
@@ -141,6 +143,7 @@ contract VotesERC20StakedV1 is
         address owner_,
         address stakedToken_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(abi.encode(owner_, stakedToken_));
         __ERC20_init(
             string(
                 abi.encodePacked("Staked ", IERC20Metadata(stakedToken_).name())

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -12,6 +12,7 @@ import {
 } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {
     IAccessControl
 } from "@openzeppelin/contracts/access/IAccessControl.sol";
@@ -75,6 +76,7 @@ contract VotesERC20V1 is
     UUPSUpgradeable,
     AccessControlUpgradeable,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -174,7 +176,15 @@ contract VotesERC20V1 is
         bool locked_,
         uint256 maxTotalSupply_
     ) public virtual override initializer {
-        // Initialize inherited contracts
+        __InitializerEventEmitter_init(
+            abi.encode(
+                metadata_,
+                allocations_,
+                owner_,
+                locked_,
+                maxTotalSupply_
+            )
+        );
         __ERC20_init(metadata_.name, metadata_.symbol);
         __ERC20Permit_init(metadata_.name);
         __ERC20Votes_init();

--- a/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardAzoriusV1.sol
@@ -13,6 +13,7 @@ import {
 } from "../../interfaces/decent/deployables/IFreezeGuardBaseV1.sol";
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -51,6 +52,7 @@ contract FreezeGuardAzoriusV1 is
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -107,6 +109,7 @@ contract FreezeGuardAzoriusV1 is
         address owner_,
         address freezeVoting_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(abi.encode(owner_, freezeVoting_));
         __Ownable_init(owner_);
         __UUPSUpgradeable_init();
         __DeploymentBlock_init();

--- a/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
@@ -14,6 +14,7 @@ import {
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {Enum} from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import {IGuard} from "@gnosis-guild/zodiac/contracts/interfaces/IGuard.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -53,6 +54,7 @@ contract FreezeGuardMultisigV1 is
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -120,7 +122,15 @@ contract FreezeGuardMultisigV1 is
         address freezeVoting_,
         address childGnosisSafe_
     ) public virtual override initializer {
-        // Initialize inherited contracts
+        __InitializerEventEmitter_init(
+            abi.encode(
+                timelockPeriod_,
+                executionPeriod_,
+                owner_,
+                freezeVoting_,
+                childGnosisSafe_
+            )
+        );
         __Ownable_init(owner_);
         __UUPSUpgradeable_init();
         __DeploymentBlock_init();

--- a/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
@@ -21,6 +21,7 @@ import {
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {FreezeVotingBase} from "./FreezeVotingBase.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -57,6 +58,7 @@ contract FreezeVotingAzoriusV1 is
     IVersion,
     FreezeVotingBase,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -119,6 +121,16 @@ contract FreezeVotingAzoriusV1 is
         address parentAzorius_,
         address lightAccountFactory_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(
+            abi.encode(
+                owner_,
+                freezeVotesThreshold_,
+                freezeProposalPeriod_,
+                freezePeriod_,
+                parentAzorius_,
+                lightAccountFactory_
+            )
+        );
         __FreezeVotingBase_init(
             owner_,
             freezeProposalPeriod_,

--- a/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
@@ -15,6 +15,7 @@ import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {ISafe} from "../../interfaces/safe/ISafe.sol";
 import {FreezeVotingBase} from "./FreezeVotingBase.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -51,6 +52,7 @@ contract FreezeVotingMultisigV1 is
     IVersion,
     FreezeVotingBase,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -113,6 +115,16 @@ contract FreezeVotingMultisigV1 is
         address parentSafe_,
         address lightAccountFactory_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(
+            abi.encode(
+                owner_,
+                freezeVotesThreshold_,
+                freezeProposalPeriod_,
+                freezePeriod_,
+                parentSafe_,
+                lightAccountFactory_
+            )
+        );
         __FreezeVotingBase_init(
             owner_,
             freezeProposalPeriod_,

--- a/contracts/deployables/modules/ModuleAzoriusV1.sol
+++ b/contracts/deployables/modules/ModuleAzoriusV1.sol
@@ -9,6 +9,7 @@ import {Transaction} from "../../interfaces/decent/Module.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {
     GuardableModule
 } from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
@@ -47,6 +48,7 @@ contract ModuleAzoriusV1 is
     IVersion,
     GuardableModule,
     DeploymentBlock,
+    InitializerEventEmitter,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
     ERC165
@@ -131,6 +133,16 @@ contract ModuleAzoriusV1 is
         uint32 timelockPeriod_,
         uint32 executionPeriod_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(
+            abi.encode(
+                owner_,
+                avatar_,
+                target_,
+                strategy_,
+                timelockPeriod_,
+                executionPeriod_
+            )
+        );
         __UUPSUpgradeable_init();
         __Ownable_init(owner_);
         __DeploymentBlock_init();

--- a/contracts/deployables/modules/ModuleFractalV1.sol
+++ b/contracts/deployables/modules/ModuleFractalV1.sol
@@ -8,6 +8,7 @@ import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {Transaction} from "../../interfaces/decent/Module.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {
     GuardableModule
 } from "@gnosis-guild/zodiac/contracts/core/GuardableModule.sol";
@@ -45,6 +46,7 @@ contract ModuleFractalV1 is
     IVersion,
     GuardableModule,
     DeploymentBlock,
+    InitializerEventEmitter,
     Ownable2StepUpgradeable,
     UUPSUpgradeable,
     ERC165
@@ -65,6 +67,7 @@ contract ModuleFractalV1 is
         address avatar_,
         address target_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(abi.encode(owner_, avatar_, target_));
         __UUPSUpgradeable_init();
         __Ownable_init(owner_);
         __DeploymentBlock_init();

--- a/contracts/deployables/strategies/StrategyV1.sol
+++ b/contracts/deployables/strategies/StrategyV1.sol
@@ -17,6 +17,7 @@ import {
     LightAccountValidator
 } from "../account-abstraction/LightAccountValidator.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -41,6 +42,7 @@ contract StrategyV1 is
     IStrategyV1,
     IVersion,
     DeploymentBlock,
+    InitializerEventEmitter,
     LightAccountValidator,
     ERC165
 {
@@ -157,6 +159,15 @@ contract StrategyV1 is
         // Initialize parent contracts
         __LightAccountValidator_init(lightAccountFactory_);
         __DeploymentBlock_init();
+        __InitializerEventEmitter_init(
+            abi.encode(
+                votingPeriod_,
+                quorumThreshold_,
+                basisNumerator_,
+                proposerAdapters_,
+                lightAccountFactory_
+            )
+        );
 
         // Store voting configuration
         StrategyStorage storage $ = _getStrategyStorage();

--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.sol
@@ -12,6 +12,7 @@ import {
     IDeploymentBlock
 } from "../../../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../../../InitializerEventEmitter.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
@@ -37,6 +38,7 @@ contract ProposerAdapterERC20V1 is
     IProposerAdapterERC20V1,
     IVersion,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -95,6 +97,7 @@ contract ProposerAdapterERC20V1 is
         address token_,
         uint256 proposerThreshold_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(abi.encode(token_, proposerThreshold_));
         __DeploymentBlock_init();
 
         ProposerAdapterERC20Storage

--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.sol
@@ -12,6 +12,7 @@ import {
     IDeploymentBlock
 } from "../../../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../../../InitializerEventEmitter.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
@@ -37,6 +38,7 @@ contract ProposerAdapterERC721V1 is
     IProposerAdapterERC721V1,
     DeploymentBlock,
     IVersion,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -95,6 +97,7 @@ contract ProposerAdapterERC721V1 is
         address token_,
         uint256 proposerThreshold_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(abi.encode(token_, proposerThreshold_));
         __DeploymentBlock_init();
 
         ProposerAdapterERC721Storage

--- a/contracts/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.sol
+++ b/contracts/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.sol
@@ -13,6 +13,7 @@ import {
     IDeploymentBlock
 } from "../../../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../../../InitializerEventEmitter.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -37,6 +38,7 @@ contract ProposerAdapterHatsV1 is
     IProposerAdapterHatsV1,
     IVersion,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -97,6 +99,9 @@ contract ProposerAdapterHatsV1 is
         address hatsContract_,
         uint256[] calldata whitelistedHatIds_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(
+            abi.encode(hatsContract_, whitelistedHatIds_)
+        );
         __DeploymentBlock_init();
 
         ProposerAdapterHatsStorage storage $ = _getProposerAdapterHatsStorage();

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC20V1.sol
@@ -17,6 +17,7 @@ import {
 } from "../../../../interfaces/decent/IDeploymentBlock.sol";
 import {VotingAdapterBase} from "./VotingAdapterBase.sol";
 import {DeploymentBlock} from "../../../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../../../InitializerEventEmitter.sol";
 import {ClockModeLib} from "../../../../libs/ClockModeLib.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -50,6 +51,7 @@ contract VotingAdapterERC20V1 is
     IVersion,
     VotingAdapterBase,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -115,6 +117,9 @@ contract VotingAdapterERC20V1 is
         address strategy_,
         uint256 weightPerToken_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(
+            abi.encode(token_, strategy_, weightPerToken_)
+        );
         __VotingAdapterBase_init(strategy_);
         __DeploymentBlock_init();
 

--- a/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
+++ b/contracts/deployables/strategies/adapters/voting/VotingAdapterERC721V1.sol
@@ -13,6 +13,7 @@ import {
 } from "../../../../interfaces/decent/IDeploymentBlock.sol";
 import {VotingAdapterBase} from "./VotingAdapterBase.sol";
 import {DeploymentBlock} from "../../../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../../../InitializerEventEmitter.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
@@ -39,6 +40,7 @@ contract VotingAdapterERC721V1 is
     IVersion,
     VotingAdapterBase,
     DeploymentBlock,
+    InitializerEventEmitter,
     ERC165
 {
     // ======================================================================
@@ -100,6 +102,9 @@ contract VotingAdapterERC721V1 is
         address strategy_,
         uint256 weightPerToken_
     ) public virtual override initializer {
+        __InitializerEventEmitter_init(
+            abi.encode(token_, strategy_, weightPerToken_)
+        );
         __VotingAdapterBase_init(strategy_);
         __DeploymentBlock_init();
 

--- a/contracts/mocks/concretes/ConcreteInitializerEventEmitter.sol
+++ b/contracts/mocks/concretes/ConcreteInitializerEventEmitter.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.30;
+
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
+
+/**
+ * @title ConcreteInitializerEventEmitter
+ * @author Decent Labs
+ * @notice Concrete implementation of InitializerEventEmitter for testing
+ * @dev This contract is used to test the InitializerEventEmitter abstract contract
+ * in isolation. It provides a minimal implementation with standard test scenarios.
+ */
+contract ConcreteInitializerEventEmitter is InitializerEventEmitter {
+    /**
+     * @notice Constructor disables initializers to prevent implementation initialization
+     * @dev Standard pattern for upgradeable contract implementations
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initializes the contract and emits initialization data
+     * @dev Standard initializer that calls the parent __InitializerEventEmitter_init
+     * @param initData_ The initialization data to emit
+     */
+    function initialize(bytes memory initData_) external initializer {
+        __InitializerEventEmitter_init(initData_);
+    }
+
+    /**
+     * @notice Attempts to reinitialize the contract (should fail)
+     * @dev This function is used to test that __InitializerEventEmitter_init
+     * cannot be called after initialization due to onlyInitializing modifier
+     * @param initData_ The initialization data to emit
+     */
+    function reinitialize(bytes memory initData_) external reinitializer(2) {
+        __InitializerEventEmitter_init(initData_);
+    }
+}

--- a/contracts/services/kyc/KYCVerifierV1.sol
+++ b/contracts/services/kyc/KYCVerifierV1.sol
@@ -7,6 +7,7 @@ import {
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
 import {DeploymentBlock} from "../../DeploymentBlock.sol";
+import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -31,7 +32,13 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  *
  * @custom:security-contact security@decentlabs.io
  */
-contract KYCVerifierV1 is IKYCVerifierV1, IVersion, DeploymentBlock, ERC165 {
+contract KYCVerifierV1 is
+    IKYCVerifierV1,
+    IVersion,
+    DeploymentBlock,
+    InitializerEventEmitter,
+    ERC165
+{
     // ======================================================================
     // CONSTRUCTOR & INITIALIZERS
     // ======================================================================
@@ -46,6 +53,7 @@ contract KYCVerifierV1 is IKYCVerifierV1, IVersion, DeploymentBlock, ERC165 {
      * this would also initialize KYC provider integrations and access controls.
      */
     function initialize() public virtual override initializer {
+        __InitializerEventEmitter_init(abi.encode());
         __DeploymentBlock_init();
     }
 

--- a/test/unit/InitializerEventEmitter.test.ts
+++ b/test/unit/InitializerEventEmitter.test.ts
@@ -1,0 +1,169 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import type { ContractTransactionReceipt } from 'ethers';
+import { ethers } from 'hardhat';
+import {
+  ConcreteInitializerEventEmitter,
+  ConcreteInitializerEventEmitter__factory,
+  ERC1967Proxy__factory,
+} from '../../typechain-types';
+
+describe('InitializerEventEmitter', () => {
+  let deployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+
+  let concreteInitializerEventEmitter: ConcreteInitializerEventEmitter;
+  let masterCopy: string;
+  let initTxReceipt: ContractTransactionReceipt;
+  let testInitData: string;
+
+  beforeEach(async () => {
+    // Get signers
+    [deployer, owner] = await ethers.getSigners();
+
+    // Deploy master copy
+    masterCopy = await (
+      await new ConcreteInitializerEventEmitter__factory(deployer).deploy()
+    ).getAddress();
+
+    // Prepare test initialization data
+    testInitData = ethers.AbiCoder.defaultAbiCoder().encode(
+      ['address', 'uint256', 'string'],
+      [owner.address, 12345n, 'test initialization'],
+    );
+
+    // Deploy proxy with initialization
+    const initData = ConcreteInitializerEventEmitter__factory.createInterface().encodeFunctionData(
+      'initialize',
+      [testInitData],
+    );
+    const proxy = await new ERC1967Proxy__factory(deployer).deploy(masterCopy, initData);
+
+    // Get the deployment transaction receipt
+    const deploymentTx = proxy.deploymentTransaction();
+    if (!deploymentTx) {
+      throw new Error('Deployment transaction is null');
+    }
+
+    const receipt = await deploymentTx.wait();
+    if (!receipt) {
+      throw new Error('Deployment transaction receipt is null');
+    }
+
+    initTxReceipt = receipt;
+
+    // Connect to the proxy
+    concreteInitializerEventEmitter = ConcreteInitializerEventEmitter__factory.connect(
+      await proxy.getAddress(),
+      owner,
+    );
+  });
+
+  describe('Initialization', () => {
+    it('should emit InitializeData event with correct data during proxy deployment', async () => {
+      // Find the InitializeData event in the deployment transaction
+      const events = initTxReceipt.logs
+        .map((log: any) => {
+          try {
+            return concreteInitializerEventEmitter.interface.parseLog(log);
+          } catch {
+            return null;
+          }
+        })
+        .filter((event: any) => event !== null);
+
+      const initializeDataEvent = events.find((event: any) => event?.name === 'InitializeData');
+
+      expect(initializeDataEvent).to.not.be.undefined;
+      expect(initializeDataEvent?.args.initData).to.equal(testInitData);
+    });
+
+    it('should not allow reinitialization', async () => {
+      const newInitData = ethers.AbiCoder.defaultAbiCoder().encode(['address'], [deployer.address]);
+
+      await expect(
+        concreteInitializerEventEmitter.initialize(newInitData),
+      ).to.be.revertedWithCustomError(concreteInitializerEventEmitter, 'InvalidInitialization');
+    });
+
+    it('should not allow reinitialization to emit the event again', async () => {
+      const newInitData = ethers.AbiCoder.defaultAbiCoder().encode(['address'], [deployer.address]);
+
+      // The reinitialize(2) function should revert because __InitializerEventEmitter_init
+      // can only be called once due to the internal check
+      await expect(
+        concreteInitializerEventEmitter.reinitialize(newInitData),
+      ).to.be.revertedWithCustomError(
+        concreteInitializerEventEmitter,
+        'InitializeDataAlreadyEmitted',
+      );
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle empty initialization data via proxy', async () => {
+      // Deploy new proxy with empty data
+      const emptyData = '0x';
+      const initData =
+        ConcreteInitializerEventEmitter__factory.createInterface().encodeFunctionData(
+          'initialize',
+          [emptyData],
+        );
+      const emptyProxy = await new ERC1967Proxy__factory(deployer).deploy(masterCopy, initData);
+      const emptyTxReceipt = await emptyProxy.deploymentTransaction()?.wait();
+
+      // Check the event was emitted with empty data
+      const emptyContract = ConcreteInitializerEventEmitter__factory.connect(
+        await emptyProxy.getAddress(),
+        owner,
+      );
+
+      const events = emptyTxReceipt?.logs
+        .map(log => {
+          try {
+            return emptyContract.interface.parseLog(log);
+          } catch {
+            return null;
+          }
+        })
+        .filter(e => e !== null && e?.name === 'InitializeData');
+
+      expect(events || []).to.have.lengthOf(1);
+      expect(events?.[0]?.args.initData).to.equal(emptyData);
+    });
+
+    it('should handle large initialization data via proxy', async () => {
+      // Create large initialization data (1KB of data)
+      const largeArray = new Array(32).fill(ethers.ZeroHash);
+      const largeInitData = ethers.AbiCoder.defaultAbiCoder().encode(['bytes32[]'], [largeArray]);
+
+      // Deploy new proxy with large data
+      const initData =
+        ConcreteInitializerEventEmitter__factory.createInterface().encodeFunctionData(
+          'initialize',
+          [largeInitData],
+        );
+      const largeProxy = await new ERC1967Proxy__factory(deployer).deploy(masterCopy, initData);
+      const largeTxReceipt = await largeProxy.deploymentTransaction()?.wait();
+
+      // Check the event was emitted with the large data
+      const largeContract = ConcreteInitializerEventEmitter__factory.connect(
+        await largeProxy.getAddress(),
+        owner,
+      );
+
+      const events = largeTxReceipt?.logs
+        .map(log => {
+          try {
+            return largeContract.interface.parseLog(log);
+          } catch {
+            return null;
+          }
+        })
+        .filter(e => e !== null && e?.name === 'InitializeData');
+
+      expect(events || []).to.have.lengthOf(1);
+      expect(events?.[0]?.args.initData).to.equal(largeInitData);
+    });
+  });
+});

--- a/test/unit/deployables/account-abstraction/DecentPaymasterV1.test.ts
+++ b/test/unit/deployables/account-abstraction/DecentPaymasterV1.test.ts
@@ -23,6 +23,7 @@ import {
   MockValidator__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests';
 
@@ -397,6 +398,25 @@ describe('DecentPaymasterV1', function () {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => decentPaymaster,
+    });
+  });
+
+  // Test InitializerEventEmitter functionality
+  describe('InitializerEventEmitter', () => {
+    runInitializerEventEmitterTests({
+      contractFactory: DecentPaymasterV1__factory,
+      masterCopy: async () => await masterCopy.getAddress(),
+      deployer: () => owner,
+      initializeParams: async () => [
+        owner.address,
+        await entryPoint.getAddress(),
+        mockLightAccountFactoryAddress,
+      ],
+      getExpectedInitData: async () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'address', 'address'],
+          [owner.address, await entryPoint.getAddress(), mockLightAccountFactoryAddress],
+        ),
     });
   });
 });

--- a/test/unit/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
+++ b/test/unit/deployables/autonomous-admin/DecentAutonomousAdminV1.test.ts
@@ -11,6 +11,7 @@ import {
   IVersion__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 
 // Helper function for deploying DecentAutonomousAdminV1 instances using ERC1967Proxy
@@ -69,6 +70,24 @@ describe('DecentAutonomousAdminV1', function () {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => decentAutonomousAdmin,
+    });
+  });
+
+  // Test InitializerEventEmitter functionality
+  describe('InitializerEventEmitter', () => {
+    let deployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [deployer] = await ethers.getSigners();
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: DecentAutonomousAdminV1__factory,
+      masterCopy: async () =>
+        await (await new DecentAutonomousAdminV1__factory(deployer).deploy()).getAddress(),
+      deployer: () => deployer,
+      initializeParams: () => [],
+      getExpectedInitData: () => ethers.AbiCoder.defaultAbiCoder().encode([], []),
     });
   });
 });

--- a/test/unit/deployables/countersign/CountersignV1.test.ts
+++ b/test/unit/deployables/countersign/CountersignV1.test.ts
@@ -18,6 +18,7 @@ import {
   MultiSendCallOnly__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 
 // Helper function for deploying Countersign instances using ERC1967Proxy
@@ -1006,6 +1007,115 @@ describe('CountersignV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => countersign,
+    });
+  });
+
+  // Test InitializerEventEmitter functionality
+  describe('InitializerEventEmitter', () => {
+    // Shared test data
+    let testFounder: SignerWithAddress;
+    let testInvestorAlice: SignerWithAddress;
+    let testMockKYCVerifierAddress: string;
+    let testMultisendAddress: string;
+    let testSigningDeadline: bigint;
+    let testExecutionDeadline: bigint;
+
+    // Deploy contracts once before all tests
+    beforeEach(async () => {
+      [testFounder, testInvestorAlice] = await ethers.getSigners();
+      const testMockKYCVerifier = await new MockKYCVerifier__factory(testFounder).deploy();
+      const testMultisend = await new MultiSendCallOnly__factory(testFounder).deploy();
+
+      testMockKYCVerifierAddress = await testMockKYCVerifier.getAddress();
+      testMultisendAddress = await testMultisend.getAddress();
+
+      const currentTime = await time.latest();
+      testSigningDeadline = BigInt(currentTime + 100);
+      testExecutionDeadline = BigInt(currentTime + 200);
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: CountersignV1__factory,
+      masterCopy: async () =>
+        await (await new CountersignV1__factory(testFounder).deploy()).getAddress(),
+      deployer: () => testFounder,
+      initializeParams: () => {
+        // Simple signers with minimal transactions
+        const testSignerTransactions = [
+          {
+            account: testFounder.address,
+            required: true,
+            weight: 0,
+            transactions: '0x', // empty bytes
+          },
+          {
+            account: testInvestorAlice.address,
+            required: false,
+            weight: ethers.parseEther('100'),
+            transactions: '0x', // empty bytes
+          },
+        ];
+
+        // Simple pre-execution transactions
+        const testPreExecutionTransactions = '0x';
+
+        return [
+          testFounder.address,
+          agreementUri,
+          testMockKYCVerifierAddress,
+          testSigningDeadline,
+          testExecutionDeadline,
+          testMultisendAddress,
+          ethers.parseEther('150'), // minWeight
+          testPreExecutionTransactions,
+          testSignerTransactions,
+        ];
+      },
+      getExpectedInitData: () => {
+        // Simple signers with minimal transactions
+        const testSignerTransactions = [
+          {
+            account: testFounder.address,
+            required: true,
+            weight: 0,
+            transactions: '0x', // empty bytes
+          },
+          {
+            account: testInvestorAlice.address,
+            required: false,
+            weight: ethers.parseEther('100'),
+            transactions: '0x', // empty bytes
+          },
+        ];
+
+        // Simple pre-execution transactions
+        const testPreExecutionTransactions = '0x';
+
+        return ethers.AbiCoder.defaultAbiCoder().encode(
+          [
+            'address',
+            'string',
+            'address',
+            'uint48',
+            'uint48',
+            'address',
+            'uint256',
+            'bytes',
+            'tuple(address account, bool required, uint256 weight, bytes transactions)[]',
+          ],
+          [
+            testFounder.address,
+            agreementUri,
+            testMockKYCVerifierAddress,
+            testSigningDeadline,
+            testExecutionDeadline,
+            testMultisendAddress,
+            ethers.parseEther('150'),
+            testPreExecutionTransactions,
+            testSignerTransactions,
+          ],
+        );
+      },
     });
   });
 });

--- a/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -16,6 +16,7 @@ import {
   VotesERC20StakedV1__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests';
 
@@ -1905,6 +1906,20 @@ describe('VotesERC20StakedV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => votesERC20Staked,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    runInitializerEventEmitterTests({
+      contractFactory: VotesERC20StakedV1__factory,
+      masterCopy: () => masterCopy,
+      deployer: () => proxyDeployer,
+      initializeParams: async () => [owner.address, await stakedToken.getAddress()],
+      getExpectedInitData: async () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'address'],
+          [owner.address, await stakedToken.getAddress()],
+        ),
     });
   });
 });

--- a/test/unit/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20V1.test.ts
@@ -17,6 +17,7 @@ import {
   VotesERC20V1__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests';
 
@@ -1071,6 +1072,47 @@ describe('VotesERC20V1', () => {
 
     runDeploymentBlockTests({
       getContract: () => votesERC20,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    let deployer: SignerWithAddress;
+    let ownerSigner: SignerWithAddress;
+
+    beforeEach(async () => {
+      [deployer, ownerSigner] = await ethers.getSigners();
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: VotesERC20V1__factory,
+      masterCopy: async () =>
+        await (await new VotesERC20V1__factory(deployer).deploy()).getAddress(),
+      deployer: () => deployer,
+      initializeParams: () => [
+        { name: 'Test Token', symbol: 'TEST' },
+        [],
+        ownerSigner.address,
+        false,
+        ethers.parseEther('1000000'),
+      ],
+      getExpectedInitData: async () => {
+        return ethers.AbiCoder.defaultAbiCoder().encode(
+          [
+            'tuple(string name, string symbol)',
+            'tuple(address to, uint256 amount)[]',
+            'address',
+            'bool',
+            'uint256',
+          ],
+          [
+            { name: 'Test Token', symbol: 'TEST' },
+            [],
+            ownerSigner.address,
+            false,
+            ethers.parseEther('1000000'),
+          ],
+        );
+      },
     });
   });
 });

--- a/test/unit/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
+++ b/test/unit/deployables/freeze-guard/FreezeGuardAzoriusV1.test.ts
@@ -15,6 +15,7 @@ import {
   MockFreezeVoting__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests';
 
@@ -271,6 +272,20 @@ describe('FreezeGuardAzoriusV1', () => {
 
     runDeploymentBlockTests({
       getContract: () => azoriusFreezeGuard,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    runInitializerEventEmitterTests({
+      contractFactory: FreezeGuardAzoriusV1__factory,
+      masterCopy: () => masterCopy,
+      deployer: () => proxyDeployer,
+      initializeParams: async () => [owner.address, await mockFreezeVoting.getAddress()],
+      getExpectedInitData: async () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'address'],
+          [owner.address, await mockFreezeVoting.getAddress()],
+        ),
     });
   });
 });

--- a/test/unit/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
+++ b/test/unit/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
@@ -18,6 +18,7 @@ import {
   MockSafe__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests';
 
@@ -495,6 +496,32 @@ describe('FreezeGuardMultisigV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => multisigFreezeGuard,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    runInitializerEventEmitterTests({
+      contractFactory: FreezeGuardMultisigV1__factory,
+      masterCopy: () => masterCopy,
+      deployer: () => proxyDeployer,
+      initializeParams: async () => [
+        TIMELOCK_PERIOD,
+        EXECUTION_PERIOD,
+        owner.address,
+        await mockFreezeVoting.getAddress(),
+        await mockSafe.getAddress(),
+      ],
+      getExpectedInitData: async () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['uint32', 'uint32', 'address', 'address', 'address'],
+          [
+            TIMELOCK_PERIOD,
+            EXECUTION_PERIOD,
+            owner.address,
+            await mockFreezeVoting.getAddress(),
+            await mockSafe.getAddress(),
+          ],
+        ),
     });
   });
 });

--- a/test/unit/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
+++ b/test/unit/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
@@ -23,6 +23,7 @@ import {
   MockVotingStrategy__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 
 async function deployAzoriusFreezeVotingProxy(
@@ -361,6 +362,34 @@ describe('FreezeVotingAzoriusV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => azoriusFreezeVoting,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    runInitializerEventEmitterTests({
+      contractFactory: FreezeVotingAzoriusV1__factory,
+      masterCopy: () => azoriusFreezeVotingImplementationAddress,
+      deployer: () => deployer,
+      initializeParams: async () => [
+        owner.address,
+        DEFAULT_FREEZE_VOTES_THRESHOLD,
+        DEFAULT_FREEZE_PROPOSAL_PERIOD,
+        DEFAULT_FREEZE_PERIOD,
+        await mockParentAzorius.getAddress(),
+        mockLightAccountFactory.target as string,
+      ],
+      getExpectedInitData: async () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'uint256', 'uint32', 'uint32', 'address', 'address'],
+          [
+            owner.address,
+            DEFAULT_FREEZE_VOTES_THRESHOLD,
+            DEFAULT_FREEZE_PROPOSAL_PERIOD,
+            DEFAULT_FREEZE_PERIOD,
+            await mockParentAzorius.getAddress(),
+            mockLightAccountFactory.target as string,
+          ],
+        ),
     });
   });
 });

--- a/test/unit/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
+++ b/test/unit/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
@@ -20,6 +20,7 @@ import {
   MockSafe__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 
 // Helper function for deploying MultisigFreezeVotingV1 proxy instances using ERC1967Proxy
@@ -605,6 +606,48 @@ describe('FreezeVotingMultisigV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => freezeVoting,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    let deployer: SignerWithAddress;
+    let testOwner: SignerWithAddress;
+    let testMockSafeAddress: string;
+    let lightAccountFactoryAddress: string;
+
+    beforeEach(async () => {
+      [deployer, testOwner] = await ethers.getSigners();
+      const testMockSafe = await new MockSafe__factory(testOwner).deploy();
+      const lightAccountFactory = await new MockLightAccountFactory__factory(testOwner).deploy();
+      testMockSafeAddress = await testMockSafe.getAddress();
+      lightAccountFactoryAddress = lightAccountFactory.target as string;
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: FreezeVotingMultisigV1__factory,
+      masterCopy: async () =>
+        await (await new FreezeVotingMultisigV1__factory(deployer).deploy()).getAddress(),
+      deployer: () => deployer,
+      initializeParams: () => [
+        testOwner.address,
+        FREEZE_VOTES_THRESHOLD,
+        FREEZE_PROPOSAL_PERIOD,
+        FREEZE_PERIOD,
+        testMockSafeAddress,
+        lightAccountFactoryAddress,
+      ],
+      getExpectedInitData: () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'uint256', 'uint32', 'uint32', 'address', 'address'],
+          [
+            testOwner.address,
+            FREEZE_VOTES_THRESHOLD,
+            FREEZE_PROPOSAL_PERIOD,
+            FREEZE_PERIOD,
+            testMockSafeAddress,
+            lightAccountFactoryAddress,
+          ],
+        ),
     });
   });
 });

--- a/test/unit/deployables/modules/ModuleAzoriusV1.test.ts
+++ b/test/unit/deployables/modules/ModuleAzoriusV1.test.ts
@@ -20,6 +20,10 @@ import {
   UUPSUpgradeable,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import {
+  ContractFactory,
+  runInitializerEventEmitterTests,
+} from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests';
 
@@ -1573,6 +1577,28 @@ describe('ModuleAzoriusV1', () => {
 
     runDeploymentBlockTests({
       getContract: () => azorius as unknown as IDeploymentBlock,
+    });
+  });
+
+  // Test InitializerEventEmitter functionality
+  describe('InitializerEventEmitter', () => {
+    runInitializerEventEmitterTests({
+      contractFactory: ModuleAzoriusV1__factory as unknown as ContractFactory,
+      masterCopy: () => masterCopy,
+      deployer: () => proxyDeployer,
+      initializeParams: () => [
+        owner.address,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        mockStrategyAddress,
+        0,
+        0,
+      ],
+      getExpectedInitData: () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'address', 'address', 'address', 'uint32', 'uint32'],
+          [owner.address, ethers.ZeroAddress, ethers.ZeroAddress, mockStrategyAddress, 0, 0],
+        ),
     });
   });
 });

--- a/test/unit/deployables/modules/ModuleFractalV1.test.ts
+++ b/test/unit/deployables/modules/ModuleFractalV1.test.ts
@@ -17,6 +17,10 @@ import {
   UUPSUpgradeable,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import {
+  ContractFactory,
+  runInitializerEventEmitterTests,
+} from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 import { runUUPSUpgradeabilityTests } from '../../shared/uupsUpgradeabilityTests';
 
@@ -470,6 +474,21 @@ describe('ModuleFractalV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => sharedFractalModule as unknown as IDeploymentBlock,
+    });
+  });
+
+  // Test InitializerEventEmitter functionality
+  describe('InitializerEventEmitter', () => {
+    runInitializerEventEmitterTests({
+      contractFactory: ModuleFractalV1__factory as unknown as ContractFactory,
+      masterCopy: () => masterCopy,
+      deployer: () => proxyDeployer,
+      initializeParams: () => [owner.address, ethers.ZeroAddress, ethers.ZeroAddress],
+      getExpectedInitData: () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'address', 'address'],
+          [owner.address, ethers.ZeroAddress, ethers.ZeroAddress],
+        ),
     });
   });
 });

--- a/test/unit/deployables/strategies/StrategyV1.test.ts
+++ b/test/unit/deployables/strategies/StrategyV1.test.ts
@@ -20,6 +20,7 @@ import {
   StrategyV1__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 
 describe('StrategyV1', () => {
@@ -2040,6 +2041,39 @@ describe('StrategyV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => strategy,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    let testDeployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [testDeployer] = await ethers.getSigners();
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: StrategyV1__factory,
+      masterCopy: async () =>
+        await (await new StrategyV1__factory(testDeployer).deploy()).getAddress(),
+      deployer: () => testDeployer,
+      initializeParams: () => [
+        DEFAULT_VOTING_PERIOD,
+        DEFAULT_QUORUM_THRESHOLD,
+        DEFAULT_BASIS_NUMERATOR,
+        defaultInitialProposerAdapters,
+        lightAccountFactoryMockAddress,
+      ],
+      getExpectedInitData: async () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['uint32', 'uint256', 'uint256', 'address[]', 'address'],
+          [
+            DEFAULT_VOTING_PERIOD,
+            DEFAULT_QUORUM_THRESHOLD,
+            DEFAULT_BASIS_NUMERATOR,
+            defaultInitialProposerAdapters,
+            lightAccountFactoryMockAddress,
+          ],
+        ),
     });
   });
 });

--- a/test/unit/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.test.ts
+++ b/test/unit/deployables/strategies/adapters/proposer/ProposerAdapterERC20V1.test.ts
@@ -14,6 +14,7 @@ import {
   ProposerAdapterERC20V1__factory,
 } from '../../../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../../../shared/supportsInterfaceTests';
 
 async function deployERC20ProposerAdapterProxy(
@@ -162,6 +163,30 @@ describe('ProposerAdapterERC20V1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => adapter,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    let testMockTokenAddress: string;
+    let testDeployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [testDeployer] = await ethers.getSigners();
+      const testMockToken = await new MockERC20Votes__factory(testDeployer).deploy();
+      testMockTokenAddress = await testMockToken.getAddress();
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: ProposerAdapterERC20V1__factory,
+      masterCopy: async () =>
+        await (await new ProposerAdapterERC20V1__factory(testDeployer).deploy()).getAddress(),
+      deployer: () => testDeployer,
+      initializeParams: () => [testMockTokenAddress, DEFAULT_PROPOSER_THRESHOLD],
+      getExpectedInitData: () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'uint256'],
+          [testMockTokenAddress, DEFAULT_PROPOSER_THRESHOLD],
+        ),
     });
   });
 });

--- a/test/unit/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.test.ts
+++ b/test/unit/deployables/strategies/adapters/proposer/ProposerAdapterERC721V1.test.ts
@@ -14,6 +14,7 @@ import {
   ProposerAdapterERC721V1__factory,
 } from '../../../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../../../shared/supportsInterfaceTests';
 
 async function deployERC721ProposerAdapterProxy(
@@ -150,6 +151,30 @@ describe('ProposerAdapterERC721V1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => adapter,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    let testMockNftAddress: string;
+    let testDeployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [testDeployer] = await ethers.getSigners();
+      const testMockNft = await new MockERC721__factory(testDeployer).deploy();
+      testMockNftAddress = await testMockNft.getAddress();
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: ProposerAdapterERC721V1__factory,
+      masterCopy: async () =>
+        await (await new ProposerAdapterERC721V1__factory(testDeployer).deploy()).getAddress(),
+      deployer: () => testDeployer,
+      initializeParams: () => [testMockNftAddress, DEFAULT_PROPOSER_THRESHOLD],
+      getExpectedInitData: () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'uint256'],
+          [testMockNftAddress, DEFAULT_PROPOSER_THRESHOLD],
+        ),
     });
   });
 });

--- a/test/unit/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
+++ b/test/unit/deployables/strategies/adapters/proposer/ProposerAdapterHatsV1.test.ts
@@ -14,6 +14,7 @@ import {
   ProposerAdapterHatsV1__factory,
 } from '../../../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../../../shared/supportsInterfaceTests';
 
 async function deployHatsProposerAdapterProxy(
@@ -233,6 +234,32 @@ describe('ProposerAdapterHatsV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => adapter,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    const HAT_ID_3 = BigInt('0x0000000100000000000000000000000000000000000000000000000000000000');
+    const HAT_ID_4 = BigInt('0x0000000100010000000000000000000000000000000000000000000000000000');
+    let testMockHatsAddress: string;
+    let testDeployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [testDeployer] = await ethers.getSigners();
+      const testMockHats = await new MockHats__factory(testDeployer).deploy();
+      testMockHatsAddress = await testMockHats.getAddress();
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: ProposerAdapterHatsV1__factory,
+      masterCopy: async () =>
+        await (await new ProposerAdapterHatsV1__factory(testDeployer).deploy()).getAddress(),
+      deployer: () => testDeployer,
+      initializeParams: () => [testMockHatsAddress, [HAT_ID_3, HAT_ID_4]],
+      getExpectedInitData: () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'uint256[]'],
+          [testMockHatsAddress, [HAT_ID_3, HAT_ID_4]],
+        ),
     });
   });
 });

--- a/test/unit/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
+++ b/test/unit/deployables/strategies/adapters/voting/VotingAdapterERC20V1.test.ts
@@ -17,6 +17,7 @@ import {
   VotingAdapterERC20V1__factory,
 } from '../../../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../../../shared/supportsInterfaceTests';
 
 // Modified helper function to return deployment tx hash
@@ -1342,6 +1343,39 @@ describe('VotingAdapterERC20V1', () => {
 
     runDeploymentBlockTests({
       getContract: () => adapter,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    let testMockTokenAddress: string;
+    let testMockStrategyAddress: string;
+    let testDeployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [testDeployer] = await ethers.getSigners();
+      const testMockToken = await new MockERC20Votes__factory(testDeployer).deploy();
+      const testMockStrategy = await new MockVotingStrategy__factory(testDeployer).deploy(
+        testDeployer,
+      );
+      testMockTokenAddress = await testMockToken.getAddress();
+      testMockStrategyAddress = await testMockStrategy.getAddress();
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: VotingAdapterERC20V1__factory,
+      masterCopy: async () =>
+        await (await new VotingAdapterERC20V1__factory(testDeployer).deploy()).getAddress(),
+      deployer: () => testDeployer,
+      initializeParams: () => [
+        testMockTokenAddress,
+        testMockStrategyAddress,
+        DEFAULT_WEIGHT_PER_TOKEN,
+      ],
+      getExpectedInitData: () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'address', 'uint256'],
+          [testMockTokenAddress, testMockStrategyAddress, DEFAULT_WEIGHT_PER_TOKEN],
+        ),
     });
   });
 });

--- a/test/unit/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
+++ b/test/unit/deployables/strategies/adapters/voting/VotingAdapterERC721V1.test.ts
@@ -17,6 +17,7 @@ import {
   VotingAdapterERC721V1__factory,
 } from '../../../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../../../shared/supportsInterfaceTests';
 
 async function deployERC721AdapterProxy(
@@ -1727,6 +1728,33 @@ describe('VotingAdapterERC721V1', () => {
 
     runDeploymentBlockTests({
       getContract: () => adapter,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    let testMockNftAddress: string;
+    let testStrategyAddress: string;
+    let testDeployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [testDeployer] = await ethers.getSigners();
+      const testMockNft = await new MockERC721__factory(testDeployer).deploy();
+      const testStrategy = await new MockVotingStrategy__factory(testDeployer).deploy(testDeployer);
+      testMockNftAddress = await testMockNft.getAddress();
+      testStrategyAddress = await testStrategy.getAddress();
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: VotingAdapterERC721V1__factory,
+      masterCopy: async () =>
+        await (await new VotingAdapterERC721V1__factory(testDeployer).deploy()).getAddress(),
+      deployer: () => testDeployer,
+      initializeParams: () => [testMockNftAddress, testStrategyAddress, DEFAULT_WEIGHT_PER_NFT],
+      getExpectedInitData: () =>
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['address', 'address', 'uint256'],
+          [testMockNftAddress, testStrategyAddress, DEFAULT_WEIGHT_PER_NFT],
+        ),
     });
   });
 });

--- a/test/unit/services/kyc/KYCVerifierV1.test.ts
+++ b/test/unit/services/kyc/KYCVerifierV1.test.ts
@@ -11,6 +11,7 @@ import {
   KYCVerifierV1__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
+import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
 
 // Helper function for deploying Countersign instances using ERC1967Proxy
@@ -81,6 +82,23 @@ describe('KYCVerifierV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => kycVerifier,
+    });
+  });
+
+  describe('InitializerEventEmitter', () => {
+    let testDeployer: SignerWithAddress;
+
+    beforeEach(async () => {
+      [testDeployer] = await ethers.getSigners();
+    });
+
+    runInitializerEventEmitterTests({
+      contractFactory: KYCVerifierV1__factory,
+      masterCopy: async () =>
+        await (await new KYCVerifierV1__factory(testDeployer).deploy()).getAddress(),
+      deployer: () => testDeployer,
+      initializeParams: () => [],
+      getExpectedInitData: async () => ethers.AbiCoder.defaultAbiCoder().encode([], []),
     });
   });
 });

--- a/test/unit/shared/initializerEventEmitterTests.ts
+++ b/test/unit/shared/initializerEventEmitterTests.ts
@@ -1,0 +1,166 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { expect } from 'chai';
+import type { BaseContract, Interface, TransactionReceipt } from 'ethers';
+import { ERC1967Proxy__factory } from '../../../typechain-types';
+
+/**
+ * Shared test utilities for testing InitializerEventEmitter functionality
+ * Used by all contracts that implement InitializerEventEmitter
+ */
+
+export type ContractFactory = {
+  createInterface(): Interface;
+  connect(address: string, signer: SignerWithAddress): BaseContract;
+};
+
+/**
+ * Parameters for running the InitializerEventEmitter tests
+ */
+interface InitializerEventEmitterTestParams {
+  /**
+   * Factory for the contract being tested (typechain generated factory)
+   */
+  contractFactory: ContractFactory;
+
+  /**
+   * The master copy address of the implementation contract
+   * Can be a string or a function that returns a string/Promise<string>
+   */
+  masterCopy: () => string | Promise<string>;
+
+  /**
+   * The deployer signer
+   * Can be a SignerWithAddress or a function that returns one
+   */
+  deployer: () => SignerWithAddress;
+
+  /**
+   * Initialize function parameters to use for deployment
+   * Can be an array or a function that returns an array/Promise<array>
+   */
+  initializeParams: () => any[] | Promise<any[]>;
+
+  /**
+   * Optional: custom encoding of the expected init data
+   * If not provided, will use abi.encode of initializeParams
+   */
+  getExpectedInitData: () => string | Promise<string>;
+}
+
+/**
+ * Run all the InitializerEventEmitter tests on the given contract
+ * @param params The test parameters
+ */
+export function runInitializerEventEmitterTests(params: InitializerEventEmitterTestParams): void {
+  let contract: BaseContract;
+  let initTxReceipt: TransactionReceipt;
+  let expectedInitData: string;
+
+  beforeEach(async function () {
+    const masterCopy = await params.masterCopy();
+    const deployer = params.deployer();
+    const initializeParams = await params.initializeParams();
+
+    // Encode the initialization data
+    const fullInitData = params.contractFactory
+      .createInterface()
+      .encodeFunctionData('initialize', initializeParams);
+
+    // Deploy proxy with initialization
+    const proxy = await new ERC1967Proxy__factory(deployer).deploy(masterCopy, fullInitData);
+
+    const tx = proxy.deploymentTransaction();
+    if (!tx) {
+      throw new Error('Deployment transaction is null');
+    }
+
+    const receipt = await tx.wait();
+    if (!receipt) {
+      throw new Error('Deployment transaction receipt is null');
+    }
+
+    initTxReceipt = receipt;
+
+    // Connect to the proxy
+    contract = params.contractFactory.connect(await proxy.getAddress(), deployer);
+
+    // Calculate expected init data
+    expectedInitData = await params.getExpectedInitData();
+  });
+
+  it('should emit InitializeData event during initialization', async () => {
+    // Ensure we have a receipt
+    expect(initTxReceipt).to.not.be.undefined;
+
+    // Parse all logs from the transaction
+    const events = initTxReceipt?.logs
+      .map((log: any) => {
+        try {
+          return contract.interface.parseLog(log);
+        } catch {
+          // Log might be from a different contract, ignore parse errors
+          return null;
+        }
+      })
+      .filter((event: any) => event !== null);
+
+    // Find the InitializeData event
+    const initializeDataEvent = events.find((event: any) => event?.name === 'InitializeData');
+
+    // Verify the event was emitted
+    expect(initializeDataEvent).to.not.be.undefined;
+    expect(initializeDataEvent).to.not.be.null;
+
+    // Verify the event data matches expected
+    expect(initializeDataEvent?.args.initData).to.equal(expectedInitData);
+  });
+
+  it('should only emit InitializeData event once during initialization', async () => {
+    // Ensure we have a receipt
+    expect(initTxReceipt).to.not.be.undefined;
+
+    // Parse all logs from the transaction
+    const events = initTxReceipt?.logs
+      .map((log: any) => {
+        try {
+          return contract.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .filter((event: any) => event !== null);
+
+    // Find all InitializeData events
+    const initializeDataEvents = events.filter((event: any) => event?.name === 'InitializeData');
+
+    // Verify exactly one InitializeData event was emitted
+    expect(initializeDataEvents.length).to.equal(
+      1,
+      'InitializeData event should be emitted exactly once',
+    );
+  });
+
+  it('should emit InitializeData as properly formatted hex string', async () => {
+    // Ensure we have a receipt
+    expect(initTxReceipt).to.not.be.undefined;
+
+    // Parse the specific InitializeData event
+    const events = initTxReceipt?.logs
+      .map((log: any) => {
+        try {
+          return contract.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .filter((event: any) => event !== null);
+
+    const initializeDataEvent = events.find((event: any) => event?.name === 'InitializeData');
+
+    // Verify the emitted data is a properly formatted hex string
+    // This is important because the contract should always emit valid hex data
+    // regardless of what format the test's expectedInitData is in
+    expect(initializeDataEvent?.args.initData).to.be.a('string');
+    expect(initializeDataEvent?.args.initData).to.match(/^0x[0-9a-fA-F]*$/);
+  });
+}


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/405

Fixes [ENG-1232](https://linear.app/decent-labs/issue/ENG-1232/implement-initializereventemitter-for-contract-initialization)

## Motivation

Implemented a standardized way to emit initialization data for all upgradeable contracts in the Decent ecosystem. This provides transparency and auditability by emitting raw initialization parameters as an event during contract deployment.

## Change Summary

- Created InitializerEventEmitter abstract contract with EIP-7201 namespaced storage
- Added one-time initialization protection to prevent reinitialization attacks
- Integrated InitializerEventEmitter into 18 upgradeable contracts:
  - DecentPaymasterV1
  - DecentAutonomousAdminV1
  - CountersignV1
  - VotesERC20StakedV1
  - VotesERC20V1
  - FreezeGuardAzoriusV1
  - FreezeGuardMultisigV1
  - FreezeVotingAzoriusV1
  - FreezeVotingMultisigV1
  - ModuleAzoriusV1
  - ModuleFractalV1
  - StrategyV1
  - ProposerAdapterERC20V1
  - ProposerAdapterERC721V1
  - ProposerAdapterHatsV1
  - VotingAdapterERC20V1
  - VotingAdapterERC721V1
  - KYCVerifierV1
- Added comprehensive test coverage with shared test utilities
- Updated ESLint configuration to suppress return-await warnings in test files
- Created ConcreteInitializerEventEmitter mock for isolated testing