### PR TITLE
refactor(contracts): Remove initializer pattern from KYCVerifierV1 service contract

### DIFF
--- a/contracts/interfaces/decent/services/IKYCVerifierV1.sol
+++ b/contracts/interfaces/decent/services/IKYCVerifierV1.sol
@@ -19,15 +19,6 @@ pragma solidity ^0.8.30;
  * - Verification logic is critical for compliance
  */
 interface IKYCVerifierV1 {
-    // --- Initializer Functions ---
-
-    /**
-     * @notice Initializes the KYC verifier contract
-     * @dev Can only be called once during deployment. Sets up any necessary state
-     * for the verification system.
-     */
-    function initialize() external;
-
     // --- View Functions ---
 
     /**

--- a/contracts/services/kyc/KYCVerifierV1.sol
+++ b/contracts/services/kyc/KYCVerifierV1.sol
@@ -6,8 +6,9 @@ import {
 } from "../../interfaces/decent/services/IKYCVerifierV1.sol";
 import {IVersion} from "../../interfaces/decent/deployables/IVersion.sol";
 import {IDeploymentBlock} from "../../interfaces/decent/IDeploymentBlock.sol";
-import {DeploymentBlock} from "../../DeploymentBlock.sol";
-import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
+import {
+    DeploymentBlockNonUpgradeable
+} from "../../DeploymentBlockNonUpgradeable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
@@ -21,7 +22,6 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  * - Mock implementation for testing and development
  * - Always returns true for any address verification
  * - Deployed as singleton service per chain
- * - Upgradeable using UUPS pattern via proxy
  * - Production implementations would integrate with real KYC providers
  *
  * Production considerations:
@@ -35,28 +35,9 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 contract KYCVerifierV1 is
     IKYCVerifierV1,
     IVersion,
-    DeploymentBlock,
-    InitializerEventEmitter,
+    DeploymentBlockNonUpgradeable,
     ERC165
 {
-    // ======================================================================
-    // CONSTRUCTOR & INITIALIZERS
-    // ======================================================================
-
-    constructor() {
-        _disableInitializers();
-    }
-
-    /**
-     * @inheritdoc IKYCVerifierV1
-     * @dev Initializes the deployment block tracking. In production implementations,
-     * this would also initialize KYC provider integrations and access controls.
-     */
-    function initialize() public virtual override initializer {
-        __InitializerEventEmitter_init(abi.encode());
-        __DeploymentBlock_init();
-    }
-
     // ======================================================================
     // IKYCVerifier
     // ======================================================================

--- a/test/unit/services/kyc/KYCVerifierV1.test.ts
+++ b/test/unit/services/kyc/KYCVerifierV1.test.ts
@@ -2,7 +2,6 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  ERC1967Proxy__factory,
   IDeploymentBlock__factory,
   IERC165__factory,
   IKYCVerifierV1__factory,
@@ -11,23 +10,7 @@ import {
   KYCVerifierV1__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
-import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
 import { runSupportsInterfaceTests } from '../../shared/supportsInterfaceTests';
-
-// Helper function for deploying Countersign instances using ERC1967Proxy
-async function deployKYCVerifierProxy(
-  proxyDeployer: SignerWithAddress,
-  implementation: string,
-): Promise<KYCVerifierV1> {
-  // Create initialization data with function selector
-  const fullInitData = KYCVerifierV1__factory.createInterface().encodeFunctionData('initialize');
-
-  // Deploy the proxy with the implementation
-  const proxy = await new ERC1967Proxy__factory(proxyDeployer).deploy(implementation, fullInitData);
-
-  // Return a contract instance connected to the proxy
-  return KYCVerifierV1__factory.connect(await proxy.getAddress(), proxyDeployer);
-}
 
 describe('KYCVerifierV1', () => {
   // signers
@@ -42,17 +25,7 @@ describe('KYCVerifierV1', () => {
     [investorAlice, deployer] = await ethers.getSigners();
 
     // deploy KYC verifier
-    const implementation = await new KYCVerifierV1__factory(deployer).deploy();
-    kycVerifier = await deployKYCVerifierProxy(deployer, await implementation.getAddress());
-  });
-
-  describe('Initialization', () => {
-    it('should not allow reinitialization', async () => {
-      await expect(kycVerifier.initialize()).to.be.revertedWithCustomError(
-        kycVerifier,
-        'InvalidInitialization',
-      );
-    });
+    kycVerifier = await new KYCVerifierV1__factory(deployer).deploy();
   });
 
   describe('Version', () => {
@@ -82,23 +55,6 @@ describe('KYCVerifierV1', () => {
   describe('Deployment Block', () => {
     runDeploymentBlockTests({
       getContract: () => kycVerifier,
-    });
-  });
-
-  describe('InitializerEventEmitter', () => {
-    let testDeployer: SignerWithAddress;
-
-    beforeEach(async () => {
-      [testDeployer] = await ethers.getSigners();
-    });
-
-    runInitializerEventEmitterTests({
-      contractFactory: KYCVerifierV1__factory,
-      masterCopy: async () =>
-        await (await new KYCVerifierV1__factory(testDeployer).deploy()).getAddress(),
-      deployer: () => testDeployer,
-      initializeParams: () => [],
-      getExpectedInitData: async () => ethers.AbiCoder.defaultAbiCoder().encode([], []),
     });
   });
 });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/406

Fixes [ENG-1233](https://linear.app/decent-labs/issue/ENG-1233/remove-initializer-pattern-from-kycverifierv1-service-contract)

## Motivation

KYCVerifierV1 is a singleton service contract, not a deployable, meaning only one instance exists per chain. The initializer pattern was incorrectly applied to this contract type, introducing unnecessary complexity and potential confusion about the contract's deployment model.

## Change Summary

- Remove initialize() function from IKYCVerifierV1 interface
- Remove InitializerEventEmitter inheritance from KYCVerifierV1
- Replace DeploymentBlock with DeploymentBlockNonUpgradeable for non-proxy pattern
- Remove proxy deployment pattern from unit tests
- Simplify contract to direct deployment without initialization
- Remove _disableInitializers() from constructor as it's no longer needed