### PR TITLE
feat(contracts): Add FreezeVotingStandaloneV1 deployment support to SystemDeployerV1

### DIFF
--- a/contracts/interfaces/decent/singletons/ISystemDeployerV1.sol
+++ b/contracts/interfaces/decent/singletons/ISystemDeployerV1.sol
@@ -46,14 +46,17 @@ interface ISystemDeployerV1 {
     /** @notice Thrown when referencing a governance token that wasn't deployed */
     error VotesERC20V1NotFoundAtIndex(uint256 tokenIndex);
 
-    /** @notice Thrown when attempting to deploy both Multisig and Azorius freeze voting */
-    error CannotDeployBothFreezeVotingContracts();
+    /** @notice Thrown when attempting to deploy multiple freeze voting contracts */
+    error CannotDeployMultipleFreezeVotingContracts();
 
     /** @notice Thrown when freeze guard references a freeze voting contract that wasn't deployed */
     error FreezeVotingContractNotDeployed();
 
     /** @notice Thrown when freeze components reference an Azorius module that wasn't deployed */
     error AzoriusModuleNotDeployed();
+
+    /** @notice Thrown when FreezeVotingStandaloneV1 is paired with FreezeGuardAzoriusV1 */
+    error InvalidFreezeVotingGuardPairing();
 
     // --- Structs ---
 
@@ -269,6 +272,24 @@ interface ISystemDeployerV1 {
     }
 
     /**
+     * @notice Parameters for standalone freeze voting
+     * @param implementation The FreezeVotingStandaloneV1 implementation
+     * @param freezeVotesThreshold Votes required to freeze
+     * @param unfreezeVotesThreshold Votes required to unfreeze
+     * @param freezeProposalPeriod Duration for freeze voting
+     * @param unfreezeProposalPeriod Duration for unfreeze voting
+     * @param lightAccountFactory Address of the LightAccountFactory
+     */
+    struct FreezeVotingStandaloneV1Params {
+        address implementation;
+        uint256 freezeVotesThreshold;
+        uint256 unfreezeVotesThreshold;
+        uint32 freezeProposalPeriod;
+        uint32 unfreezeProposalPeriod;
+        address lightAccountFactory;
+    }
+
+    /**
      * @notice Freeze guard configurations (choose one)
      */
     struct FreezeGuardParams {
@@ -277,11 +298,22 @@ interface ISystemDeployerV1 {
     }
 
     /**
+     * @notice Parameters for standalone freeze voting with its voting configs
+     * @param freezeVotingStandaloneV1Params Configuration for standalone token-based freeze voting
+     * @param votingConfigParams Voting configurations for the standalone freeze voting
+     */
+    struct FreezeVotingStandaloneParams {
+        FreezeVotingStandaloneV1Params freezeVotingStandaloneV1Params;
+        VotingConfigParams votingConfigParams;
+    }
+
+    /**
      * @notice Freeze voting configurations (choose one)
      */
     struct FreezeVotingParams {
         FreezeVotingMultisigV1Params freezeVotingMultisigV1Params;
         FreezeVotingAzoriusV1Params freezeVotingAzoriusV1Params;
+        FreezeVotingStandaloneParams freezeVotingStandaloneParams;
     }
 
     /**

--- a/contracts/singletons/SystemDeployerV1.sol
+++ b/contracts/singletons/SystemDeployerV1.sol
@@ -41,6 +41,9 @@ import {
     IFreezeVotingAzoriusV1
 } from "../interfaces/decent/deployables/IFreezeVotingAzoriusV1.sol";
 import {
+    IFreezeVotingStandaloneV1
+} from "../interfaces/decent/deployables/IFreezeVotingStandaloneV1.sol";
+import {
     IFreezeGuardMultisigV1
 } from "../interfaces/decent/deployables/IFreezeGuardMultisigV1.sol";
 import {
@@ -241,7 +244,12 @@ contract SystemDeployerV1 is
 
         _deployModuleFractal(salt_, moduleFractalV1Params_);
 
-        _deployFreezeContracts(salt_, freezeParams_, azoriusModuleAddress);
+        _deployFreezeContracts(
+            salt_,
+            freezeParams_,
+            azoriusModuleAddress,
+            newVotesERC20V1Addresses
+        );
 
         bytes memory initData = abi.encode(
             votesERC20V1Params_,
@@ -935,16 +943,36 @@ contract SystemDeployerV1 is
      * @param salt_ Salt for deterministic deployment
      * @param freezeParams_ Freeze mechanism configurations
      * @param azoriusModuleAddress Address of Azorius module (for freeze guard attachment)
+     * @param newVotesERC20V1Addresses Addresses of newly deployed governance tokens
      */
     function _deployFreezeContracts(
         bytes32 salt_,
         FreezeParams memory freezeParams_,
-        address azoriusModuleAddress
+        address azoriusModuleAddress,
+        address[] memory newVotesERC20V1Addresses
     ) internal {
+        // Validate that FreezeVotingStandaloneV1 is not paired with FreezeGuardAzoriusV1
+        if (
+            freezeParams_
+                .freezeVotingParams
+                .freezeVotingStandaloneParams
+                .freezeVotingStandaloneV1Params
+                .implementation !=
+            address(0) &&
+            freezeParams_
+                .freezeGuardParams
+                .freezeGuardAzoriusV1Params
+                .implementation !=
+            address(0)
+        ) {
+            revert InvalidFreezeVotingGuardPairing();
+        }
+
         // Deploy freeze voting contract (controls when child can be frozen)
         address freezeVotingAddress = _deployFreezeVoting(
             salt_,
-            freezeParams_.freezeVotingParams
+            freezeParams_.freezeVotingParams,
+            newVotesERC20V1Addresses
         );
 
         // Deploy freeze guard (enforces freeze when activated)
@@ -957,16 +985,18 @@ contract SystemDeployerV1 is
     }
 
     /**
-     * @notice Deploys freeze voting contract (multisig or Azorius-based)
+     * @notice Deploys freeze voting contract (multisig, Azorius-based, or standalone)
      * @dev Only one type can be deployed. Returns the deployed address or zero.
-     * Validates that both types aren't specified.
+     * Validates that multiple types aren't specified.
      * @param salt_ Salt for deterministic deployment
      * @param freezeVotingParams_ Freeze voting configurations
+     * @param newVotesERC20V1Addresses_ Addresses of newly deployed governance tokens
      * @return freezeVotingAddress The deployed freeze voting contract address
      */
     function _deployFreezeVoting(
         bytes32 salt_,
-        FreezeVotingParams memory freezeVotingParams_
+        FreezeVotingParams memory freezeVotingParams_,
+        address[] memory newVotesERC20V1Addresses_
     ) internal returns (address) {
         FreezeVotingMultisigV1Params
             memory freezeVotingMultisigV1Params = freezeVotingParams_
@@ -976,11 +1006,24 @@ contract SystemDeployerV1 is
             memory freezeVotingAzoriusV1Params = freezeVotingParams_
                 .freezeVotingAzoriusV1Params;
 
+        FreezeVotingStandaloneParams
+            memory freezeVotingStandaloneParams = freezeVotingParams_
+                .freezeVotingStandaloneParams;
+
+        // Count how many freeze voting types are specified
+        uint8 freezeVotingCount = 0;
+        if (freezeVotingMultisigV1Params.implementation != address(0))
+            freezeVotingCount++;
+        if (freezeVotingAzoriusV1Params.implementation != address(0))
+            freezeVotingCount++;
         if (
-            freezeVotingMultisigV1Params.implementation != address(0) &&
-            freezeVotingAzoriusV1Params.implementation != address(0)
-        ) {
-            revert CannotDeployBothFreezeVotingContracts();
+            freezeVotingStandaloneParams
+                .freezeVotingStandaloneV1Params
+                .implementation != address(0)
+        ) freezeVotingCount++;
+
+        if (freezeVotingCount > 1) {
+            revert CannotDeployMultipleFreezeVotingContracts();
         }
 
         address freezeVotingAddress;
@@ -1016,6 +1059,18 @@ contract SystemDeployerV1 is
                     )
                 ),
                 salt_
+            );
+        }
+
+        if (
+            freezeVotingStandaloneParams
+                .freezeVotingStandaloneV1Params
+                .implementation != address(0)
+        ) {
+            freezeVotingAddress = _deployFreezeVotingStandalone(
+                salt_,
+                freezeVotingStandaloneParams,
+                newVotesERC20V1Addresses_
             );
         }
 
@@ -1134,5 +1189,64 @@ contract SystemDeployerV1 is
             // Azorius Module has same "setGuard" function signature as Safe
             ISafe(azoriusModuleAddress).setGuard(azoriusFreezeGuardAddress);
         }
+    }
+
+    /**
+     * @notice Deploys FreezeVotingStandaloneV1 with voting configs
+     * @dev Handles the circular dependency between FreezeVotingStandalone and VoteTrackers
+     * by using a two-step initialization process.
+     * @param salt_ Salt for deterministic deployment
+     * @param freezeVotingStandaloneParams Parameters for standalone freeze voting and its voting configs
+     * @param newVotesERC20V1Addresses_ Addresses of newly deployed governance tokens
+     * @return freezeVotingAddress The deployed freeze voting standalone address
+     */
+    function _deployFreezeVotingStandalone(
+        bytes32 salt_,
+        FreezeVotingStandaloneParams memory freezeVotingStandaloneParams,
+        address[] memory newVotesERC20V1Addresses_
+    ) internal returns (address) {
+        // Step 1: Deploy FreezeVotingStandalone without voting configs
+        // This gives us a deterministic address we can use for vote tracker authorization
+        address freezeVotingAddress = deployProxy(
+            freezeVotingStandaloneParams
+                .freezeVotingStandaloneV1Params
+                .implementation,
+            abi.encodeCall(
+                IFreezeVotingStandaloneV1.initialize,
+                (
+                    freezeVotingStandaloneParams
+                        .freezeVotingStandaloneV1Params
+                        .freezeVotesThreshold,
+                    freezeVotingStandaloneParams
+                        .freezeVotingStandaloneV1Params
+                        .unfreezeVotesThreshold,
+                    freezeVotingStandaloneParams
+                        .freezeVotingStandaloneV1Params
+                        .freezeProposalPeriod,
+                    freezeVotingStandaloneParams
+                        .freezeVotingStandaloneV1Params
+                        .unfreezeProposalPeriod,
+                    freezeVotingStandaloneParams
+                        .freezeVotingStandaloneV1Params
+                        .lightAccountFactory
+                )
+            ),
+            salt_
+        );
+
+        // Step 2: Deploy voting configs with FreezeVotingStandalone as authorized caller
+        IVotingTypes.VotingConfig[] memory votingConfigs = _deployVotingConfigs(
+            salt_,
+            freezeVotingStandaloneParams.votingConfigParams,
+            newVotesERC20V1Addresses_,
+            freezeVotingAddress // Use freeze voting as authorized caller
+        );
+
+        // Step 3: Complete initialization by setting the voting configs
+        IFreezeVotingStandaloneV1(freezeVotingAddress).initialize2(
+            votingConfigs
+        );
+
+        return freezeVotingAddress;
     }
 }

--- a/ignition/modules/deployables/DeployablesModule.ts
+++ b/ignition/modules/deployables/DeployablesModule.ts
@@ -26,6 +26,7 @@ export default buildModule('Deployables', m => {
   // Deploy Freeze Voting
   const freezeVotingAzoriusV1 = m.contract('FreezeVotingAzoriusV1');
   const freezeVotingMultisigV1 = m.contract('FreezeVotingMultisigV1');
+  const freezeVotingStandaloneV1 = m.contract('FreezeVotingStandaloneV1');
 
   // Deploy VotesERC20 implementations
   const votesERC20V1 = m.contract('VotesERC20V1');
@@ -63,6 +64,7 @@ export default buildModule('Deployables', m => {
 
     freezeVotingAzoriusV1,
     freezeVotingMultisigV1,
+    freezeVotingStandaloneV1,
 
     votesERC20V1,
     votesERC20StakedV1,

--- a/test/unit/singletons/SystemDeployerV1.test.ts
+++ b/test/unit/singletons/SystemDeployerV1.test.ts
@@ -10,6 +10,7 @@ import {
   FreezeGuardMultisigV1__factory,
   FreezeVotingAzoriusV1__factory,
   FreezeVotingMultisigV1__factory,
+  FreezeVotingStandaloneV1__factory,
   IDeploymentBlock__factory,
   IncompatibleStorageContract__factory,
   ISystemDeployerV1,
@@ -303,6 +304,7 @@ function createSetupSafeParams(overrides?: {
   freezeGuardAzoriusParams?: Partial<ISystemDeployerV1.FreezeGuardAzoriusV1ParamsStruct>;
   freezeVotingMultisigParams?: Partial<ISystemDeployerV1.FreezeVotingMultisigV1ParamsStruct>;
   freezeVotingAzoriusParams?: Partial<ISystemDeployerV1.FreezeVotingAzoriusV1ParamsStruct>;
+  freezeVotingStandaloneParams?: Partial<ISystemDeployerV1.FreezeVotingStandaloneParamsStruct>;
 }) {
   // Default Votes ERC20 params (all empty/zero)
   const votesERC20Params: ISystemDeployerV1.VotesERC20V1ParamsStruct[] = overrides?.votesERC20Params
@@ -354,6 +356,7 @@ function createSetupSafeParams(overrides?: {
   };
 
   // Default Freeze params (all empty/zero)
+  // Build freeze params from individual parameters
   const freezeParams: ISystemDeployerV1.FreezeParamsStruct = {
     freezeGuardParams: {
       freezeGuardMultisigV1Params: {
@@ -387,6 +390,21 @@ function createSetupSafeParams(overrides?: {
         parentAzorius: ethers.ZeroAddress,
         lightAccountFactory: ethers.ZeroAddress,
         ...overrides?.freezeVotingAzoriusParams,
+      },
+      freezeVotingStandaloneParams: {
+        freezeVotingStandaloneV1Params: {
+          implementation: ethers.ZeroAddress,
+          freezeVotesThreshold: 0,
+          unfreezeVotesThreshold: 0,
+          freezeProposalPeriod: 0,
+          unfreezeProposalPeriod: 0,
+          lightAccountFactory: ethers.ZeroAddress,
+        },
+        votingConfigParams: {
+          votingConfigERC20V1Params: [],
+          votingConfigERC721V1Params: [],
+        },
+        ...overrides?.freezeVotingStandaloneParams,
       },
     },
   };
@@ -1395,6 +1413,131 @@ async function findAndVerifyFreezeVotingAzoriusV1(params: {
   return freezeVotingAzoriusProxy;
 }
 
+// Helper function to find and verify FreezeVotingStandalone deployment and configuration
+async function findAndVerifyFreezeVotingStandaloneV1(params: {
+  fixtureData: {
+    systemDeployer: SystemDeployerV1;
+    deployer: SignerWithAddress;
+    votingWeightERC20V1: VotingWeightERC20V1;
+    votingWeightERC721V1: VotingWeightERC721V1;
+    voteTrackerERC20V1: VoteTrackerERC20V1;
+    voteTrackerERC721V1: VoteTrackerERC721V1;
+    votesERC20V1: VotesERC20V1;
+  };
+  receipt: ContractTransactionReceipt;
+  implementation: AddressLike;
+  freezeVotesThreshold: BigNumberish;
+  unfreezeVotesThreshold: BigNumberish;
+  freezeProposalPeriod: BigNumberish;
+  unfreezeProposalPeriod: BigNumberish;
+  lightAccountFactory: AddressLike;
+  votesERC20V1Tokens?: VotesERC20V1[];
+  votingConfigERC20V1Datas?: {
+    params: {
+      votingWeightImplementation: AddressLike;
+      voteTrackerImplementation: AddressLike;
+      token: AddressLike;
+      newTokenIndex: BigNumberish;
+      weightPerToken: BigNumberish;
+    };
+    token?: string;
+  }[];
+  votingConfigERC721V1Datas?: {
+    params: {
+      votingWeightImplementation: AddressLike;
+      voteTrackerImplementation: AddressLike;
+      token: AddressLike;
+      weightPerToken: BigNumberish;
+    };
+  }[];
+}) {
+  const {
+    fixtureData,
+    receipt,
+    implementation,
+    freezeVotesThreshold,
+    unfreezeVotesThreshold,
+    freezeProposalPeriod,
+    unfreezeProposalPeriod,
+    lightAccountFactory,
+    votesERC20V1Tokens = [],
+    votingConfigERC20V1Datas,
+    votingConfigERC721V1Datas,
+  } = params;
+
+  const freezeVotingStandaloneAddress = await findProxyDeployed({
+    fixtureData,
+    receipt,
+    implementation,
+  });
+
+  // Connect to the deployed FreezeVotingStandalone proxy
+  const freezeVotingStandaloneProxy = FreezeVotingStandaloneV1__factory.connect(
+    freezeVotingStandaloneAddress,
+    fixtureData.deployer,
+  );
+
+  // Verify basic parameters
+  expect(await freezeVotingStandaloneProxy.freezeVotesThreshold()).to.equal(freezeVotesThreshold);
+  expect(await freezeVotingStandaloneProxy.unfreezeVotesThreshold()).to.equal(
+    unfreezeVotesThreshold,
+  );
+  expect(await freezeVotingStandaloneProxy.freezeProposalPeriod()).to.equal(freezeProposalPeriod);
+  expect(await freezeVotingStandaloneProxy.unfreezeProposalPeriod()).to.equal(
+    unfreezeProposalPeriod,
+  );
+  expect(await freezeVotingStandaloneProxy.lightAccountFactory()).to.equal(lightAccountFactory);
+
+  // Verify voting configs
+  let votingConfigERC20s: { votingWeight: string; voteTracker: string }[] = [];
+  if (votingConfigERC20V1Datas) {
+    votingConfigERC20s = await findAndVerifyVotingConfigERC20V1s({
+      fixtureData,
+      receipt,
+      implementation: await fixtureData.votingWeightERC20V1.getAddress(),
+      votingConfigDatas: await Promise.all(
+        votingConfigERC20V1Datas.map(async data => ({
+          ...data,
+          params: {
+            ...data.params,
+            strategy: freezeVotingStandaloneAddress, // Use freeze voting as the strategy
+          },
+          token:
+            data.token ??
+            (await votesERC20V1Tokens[Number(data.params.newTokenIndex)].getAddress()),
+        })),
+      ),
+    });
+  }
+
+  let votingConfigERC721s: { votingWeight: string; voteTracker: string }[] = [];
+  if (votingConfigERC721V1Datas) {
+    votingConfigERC721s = await findAndVerifyVotingConfigERC721V1s({
+      fixtureData,
+      receipt,
+      implementation: await fixtureData.votingWeightERC721V1.getAddress(),
+      votingConfigDatas: await Promise.all(
+        votingConfigERC721V1Datas.map(async data => ({
+          ...data,
+          params: { ...data.params, strategy: freezeVotingStandaloneAddress },
+        })),
+      ),
+    });
+  }
+
+  // Verify the voting configs match what's in the contract
+  const actualVotingConfigs = await freezeVotingStandaloneProxy.getVotingConfigs();
+  const expectedVotingConfigs = [...votingConfigERC20s, ...votingConfigERC721s];
+
+  expect(actualVotingConfigs.length).to.equal(expectedVotingConfigs.length);
+  for (let i = 0; i < actualVotingConfigs.length; i++) {
+    expect(actualVotingConfigs[i].votingWeight).to.equal(expectedVotingConfigs[i].votingWeight);
+    expect(actualVotingConfigs[i].voteTracker).to.equal(expectedVotingConfigs[i].voteTracker);
+  }
+
+  return freezeVotingStandaloneProxy;
+}
+
 // Helper function to verify the number of new contracts deployed
 function verifyNumberOfNewContractsDeployed(params: {
   fixtureData: {
@@ -1557,6 +1700,16 @@ async function findAndVerifySafe(params: {
     guardParams: ISystemDeployerV1.FreezeGuardMultisigV1ParamsStruct;
     votingMultisigParams?: ISystemDeployerV1.FreezeVotingMultisigV1ParamsStruct;
     votingAzoriusParams?: ISystemDeployerV1.FreezeVotingAzoriusV1ParamsStruct;
+    votingStandaloneParams?: {
+      freezeVotingParams: ISystemDeployerV1.FreezeVotingStandaloneV1ParamsStruct;
+      votingConfigERC20V1Datas?: {
+        params: ISystemDeployerV1.VotingConfigERC20V1ParamsStruct;
+        token?: string;
+      }[];
+      votingConfigERC721V1Datas?: {
+        params: ISystemDeployerV1.VotingConfigERC721V1ParamsStruct;
+      }[];
+    };
   };
   freezeGuardAzoriusV1Data?: {
     guardParams: ISystemDeployerV1.FreezeGuardAzoriusV1ParamsStruct;
@@ -1616,7 +1769,7 @@ async function findAndVerifySafe(params: {
     });
   }
 
-  let votesERC20V1Tokens: VotesERC20V1[];
+  let votesERC20V1Tokens: VotesERC20V1[] = [];
   if (votesERC20V1Datas && votesERC20V1Datas.length > 0) {
     votesERC20V1Tokens = await findAndVerifyVotesERC20V1s({
       fixtureData,
@@ -1753,11 +1906,14 @@ async function findAndVerifySafe(params: {
   }
 
   if (freezeGuardMultisigV1Data) {
-    if (
-      freezeGuardMultisigV1Data.votingAzoriusParams &&
-      freezeGuardMultisigV1Data.votingMultisigParams
-    ) {
-      throw new Error('Cannot have both votingAzoriusParams and votingMultisigParams');
+    const votingParamsCount = [
+      freezeGuardMultisigV1Data.votingAzoriusParams,
+      freezeGuardMultisigV1Data.votingMultisigParams,
+      freezeGuardMultisigV1Data.votingStandaloneParams,
+    ].filter(Boolean).length;
+
+    if (votingParamsCount > 1) {
+      throw new Error('Cannot have multiple voting params types');
     }
 
     let freezeVotingAddress: string | undefined;
@@ -1782,6 +1938,21 @@ async function findAndVerifySafe(params: {
       ).getAddress();
     }
 
+    if (freezeGuardMultisigV1Data.votingStandaloneParams) {
+      freezeVotingAddress = await (
+        await findAndVerifyFreezeVotingStandaloneV1({
+          fixtureData,
+          receipt,
+          ...freezeGuardMultisigV1Data.votingStandaloneParams.freezeVotingParams,
+          votesERC20V1Tokens,
+          votingConfigERC20V1Datas:
+            freezeGuardMultisigV1Data.votingStandaloneParams.votingConfigERC20V1Datas,
+          votingConfigERC721V1Datas:
+            freezeGuardMultisigV1Data.votingStandaloneParams.votingConfigERC721V1Datas,
+        })
+      ).getAddress();
+    }
+
     if (!freezeVotingAddress) {
       throw new Error('No freeze voting address found');
     }
@@ -1800,11 +1971,13 @@ async function findAndVerifySafe(params: {
       throw new Error('Azorius module is required to verify freeze guard Azorius');
     }
 
-    if (
-      freezeGuardAzoriusV1Data.votingAzoriusParams &&
-      freezeGuardAzoriusV1Data.votingMultisigParams
-    ) {
-      throw new Error('Cannot have both votingAzoriusParams and votingMultisigParams');
+    const votingParamsCount = [
+      freezeGuardAzoriusV1Data.votingAzoriusParams,
+      freezeGuardAzoriusV1Data.votingMultisigParams,
+    ].filter(Boolean).length;
+
+    if (votingParamsCount > 1) {
+      throw new Error('Cannot have multiple voting params types');
     }
 
     let freezeVotingAddress: string | undefined;
@@ -1980,6 +2153,7 @@ async function setupState() {
   const freezeGuardAzoriusV1 = await new FreezeGuardAzoriusV1__factory(deployer).deploy();
   const freezeVotingMultisigV1 = await new FreezeVotingMultisigV1__factory(deployer).deploy();
   const freezeVotingAzoriusV1 = await new FreezeVotingAzoriusV1__factory(deployer).deploy();
+  const freezeVotingStandaloneV1 = await new FreezeVotingStandaloneV1__factory(deployer).deploy();
   const moduleAzoriusV1 = await new ModuleAzoriusV1__factory(deployer).deploy();
   const strategyV1 = await new StrategyV1__factory(deployer).deploy();
   const votesERC20V1 = await new VotesERC20V1__factory(deployer).deploy();
@@ -2044,6 +2218,7 @@ async function setupState() {
     freezeGuardAzoriusV1,
     freezeVotingMultisigV1,
     freezeVotingAzoriusV1,
+    freezeVotingStandaloneV1,
     moduleAzoriusV1,
     strategyV1,
     votesERC20V1,
@@ -2293,6 +2468,66 @@ describe('SystemDeployerV1', () => {
               votingAzoriusParams: freezeVotingAzoriusParams,
             },
             numberOfNewContracts: 2,
+          });
+        });
+
+        it('succeeds with FreezeGuardMultisig and FreezeVotingStandalone contracts', async () => {
+          const freezeVotingStandaloneParams: ISystemDeployerV1.FreezeVotingStandaloneParamsStruct =
+            {
+              freezeVotingStandaloneV1Params: {
+                implementation: await fixtureData.freezeVotingStandaloneV1.getAddress(),
+                freezeVotesThreshold: ethers.parseEther('100'),
+                unfreezeVotesThreshold: ethers.parseEther('150'),
+                freezeProposalPeriod: 7200,
+                unfreezeProposalPeriod: 3600,
+                lightAccountFactory: ethers.ZeroAddress,
+              },
+              votingConfigParams: {
+                votingConfigERC20V1Params: [
+                  {
+                    votingWeightImplementation: await fixtureData.votingWeightERC20V1.getAddress(),
+                    voteTrackerImplementation: await fixtureData.voteTrackerERC20V1.getAddress(),
+                    token: ethers.ZeroAddress,
+                    newTokenIndex: 0,
+                    weightPerToken: ethers.parseEther('1'),
+                  },
+                ],
+                votingConfigERC721V1Params: [],
+              },
+            };
+
+          const setupSafeParams = createSetupSafeParams({
+            votesERC20Params: [votesERC20V1Params1],
+            freezeVotingStandaloneParams,
+            freezeGuardMultisigParams,
+          });
+
+          await findAndVerifySafe({
+            ...(await deploySafeWithSetup({
+              fixtureData,
+              owners,
+              threshold,
+              setupSafeParams,
+            })),
+            fixtureData,
+            owners,
+            threshold,
+            votesERC20V1Datas: [votesERC20V1Params1],
+            freezeGuardMultisigV1Data: {
+              guardParams: freezeGuardMultisigParams,
+              votingStandaloneParams: {
+                freezeVotingParams: freezeVotingStandaloneParams.freezeVotingStandaloneV1Params,
+                votingConfigERC20V1Datas:
+                  freezeVotingStandaloneParams.votingConfigParams.votingConfigERC20V1Params.map(
+                    p => ({ params: p }),
+                  ),
+                votingConfigERC721V1Datas:
+                  freezeVotingStandaloneParams.votingConfigParams.votingConfigERC721V1Params.map(
+                    p => ({ params: p }),
+                  ),
+              },
+            },
+            numberOfNewContracts: 5, // Safe + Token + FreezeVotingStandalone + VotingWeight + VoteTracker + FreezeGuardMultisig = 6, but Safe is not counted as "new"
           });
         });
       });
@@ -3956,6 +4191,109 @@ describe('SystemDeployerV1', () => {
               // now deploying should fail
               await expect(deploySafeWithSetup(data)).to.be.reverted;
             });
+
+            it('deploys with a FreezeGuardMultisig with FreezeVotingStandalone', async () => {
+              const freezeVotingStandaloneParams: ISystemDeployerV1.FreezeVotingStandaloneParamsStruct =
+                {
+                  freezeVotingStandaloneV1Params: {
+                    implementation: await fixtureData.freezeVotingStandaloneV1.getAddress(),
+                    freezeVotesThreshold: ethers.parseEther('150'),
+                    unfreezeVotesThreshold: ethers.parseEther('200'),
+                    freezeProposalPeriod: 7200,
+                    unfreezeProposalPeriod: 3600,
+                    lightAccountFactory: ethers.ZeroAddress,
+                  },
+                  votingConfigParams: {
+                    votingConfigERC20V1Params: [
+                      {
+                        votingWeightImplementation:
+                          await fixtureData.votingWeightERC20V1.getAddress(),
+                        voteTrackerImplementation:
+                          await fixtureData.voteTrackerERC20V1.getAddress(),
+                        token: ethers.ZeroAddress,
+                        newTokenIndex: 0,
+                        weightPerToken: ethers.parseEther('1'),
+                      },
+                    ],
+                    votingConfigERC721V1Params: [],
+                  },
+                };
+
+              const setupSafeParams = createSetupSafeParams({
+                votesERC20Params: [votesERC20V1Params1],
+                freezeGuardMultisigParams,
+                freezeVotingStandaloneParams,
+              });
+
+              await findAndVerifySafe({
+                ...(await deploySafeWithSetup({
+                  fixtureData,
+                  owners,
+                  threshold,
+                  setupSafeParams,
+                })),
+                fixtureData,
+                owners,
+                threshold,
+                votesERC20V1Datas: [votesERC20V1Params1],
+                freezeGuardMultisigV1Data: {
+                  guardParams: freezeGuardMultisigParams,
+                  votingStandaloneParams: {
+                    freezeVotingParams: freezeVotingStandaloneParams.freezeVotingStandaloneV1Params,
+                    votingConfigERC20V1Datas:
+                      freezeVotingStandaloneParams.votingConfigParams.votingConfigERC20V1Params.map(
+                        p => ({ params: p }),
+                      ),
+                    votingConfigERC721V1Datas:
+                      freezeVotingStandaloneParams.votingConfigParams.votingConfigERC721V1Params.map(
+                        p => ({ params: p }),
+                      ),
+                  },
+                },
+                numberOfNewContracts: 5, // Safe + Token + FreezeVotingStandalone + VotingWeight + VoteTracker + FreezeGuardMultisig = 6, but Safe is not counted as "new"
+              });
+            });
+
+            it('should revert when multiple freeze voting types are deployed', async () => {
+              // First, demonstrate that FreezeGuardMultisig works with FreezeVotingStandalone alone
+              const freezeVotingStandaloneParams: ISystemDeployerV1.FreezeVotingStandaloneParamsStruct =
+                {
+                  freezeVotingStandaloneV1Params: {
+                    implementation: await fixtureData.freezeVotingStandaloneV1.getAddress(),
+                    freezeVotesThreshold: 100,
+                    unfreezeVotesThreshold: 200,
+                    freezeProposalPeriod: 3600,
+                    unfreezeProposalPeriod: 1800,
+                    lightAccountFactory: ethers.ZeroAddress,
+                  },
+                  votingConfigParams: {
+                    votingConfigERC20V1Params: [],
+                    votingConfigERC721V1Params: [],
+                  },
+                };
+
+              const setupSafeParams = createSetupSafeParams({
+                freezeGuardMultisigParams,
+                freezeVotingStandaloneParams,
+              });
+
+              const data = {
+                fixtureData,
+                owners,
+                threshold,
+                setupSafeParams,
+              };
+
+              // Initial deployment should succeed
+              await deploySafeWithSetup(data);
+
+              // Now add FreezeVotingMultisig - the minimal change that triggers the error
+              data.setupSafeParams.freezeParams.freezeVotingParams.freezeVotingMultisigV1Params.implementation =
+                await fixtureData.freezeVotingMultisigV1.getAddress();
+
+              // Now deploying should fail
+              await expect(deploySafeWithSetup(data)).to.be.reverted;
+            });
           });
 
           describe('FreezeGuardAzorius configurations', () => {
@@ -4132,6 +4470,46 @@ describe('SystemDeployerV1', () => {
                 freezeVotingMultisigParams;
 
               // now deploying should fail
+              await expect(deploySafeWithSetup(data)).to.be.reverted;
+            });
+
+            it('should revert when FreezeVotingStandalone is paired with FreezeGuardAzorius', async () => {
+              // First, demonstrate that FreezeGuardAzorius works with FreezeVotingAzorius
+              const setupSafeParams = createSetupSafeParams({
+                azoriusGovernanceParams: {
+                  proposerAdapterParams: {
+                    proposerAdapterERC20V1Params: [{ ...proposerAdapterERC20V1Params1 }],
+                    proposerAdapterERC721V1Params: [],
+                    proposerAdapterHatsV1Params: [],
+                  },
+                  strategyV1Params,
+                  votingConfigParams: {
+                    votingConfigERC20V1Params: [{ ...votingConfigERC20V1Params1 }],
+                    votingConfigERC721V1Params: [],
+                  },
+                  moduleAzoriusV1Params,
+                },
+                freezeGuardAzoriusParams,
+                freezeVotingAzoriusParams,
+              });
+
+              const data = {
+                fixtureData,
+                owners,
+                threshold,
+                setupSafeParams,
+              };
+
+              // Initial deployment should succeed
+              await deploySafeWithSetup(data);
+
+              // Now change to FreezeVotingStandalone - the minimal change that triggers the error
+              data.setupSafeParams.freezeParams.freezeVotingParams.freezeVotingAzoriusV1Params.implementation =
+                ethers.ZeroAddress;
+              data.setupSafeParams.freezeParams.freezeVotingParams.freezeVotingStandaloneParams.freezeVotingStandaloneV1Params.implementation =
+                await fixtureData.freezeVotingStandaloneV1.getAddress();
+
+              // Now deploying should fail
               await expect(deploySafeWithSetup(data)).to.be.reverted;
             });
           });


### PR DESCRIPTION
Depends on https://github.com/decentdao/decent-contracts/pull/423

Fixes [ENG-1272](https://linear.app/decent-labs/issue/ENG-1272/add-freezevotingstandalonev1-deployment-to-systemdeployerv1)

## Motivation

Enable SystemDeployerV1 to deploy FreezeVotingStandaloneV1 contracts as part of the DAO setup process. This allows multisig Safes to be deployed with integrated token-based freeze voting capabilities without requiring a parent/child DAO structure.

## Change Summary

- Add FreezeVotingStandaloneV1Params struct to ISystemDeployerV1 interface
- Update FreezeVotingParams to include standalone option
- Implement deployment logic for FreezeVotingStandaloneV1 with voting configs
- Handle the two-step initialization pattern for circular dependencies
- Update validation logic to support three freeze voting options

# Project Plan

## Current State Analysis

SystemDeployerV1 currently supports deploying freeze mechanisms for parent/child DAO relationships:

- FreezeVotingMultisigV1: For parent multisig Safes voting to freeze child multisig
- FreezeVotingAzoriusV1: For parent Azorius DAOs voting to freeze child (multisig or Azorius)
- Missing: Standalone freeze voting where token holders vote to freeze their own multisig Safe

### Key Constraints from ISystemDeployerV1:

1. **Mutual Exclusivity**: Only ONE freeze voting type can be deployed (enforced by `CannotDeployBothFreezeVotingContracts`)
2. **Guard Dependency**: Freeze guards require a freeze voting contract (`FreezeVotingContractNotDeployed`)
3. **Guard Deployment**: Can deploy one or both guards (FreezeGuardMultisigV1 and/or FreezeGuardAzoriusV1)
4. **Pairing Restriction**: FreezeVotingStandaloneV1 can ONLY be used with FreezeGuardMultisigV1
   - If FreezeVotingStandaloneV1 + FreezeGuardAzoriusV1 are both specified → validation error

The deployment flow needs to handle voting config creation and the circular dependency between FreezeVotingStandaloneV1 and its VoteTrackers.

## Goals and Success Criteria

- [ ] SystemDeployerV1 can deploy FreezeVotingStandaloneV1 contracts
- [ ] Proper handling of voting config deployment (weight strategies + vote trackers)
- [ ] Validation ensures only one freeze voting type is deployed
- [ ] Integration with existing freeze guard deployment
- [ ] Deterministic addresses via CREATE2
- [ ] Comprehensive test coverage

## Implementation Steps

1. **Update ISystemDeployerV1 Interface**

   - [ ] Add FreezeVotingStandaloneV1Params struct: ```solidity struct FreezeVotingStandaloneV1Params { address implementation; uint256 freezeVotesThreshold; uint256 unfreezeVotesThreshold; uint32 freezeProposalPeriod; uint32 unfreezeProposalPeriod; address lightAccountFactory; } // Note: voting configs handled separately like Azorius ```
   - [ ] Update FreezeVotingParams to include standalone option
   - [ ] Update error name from `CannotDeployBothFreezeVotingContracts` to `CannotDeployMultipleFreezeVotingContracts`
   - [ ] Add validation error for invalid freeze voting/guard pairing (e.g., `InvalidFreezeVotingGuardPairing`)

2. **Implement Deployment Logic**

   - [ ] Add \_deployFreezeVotingStandalone internal function
   - [ ] Deploy voting weight strategies for configured tokens
   - [ ] Deploy vote trackers with proper authorization
   - [ ] Handle initialization with voting configs
   - [ ] Update \_deployFreezeVoting to support three options

3. **Handle Circular Dependencies**

   - [ ] Deploy FreezeVotingStandaloneV1 proxy
   - [ ] Deploy voting configs (weights + trackers)
   - [ ] Initialize vote trackers with FreezeVotingStandalone as authorized caller
   - [ ] Initialize FreezeVotingStandalone with voting configs

4. **Update Validation Logic**

   - [ ] Ensure only one freeze voting type can be specified (check all 3 options are mutually exclusive)
   - [ ] Validate FreezeVotingStandaloneV1 + FreezeGuardAzoriusV1 combination is rejected ```solidity if (freezeVotingStandaloneV1Params provided && freezeGuardAzoriusV1Params provided) { revert InvalidFreezeVotingGuardPairing(); } ```
   - [ ] Validate voting config parameters (token addresses, thresholds)
   - [ ] Check implementation addresses exist
   - [ ] Allow both guards with other freeze voting types (Multisig/Azorius)

5. **Testing**
   - [ ] Unit tests for new deployment functions
   - [ ] Integration tests with freeze guards
   - [ ] Test validation errors
   - [ ] Test deterministic addressing

## Benefits

- **Complete Freeze Solution**: SystemDeployerV1 supports all three freeze voting patterns
- **Single Transaction Setup**: Deploy entire Safe with freeze voting in one transaction
- **Consistent Architecture**: Follows existing patterns for voting config deployment
- **Gas Efficient**: Reuses existing voting config deployment logic

## Progress Tracking

- [ ] Add interface definitions
- [ ] Implement deployment logic
- [ ] Add validation
- [ ] Write unit tests
- [ ] Write integration tests
- [ ] Update documentation

## Notes and Decisions

- **Voting Config Reuse**: Can leverage existing voting config deployment functions from Azorius deployment
- **Salt Strategy**: Use consistent salt derivation for deterministic addresses
- **Guard Compatibility**: FreezeVotingStandaloneV1 implements IFreezable, compatible with existing guards
- **No Strategy Dependency**: Unlike Azorius voting configs, standalone configs don't need strategy reference
- **Pairing Constraint**: FreezeVotingStandaloneV1 cannot be used with FreezeGuardAzoriusV1
  - Rationale: Token holders freezing their own Azorius proposals doesn't make sense
  - They already control proposals through normal Azorius voting
  - Standalone is specifically for freezing Safe transactions, not Azorius governance
- **Guard Flexibility**: FreezeVotingMultisigV1 and FreezeVotingAzoriusV1 can work with either/both guards
- **Validation Updates**: Need to rename error to reflect three options instead of two