### PR TITLE
`[ENG-1238]` use AccessControlEnumerableUpgradeable...

### DIFF
--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -16,8 +16,8 @@ import {
 } from "../../DeploymentBlockInitializable.sol";
 import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {
-    IAccessControl
-} from "@openzeppelin/contracts/access/IAccessControl.sol";
+    IAccessControlEnumerable
+} from "@openzeppelin/contracts/access/extensions/IAccessControlEnumerable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {
     ERC20Upgradeable
@@ -38,8 +38,8 @@ import {
     UUPSUpgradeable
 } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {
-    AccessControlUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+    AccessControlEnumerableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 
 /**
  * @title VotesERC20V1
@@ -76,7 +76,7 @@ contract VotesERC20V1 is
     ERC20VotesUpgradeable,
     ERC20PermitUpgradeable,
     UUPSUpgradeable,
-    AccessControlUpgradeable,
+    AccessControlEnumerableUpgradeable,
     DeploymentBlockInitializable,
     InitializerEventEmitter,
     ERC165
@@ -433,7 +433,7 @@ contract VotesERC20V1 is
         public
         view
         virtual
-        override(AccessControlUpgradeable, ERC165)
+        override(AccessControlEnumerableUpgradeable, ERC165)
         returns (bool)
     {
         return
@@ -443,7 +443,7 @@ contract VotesERC20V1 is
             interfaceId_ == type(IVotes).interfaceId ||
             interfaceId_ == type(IVersion).interfaceId ||
             interfaceId_ == type(IDeploymentBlock).interfaceId ||
-            interfaceId_ == type(IAccessControl).interfaceId ||
+            interfaceId_ == type(IAccessControlEnumerable).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/deployables/erc20/VotesERC20V1.sol
+++ b/contracts/deployables/erc20/VotesERC20V1.sol
@@ -16,6 +16,9 @@ import {
 } from "../../DeploymentBlockInitializable.sol";
 import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {
+    IAccessControl
+} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {
     IAccessControlEnumerable
 } from "@openzeppelin/contracts/access/extensions/IAccessControlEnumerable.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
@@ -425,7 +428,7 @@ contract VotesERC20V1 is
     /**
      * @inheritdoc ERC165
      * @dev Supports IVotesERC20V1, IERC20, IERC20Permit, IVotes, IVersion,
-     * IDeploymentBlock, IAccessControl, and IERC165
+     * IDeploymentBlock, IAccessControlEnumerable, IAccessControl, and IERC165
      */
     function supportsInterface(
         bytes4 interfaceId_
@@ -444,6 +447,7 @@ contract VotesERC20V1 is
             interfaceId_ == type(IVersion).interfaceId ||
             interfaceId_ == type(IDeploymentBlock).interfaceId ||
             interfaceId_ == type(IAccessControlEnumerable).interfaceId ||
+            interfaceId_ == type(IAccessControl).interfaceId ||
             super.supportsInterface(interfaceId_);
     }
 }

--- a/test/unit/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20V1.test.ts
@@ -5,6 +5,7 @@ import type { ContractTransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
+  IAccessControl__factory,
   IAccessControlEnumerable__factory,
   IDeploymentBlock__factory,
   IERC165__factory,
@@ -1013,7 +1014,11 @@ describe('VotesERC20V1', () => {
         IERC20Permit__factory,
         IVotes__factory,
         IDeploymentBlock__factory,
-        IAccessControlEnumerable__factory,
+        IAccessControl__factory,
+        {
+          factory: IAccessControlEnumerable__factory,
+          inheritedFactories: [IAccessControl__factory],
+        },
       ],
     });
   });

--- a/test/unit/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20V1.test.ts
@@ -956,13 +956,19 @@ describe('VotesERC20V1', () => {
     });
 
     it('can get all members info of the tranfer role', async () => {
-      expect(await proxy.getRoleMembers(TRANSFER_FROM_ROLE)).to.deep.equal([owner.address,'0x0000000000000000000000000000000000000000', alice.address]);
+      expect(await proxy.getRoleMembers(TRANSFER_FROM_ROLE)).to.deep.equal([
+        owner.address,
+        '0x0000000000000000000000000000000000000000',
+        alice.address,
+      ]);
       expect(await proxy.getRoleMemberCount(TRANSFER_FROM_ROLE)).to.equal(3);
       expect(await proxy.getRoleMember(TRANSFER_FROM_ROLE, 0)).to.equal(owner.address);
-      expect(await proxy.getRoleMember(TRANSFER_FROM_ROLE, 1)).to.equal('0x0000000000000000000000000000000000000000');
+      expect(await proxy.getRoleMember(TRANSFER_FROM_ROLE, 1)).to.equal(
+        '0x0000000000000000000000000000000000000000',
+      );
       expect(await proxy.getRoleMember(TRANSFER_FROM_ROLE, 2)).to.equal(alice.address);
     });
-  })
+  });
 
   describe('Version', () => {
     beforeEach(async () => {

--- a/test/unit/deployables/erc20/VotesERC20V1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20V1.test.ts
@@ -5,7 +5,7 @@ import type { ContractTransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
-  IAccessControl__factory,
+  IAccessControlEnumerable__factory,
   IDeploymentBlock__factory,
   IERC165__factory,
   IERC20__factory,
@@ -938,6 +938,32 @@ describe('VotesERC20V1', () => {
     });
   });
 
+  describe('AccessControlEnumerable functions', () => {
+    let proxy: VotesERC20V1;
+
+    beforeEach(async () => {
+      proxy = await deployVotesERC20Proxy(
+        proxyDeployer,
+        owner,
+        true,
+        ethers.parseEther('2100'),
+        'Test',
+        'TEST',
+        [],
+        [],
+      );
+      await proxy.connect(owner).grantRole(TRANSFER_FROM_ROLE, alice.address);
+    });
+
+    it('can get all members info of the tranfer role', async () => {
+      expect(await proxy.getRoleMembers(TRANSFER_FROM_ROLE)).to.deep.equal([owner.address,'0x0000000000000000000000000000000000000000', alice.address]);
+      expect(await proxy.getRoleMemberCount(TRANSFER_FROM_ROLE)).to.equal(3);
+      expect(await proxy.getRoleMember(TRANSFER_FROM_ROLE, 0)).to.equal(owner.address);
+      expect(await proxy.getRoleMember(TRANSFER_FROM_ROLE, 1)).to.equal('0x0000000000000000000000000000000000000000');
+      expect(await proxy.getRoleMember(TRANSFER_FROM_ROLE, 2)).to.equal(alice.address);
+    });
+  })
+
   describe('Version', () => {
     beforeEach(async () => {
       votesERC20 = await deployVotesERC20Proxy(
@@ -981,7 +1007,7 @@ describe('VotesERC20V1', () => {
         IERC20Permit__factory,
         IVotes__factory,
         IDeploymentBlock__factory,
-        IAccessControl__factory,
+        IAccessControlEnumerable__factory,
       ],
     });
   });


### PR DESCRIPTION
...so we can query list of whitelisted address for [this linear ticket](https://linear.app/decent-labs/issue/ENG-1070/stretch-add-transfer-whitelist-to-token-tab)

I'm not sure why `runSupportsInterfaceTests` failed with this new `IAccessControlEnumerable` interface. @adamgall 