### PR TITLE
feat(contracts): Remove auto-expiry from freeze voting behavior

### DIFF
--- a/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingAzoriusV1.sol
@@ -126,7 +126,6 @@ contract FreezeVotingAzoriusV1 is
         address owner_,
         uint256 freezeVotesThreshold_,
         uint32 freezeProposalPeriod_,
-        uint32 freezePeriod_,
         address parentAzorius_,
         address lightAccountFactory_
     ) public virtual override initializer {
@@ -135,7 +134,6 @@ contract FreezeVotingAzoriusV1 is
                 owner_,
                 freezeVotesThreshold_,
                 freezeProposalPeriod_,
-                freezePeriod_,
                 parentAzorius_,
                 lightAccountFactory_
             )
@@ -143,7 +141,6 @@ contract FreezeVotingAzoriusV1 is
         __FreezeVotingBase_init(
             owner_,
             freezeProposalPeriod_,
-            freezePeriod_,
             freezeVotesThreshold_,
             lightAccountFactory_
         );

--- a/contracts/deployables/freeze-voting/FreezeVotingBase.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingBase.sol
@@ -57,12 +57,10 @@ abstract contract FreezeVotingBase is
         uint256 freezeProposalVoteCount;
         /** @notice Duration freeze proposals remain active */
         uint32 freezeProposalPeriod;
-        /** @notice Duration a freeze remains active once triggered */
-        uint32 freezePeriod;
+        /** @notice Whether the DAO is currently frozen */
+        bool isFrozen;
         /** @notice Voting weight required to trigger a freeze */
         uint256 freezeVotesThreshold;
-        /** @notice Timestamp when freeze was activated (0 if not frozen) */
-        uint48 freezeActivated;
     }
 
     /**
@@ -102,7 +100,6 @@ abstract contract FreezeVotingBase is
      * Sets up owner, light account support, and freeze parameters.
      * @param owner_ The owner address (typically parent DAO)
      * @param freezeProposalPeriod_ Duration freeze proposals remain active
-     * @param freezePeriod_ Duration freezes remain active once triggered
      * @param freezeVotesThreshold_ Voting weight required to trigger freeze
      * @param lightAccountFactory_ Factory for gasless voting support
      */
@@ -110,7 +107,6 @@ abstract contract FreezeVotingBase is
         // solhint-disable-previous-line func-name-mixedcase
         address owner_,
         uint32 freezeProposalPeriod_,
-        uint32 freezePeriod_,
         uint256 freezeVotesThreshold_,
         address lightAccountFactory_
     ) internal onlyInitializing {
@@ -122,7 +118,6 @@ abstract contract FreezeVotingBase is
         FreezeVotingBaseStorage storage $ = _getFreezeVotingBaseStorage();
         $.freezeVotesThreshold = freezeVotesThreshold_;
         $.freezeProposalPeriod = freezeProposalPeriod_;
-        $.freezePeriod = freezePeriod_;
     }
 
     // ======================================================================
@@ -133,17 +128,11 @@ abstract contract FreezeVotingBase is
 
     /**
      * @inheritdoc IFreezable
-     * @dev Returns true only if:
-     * 1. Vote count has reached threshold
-     * 2. Current time is within the freeze period
+     * @dev Returns true if the DAO has been frozen (permanent until explicitly unfrozen)
      */
     function isFrozen() public view virtual override returns (bool) {
         FreezeVotingBaseStorage storage $ = _getFreezeVotingBaseStorage();
-
-        // Check both conditions for freeze to be active
-        return
-            $.freezeProposalVoteCount >= $.freezeVotesThreshold && // Threshold reached
-            block.timestamp < $.freezeActivated + $.freezePeriod; // Within freeze period
+        return $.isFrozen;
     }
 
     // ======================================================================
@@ -197,14 +186,6 @@ abstract contract FreezeVotingBase is
     /**
      * @inheritdoc IFreezeVotingBase
      */
-    function freezePeriod() public view virtual override returns (uint32) {
-        FreezeVotingBaseStorage storage $ = _getFreezeVotingBaseStorage();
-        return $.freezePeriod;
-    }
-
-    /**
-     * @inheritdoc IFreezeVotingBase
-     */
     function freezeVotesThreshold()
         public
         view
@@ -214,14 +195,6 @@ abstract contract FreezeVotingBase is
     {
         FreezeVotingBaseStorage storage $ = _getFreezeVotingBaseStorage();
         return $.freezeVotesThreshold;
-    }
-
-    /**
-     * @inheritdoc IFreezeVotingBase
-     */
-    function freezeActivated() public view virtual override returns (uint48) {
-        FreezeVotingBaseStorage storage $ = _getFreezeVotingBaseStorage();
-        return $.freezeActivated;
     }
 
     // --- State-Changing Functions ---
@@ -234,9 +207,9 @@ abstract contract FreezeVotingBase is
         FreezeVotingBaseStorage storage $ = _getFreezeVotingBaseStorage();
 
         // Reset all freeze state
+        $.isFrozen = false; // Clear frozen state
         $.freezeProposalCreated = 0; // Clear proposal timestamp
         $.freezeProposalVoteCount = 0; // Reset vote count
-        $.freezeActivated = 0; // Clear freeze activation
     }
 
     // ======================================================================
@@ -246,7 +219,7 @@ abstract contract FreezeVotingBase is
     /**
      * @notice Creates a new freeze proposal or resets an expired one
      * @dev Called internally when the first vote is cast on a new proposal.
-     * Resets vote count and freeze activation status.
+     * Resets vote count for the new proposal.
      */
     function _initializeFreezeVote() internal virtual {
         FreezeVotingBaseStorage storage $ = _getFreezeVotingBaseStorage();
@@ -255,7 +228,7 @@ abstract contract FreezeVotingBase is
         // Use previous timestamp to ensure ERC5805 getPastVotes works
         $.freezeProposalCreated = uint48(block.timestamp - 1); // Mark creation time
         $.freezeProposalVoteCount = 0; // Reset vote count
-        $.freezeActivated = 0; // Clear any previous freeze
+        $.isFrozen = false; // Ensure not frozen at start
     }
 
     /**
@@ -279,8 +252,11 @@ abstract contract FreezeVotingBase is
         $.freezeProposalVoteCount += weightCasted_;
 
         // Check if threshold is reached and activate freeze immediately
-        if ($.freezeProposalVoteCount >= $.freezeVotesThreshold) {
-            $.freezeActivated = uint48(block.timestamp);
+        if (
+            $.freezeProposalVoteCount >= $.freezeVotesThreshold && !$.isFrozen
+        ) {
+            $.isFrozen = true;
+            emit DAOFrozen(block.timestamp);
         }
 
         // Emit event for transparency

--- a/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingMultisigV1.sol
@@ -114,7 +114,6 @@ contract FreezeVotingMultisigV1 is
         address owner_,
         uint256 freezeVotesThreshold_,
         uint32 freezeProposalPeriod_,
-        uint32 freezePeriod_,
         address parentSafe_,
         address lightAccountFactory_
     ) public virtual override initializer {
@@ -123,7 +122,6 @@ contract FreezeVotingMultisigV1 is
                 owner_,
                 freezeVotesThreshold_,
                 freezeProposalPeriod_,
-                freezePeriod_,
                 parentSafe_,
                 lightAccountFactory_
             )
@@ -131,7 +129,6 @@ contract FreezeVotingMultisigV1 is
         __FreezeVotingBase_init(
             owner_,
             freezeProposalPeriod_,
-            freezePeriod_,
             freezeVotesThreshold_,
             lightAccountFactory_
         );

--- a/contracts/interfaces/decent/deployables/IFreezeVotingAzoriusV1.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeVotingAzoriusV1.sol
@@ -73,7 +73,6 @@ interface IFreezeVotingAzoriusV1 {
      * @param owner_ The parent DAO that will have unfreeze powers
      * @param freezeVotesThreshold_ Voting weight required to freeze the child DAO
      * @param freezeProposalPeriod_ Duration in seconds that freeze proposals remain active
-     * @param freezePeriod_ Duration in seconds that a freeze remains active
      * @param parentAzorius_ The parent DAO's Azorius module address
      * @param lightAccountFactory_ Factory for Light Account support (ERC-4337)
      */
@@ -81,7 +80,6 @@ interface IFreezeVotingAzoriusV1 {
         address owner_,
         uint256 freezeVotesThreshold_,
         uint32 freezeProposalPeriod_,
-        uint32 freezePeriod_,
         address parentAzorius_,
         address lightAccountFactory_
     ) external;

--- a/contracts/interfaces/decent/deployables/IFreezeVotingBase.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeVotingBase.sol
@@ -12,12 +12,12 @@ pragma solidity ^0.8.30;
  * - Freeze proposals are separate from regular governance proposals
  * - Votes accumulate until the threshold is reached
  * - Once threshold is met, the child DAO is immediately frozen
- * - Freeze automatically expires after a set period
+ * - Freezes are permanent until explicitly unfrozen
  * - Only the owner (parent DAO) can manually unfreeze
  *
  * Security features:
  * - Time-limited freeze proposals prevent stale votes
- * - Automatic expiration prevents permanent freezing
+ * - Permanent freezes require explicit unfreeze action
  * - Configurable threshold allows DAOs to set appropriate requirements
  * - Parent DAO retains ultimate control through ownership
  *
@@ -34,10 +34,16 @@ interface IFreezeVotingBase {
 
     /**
      * @notice Emitted when a freeze vote is successfully cast
-     * @param voter_ The address that cast the vote
-     * @param votesCast_ The voting weight applied to the freeze proposal
+     * @param voter The address that cast the vote
+     * @param votesCast The voting weight applied to the freeze proposal
      */
-    event FreezeVoteCast(address indexed voter_, uint256 votesCast_);
+    event FreezeVoteCast(address indexed voter, uint256 votesCast);
+
+    /**
+     * @notice Emitted when the DAO is frozen
+     * @param freezeTimestamp The timestamp when the freeze was activated
+     */
+    event DAOFrozen(uint256 freezeTimestamp);
 
     // --- View Functions ---
 
@@ -72,13 +78,6 @@ interface IFreezeVotingBase {
         returns (uint32 freezeProposalPeriod);
 
     /**
-     * @notice Returns the duration for which a freeze remains active once triggered
-     * @dev After this period, the DAO automatically unfreezes
-     * @return freezePeriod Duration in seconds
-     */
-    function freezePeriod() external view returns (uint32 freezePeriod);
-
-    /**
      * @notice Returns the voting weight threshold required to freeze the child DAO
      * @dev When vote count reaches this threshold, freeze is activated immediately
      * @return freezeVotesThreshold The required voting weight
@@ -88,18 +87,12 @@ interface IFreezeVotingBase {
         view
         returns (uint256 freezeVotesThreshold);
 
-    /**
-     * @notice Returns when the current freeze was activated
-     * @dev Returns 0 if not currently frozen
-     * @return freezeActivated Timestamp when the freeze was triggered
-     */
-    function freezeActivated() external view returns (uint48 freezeActivated);
-
     // --- State-Changing Functions ---
 
     /**
      * @notice Allows the owner to manually unfreeze the child DAO
      * @dev Resets freeze state and proposal counts. Only the parent DAO can call this.
+     * Freezes are permanent until this function is called.
      * @custom:access Restricted to owner (parent DAO)
      */
     function unfreeze() external;

--- a/contracts/interfaces/decent/deployables/IFreezeVotingMultisigV1.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeVotingMultisigV1.sol
@@ -49,7 +49,6 @@ interface IFreezeVotingMultisigV1 {
      * @param owner_ The parent Safe that will have unfreeze powers
      * @param freezeVotesThreshold_ Number of signer votes required to freeze
      * @param freezeProposalPeriod_ Duration in seconds that freeze proposals remain active
-     * @param freezePeriod_ Duration in seconds that a freeze remains active
      * @param parentSafe_ The parent multisig Safe contract address
      * @param lightAccountFactory Factory for Light Account support (ERC-4337)
      */
@@ -57,7 +56,6 @@ interface IFreezeVotingMultisigV1 {
         address owner_,
         uint256 freezeVotesThreshold_,
         uint32 freezeProposalPeriod_,
-        uint32 freezePeriod_,
         address parentSafe_,
         address lightAccountFactory
     ) external;

--- a/contracts/interfaces/decent/singletons/ISystemDeployerV1.sol
+++ b/contracts/interfaces/decent/singletons/ISystemDeployerV1.sol
@@ -238,7 +238,6 @@ interface ISystemDeployerV1 {
      * @param owner The parent DAO that can update settings
      * @param freezeVotesThreshold Votes required to freeze
      * @param freezeProposalPeriod Duration for freeze voting
-     * @param freezePeriod How long the child DAO stays frozen
      * @param parentSafe The parent Safe whose owners can cast freeze votes
      * @param lightAccountFactory Address of the LightAccountFactory
      */
@@ -247,7 +246,6 @@ interface ISystemDeployerV1 {
         address owner;
         uint256 freezeVotesThreshold;
         uint32 freezeProposalPeriod;
-        uint32 freezePeriod;
         address parentSafe;
         address lightAccountFactory;
     }
@@ -258,7 +256,6 @@ interface ISystemDeployerV1 {
      * @param owner The parent DAO that can update settings
      * @param freezeVotesThreshold Votes required to freeze
      * @param freezeProposalPeriod Duration for freeze voting
-     * @param freezePeriod How long the child DAO stays frozen
      * @param parentAzorius The parent DAO's Azorius module
      * @param lightAccountFactory Address of the LightAccountFactory
      */
@@ -267,7 +264,6 @@ interface ISystemDeployerV1 {
         address owner;
         uint256 freezeVotesThreshold;
         uint32 freezeProposalPeriod;
-        uint32 freezePeriod;
         address parentAzorius;
         address lightAccountFactory;
     }

--- a/contracts/mocks/concretes/deployables/freeze-voting/ConcreteFreezeVotingBase.sol
+++ b/contracts/mocks/concretes/deployables/freeze-voting/ConcreteFreezeVotingBase.sol
@@ -9,14 +9,12 @@ contract ConcreteFreezeVotingBase is FreezeVotingBase {
     function initialize(
         address owner_,
         uint256 freezeVotesThreshold_,
-        uint32 freezeProposalPeriod_,
-        uint32 freezePeriod_
+        uint32 freezeProposalPeriod_
     ) public initializer {
         __Ownable_init(owner_);
         FreezeVotingBaseStorage storage $base = _getFreezeVotingBaseStorage();
         $base.freezeVotesThreshold = freezeVotesThreshold_;
         $base.freezeProposalPeriod = freezeProposalPeriod_;
-        $base.freezePeriod = freezePeriod_;
     }
 
     function castFreezeVote() external {

--- a/contracts/singletons/SystemDeployerV1.sol
+++ b/contracts/singletons/SystemDeployerV1.sol
@@ -993,7 +993,6 @@ contract SystemDeployerV1 is
                         freezeVotingMultisigV1Params.owner,
                         freezeVotingMultisigV1Params.freezeVotesThreshold,
                         freezeVotingMultisigV1Params.freezeProposalPeriod,
-                        freezeVotingMultisigV1Params.freezePeriod,
                         freezeVotingMultisigV1Params.parentSafe,
                         freezeVotingMultisigV1Params.lightAccountFactory
                     )
@@ -1011,7 +1010,6 @@ contract SystemDeployerV1 is
                         freezeVotingAzoriusV1Params.owner,
                         freezeVotingAzoriusV1Params.freezeVotesThreshold,
                         freezeVotingAzoriusV1Params.freezeProposalPeriod,
-                        freezeVotingAzoriusV1Params.freezePeriod,
                         freezeVotingAzoriusV1Params.parentAzorius,
                         freezeVotingAzoriusV1Params.lightAccountFactory
                     )

--- a/test/unit/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
+++ b/test/unit/deployables/freeze-voting/FreezeVotingAzoriusV1.test.ts
@@ -38,7 +38,6 @@ async function deployAzoriusFreezeVotingProxy(
   owner: string,
   freezeVotesThreshold: bigint,
   freezeProposalPeriod: number,
-  freezePeriod: number,
   parentAzoriusAddress: string,
   lightAccountFactoryAddress: string,
 ): Promise<FreezeVotingAzoriusV1> {
@@ -48,7 +47,6 @@ async function deployAzoriusFreezeVotingProxy(
       owner,
       freezeVotesThreshold,
       freezeProposalPeriod,
-      freezePeriod,
       parentAzoriusAddress,
       lightAccountFactoryAddress,
     ],
@@ -76,7 +74,6 @@ describe('FreezeVotingAzoriusV1', () => {
 
   const DEFAULT_FREEZE_VOTES_THRESHOLD = 100n;
   const DEFAULT_FREEZE_PROPOSAL_PERIOD = 60 * 60 * 24; // 1 day
-  const DEFAULT_FREEZE_PERIOD = 60 * 60 * 24 * 7; // 7 days
 
   async function fixture() {
     const [d, o, paa, v1, v2] = await ethers.getSigners();
@@ -133,7 +130,6 @@ describe('FreezeVotingAzoriusV1', () => {
       owner.address,
       DEFAULT_FREEZE_VOTES_THRESHOLD,
       DEFAULT_FREEZE_PROPOSAL_PERIOD,
-      DEFAULT_FREEZE_PERIOD,
       await mockParentAzorius.getAddress(),
       mockLightAccountFactory.target as string,
     );
@@ -148,7 +144,6 @@ describe('FreezeVotingAzoriusV1', () => {
       expect(await azoriusFreezeVoting.freezeProposalPeriod()).to.equal(
         DEFAULT_FREEZE_PROPOSAL_PERIOD,
       );
-      expect(await azoriusFreezeVoting.freezePeriod()).to.equal(DEFAULT_FREEZE_PERIOD);
       expect(await azoriusFreezeVoting.parentAzorius()).to.equal(
         await mockParentAzorius.getAddress(),
       );
@@ -163,7 +158,6 @@ describe('FreezeVotingAzoriusV1', () => {
           owner.address,
           DEFAULT_FREEZE_VOTES_THRESHOLD,
           DEFAULT_FREEZE_PROPOSAL_PERIOD,
-          DEFAULT_FREEZE_PERIOD,
           await mockParentAzorius.getAddress(),
           mockLightAccountFactory.target as string,
         ),
@@ -180,7 +174,6 @@ describe('FreezeVotingAzoriusV1', () => {
           owner.address,
           DEFAULT_FREEZE_VOTES_THRESHOLD,
           DEFAULT_FREEZE_PROPOSAL_PERIOD,
-          DEFAULT_FREEZE_PERIOD,
           await mockParentAzorius.getAddress(),
           mockLightAccountFactory.target as string,
         ),
@@ -668,18 +661,16 @@ describe('FreezeVotingAzoriusV1', () => {
         owner.address,
         DEFAULT_FREEZE_VOTES_THRESHOLD,
         DEFAULT_FREEZE_PROPOSAL_PERIOD,
-        DEFAULT_FREEZE_PERIOD,
         await mockParentAzorius.getAddress(),
         mockLightAccountFactory.target as string,
       ],
       getExpectedInitData: async () =>
         ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'uint256', 'uint32', 'uint32', 'address', 'address'],
+          ['address', 'uint256', 'uint32', 'address', 'address'],
           [
             owner.address,
             DEFAULT_FREEZE_VOTES_THRESHOLD,
             DEFAULT_FREEZE_PROPOSAL_PERIOD,
-            DEFAULT_FREEZE_PERIOD,
             await mockParentAzorius.getAddress(),
             mockLightAccountFactory.target as string,
           ],

--- a/test/unit/deployables/freeze-voting/FreezeVotingBase.test.ts
+++ b/test/unit/deployables/freeze-voting/FreezeVotingBase.test.ts
@@ -15,12 +15,11 @@ async function deployConcreteBaseFreezeVotingProxy(
   owner: SignerWithAddress,
   freezeVotesThreshold: number,
   freezeProposalPeriod: number,
-  freezePeriod: number,
 ): Promise<ConcreteFreezeVotingBase> {
   // Combine selector and encoded params
   const fullInitData = ConcreteFreezeVotingBase__factory.createInterface().encodeFunctionData(
     'initialize',
-    [owner.address, freezeVotesThreshold, freezeProposalPeriod, freezePeriod],
+    [owner.address, freezeVotesThreshold, freezeProposalPeriod],
   );
 
   // Deploy the proxy with the implementation
@@ -45,7 +44,6 @@ describe('FreezeVotingBase', () => {
   // constants
   const FREEZE_VOTES_THRESHOLD = 3;
   const FREEZE_PROPOSAL_PERIOD = 5;
-  const FREEZE_PERIOD = 10;
 
   beforeEach(async () => {
     // Get signers
@@ -62,7 +60,6 @@ describe('FreezeVotingBase', () => {
       owner,
       FREEZE_VOTES_THRESHOLD,
       FREEZE_PROPOSAL_PERIOD,
-      FREEZE_PERIOD,
     );
   });
 
@@ -71,17 +68,11 @@ describe('FreezeVotingBase', () => {
       expect(await freezeVoting.owner()).to.equal(owner.address);
       expect(await freezeVoting.freezeVotesThreshold()).to.equal(FREEZE_VOTES_THRESHOLD);
       expect(await freezeVoting.freezeProposalPeriod()).to.equal(FREEZE_PROPOSAL_PERIOD);
-      expect(await freezeVoting.freezePeriod()).to.equal(FREEZE_PERIOD);
     });
 
     it('should not allow reinitialization', async () => {
       await expect(
-        freezeVoting.initialize(
-          owner.address,
-          FREEZE_VOTES_THRESHOLD,
-          FREEZE_PROPOSAL_PERIOD,
-          FREEZE_PERIOD,
-        ),
+        freezeVoting.initialize(owner.address, FREEZE_VOTES_THRESHOLD, FREEZE_PROPOSAL_PERIOD),
       ).to.be.revertedWithCustomError(freezeVoting, 'InvalidInitialization');
     });
 
@@ -96,7 +87,6 @@ describe('FreezeVotingBase', () => {
           owner.address,
           FREEZE_VOTES_THRESHOLD,
           FREEZE_PROPOSAL_PERIOD,
-          FREEZE_PERIOD,
         ),
       ).to.be.revertedWithCustomError(implementationContract, 'InvalidInitialization');
     });
@@ -171,7 +161,7 @@ describe('FreezeVotingBase', () => {
       expect(await freezeVoting.isFrozen()).to.be.true;
     });
 
-    it('should automatically unfreeze after freeze period', async () => {
+    it('should remain frozen until explicitly unfrozen', async () => {
       // Cast enough votes to meet threshold
       await freezeVoting.connect(voter1).castFreezeVote();
       await freezeVoting.connect(voter2).castFreezeVote();
@@ -180,11 +170,11 @@ describe('FreezeVotingBase', () => {
       // Should be frozen initially
       expect(await freezeVoting.isFrozen()).to.be.true;
 
-      // Increase time to pass the freeze period
-      await time.increase(FREEZE_PERIOD + 1);
+      // Increase time significantly
+      await time.increase(60 * 60 * 24 * 30); // 30 days
 
-      // Should no longer be frozen
-      expect(await freezeVoting.isFrozen()).to.be.false;
+      // Should still be frozen (permanent freeze)
+      expect(await freezeVoting.isFrozen()).to.be.true;
     });
 
     it('should allow owner to unfreeze manually', async () => {
@@ -205,7 +195,6 @@ describe('FreezeVotingBase', () => {
       // Check that state was reset
       expect(await freezeVoting.freezeProposalCreated()).to.equal(0);
       expect(await freezeVoting.freezeProposalVoteCount()).to.equal(0);
-      expect(await freezeVoting.freezeActivated()).to.equal(0);
     });
 
     it('should not allow non-owner to unfreeze', async () => {
@@ -254,108 +243,42 @@ describe('FreezeVotingBase', () => {
     });
   });
 
-  describe('Freeze Activation', () => {
-    it('should return 0 for freezeActivated initially', async () => {
-      expect(await freezeVoting.freezeActivated()).to.equal(0);
-    });
-
-    it('should return 0 for freezeActivated before threshold is reached', async () => {
-      // Cast votes below threshold
-      await freezeVoting.connect(voter1).castFreezeVote();
-      await freezeVoting.connect(voter2).castFreezeVote();
-
-      // freezeActivated should still be 0
-      expect(await freezeVoting.freezeActivated()).to.equal(0);
-    });
-
-    it('should set freezeActivated when threshold is reached', async () => {
+  describe('DAOFrozen Event', () => {
+    it('should emit DAOFrozen event when threshold is reached', async () => {
       // Cast votes to reach threshold
       await freezeVoting.connect(voter1).castFreezeVote();
       await freezeVoting.connect(voter2).castFreezeVote();
 
-      // Get timestamp before the final vote
-      const beforeTimestamp = await time.latest();
-
-      // Cast the threshold-reaching vote
-      await freezeVoting.connect(voter3).castFreezeVote();
-
-      // freezeActivated should be set to current timestamp
-      const afterTimestamp = await time.latest();
-      const freezeActivated = await freezeVoting.freezeActivated();
-
-      expect(freezeActivated).to.be.gte(beforeTimestamp);
-      expect(freezeActivated).to.be.lte(afterTimestamp);
+      // The final vote that reaches threshold should emit DAOFrozen
+      await expect(freezeVoting.connect(voter3).castFreezeVote()).to.emit(
+        freezeVoting,
+        'DAOFrozen',
+      );
     });
 
-    it('should reset freezeActivated when manually unfrozen', async () => {
-      // Cast enough votes to meet threshold
+    it('should emit DAOFrozen event only once when threshold is reached', async () => {
+      // Cast votes to reach threshold
       await freezeVoting.connect(voter1).castFreezeVote();
       await freezeVoting.connect(voter2).castFreezeVote();
-      await freezeVoting.connect(voter3).castFreezeVote();
 
-      // Verify freeze is activated
-      expect(await freezeVoting.freezeActivated()).to.not.equal(0);
+      // This vote reaches threshold and should emit DAOFrozen
+      await expect(freezeVoting.connect(voter3).castFreezeVote()).to.emit(
+        freezeVoting,
+        'DAOFrozen',
+      );
 
-      // Owner unfreezes manually
+      // After unfreezing and voting again
       await freezeVoting.connect(owner).unfreeze();
 
-      // freezeActivated should be reset to 0
-      expect(await freezeVoting.freezeActivated()).to.equal(0);
-    });
-
-    it('should use freezeActivated timestamp for freeze period calculation', async () => {
-      // Cast enough votes to meet threshold
+      // Start new freeze cycle
       await freezeVoting.connect(voter1).castFreezeVote();
       await freezeVoting.connect(voter2).castFreezeVote();
-      await freezeVoting.connect(voter3).castFreezeVote();
 
-      // Should be frozen immediately after threshold is reached
-      expect(await freezeVoting.isFrozen()).to.be.true;
-
-      // Get the freeze activation timestamp
-      const freezeActivated = await freezeVoting.freezeActivated();
-
-      // Advance time to just before freeze period expires
-      await time.increaseTo(Number(freezeActivated) + FREEZE_PERIOD - 1);
-
-      // Should still be frozen
-      expect(await freezeVoting.isFrozen()).to.be.true;
-
-      // Advance time to exactly when freeze period expires
-      await time.increaseTo(Number(freezeActivated) + FREEZE_PERIOD);
-
-      // Should no longer be frozen at the exact expiry time
-      expect(await freezeVoting.isFrozen()).to.be.false;
-
-      // Advance time past freeze period
-      await time.increaseTo(Number(freezeActivated) + FREEZE_PERIOD + 1);
-
-      // Should no longer be frozen
-      expect(await freezeVoting.isFrozen()).to.be.false;
-    });
-
-    it('should handle multiple freeze activation cycles correctly', async () => {
-      // First freeze cycle
-      await freezeVoting.connect(voter1).castFreezeVote();
-      await freezeVoting.connect(voter2).castFreezeVote();
-      await freezeVoting.connect(voter3).castFreezeVote();
-
-      const firstFreezeActivated = await freezeVoting.freezeActivated();
-      expect(firstFreezeActivated).to.not.equal(0);
-
-      // Manually unfreeze
-      await freezeVoting.connect(owner).unfreeze();
-      expect(await freezeVoting.freezeActivated()).to.equal(0);
-
-      // Second freeze cycle
-      await time.increase(1); // Ensure different timestamp
-      await freezeVoting.connect(voter1).castFreezeVote();
-      await freezeVoting.connect(voter2).castFreezeVote();
-      await freezeVoting.connect(voter3).castFreezeVote();
-
-      const secondFreezeActivated = await freezeVoting.freezeActivated();
-      expect(secondFreezeActivated).to.not.equal(0);
-      expect(secondFreezeActivated).to.be.gt(firstFreezeActivated);
+      // Should emit DAOFrozen again for the new freeze
+      await expect(freezeVoting.connect(voter3).castFreezeVote()).to.emit(
+        freezeVoting,
+        'DAOFrozen',
+      );
     });
   });
 });

--- a/test/unit/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
+++ b/test/unit/deployables/freeze-voting/FreezeVotingMultisigV1.test.ts
@@ -31,7 +31,6 @@ async function deployMultisigFreezeVotingProxy(
   owner: SignerWithAddress,
   freezeVotesThreshold: number,
   freezeProposalPeriod: number,
-  freezePeriod: number,
   parentGnosisSafe: MockSafe,
   lightAccountFactoryAddress: string,
 ): Promise<FreezeVotingMultisigV1> {
@@ -42,7 +41,6 @@ async function deployMultisigFreezeVotingProxy(
       owner.address,
       freezeVotesThreshold,
       freezeProposalPeriod,
-      freezePeriod,
       await parentGnosisSafe.getAddress(),
       lightAccountFactoryAddress,
     ],
@@ -73,7 +71,6 @@ describe('FreezeVotingMultisigV1', () => {
   // constants
   const FREEZE_VOTES_THRESHOLD = 2;
   const FREEZE_PROPOSAL_PERIOD = 5;
-  const FREEZE_PERIOD = 10;
 
   beforeEach(async () => {
     // Get signers
@@ -99,7 +96,6 @@ describe('FreezeVotingMultisigV1', () => {
       owner,
       FREEZE_VOTES_THRESHOLD,
       FREEZE_PROPOSAL_PERIOD,
-      FREEZE_PERIOD,
       mockSafe,
       lightAccountFactoryMockAddress,
     );
@@ -110,7 +106,6 @@ describe('FreezeVotingMultisigV1', () => {
       expect(await freezeVoting.owner()).to.equal(owner.address);
       expect(await freezeVoting.freezeVotesThreshold()).to.equal(FREEZE_VOTES_THRESHOLD);
       expect(await freezeVoting.freezeProposalPeriod()).to.equal(FREEZE_PROPOSAL_PERIOD);
-      expect(await freezeVoting.freezePeriod()).to.equal(FREEZE_PERIOD);
       expect(await freezeVoting.parentSafe()).to.equal(await mockSafe.getAddress());
       expect(await freezeVoting.lightAccountFactory()).to.equal(lightAccountFactoryMockAddress);
     });
@@ -121,7 +116,6 @@ describe('FreezeVotingMultisigV1', () => {
           owner.address,
           FREEZE_VOTES_THRESHOLD,
           FREEZE_PROPOSAL_PERIOD,
-          FREEZE_PERIOD,
           await mockSafe.getAddress(),
           lightAccountFactoryMockAddress,
         ),
@@ -139,7 +133,6 @@ describe('FreezeVotingMultisigV1', () => {
           owner.address,
           FREEZE_VOTES_THRESHOLD,
           FREEZE_PROPOSAL_PERIOD,
-          FREEZE_PERIOD,
           await mockSafe.getAddress(),
           lightAccountFactoryMockAddress,
         ),
@@ -325,7 +318,7 @@ describe('FreezeVotingMultisigV1', () => {
       expect(await freezeVoting.isFrozen()).to.be.true;
     });
 
-    it('should automatically unfreeze after freeze period', async () => {
+    it('should remain frozen until explicitly unfrozen', async () => {
       // Set first Safe owner
       await mockSafe.setOwner(safeOwner1.address);
 
@@ -341,11 +334,11 @@ describe('FreezeVotingMultisigV1', () => {
       // Should be frozen initially
       expect(await freezeVoting.isFrozen()).to.be.true;
 
-      // Increase time to pass the freeze period
-      await time.increase(FREEZE_PERIOD + 1);
+      // Increase time significantly
+      await time.increase(60 * 60 * 24 * 30); // 30 days
 
-      // Should no longer be frozen
-      expect(await freezeVoting.isFrozen()).to.be.false;
+      // Should still be frozen (permanent freeze)
+      expect(await freezeVoting.isFrozen()).to.be.true;
     });
 
     it('should allow owner to unfreeze manually', async () => {
@@ -564,7 +557,6 @@ describe('FreezeVotingMultisigV1', () => {
         owner,
         FREEZE_VOTES_THRESHOLD,
         FREEZE_PROPOSAL_PERIOD,
-        FREEZE_PERIOD,
         mockSafeSA,
         lightAccountFactorySA.target as string,
       );
@@ -631,18 +623,16 @@ describe('FreezeVotingMultisigV1', () => {
         testOwner.address,
         FREEZE_VOTES_THRESHOLD,
         FREEZE_PROPOSAL_PERIOD,
-        FREEZE_PERIOD,
         testMockSafeAddress,
         lightAccountFactoryAddress,
       ],
       getExpectedInitData: () =>
         ethers.AbiCoder.defaultAbiCoder().encode(
-          ['address', 'uint256', 'uint32', 'uint32', 'address', 'address'],
+          ['address', 'uint256', 'uint32', 'address', 'address'],
           [
             testOwner.address,
             FREEZE_VOTES_THRESHOLD,
             FREEZE_PROPOSAL_PERIOD,
-            FREEZE_PERIOD,
             testMockSafeAddress,
             lightAccountFactoryAddress,
           ],

--- a/test/unit/singletons/SystemDeployerV1.test.ts
+++ b/test/unit/singletons/SystemDeployerV1.test.ts
@@ -375,7 +375,6 @@ function createSetupSafeParams(overrides?: {
         owner: ethers.ZeroAddress,
         freezeVotesThreshold: 0,
         freezeProposalPeriod: 0,
-        freezePeriod: 0,
         parentSafe: ethers.ZeroAddress,
         lightAccountFactory: ethers.ZeroAddress,
         ...overrides?.freezeVotingMultisigParams,
@@ -385,7 +384,6 @@ function createSetupSafeParams(overrides?: {
         owner: ethers.ZeroAddress,
         freezeVotesThreshold: 0,
         freezeProposalPeriod: 0,
-        freezePeriod: 0,
         parentAzorius: ethers.ZeroAddress,
         lightAccountFactory: ethers.ZeroAddress,
         ...overrides?.freezeVotingAzoriusParams,
@@ -1319,7 +1317,6 @@ async function findAndVerifyFreezeVotingMultisigV1(params: {
   owner: AddressLike;
   freezeVotesThreshold: BigNumberish;
   freezeProposalPeriod: BigNumberish;
-  freezePeriod: BigNumberish;
   lightAccountFactory: AddressLike;
 }) {
   const {
@@ -1329,7 +1326,6 @@ async function findAndVerifyFreezeVotingMultisigV1(params: {
     owner,
     freezeVotesThreshold,
     freezeProposalPeriod,
-    freezePeriod,
     lightAccountFactory,
   } = params;
 
@@ -1348,7 +1344,6 @@ async function findAndVerifyFreezeVotingMultisigV1(params: {
   expect(await freezeVotingMultisigProxy.owner()).to.equal(owner);
   expect(await freezeVotingMultisigProxy.freezeVotesThreshold()).to.equal(freezeVotesThreshold);
   expect(await freezeVotingMultisigProxy.freezeProposalPeriod()).to.equal(freezeProposalPeriod);
-  expect(await freezeVotingMultisigProxy.freezePeriod()).to.equal(freezePeriod);
   expect(await freezeVotingMultisigProxy.lightAccountFactory()).to.equal(lightAccountFactory);
 
   return freezeVotingMultisigProxy;
@@ -1365,7 +1360,6 @@ async function findAndVerifyFreezeVotingAzoriusV1(params: {
   owner: AddressLike;
   freezeVotesThreshold: BigNumberish;
   freezeProposalPeriod: BigNumberish;
-  freezePeriod: BigNumberish;
   parentAzorius: AddressLike;
   lightAccountFactory: AddressLike;
 }) {
@@ -1376,7 +1370,6 @@ async function findAndVerifyFreezeVotingAzoriusV1(params: {
     owner,
     freezeVotesThreshold,
     freezeProposalPeriod,
-    freezePeriod,
     parentAzorius,
     lightAccountFactory,
   } = params;
@@ -1395,7 +1388,6 @@ async function findAndVerifyFreezeVotingAzoriusV1(params: {
 
   expect(await freezeVotingAzoriusProxy.owner()).to.equal(owner);
   expect(await freezeVotingAzoriusProxy.freezeProposalPeriod()).to.equal(freezeProposalPeriod);
-  expect(await freezeVotingAzoriusProxy.freezePeriod()).to.equal(freezePeriod);
   expect(await freezeVotingAzoriusProxy.freezeVotesThreshold()).to.equal(freezeVotesThreshold);
   expect(await freezeVotingAzoriusProxy.parentAzorius()).to.equal(parentAzorius);
   expect(await freezeVotingAzoriusProxy.lightAccountFactory()).to.equal(lightAccountFactory);
@@ -2150,7 +2142,6 @@ describe('SystemDeployerV1', () => {
         owner: fixtureData.user1.address,
         freezeVotesThreshold: 26,
         freezeProposalPeriod: 65,
-        freezePeriod: 129,
         parentSafe: ethers.ZeroAddress,
         lightAccountFactory: ethers.ZeroAddress,
       };
@@ -2160,7 +2151,6 @@ describe('SystemDeployerV1', () => {
         owner: fixtureData.user1.address,
         freezeVotesThreshold: 12,
         freezeProposalPeriod: 60,
-        freezePeriod: 120,
         parentAzorius: ethers.ZeroAddress,
         lightAccountFactory: ethers.ZeroAddress,
       };


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/418

Fixes [ENG-1275](https://linear.app/decent-labs/issue/ENG-1275/make-freeze-voting-permanent-until-explicitly-unfrozen)

BREAKING CHANGE: Freeze voting contracts no longer support auto-expiry. All freezes are now permanent until explicitly unfrozen.

Changes:
- Remove `freezePeriod` parameter from all freeze voting contracts
- Remove `freezeActivated` timestamp tracking from FreezeVotingBase
- Replace time-based freeze logic with simple boolean `isFrozen` state
- Add `DAOFrozen` event emission when freeze threshold is reached
- Update initialize functions to remove freezePeriod parameter:
  - FreezeVotingMultisigV1.initialize()
  - FreezeVotingAzoriusV1.initialize()
  - FreezeVotingBase.__FreezeVotingBase_init()
- Update SystemDeployerV1 to remove freezePeriod from deployment params
- Update all interfaces to match new signatures
- Update all tests to work with permanent freeze behavior

This change simplifies the freeze voting mechanism by removing the complexity of time-based auto-expiry. DAOs can still manually unfreeze at any time through the existing unfreeze() function.

The unified freeze model ensures consistent behavior across all freeze voting implementations - freezes are always permanent until explicitly reversed by the DAO owner.