### PR TITLE
feat(security): Add freeze guard protection against pre-freeze timelocked transactions

### DIFF
--- a/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
+++ b/contracts/deployables/freeze-guard/FreezeGuardMultisigV1.sol
@@ -224,6 +224,9 @@ contract FreezeGuardMultisigV1 is
     ) public virtual override {
         FreezeGuardMultisigStorage storage $ = _getFreezeGuardMultisigStorage();
 
+        // Check if DAO is frozen - no new timelocks allowed while frozen
+        if ($.freezable.isFrozen()) revert DAOFrozen();
+
         // Check 1: Ensure this exact set of signatures hasn't been timelocked already
         // Using signature hash as unique identifier prevents replay attacks
         if ($.transactionTimelocked[keccak256(signatures_)] != 0)
@@ -311,7 +314,12 @@ contract FreezeGuardMultisigV1 is
      * 1. Transaction must be timelocked
      * 2. Timelock period must have passed
      * 3. Must be within execution window
-     * 4. DAO must not be frozen
+     * 4. Transaction must have been timelocked AFTER the most recent freeze
+     * 5. DAO must not be currently frozen
+     *
+     * CRITICAL SECURITY INVARIANT: Check 4 ensures that any transaction timelocked
+     * before the most recent freeze is permanently invalidated, even after unfreeze.
+     *
      * Only the signatures parameter is used; others are ignored.
      */
     function checkTransaction(
@@ -352,8 +360,21 @@ contract FreezeGuardMultisigV1 is
                 $.executionPeriod
         ) revert Expired();
 
-        // Check 4: DAO must not be frozen
-        // Final check allows parent to block execution even after timelock
+        // Check 4: Enforce critical security invariant for freeze protection
+        // SECURITY INVARIANT: Any transaction timelocked BEFORE the most recent freeze
+        // is permanently invalidated and can NEVER be executed, even after unfreeze.
+        // This prevents malicious signers from queuing harmful transactions and waiting
+        // for an unfreeze to execute them.
+        uint48 lastFreeze = $.freezable.lastFreezeTime();
+        if (
+            lastFreeze != 0 &&
+            $.transactionTimelocked[signaturesHash] < lastFreeze
+        ) {
+            revert TimelockedBeforeFreeze();
+        }
+
+        // Check 5: DAO must not be currently frozen
+        // Final check prevents execution during freeze
         if ($.freezable.isFrozen()) revert DAOFrozen();
     }
 

--- a/contracts/deployables/freeze-voting/FreezeVotingBase.sol
+++ b/contracts/deployables/freeze-voting/FreezeVotingBase.sol
@@ -61,6 +61,8 @@ abstract contract FreezeVotingBase is
         bool isFrozen;
         /** @notice Voting weight required to trigger a freeze */
         uint256 freezeVotesThreshold;
+        /** @notice Timestamp of the most recent freeze (NEVER cleared, even on unfreeze) */
+        uint48 lastFreezeTimestamp;
     }
 
     /**
@@ -133,6 +135,17 @@ abstract contract FreezeVotingBase is
     function isFrozen() public view virtual override returns (bool) {
         FreezeVotingBaseStorage storage $ = _getFreezeVotingBaseStorage();
         return $.isFrozen;
+    }
+
+    /**
+     * @inheritdoc IFreezable
+     * @dev CRITICAL SECURITY FUNCTION: Returns the most recent freeze timestamp.
+     * This timestamp is NEVER cleared, even after unfreeze or auto-expiry.
+     * Used by guards to permanently invalidate all transactions timelocked before this time.
+     */
+    function lastFreezeTime() public view virtual override returns (uint48) {
+        FreezeVotingBaseStorage storage $ = _getFreezeVotingBaseStorage();
+        return $.lastFreezeTimestamp;
     }
 
     // ======================================================================
@@ -255,6 +268,11 @@ abstract contract FreezeVotingBase is
         if (
             $.freezeProposalVoteCount >= $.freezeVotesThreshold && !$.isFrozen
         ) {
+            // CRITICAL: Update lastFreezeTimestamp to enforce security invariant
+            // This timestamp is NEVER cleared and ensures all transactions
+            // timelocked before this moment are permanently invalidated
+            $.lastFreezeTimestamp = uint48(block.timestamp);
+
             $.isFrozen = true;
             emit DAOFrozen(block.timestamp);
         }

--- a/contracts/interfaces/decent/deployables/IFreezable.sol
+++ b/contracts/interfaces/decent/deployables/IFreezable.sol
@@ -24,4 +24,23 @@ interface IFreezable {
      * @return isFrozen True if the DAO is currently frozen, false otherwise
      */
     function isFrozen() external view returns (bool isFrozen);
+
+    /**
+     * @notice Returns the timestamp of the most recent freeze, even if currently unfrozen
+     * @dev CRITICAL SECURITY FUNCTION: This enables the freeze guard security model.
+     *
+     * Security Invariant: Any transaction that was timelocked BEFORE this timestamp
+     * will NEVER be executable, regardless of the current freeze/unfreeze state.
+     *
+     * This timestamp:
+     * - Is set to block.timestamp whenever the DAO is frozen
+     * - Is NEVER cleared (remains set even after unfreeze)
+     * - Ensures all pre-freeze timelocked transactions are permanently invalidated
+     *
+     * @return lastFreezeTimestamp Timestamp of the most recent freeze, or 0 if never frozen
+     */
+    function lastFreezeTime()
+        external
+        view
+        returns (uint48 lastFreezeTimestamp);
 }

--- a/contracts/interfaces/decent/deployables/IFreezeGuardMultisigV1.sol
+++ b/contracts/interfaces/decent/deployables/IFreezeGuardMultisigV1.sol
@@ -44,6 +44,9 @@ interface IFreezeGuardMultisigV1 is IFreezeGuardBaseV1 {
     /** @notice Thrown when attempting to execute a transaction after execution period expired */
     error Expired();
 
+    /** @notice Thrown when attempting to execute a transaction that was timelocked before the most recent freeze */
+    error TimelockedBeforeFreeze();
+
     // --- Events ---
 
     /**

--- a/contracts/mocks/MockFreezable.sol
+++ b/contracts/mocks/MockFreezable.sol
@@ -10,6 +10,7 @@ import {IFreezable} from "../interfaces/decent/deployables/IFreezable.sol";
  */
 contract MockFreezable is IFreezable {
     bool private _isFrozen;
+    uint48 private _lastFreezeTimestamp;
 
     /**
      * @notice Sets the frozen state for testing
@@ -20,9 +21,24 @@ contract MockFreezable is IFreezable {
     }
 
     /**
+     * @notice Sets the last known freeze timestamp for testing
+     * @param timestamp The most recent freeze timestamp
+     */
+    function setLastKnownFreezeTime(uint48 timestamp) external {
+        _lastFreezeTimestamp = timestamp;
+    }
+
+    /**
      * @inheritdoc IFreezable
      */
     function isFrozen() external view override returns (bool) {
         return _isFrozen;
+    }
+
+    /**
+     * @inheritdoc IFreezable
+     */
+    function lastFreezeTime() external view override returns (uint48) {
+        return _lastFreezeTimestamp;
     }
 }

--- a/test/unit/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
+++ b/test/unit/deployables/freeze-guard/FreezeGuardMultisigV1.test.ts
@@ -269,6 +269,27 @@ describe('FreezeGuardMultisigV1', () => {
         ),
       ).to.be.reverted;
     });
+
+    it('should revert if trying to timelock when DAO is frozen', async () => {
+      // Set DAO to frozen
+      await mockFreezable.setIsFrozen(true);
+
+      await expect(
+        multisigFreezeGuard.timelockTransaction(
+          to,
+          value,
+          data,
+          operation,
+          safeTxGas,
+          baseGas,
+          gasPrice,
+          gasToken,
+          refundReceiver,
+          mockSignatures,
+          nonce,
+        ),
+      ).to.be.revertedWithCustomError(multisigFreezeGuard, 'DAOFrozen');
+    });
   });
 
   describe('Transaction Checking', () => {
@@ -406,6 +427,188 @@ describe('FreezeGuardMultisigV1', () => {
           ethers.ZeroAddress,
         ),
       ).not.to.be.reverted;
+    });
+
+    it('should revert if transaction was timelocked before the most recent freeze', async () => {
+      // First timelock the transaction (already done in beforeEach)
+      // Get the timelock timestamp
+      const timelockTimestamp =
+        await multisigFreezeGuard.getTransactionTimelocked(mockSignaturesHash);
+
+      // Wait for timelock period to pass
+      await time.increase(TIMELOCK_PERIOD + 1);
+
+      // Simulate a freeze that happened AFTER the timelock
+      const freezeTimestamp = timelockTimestamp + 10n; // 10 seconds after timelock
+      await mockFreezable.setLastKnownFreezeTime(freezeTimestamp);
+
+      // DAO is not currently frozen but there was a freeze after this transaction was timelocked
+      await mockFreezable.setIsFrozen(false);
+
+      // Should revert because transaction was timelocked before the most recent freeze
+      await expect(
+        multisigFreezeGuard.checkTransaction(
+          to,
+          value,
+          data,
+          operation,
+          safeTxGas,
+          baseGas,
+          gasPrice,
+          gasToken,
+          refundReceiver,
+          mockSignatures,
+          ethers.ZeroAddress,
+        ),
+      ).to.be.revertedWithCustomError(multisigFreezeGuard, 'TimelockedBeforeFreeze');
+    });
+
+    it('should allow transaction if timelocked after the most recent freeze', async () => {
+      // First timelock the transaction (already done in beforeEach)
+      // Get the timelock timestamp
+      const timelockTimestamp =
+        await multisigFreezeGuard.getTransactionTimelocked(mockSignaturesHash);
+
+      // Wait for timelock period to pass
+      await time.increase(TIMELOCK_PERIOD + 1);
+
+      // Simulate a freeze that happened BEFORE the timelock
+      const freezeTimestamp = timelockTimestamp - 10n; // 10 seconds before timelock
+      await mockFreezable.setLastKnownFreezeTime(freezeTimestamp);
+
+      // DAO is not currently frozen
+      await mockFreezable.setIsFrozen(false);
+
+      // Should not revert because transaction was timelocked after the most recent freeze
+      await expect(
+        multisigFreezeGuard.checkTransaction(
+          to,
+          value,
+          data,
+          operation,
+          safeTxGas,
+          baseGas,
+          gasPrice,
+          gasToken,
+          refundReceiver,
+          mockSignatures,
+          ethers.ZeroAddress,
+        ),
+      ).not.to.be.reverted;
+    });
+
+    it('should allow transaction if lastKnownFreezeTime returns 0 (never frozen)', async () => {
+      await time.increase(TIMELOCK_PERIOD + 1);
+
+      // Set never frozen state
+      await mockFreezable.setIsFrozen(false);
+      await mockFreezable.setLastKnownFreezeTime(0);
+
+      // Should not revert
+      await expect(
+        multisigFreezeGuard.checkTransaction(
+          to,
+          value,
+          data,
+          operation,
+          safeTxGas,
+          baseGas,
+          gasPrice,
+          gasToken,
+          refundReceiver,
+          mockSignatures,
+          ethers.ZeroAddress,
+        ),
+      ).not.to.be.reverted;
+    });
+
+    it('should enforce security invariant across multiple freeze/unfreeze cycles', async () => {
+      // CRITICAL TEST: Demonstrates the security invariant that transactions
+      // timelocked before the most recent freeze are permanently invalid
+
+      // Timeline:
+      // T1: Transaction A is timelocked (already done in beforeEach)
+
+      // T2: First freeze occurs after the timelock
+      await time.increase(10);
+      const firstFreezeTime = await time.latest();
+      await mockFreezable.setLastKnownFreezeTime(firstFreezeTime);
+      await mockFreezable.setIsFrozen(true);
+
+      // T3: DAO is unfrozen
+      await time.increase(10);
+      await mockFreezable.setIsFrozen(false);
+      // CRITICAL: lastKnownFreezeTime is NOT cleared
+
+      // Transaction A should still be blocked even though DAO is unfrozen
+      // Wait for timelock period to pass
+      await time.increase(TIMELOCK_PERIOD);
+
+      await expect(
+        multisigFreezeGuard.checkTransaction(
+          to,
+          value,
+          data,
+          operation,
+          safeTxGas,
+          baseGas,
+          gasPrice,
+          gasToken,
+          refundReceiver,
+          mockSignatures,
+          ethers.ZeroAddress,
+        ),
+      ).to.be.revertedWithCustomError(multisigFreezeGuard, 'TimelockedBeforeFreeze');
+
+      // T4: New transaction B is timelocked after unfreeze
+      const newSignatures = ethers.randomBytes(65);
+      const newSignaturesHash = ethers.keccak256(newSignatures);
+      await mockSafe.setValidSignature(newSignaturesHash, true);
+
+      await multisigFreezeGuard.timelockTransaction(
+        ethers.ZeroAddress,
+        0,
+        '0x',
+        Operation.Call,
+        0,
+        0,
+        0,
+        ethers.ZeroAddress,
+        ethers.ZeroAddress,
+        newSignatures,
+        1,
+      );
+
+      // T5: Second freeze occurs
+      await time.increase(10);
+      const secondFreezeTime = await time.latest();
+      await mockFreezable.setLastKnownFreezeTime(secondFreezeTime);
+      await mockFreezable.setIsFrozen(true);
+
+      // T6: DAO is unfrozen again
+      await time.increase(10);
+      await mockFreezable.setIsFrozen(false);
+
+      // Transaction A has now exceeded its execution window, but let's verify
+      // Transaction B which is still within its window
+
+      // Transaction B should be blocked (was before second freeze)
+      await time.increase(TIMELOCK_PERIOD);
+      await expect(
+        multisigFreezeGuard.checkTransaction(
+          ethers.ZeroAddress,
+          0,
+          '0x',
+          Operation.Call,
+          0,
+          0,
+          0,
+          ethers.ZeroAddress,
+          ethers.ZeroAddress,
+          newSignatures,
+          ethers.ZeroAddress,
+        ),
+      ).to.be.revertedWithCustomError(multisigFreezeGuard, 'TimelockedBeforeFreeze');
     });
   });
 


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/419

Fixes [ENG-1274](https://linear.app/decent-labs/issue/ENG-1274/implement-security-protection-against-pre-freeze-timelocked)

Implements critical security features to prevent circumvention of freeze mechanism:

Security Features:
- Prevent new timelocks when DAO is frozen
- Block execution of transactions timelocked before the most recent freeze
- Track permanent freeze timestamp that is never cleared

Changes:
- Add lastKnownFreezeTime() to IFreezable interface
- Implement lastFreezeTimestamp tracking in FreezeVotingBase
- Add security checks in FreezeGuardMultisigV1:
  - timelockTransaction() reverts if DAO is frozen
  - checkTransaction() reverts if transaction was timelocked before freeze
- Add new TimelockedBeforeFreeze error for clarity
- Update MockFreezable to support lastKnownFreezeTime()
- Add comprehensive tests for security invariants

SECURITY INVARIANT: Any transaction timelocked before the most recent freeze is permanently invalidated and can never be executed, even after the DAO is unfrozen. This prevents malicious actors from queuing harmful transactions and waiting for an unfreeze to execute them.

The lastFreezeTimestamp is set when a DAO freezes and is NEVER cleared, ensuring the security model remains intact across freeze/unfreeze cycles.