### PR TITLE
Public sale hedgey

### DIFF
--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -162,12 +162,18 @@ contract PublicSaleV1 is
 
         // if hedgey lockup is enabled, validate the params
         if (params_.hedgeyLockupParams.enabled) {
+            if (params_.commitmentToken == NATIVE_ASSET)
+                revert InvalidHedgeyNativeAsset();
+
+            uint256 minimumLockupAmount = (params_.minimumCommitment *
+                PRECISION) / params_.saleTokenPrice;
+
             _validateHedgeyParams(
-                (params_.minimumCommitment * PRECISION) /
-                    params_.saleTokenPrice,
+                minimumLockupAmount,
                 params_.hedgeyLockupParams.start,
                 params_.hedgeyLockupParams.cliff,
-                params_.hedgeyLockupParams.rate,
+                (minimumLockupAmount *
+                    params_.hedgeyLockupParams.ratePercentage) / PRECISION,
                 params_.hedgeyLockupParams.period
             );
         }
@@ -428,6 +434,90 @@ contract PublicSaleV1 is
         return $.settled[account_];
     }
 
+    /**
+     * @inheritdoc IPublicSaleV1
+     */
+    function hedgeyLockupEnabled()
+        external
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        PublicSaleStorage storage $ = _getPublicSaleStorage();
+        return $.hedgeyLockupParams.enabled;
+    }
+
+    /**
+     * @inheritdoc IPublicSaleV1
+     */
+    function hedgeyLockupStart()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        PublicSaleStorage storage $ = _getPublicSaleStorage();
+        return $.hedgeyLockupParams.start;
+    }
+
+    /**
+     * @inheritdoc IPublicSaleV1
+     */
+    function hedgeyLockupCliff()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        PublicSaleStorage storage $ = _getPublicSaleStorage();
+        return $.hedgeyLockupParams.cliff;
+    }
+
+    /**
+     * @inheritdoc IPublicSaleV1
+     */
+    function hedgeyLockupRatePercentage()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        PublicSaleStorage storage $ = _getPublicSaleStorage();
+        return $.hedgeyLockupParams.ratePercentage;
+    }
+
+    /**
+     * @inheritdoc IPublicSaleV1
+     */
+    function hedgeyLockupPeriod()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        PublicSaleStorage storage $ = _getPublicSaleStorage();
+        return $.hedgeyLockupParams.period;
+    }
+
+    /**
+     * @inheritdoc IPublicSaleV1
+     */
+    function hedgeyVotingTokenLockupPlans()
+        external
+        view
+        virtual
+        override
+        returns (address)
+    {
+        PublicSaleStorage storage $ = _getPublicSaleStorage();
+        return $.hedgeyLockupParams.votingTokenLockupPlans;
+    }
+
     // --- State-Changing Functions ---
 
     /**
@@ -491,6 +581,8 @@ contract PublicSaleV1 is
         SaleState state = saleState();
 
         if (state == SaleState.SUCCEEDED) {
+            // sale succeeded
+
             uint256 saleTokenAmount = ($.commitments[msg.sender] * PRECISION) /
                 $.saleTokenPrice;
 
@@ -510,21 +602,18 @@ contract PublicSaleV1 is
                         saleTokenAmount,
                         $.hedgeyLockupParams.start,
                         $.hedgeyLockupParams.cliff,
-                        $.hedgeyLockupParams.rate,
+                        (saleTokenAmount *
+                            $.hedgeyLockupParams.ratePercentage) / PRECISION,
                         $.hedgeyLockupParams.period
                     );
             } else {
                 // send the caller their purchased sale tokens
                 IERC20($.saleToken).safeTransfer(recipient_, saleTokenAmount);
-
-                emit SuccessfulSaleSettled(
-                    msg.sender,
-                    recipient_,
-                    saleTokenAmount
-                );
             }
+
+            emit SuccessfulSaleSettled(msg.sender, recipient_, saleTokenAmount);
         } else if (state == SaleState.FAILED) {
-            // refund the caller their commitment tokens
+            // sale failed, refund the caller their commitment tokens
             uint256 commitmentTokenAmount = $.commitments[msg.sender];
 
             _transferTokenOrNative(

--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -495,11 +495,17 @@ contract PublicSaleV1 is
                 $.saleTokenPrice;
 
             if ($.hedgeyLockupParams.enabled) {
+                // approve hedgey lockup plan to transfer the sale token
+                IERC20($.saleToken).approve(
+                    $.hedgeyLockupParams.votingTokenLockupPlans,
+                    saleTokenAmount
+                );
+
                 // create hedgey lockup plan for the caller
                 IVotingTokenLockupPlans(
                     $.hedgeyLockupParams.votingTokenLockupPlans
                 ).createPlan(
-                        msg.sender,
+                        recipient_,
                         $.saleToken,
                         saleTokenAmount,
                         $.hedgeyLockupParams.start,

--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -162,9 +162,6 @@ contract PublicSaleV1 is
 
         // if hedgey lockup is enabled, validate the params
         if (params_.hedgeyLockupParams.enabled) {
-            if (params_.commitmentToken == NATIVE_ASSET)
-                revert InvalidHedgeyNativeAsset();
-
             uint256 minimumLockupAmount = (params_.minimumCommitment *
                 PRECISION) / params_.saleTokenPrice;
 

--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -10,6 +10,9 @@ import {
     IKYCVerifierV1
 } from "../../interfaces/decent/services/IKYCVerifierV1.sol";
 import {
+    IVotingTokenLockupPlans
+} from "../../interfaces/hedgey/IVotingTokenLockupPlans.sol";
+import {
     DeploymentBlockInitializable
 } from "../../DeploymentBlockInitializable.sol";
 import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
@@ -63,6 +66,7 @@ contract PublicSaleV1 is
         uint256 saleTokenPrice;
         uint256 protocolFee;
         uint256 totalCommitments;
+        HedgeyLockupParams hedgeyLockupParams;
         mapping(address account => uint256 commitmentAmount) commitments;
         mapping(address account => bool settled) settled;
     }
@@ -156,6 +160,18 @@ contract PublicSaleV1 is
         __Ownable_init(params_.owner);
         __DeploymentBlockInitializable_init();
 
+        // if hedgey lockup is enabled, validate the params
+        if (params_.hedgeyLockupParams.enabled) {
+            _validateHedgeyParams(
+                (params_.minimumCommitment * PRECISION) /
+                    params_.saleTokenPrice,
+                params_.hedgeyLockupParams.start,
+                params_.hedgeyLockupParams.cliff,
+                params_.hedgeyLockupParams.rate,
+                params_.hedgeyLockupParams.period
+            );
+        }
+
         PublicSaleStorage storage $ = _getPublicSaleStorage();
 
         $.saleStartTimestamp = params_.saleStartTimestamp;
@@ -171,6 +187,7 @@ contract PublicSaleV1 is
         $.maximumTotalCommitment = params_.maximumTotalCommitment;
         $.saleTokenPrice = params_.saleTokenPrice;
         $.protocolFee = params_.protocolFee;
+        $.hedgeyLockupParams = params_.hedgeyLockupParams;
 
         uint256 saleTokenEscrowAmount = (params_.maximumTotalCommitment *
             PRECISION) / params_.saleTokenPrice;
@@ -474,14 +491,34 @@ contract PublicSaleV1 is
         SaleState state = saleState();
 
         if (state == SaleState.SUCCEEDED) {
-            // send the caller their purchased sale tokens
             uint256 saleTokenAmount = ($.commitments[msg.sender] * PRECISION) /
                 $.saleTokenPrice;
 
-            IERC20($.saleToken).safeTransfer(recipient_, saleTokenAmount);
+            if ($.hedgeyLockupParams.enabled) {
+                // create hedgey lockup plan for the caller
+                IVotingTokenLockupPlans(
+                    $.hedgeyLockupParams.votingTokenLockupPlans
+                ).createPlan(
+                        msg.sender,
+                        $.saleToken,
+                        saleTokenAmount,
+                        $.hedgeyLockupParams.start,
+                        $.hedgeyLockupParams.cliff,
+                        $.hedgeyLockupParams.rate,
+                        $.hedgeyLockupParams.period
+                    );
+            } else {
+                // send the caller their purchased sale tokens
+                IERC20($.saleToken).safeTransfer(recipient_, saleTokenAmount);
 
-            emit SuccessfulSaleSettled(msg.sender, recipient_, saleTokenAmount);
+                emit SuccessfulSaleSettled(
+                    msg.sender,
+                    recipient_,
+                    saleTokenAmount
+                );
+            }
         } else if (state == SaleState.FAILED) {
+            // refund the caller their commitment tokens
             uint256 commitmentTokenAmount = $.commitments[msg.sender];
 
             _transferTokenOrNative(
@@ -598,6 +635,40 @@ contract PublicSaleV1 is
     // ======================================================================
     // INTERNAL HELPERS
     // ======================================================================
+
+    /**
+     * @notice Validates Hedgey vesting parameters and calculates end time
+     * @dev Ensures all parameters create a valid vesting schedule
+     * @param start_ Start time of vesting
+     * @param cliff_ Absolute cliff time
+     * @param amount_ Total amount to vest
+     * @param rate_ Amount vested per period
+     * @param period_ Duration of each vesting period
+     * @custom:throws InvalidAmount if amount is zero
+     * @custom:throws InvalidRate if rate is zero
+     * @custom:throws RateExceedsAmount if rate is greater than amount
+     * @custom:throws InvalidPeriod if period is zero
+     * @custom:throws CliffExceedsEnd if cliff time exceeds vesting end time
+     */
+    function _validateHedgeyParams(
+        uint256 amount_,
+        uint256 start_,
+        uint256 cliff_,
+        uint256 rate_,
+        uint256 period_
+    ) internal pure {
+        if (amount_ == 0) revert InvalidAmount();
+        if (rate_ == 0) revert InvalidRate();
+        if (rate_ > amount_) revert RateExceedsAmount();
+        if (period_ == 0) revert InvalidPeriod();
+
+        // Calculate vesting end time
+        uint256 end = (amount_ % rate_ == 0)
+            ? (amount_ / rate_) * period_ + start_
+            : ((amount_ / rate_) * period_) + period_ + start_;
+
+        if (cliff_ > end) revert CliffExceedsEnd();
+    }
 
     /**
      * @notice Transfers tokens or native assets to a recipient

--- a/contracts/external/hedgey/VotingTokenLockupPlans.sol
+++ b/contracts/external/hedgey/VotingTokenLockupPlans.sol
@@ -1,0 +1,2911 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.19;
+
+/// @title TokenLockupPlans - An efficient way to allocate tokens to beneficiaries that unlock over time
+/// @notice This contract allows people to grant tokens to beneficiaries that unlock over time with the added functionalities;
+/// Owners of unlock plans can manage all of their token unlocks across all of their positions in a single contract.
+/// Each lockup plan is a unique NFT, leveraging the backbone of the ERC721 contract to represent a unique lockup plan
+/// 1. Not-Revokable: plans cannot be revoked, once granted the entire amount will be claimable by the beneficiary over time.
+/// 2. Transferable: Lockup plans can be transferred by the owner - opening up defi opportunities like NFT sales, borrowing and lending, and many others.
+/// 3. Governance optimized for on-chain voting: These are built to allow beneficiaries to vote with their unvested tokens on chain with the standard ERC20Votes contract, as well as on snapshot
+/// 4. Beneficiary Claims: Beneficiaries get to choose when to claim their tokens, and can claim partial amounts that are less than the amount they have unlocked for tax optimization
+/// 5. Segmenting plans: Beneficiaries can segment a single lockup into  smaller chunks for subdelegation of tokens, or to use in defi with smaller chunks
+/// 6. Combingin Plans: Beneficiaries can combine plans that have the same details in one larger chunk for easier bulk management
+contract VotingTokenLockupPlans is PlanDelegator, LockupStorage, ReentrancyGuard, URIAdmin {
+  /// @notice uses counters for incrementing token IDs which are the planIds
+  using Counters for Counters.Counter;
+  Counters.Counter private _planIds;
+
+  /// @dev Voting Vaults are external contracts that hold tokens for a lockup plan allowing an owner to delegate their tokens for on-chain governance
+  /// the lockup plan ID is mapped to the votingVault address so that it is one to one and unique to the NFT
+  mapping(uint256 => address) public votingVaults;
+
+  /// @notice event emitted when a new voting vault is generated and setup
+  event VotingVaultCreated(uint256 indexed id, address vaultAddress);
+
+  constructor(string memory name, string memory symbol) ERC721(name, symbol) {
+    uriAdmin = msg.sender;
+  }
+
+  function _baseURI() internal view override returns (string memory) {
+    return baseURI;
+  }
+
+  /****CORE EXTERNAL FUNCTIONS*********************************************************************************************************************************************/
+
+  /// @notice function to create a lockup plan.
+  /// @dev this function will pull the tokens into this contract for escrow, increment the planIds, mint an NFT to the recipient, and create the storage Plan and map it to the newly minted NFT token ID in storage
+  /// @param recipient the address of the recipient and beneficiary of the plan
+  /// @param token the address of the ERC20 token
+  /// @param amount the amount of tokens to be locked in the plan
+  /// @param start the start date of the lockup plan, unix time
+  /// @param cliff a cliff date which is a discrete date where tokens are not unlocked until this date, and then vest in a large single chunk on the cliff date
+  /// @param rate the amount of tokens that vest in a single period
+  /// @param period the amount of time in between each unlock time stamp, in seconds. A period of 1 means that tokens vest every second in a 'streaming' style.
+  function createPlan(
+    address recipient,
+    address token,
+    uint256 amount,
+    uint256 start,
+    uint256 cliff,
+    uint256 rate,
+    uint256 period
+  ) external nonReentrant returns (uint256 newPlanId) {
+    require(recipient != address(0), '0_recipient');
+    require(token != address(0), '0_token');
+    (uint256 end, bool valid) = TimelockLibrary.validateEnd(start, cliff, amount, rate, period);
+    require(valid);
+    _planIds.increment();
+    newPlanId = _planIds.current();
+    TransferHelper.transferTokens(token, msg.sender, address(this), amount);
+    plans[newPlanId] = Plan(token, amount, start, cliff, rate, period);
+    _safeMint(recipient, newPlanId);
+    emit PlanCreated(newPlanId, recipient, token, amount, start, cliff, end, rate, period);
+  }
+
+  /// @notice function for a beneficiary to redeem unlocked tokens from a group of plans
+  /// @dev this will call an internal function for processing the actual redemption of tokens, which will withdraw unlocked tokens and deliver them to the beneficiary
+  /// @dev this function will redeem all claimable and unlocked tokens up to the current block.timestamp
+  /// @param planIds is the array of the NFT planIds that are to be redeemed. If any have no redeemable balance they will be skipped.
+  function redeemPlans(uint256[] calldata planIds) external nonReentrant {
+    _redeemPlans(planIds, block.timestamp);
+  }
+
+  /// @notice function for a beneficiary to redeem unlocked tokens from a group of plans
+  /// @dev this will call an internal function for processing the actual redemption of tokens, which will withdraw unlocked tokens and deliver them to the beneficiary
+  /// @dev this function will redeem only a partial amount of tokens based on a redemption timestamp that is in the past. This allows holders to redeem less than their fully unlocked amount for various reasons
+  /// @param planIds is the array of the NFT planIds that are to be redeemed. If any have no redeemable balance they will be skipped.
+  /// @param redemptionTime is the timestamp which will calculate the amount of tokens redeemable and redeem them based on that timestamp
+  function partialRedeemPlans(uint256[] calldata planIds, uint256 redemptionTime) external nonReentrant {
+    require(redemptionTime < block.timestamp, '!future');
+    _redeemPlans(planIds, redemptionTime);
+  }
+
+  /// @notice this function will redeem all plans owned by a single wallet - useful for custodians or other intermeidaries that do not have the ability to lookup individual planIds
+  /// @dev this will iterate through all of the plans owned by the wallet based on the ERC721Enumerable backbone, and redeem each one with a redemption time of the current block.timestamp
+  function redeemAllPlans() external nonReentrant {
+    uint256 balance = balanceOf(msg.sender);
+    uint256[] memory planIds = new uint256[](balance);
+    for (uint256 i; i < balance; i++) {
+      uint256 planId = tokenOfOwnerByIndex(msg.sender, i);
+      planIds[i] = planId;
+    }
+    _redeemPlans(planIds, block.timestamp);
+  }
+
+  /// @notice function for an owner of a lockup plan to segment a single plan into multiple chunks; segments.
+  /// @dev the single plan can be divided up into many segments in this transaction, but care must be taken to ensure that the array is processed in a proper order
+  /// if the tokens are send in the wrong order the function will revert becuase the amount of the segment could be larger than the original plan.
+  /// this function iterates through the segment amounts and breaks up the same original plan into smaller sizes
+  /// each time a segment happens it is always with the single planId, which will generate a new NFT for each new segment, and the original plan is updated in storage
+  /// the original plan amount newPlanAmount + segmentAmount && original plan Rate = newPlanRate + segmentRate
+  /// IF The plan that is being segmented has a voting vault setup, it will generate a new voting vault for the segmented tokens, however it will not delegate those
+  /// @dev Segmenting plans where the segment amount is not divisible by the rate will result in a new End date that is 1 period farther than the original plan
+  /// @param planId is the plan that is going to be segmented
+  /// @param segmentAmounts is the array of amounts of each individual segment, which must each be smaller than the plan when it is being segmented.
+  function segmentPlan(
+    uint256 planId,
+    uint256[] memory segmentAmounts
+  ) external nonReentrant returns (uint256[] memory newPlanIds) {
+    newPlanIds = new uint256[](segmentAmounts.length);
+    for (uint256 i; i < segmentAmounts.length; i++) {
+      uint256 newPlanId = _segmentPlan(planId, segmentAmounts[i]);
+      newPlanIds[i] = newPlanId;
+    }
+  }
+
+  /// @notice this function combines the functionality of segmenting plans and then immediately delegating the new semgent plans to a delegate address
+  /// @dev this function does NOT delegate the original planId at all, it will only delegate the newly create segments
+  /// if the plan has a Voting Vault, it will create a new voting vault for each segment, and then delegate the tokens in the voting vault to the delegatee address
+  /// @param planId is the plan that will be segmented (and not delegated)
+  /// @param segmentAmounts is the array of each segment amount
+  /// @param delegatees is the array of delegatees that each new segment will be delegated to
+  function segmentAndDelegatePlans(
+    uint256 planId,
+    uint256[] memory segmentAmounts,
+    address[] memory delegatees
+  ) external nonReentrant returns (uint256[] memory newPlanIds) {
+    require(segmentAmounts.length == delegatees.length, '!length');
+    newPlanIds = new uint256[](segmentAmounts.length);
+    for (uint256 i; i < segmentAmounts.length; i++) {
+      uint256 newPlanId = _segmentPlan(planId, segmentAmounts[i]);
+      _delegate(newPlanId, delegatees[i]);
+      newPlanIds[i] = newPlanId;
+    }
+  }
+
+  /// @notice this function allows a beneficiary of two plans that share the same details to combine them into a single surviving plan
+  /// @dev the plans must have the same details except the amount and rate, but must share the same end date to be combined
+  /// if one of the plans has a voting vault, that plan will be the surviving plan and all tokens will be transferred to the surviving plan voting vault
+  /// @param planId0 is the planId of a first plan to be combined
+  /// @param planId1 is the planId of a second plan to be combined
+  function combinePlans(uint256 planId0, uint256 planId1) external nonReentrant returns (uint256 survivingPlanId) {
+    survivingPlanId = _combinePlans(planId0, planId1);
+  }
+
+  /****EXTERNAL VOTING FUNCTIONS*********************************************************************************************************************************************/
+  /// @notice functions for the owners of lockup plans to setup on chain voting vaults, and then delegate those tokens.
+  /// these are explicity for tokens that are of the ERC20Votes format, which have a delegate and delegates function.
+  /// tokens that do not have the standard delegate and delegates functionality for on-chain voting will revert when delegating or creating onchain voting vaults.
+
+  /// @notice function to setup a voting vault, this calls an internal voting function to set it up
+  // this will physically transfer tokens to the new voting vault contract once deployed
+  /// @param planId is the id of the lockup plan and NFT
+  function setupVoting(uint256 planId) external nonReentrant returns (address votingVault) {
+    votingVault = _setupVoting(planId);
+  }
+
+  /// @notice function for an owner of a lockup plan to delegate a single lockup plan to  single delegate
+  /// @dev this will call an internal delegate function for processing
+  /// if there is no voting vault setup, this function will automatically create a voting vault and then delegate the tokens to the delegatee
+  /// @param planId is the id of the lockup plan and NFT
+  function delegate(uint256 planId, address delegatee) external nonReentrant {
+    _delegate(planId, delegatee);
+  }
+
+  /// @notice this function allows an owner of multiple lockup plans to delegate multiple of them in a single transaction, each planId corresponding to a delegatee address
+  /// @param planIds is the ids of the lockup plan and NFT
+  /// @param delegatees is the array of addresses where each lockup plan will delegate the tokens to
+  function delegatePlans(uint256[] calldata planIds, address[] calldata delegatees) external nonReentrant {
+    require(planIds.length == delegatees.length, 'array error');
+    for (uint256 i; i < planIds.length; i++) {
+      _delegate(planIds[i], delegatees[i]);
+    }
+  }
+
+  /// @notice this function lets an owner delegate all of their lockup plans for a single token to a single delegatee
+  /// @dev this function will iterate through all of the owned lockup plans of the msg.sender, and if the token address matches the lockup plan token address, it will delegate that plan
+  /// @param token is the ERC20Votes token address of the tokens in the lockup plans
+  /// @param delegatee is the address of the delegate that the beneficiary is delegating their tokens to
+  function delegateAll(address token, address delegatee) external nonReentrant {
+    uint256 balance = balanceOf(msg.sender);
+    for (uint256 i; i < balance; i++) {
+      uint256 planId = tokenOfOwnerByIndex(msg.sender, i);
+      if (plans[planId].token == token) _delegate(planId, delegatee);
+    }
+  }
+
+  function transferAndDelegate(uint256 planId, address from, address to) external virtual nonReentrant {
+    safeTransferFrom(from, to, planId);
+    _delegate(planId, to);
+  }
+
+  /****CORE INTERNAL FUNCTIONS*********************************************************************************************************************************************/
+
+  /// @notice function that will intake an array of planIds and a redemption time, and then check the balances that are available to be redeemed
+  /// @dev if the nft has an available balance, it is then passed on to the _redeemPlan function for further processing
+  /// if there is no balance to be redeemed, the plan is skipped from being processed
+  /// @param planIds is the array of plans to be redeemed
+  /// @param redemptionTime is the requested redemption time, either the current block.timestamp or a timestamp from the past, but must be greater than the start date
+  function _redeemPlans(uint256[] memory planIds, uint256 redemptionTime) internal {
+    for (uint256 i; i < planIds.length; i++) {
+      (uint256 balance, uint256 remainder, uint256 latestUnlock) = planBalanceOf(
+        planIds[i],
+        block.timestamp,
+        redemptionTime
+      );
+      if (balance > 0) _redeemPlan(planIds[i], balance, remainder, latestUnlock);
+    }
+  }
+
+  /// @notice internal function that process the redemption for a single lockup plan
+  /// @dev this takes the inputs from the _redeemPlans and processes the redemption delivering the available balance of redeemable tokens to the beneficiary
+  /// if the plan has a voting vault then tokens will be redeemed and transferred from the voting vault to the beneficiary.
+  /// if the plan is fully redeemed, as defined that the balance == amount, then the plan is deleted and NFT burned
+  // if the plan is not fully redeemed, then the storage of start and amount are updated to reflect the remaining amount and most recent time redeemed for the new start date
+  /// @param planId is the id of the lockup plan and NFT
+  /// @param balance is the available redeemable balance
+  /// @param remainder is the amount of tokens that are still lcoked in the plan, and will be the new amount in the plan storage
+  /// @param latestUnlock is the most recent timestamp for when redemption occured. Because periods may be longer than 1 second,
+  /// the latestUnlock time may be the current block time, or the timestamp of the most recent period timestamp
+  function _redeemPlan(uint256 planId, uint256 balance, uint256 remainder, uint256 latestUnlock) internal {
+    require(ownerOf(planId) == msg.sender, '!owner');
+    address token = plans[planId].token;
+    address vault = votingVaults[planId];
+    if (remainder == 0) {
+      delete plans[planId];
+      delete votingVaults[planId];
+      _burn(planId);
+    } else {
+      plans[planId].amount = remainder;
+      plans[planId].start = latestUnlock;
+    }
+    if (vault == address(0)) {
+      TransferHelper.withdrawTokens(token, msg.sender, balance);
+    } else {
+      VotingVault(vault).withdrawTokens(msg.sender, balance);
+    }
+    emit PlanRedeemed(planId, balance, remainder, latestUnlock);
+  }
+
+  /// @notice the internal function for segmenting a single plan into two
+  /// @dev the function takes a plan, performs some checks that the segment amount cannot be 0 and must be strictly less than the original plan amount
+  /// then it will subtract the segmentamount from the original plan amount to get the new plan amount
+  /// then it will get a new pro-rata rate for the newplan based on the new plan amount divided by the original plan amount
+  /// while this pro-rata new rate is not perfect because of unitization (ie no decimal suppport), the segment rate is calculated by subtracting the new plan rate from the original plan rate
+  /// because the newplan amount and segment amount == original plan amount, and the new plan rate + segment rate == original plan rate, the beneficiary will still unlock the same number of tokens at approximatley the same rate
+  /// however because of uneven division, the end dates of each of the new rates may be different than the original rate. We check to make sure that the new end is farther than the original end
+  /// so that tokens do not unlock early, and then it is a valid segment.
+  /// finally a new NFT is minted with the Segment plan details
+  /// and the storage of the original plan amount and rate is updated with the newplan amount and rate.
+  /// at the end this checks if there is a voting vault setup for the original plan. If there is a voting vault setup, it will transfer tokens back from the original plan vault,
+  /// then setup a new voting vault for the segment plan, thereby transferring the segment tokens to the new segment voting vault
+  /// @param planId is the id of the lockup plan
+  /// @param segmentAmount is the amount of tokens to be segmented off from the original plan and created into a new segment plan
+  function _segmentPlan(uint256 planId, uint256 segmentAmount) internal returns (uint256 newPlanId) {
+    require(ownerOf(planId) == msg.sender, '!owner');
+    Plan memory plan = plans[planId];
+    require(segmentAmount < plan.amount, 'amount error');
+    require(segmentAmount > 0, '0_segment');
+    uint256 end = TimelockLibrary.endDate(plan.start, plan.amount, plan.rate, plan.period);
+    _planIds.increment();
+    newPlanId = _planIds.current();
+    uint256 planAmount = plan.amount - segmentAmount;
+    (uint256 planRate, uint256 segmentRate, uint256 planEnd, uint256 segmentEnd) = TimelockLibrary
+      .calculateSegmentRates(
+        plan.rate,
+        plan.amount,
+        planAmount,
+        segmentAmount,
+        plan.start,
+        end,
+        plan.period,
+        plan.cliff
+      );
+    uint256 endCheck = segmentOriginalEnd[planId] == 0 ? end : segmentOriginalEnd[planId];
+    require(planEnd >= endCheck, 'plan end error');
+    require(segmentEnd >= endCheck, 'segmentEnd error');
+    plans[planId].amount = planAmount;
+    plans[planId].rate = planRate;
+    _safeMint(msg.sender, newPlanId);
+    plans[newPlanId] = Plan(plan.token, segmentAmount, plan.start, plan.cliff, segmentRate, plan.period);
+    if (segmentOriginalEnd[planId] == 0) {
+      segmentOriginalEnd[planId] = end;
+      segmentOriginalEnd[newPlanId] = end;
+    } else {
+      segmentOriginalEnd[newPlanId] = segmentOriginalEnd[planId];
+    }
+    if (votingVaults[planId] != address(0)) {
+      VotingVault(votingVaults[planId]).withdrawTokens(address(this), segmentAmount);
+      _setupVoting(newPlanId);
+    }
+    emit PlanSegmented(
+      planId,
+      newPlanId,
+      planAmount,
+      planRate,
+      segmentAmount,
+      segmentRate,
+      plan.start,
+      plan.cliff,
+      plan.period,
+      planEnd,
+      segmentEnd
+    );
+  }
+
+  /// @notice this funtion allows the holder of two plans that have the same parameters to combine them into a single surviving plan
+  /// @dev all of the details of the plans must be the same except the amounts and rates may be different
+  /// this function will check that the owners are the same, the ERC20 tokens are the same, the start, cliff and periods are the same.
+  /// then it performs some checks on the end dates to ensure that either the end dates are the same, or if the user is combining previously segmented plans,
+  /// that the original end dates of those segments are the same.
+  /// if everything checks out, and the new end date of the combined plan will result in an end date equal to or later than the two plans, then they can be combined
+  /// combining plans will delete the plan1 and burn the NFT related to it
+  /// and then update the storage of the plan0 with the combined amount and combined rate
+  /// if One of the plans has a voting vault, then that plan will be the survivor and then tokens will be transferred and consolidated into that plan
+  /// if both have a voting vault, then plan0 will be the survivor and tokens consolidated to plan0 voting vault
+  /// if neither have a voting vault then nothing is done for voting vaults.
+  /// @param planId0 is the planId of the first plan in the combination
+  /// @param planId1 is the planId of a second plan to be combined
+  function _combinePlans(uint256 planId0, uint256 planId1) internal returns (uint256 survivingPlan) {
+    require(ownerOf(planId0) == msg.sender, '!owner');
+    require(ownerOf(planId1) == msg.sender, '!owner');
+    Plan memory plan0 = plans[planId0];
+    Plan memory plan1 = plans[planId1];
+    require(plan0.token == plan1.token, 'token error');
+    require(plan0.start == plan1.start, 'start error');
+    require(plan0.cliff == plan1.cliff, 'cliff error');
+    require(plan0.period == plan1.period, 'period error');
+    uint256 plan0End = TimelockLibrary.endDate(plan0.start, plan0.amount, plan0.rate, plan0.period);
+    uint256 plan1End = TimelockLibrary.endDate(plan1.start, plan1.amount, plan1.rate, plan1.period);
+    require(
+      plan0End == plan1End ||
+        (segmentOriginalEnd[planId0] == segmentOriginalEnd[planId1] && segmentOriginalEnd[planId0] != 0),
+      'end error'
+    );
+    address vault0 = votingVaults[planId0];
+    address vault1 = votingVaults[planId1];
+    survivingPlan = planId0;
+    if (vault0 != address(0)) {
+      plans[planId0].amount += plans[planId1].amount;
+      (uint256 survivorRate, uint256 survivorEnd) = TimelockLibrary.calculateCombinedRate(
+        plan0.amount + plan1.amount,
+        plan0.rate + plan1.rate,
+        plan0.start,
+        plan0.period,
+        plan0End
+      );
+      plans[planId0].rate = survivorRate;
+      if (survivorEnd < plan0End) {
+        require(
+          survivorEnd == segmentOriginalEnd[planId0] || survivorEnd == segmentOriginalEnd[planId1],
+          'original end error'
+        );
+      }
+      if (vault1 != address(0)) {
+        VotingVault(vault1).withdrawTokens(vault0, plan1.amount);
+      } else {
+        TransferHelper.withdrawTokens(plan0.token, vault0, plan1.amount);
+      }
+      delete plans[planId1];
+      _burn(planId1);
+      emit PlansCombined(
+        planId0,
+        planId1,
+        survivingPlan,
+        plans[planId0].amount,
+        plans[planId0].rate,
+        plan0.start,
+        plan0.cliff,
+        plan0.period,
+        survivorEnd
+      );
+    } else if (vault1 != address(0)) {
+      plans[planId1].amount += plans[planId0].amount;
+      (uint256 survivorRate, uint256 survivorEnd) = TimelockLibrary.calculateCombinedRate(
+        plan0.amount + plan1.amount,
+        plan0.rate + plan1.rate,
+        plan1.start,
+        plan1.period,
+        plan1End
+      );
+      plans[planId1].rate = survivorRate;
+      if (survivorEnd < plan1End) {
+        require(
+          survivorEnd == segmentOriginalEnd[planId0] || survivorEnd == segmentOriginalEnd[planId1],
+          'original end error'
+        );
+      }
+      TransferHelper.withdrawTokens(plan0.token, vault1, plan0.amount);
+      survivingPlan = planId1;
+      delete plans[planId0];
+      _burn(planId0);
+      emit PlansCombined(
+        planId0,
+        planId1,
+        survivingPlan,
+        plans[planId1].amount,
+        plans[planId1].rate,
+        plan1.start,
+        plan1.cliff,
+        plan1.period,
+        survivorEnd
+      );
+    } else {
+      plans[planId0].amount += plans[planId1].amount;
+      (uint256 survivorRate, uint256 survivorEnd) = TimelockLibrary.calculateCombinedRate(
+        plan0.amount + plan1.amount,
+        plan0.rate + plan1.rate,
+        plan0.start,
+        plan0.period,
+        plan0End
+      );
+      plans[planId0].rate = survivorRate;
+      if (survivorEnd < plan0End) {
+        require(
+          survivorEnd == segmentOriginalEnd[planId0] || survivorEnd == segmentOriginalEnd[planId1],
+          'original end error'
+        );
+      }
+      delete plans[planId1];
+      _burn(planId1);
+      emit PlansCombined(
+        planId0,
+        planId1,
+        survivingPlan,
+        plans[planId0].amount,
+        plans[planId0].rate,
+        plan0.start,
+        plan0.cliff,
+        plan0.period,
+        survivorEnd
+      );
+    }
+  }
+
+  /****INTERNAL VOTING & DELEGATION FUNCTIONS*********************************************************************************************************************************************/
+
+  /// @notice the internal function to setup a voting vault.
+  /// @dev this will check that no voting vault exists already and then deploy a new voting vault contract
+  // during the constructor setup of the voting vault, it will auto delegate the voting vault address to whatever the existing delegate of the  plan holder has delegated to
+  // if it has not delegated yet, it will self-delegate the tokens
+  /// then transfer the tokens remaining in the lockup plan to the voting vault physically
+  /// @param planId is the id of the lockup plan and NFT
+  function _setupVoting(uint256 planId) internal returns (address) {
+    require(_isApprovedDelegatorOrOwner(msg.sender, planId), '!delegator');
+    require(votingVaults[planId] == address(0), 'exists');
+    Plan memory plan = plans[planId];
+    VotingVault vault = new VotingVault(plan.token, ownerOf(planId));
+    votingVaults[planId] = address(vault);
+    TransferHelper.withdrawTokens(plan.token, address(vault), plan.amount);
+    emit VotingVaultCreated(planId, address(vault));
+    return address(vault);
+  }
+
+  /// @notice this internal function will physically delegate tokens held in a voting vault to a delegatee
+  /// @dev if a voting vautl has not been setup yet, then the function will call the internal _setupVoting function and setup a new voting vault
+  /// and then it will delegate the tokens held in the vault to the delegatee
+  /// @param planId is the id of the lockup plan and NFT
+  /// @param delegatee is the address of the delegatee where the tokens in the voting vault will be delegated to
+  function _delegate(uint256 planId, address delegatee) internal {
+    require(_isApprovedDelegatorOrOwner(msg.sender, planId), '!delegator');
+    address vault = votingVaults[planId];
+    if (votingVaults[planId] == address(0)) {
+      vault = _setupVoting(planId);
+    }
+    VotingVault(vault).delegateTokens(delegatee);
+  }
+
+  /****VIEW VOTING FUNCTIONS*********************************************************************************************************************************************/
+
+  /// @notice this function will pull all of the unclaimed tokens for a specific holder across all of their plans, based on a single ERC20 token
+  /// very useful for snapshot voting, and other view functionalities. This aggregates all balances, including any in voting vaults.
+  /// @param holder is the address of the beneficiary who owns the lockup plan(s)
+  /// @param token is the ERC20 address of the token that is stored across the lockup plans
+  function lockedBalances(address holder, address token) external view returns (uint256 lockedBalance) {
+    uint256 holdersBalance = balanceOf(holder);
+    for (uint256 i; i < holdersBalance; i++) {
+      uint256 planId = tokenOfOwnerByIndex(holder, i);
+      Plan memory plan = plans[planId];
+      if (token == plan.token) {
+        lockedBalance += plan.amount;
+      }
+    }
+  }
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (security/ReentrancyGuard.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Contract module that helps prevent reentrant calls to a function.
+ *
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
+ *
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
+ *
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
+ */
+abstract contract ReentrancyGuard {
+    // Booleans are more expensive than uint256 or any type that takes up a full
+    // word because each write operation emits an extra SLOAD to first read the
+    // slot's contents, replace the bits taken up by the boolean, and then write
+    // back. This is the compiler's defense against contract upgrades and
+    // pointer aliasing, and it cannot be disabled.
+
+    // The values being non-zero value makes deployment a bit more expensive,
+    // but in exchange the refund on every call to nonReentrant will be lower in
+    // amount. Since refunds are capped to a percentage of the total
+    // transaction's gas, it is best to keep them low in cases like this one, to
+    // increase the likelihood of the full refund coming into effect.
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+
+    uint256 private _status;
+
+    constructor() {
+        _status = _NOT_ENTERED;
+    }
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and making it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+
+    function _nonReentrantBefore() private {
+        // On the first call to nonReentrant, _status will be _NOT_ENTERED
+        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+
+        // Any calls to nonReentrant after this point will fail
+        _status = _ENTERED;
+    }
+
+    function _nonReentrantAfter() private {
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = _NOT_ENTERED;
+    }
+
+    /**
+     * @dev Returns true if the reentrancy guard is currently set to "entered", which indicates there is a
+     * `nonReentrant` function in the call stack.
+     */
+    function _reentrancyGuardEntered() internal view returns (bool) {
+        return _status == _ENTERED;
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/extensions/IERC20Permit.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
+ * https://eips.ethereum.org/EIPS/eip-2612[EIP-2612].
+ *
+ * Adds the {permit} method, which can be used to change an account's ERC20 allowance (see {IERC20-allowance}) by
+ * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't
+ * need to send a transaction, and thus is not required to hold Ether at all.
+ */
+interface IERC20Permit {
+    /**
+     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,
+     * given ``owner``'s signed approval.
+     *
+     * IMPORTANT: The same issues {IERC20-approve} has related to transaction
+     * ordering also apply here.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `deadline` must be a timestamp in the future.
+     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`
+     * over the EIP712-formatted function arguments.
+     * - the signature must use ``owner``'s current nonce (see {nonces}).
+     *
+     * For more information on the signature format, see the
+     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP
+     * section].
+     */
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    /**
+     * @dev Returns the current nonce for `owner`. This value must be
+     * included whenever a signature is generated for {permit}.
+     *
+     * Every successful call to {permit} increases ``owner``'s nonce by one. This
+     * prevents a signature from being used multiple times.
+     */
+    function nonces(address owner) external view returns (uint256);
+
+    /**
+     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/IERC20.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `to`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address to, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `from` to `to` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/utils/SafeERC20.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title SafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+ */
+library SafeERC20 {
+    using Address for address;
+
+    /**
+     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     */
+    function safeTransfer(IERC20 token, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+    }
+
+    /**
+     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the
+     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.
+     */
+    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+    }
+
+    /**
+     * @dev Deprecated. This function has issues similar to the ones found in
+     * {IERC20-approve}, and its usage is discouraged.
+     *
+     * Whenever possible, use {safeIncreaseAllowance} and
+     * {safeDecreaseAllowance} instead.
+     */
+    function safeApprove(IERC20 token, address spender, uint256 value) internal {
+        // safeApprove should only be called when setting an initial allowance,
+        // or when resetting it to zero. To increase and decrease it, use
+        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
+        require(
+            (value == 0) || (token.allowance(address(this), spender) == 0),
+            "SafeERC20: approve from non-zero to non-zero allowance"
+        );
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
+    }
+
+    /**
+     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     */
+    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {
+        uint256 oldAllowance = token.allowance(address(this), spender);
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, oldAllowance + value));
+    }
+
+    /**
+     * @dev Decrease the calling contract's allowance toward `spender` by `value`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     */
+    function safeDecreaseAllowance(IERC20 token, address spender, uint256 value) internal {
+        unchecked {
+            uint256 oldAllowance = token.allowance(address(this), spender);
+            require(oldAllowance >= value, "SafeERC20: decreased allowance below zero");
+            _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, oldAllowance - value));
+        }
+    }
+
+    /**
+     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful. Compatible with tokens that require the approval to be set to
+     * 0 before setting it to a non-zero value.
+     */
+    function forceApprove(IERC20 token, address spender, uint256 value) internal {
+        bytes memory approvalCall = abi.encodeWithSelector(token.approve.selector, spender, value);
+
+        if (!_callOptionalReturnBool(token, approvalCall)) {
+            _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, 0));
+            _callOptionalReturn(token, approvalCall);
+        }
+    }
+
+    /**
+     * @dev Use a ERC-2612 signature to set the `owner` approval toward `spender` on `token`.
+     * Revert on invalid signature.
+     */
+    function safePermit(
+        IERC20Permit token,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal {
+        uint256 nonceBefore = token.nonces(owner);
+        token.permit(owner, spender, value, deadline, v, r, s);
+        uint256 nonceAfter = token.nonces(owner);
+        require(nonceAfter == nonceBefore + 1, "SafeERC20: permit did not succeed");
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(IERC20 token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {Address-functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = address(token).functionCall(data, "SafeERC20: low-level call failed");
+        require(returndata.length == 0 || abi.decode(returndata, (bool)), "SafeERC20: ERC20 operation did not succeed");
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     *
+     * This is a variant of {_callOptionalReturn} that silents catches all reverts and returns a bool instead.
+     */
+    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We cannot use {Address-functionCall} here since this should return false
+        // and not revert is the subcall reverts.
+
+        (bool success, bytes memory returndata) = address(token).call(data);
+        return
+            success && (returndata.length == 0 || abi.decode(returndata, (bool))) && Address.isContract(address(token));
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC721/ERC721.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Implementation of https://eips.ethereum.org/EIPS/eip-721[ERC721] Non-Fungible Token Standard, including
+ * the Metadata extension, but not including the Enumerable extension, which is available separately as
+ * {ERC721Enumerable}.
+ */
+contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
+    using Address for address;
+    using Strings for uint256;
+
+    // Token name
+    string private _name;
+
+    // Token symbol
+    string private _symbol;
+
+    // Mapping from token ID to owner address
+    mapping(uint256 => address) private _owners;
+
+    // Mapping owner address to token count
+    mapping(address => uint256) private _balances;
+
+    // Mapping from token ID to approved address
+    mapping(uint256 => address) private _tokenApprovals;
+
+    // Mapping from owner to operator approvals
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
+
+    /**
+     * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
+     */
+    constructor(string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
+        return
+            interfaceId == type(IERC721).interfaceId ||
+            interfaceId == type(IERC721Metadata).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev See {IERC721-balanceOf}.
+     */
+    function balanceOf(address owner) public view virtual override returns (uint256) {
+        require(owner != address(0), "ERC721: address zero is not a valid owner");
+        return _balances[owner];
+    }
+
+    /**
+     * @dev See {IERC721-ownerOf}.
+     */
+    function ownerOf(uint256 tokenId) public view virtual override returns (address) {
+        address owner = _ownerOf(tokenId);
+        require(owner != address(0), "ERC721: invalid token ID");
+        return owner;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-name}.
+     */
+    function name() public view virtual override returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-symbol}.
+     */
+    function symbol() public view virtual override returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-tokenURI}.
+     */
+    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+        _requireMinted(tokenId);
+
+        string memory baseURI = _baseURI();
+        return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
+    }
+
+    /**
+     * @dev Base URI for computing {tokenURI}. If set, the resulting URI for each
+     * token will be the concatenation of the `baseURI` and the `tokenId`. Empty
+     * by default, can be overridden in child contracts.
+     */
+    function _baseURI() internal view virtual returns (string memory) {
+        return "";
+    }
+
+    /**
+     * @dev See {IERC721-approve}.
+     */
+    function approve(address to, uint256 tokenId) public virtual override {
+        address owner = ERC721.ownerOf(tokenId);
+        require(to != owner, "ERC721: approval to current owner");
+
+        require(
+            _msgSender() == owner || isApprovedForAll(owner, _msgSender()),
+            "ERC721: approve caller is not token owner or approved for all"
+        );
+
+        _approve(to, tokenId);
+    }
+
+    /**
+     * @dev See {IERC721-getApproved}.
+     */
+    function getApproved(uint256 tokenId) public view virtual override returns (address) {
+        _requireMinted(tokenId);
+
+        return _tokenApprovals[tokenId];
+    }
+
+    /**
+     * @dev See {IERC721-setApprovalForAll}.
+     */
+    function setApprovalForAll(address operator, bool approved) public virtual override {
+        _setApprovalForAll(_msgSender(), operator, approved);
+    }
+
+    /**
+     * @dev See {IERC721-isApprovedForAll}.
+     */
+    function isApprovedForAll(address owner, address operator) public view virtual override returns (bool) {
+        return _operatorApprovals[owner][operator];
+    }
+
+    /**
+     * @dev See {IERC721-transferFrom}.
+     */
+    function transferFrom(address from, address to, uint256 tokenId) public virtual override {
+        //solhint-disable-next-line max-line-length
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: caller is not token owner or approved");
+
+        _transfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId) public virtual override {
+        safeTransferFrom(from, to, tokenId, "");
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public virtual override {
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: caller is not token owner or approved");
+        _safeTransfer(from, to, tokenId, data);
+    }
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
+     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
+     *
+     * `data` is additional data, it has no specified format and it is sent in call to `to`.
+     *
+     * This internal function is equivalent to {safeTransferFrom}, and can be used to e.g.
+     * implement alternative mechanisms to perform token transfer, such as signature-based.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _safeTransfer(address from, address to, uint256 tokenId, bytes memory data) internal virtual {
+        _transfer(from, to, tokenId);
+        require(_checkOnERC721Received(from, to, tokenId, data), "ERC721: transfer to non ERC721Receiver implementer");
+    }
+
+    /**
+     * @dev Returns the owner of the `tokenId`. Does NOT revert if token doesn't exist
+     */
+    function _ownerOf(uint256 tokenId) internal view virtual returns (address) {
+        return _owners[tokenId];
+    }
+
+    /**
+     * @dev Returns whether `tokenId` exists.
+     *
+     * Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
+     *
+     * Tokens start existing when they are minted (`_mint`),
+     * and stop existing when they are burned (`_burn`).
+     */
+    function _exists(uint256 tokenId) internal view virtual returns (bool) {
+        return _ownerOf(tokenId) != address(0);
+    }
+
+    /**
+     * @dev Returns whether `spender` is allowed to manage `tokenId`.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function _isApprovedOrOwner(address spender, uint256 tokenId) internal view virtual returns (bool) {
+        address owner = ERC721.ownerOf(tokenId);
+        return (spender == owner || isApprovedForAll(owner, spender) || getApproved(tokenId) == spender);
+    }
+
+    /**
+     * @dev Safely mints `tokenId` and transfers it to `to`.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must not exist.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _safeMint(address to, uint256 tokenId) internal virtual {
+        _safeMint(to, tokenId, "");
+    }
+
+    /**
+     * @dev Same as {xref-ERC721-_safeMint-address-uint256-}[`_safeMint`], with an additional `data` parameter which is
+     * forwarded in {IERC721Receiver-onERC721Received} to contract recipients.
+     */
+    function _safeMint(address to, uint256 tokenId, bytes memory data) internal virtual {
+        _mint(to, tokenId);
+        require(
+            _checkOnERC721Received(address(0), to, tokenId, data),
+            "ERC721: transfer to non ERC721Receiver implementer"
+        );
+    }
+
+    /**
+     * @dev Mints `tokenId` and transfers it to `to`.
+     *
+     * WARNING: Usage of this method is discouraged, use {_safeMint} whenever possible
+     *
+     * Requirements:
+     *
+     * - `tokenId` must not exist.
+     * - `to` cannot be the zero address.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _mint(address to, uint256 tokenId) internal virtual {
+        require(to != address(0), "ERC721: mint to the zero address");
+        require(!_exists(tokenId), "ERC721: token already minted");
+
+        _beforeTokenTransfer(address(0), to, tokenId, 1);
+
+        // Check that tokenId was not minted by `_beforeTokenTransfer` hook
+        require(!_exists(tokenId), "ERC721: token already minted");
+
+        unchecked {
+            // Will not overflow unless all 2**256 token ids are minted to the same owner.
+            // Given that tokens are minted one by one, it is impossible in practice that
+            // this ever happens. Might change if we allow batch minting.
+            // The ERC fails to describe this case.
+            _balances[to] += 1;
+        }
+
+        _owners[tokenId] = to;
+
+        emit Transfer(address(0), to, tokenId);
+
+        _afterTokenTransfer(address(0), to, tokenId, 1);
+    }
+
+    /**
+     * @dev Destroys `tokenId`.
+     * The approval is cleared when the token is burned.
+     * This is an internal function that does not check if the sender is authorized to operate on the token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _burn(uint256 tokenId) internal virtual {
+        address owner = ERC721.ownerOf(tokenId);
+
+        _beforeTokenTransfer(owner, address(0), tokenId, 1);
+
+        // Update ownership in case tokenId was transferred by `_beforeTokenTransfer` hook
+        owner = ERC721.ownerOf(tokenId);
+
+        // Clear approvals
+        delete _tokenApprovals[tokenId];
+
+        unchecked {
+            // Cannot overflow, as that would require more tokens to be burned/transferred
+            // out than the owner initially received through minting and transferring in.
+            _balances[owner] -= 1;
+        }
+        delete _owners[tokenId];
+
+        emit Transfer(owner, address(0), tokenId);
+
+        _afterTokenTransfer(owner, address(0), tokenId, 1);
+    }
+
+    /**
+     * @dev Transfers `tokenId` from `from` to `to`.
+     *  As opposed to {transferFrom}, this imposes no restrictions on msg.sender.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must be owned by `from`.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _transfer(address from, address to, uint256 tokenId) internal virtual {
+        require(ERC721.ownerOf(tokenId) == from, "ERC721: transfer from incorrect owner");
+        require(to != address(0), "ERC721: transfer to the zero address");
+
+        _beforeTokenTransfer(from, to, tokenId, 1);
+
+        // Check that tokenId was not transferred by `_beforeTokenTransfer` hook
+        require(ERC721.ownerOf(tokenId) == from, "ERC721: transfer from incorrect owner");
+
+        // Clear approvals from the previous owner
+        delete _tokenApprovals[tokenId];
+
+        unchecked {
+            // `_balances[from]` cannot overflow for the same reason as described in `_burn`:
+            // `from`'s balance is the number of token held, which is at least one before the current
+            // transfer.
+            // `_balances[to]` could overflow in the conditions described in `_mint`. That would require
+            // all 2**256 token ids to be minted, which in practice is impossible.
+            _balances[from] -= 1;
+            _balances[to] += 1;
+        }
+        _owners[tokenId] = to;
+
+        emit Transfer(from, to, tokenId);
+
+        _afterTokenTransfer(from, to, tokenId, 1);
+    }
+
+    /**
+     * @dev Approve `to` to operate on `tokenId`
+     *
+     * Emits an {Approval} event.
+     */
+    function _approve(address to, uint256 tokenId) internal virtual {
+        _tokenApprovals[tokenId] = to;
+        emit Approval(ERC721.ownerOf(tokenId), to, tokenId);
+    }
+
+    /**
+     * @dev Approve `operator` to operate on all of `owner` tokens
+     *
+     * Emits an {ApprovalForAll} event.
+     */
+    function _setApprovalForAll(address owner, address operator, bool approved) internal virtual {
+        require(owner != operator, "ERC721: approve to caller");
+        _operatorApprovals[owner][operator] = approved;
+        emit ApprovalForAll(owner, operator, approved);
+    }
+
+    /**
+     * @dev Reverts if the `tokenId` has not been minted yet.
+     */
+    function _requireMinted(uint256 tokenId) internal view virtual {
+        require(_exists(tokenId), "ERC721: invalid token ID");
+    }
+
+    /**
+     * @dev Internal function to invoke {IERC721Receiver-onERC721Received} on a target address.
+     * The call is not executed if the target address is not a contract.
+     *
+     * @param from address representing the previous owner of the given token ID
+     * @param to target address that will receive the tokens
+     * @param tokenId uint256 ID of the token to be transferred
+     * @param data bytes optional data to send along with the call
+     * @return bool whether the call correctly returned the expected magic value
+     */
+    function _checkOnERC721Received(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) private returns (bool) {
+        if (to.isContract()) {
+            try IERC721Receiver(to).onERC721Received(_msgSender(), from, tokenId, data) returns (bytes4 retval) {
+                return retval == IERC721Receiver.onERC721Received.selector;
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    revert("ERC721: transfer to non ERC721Receiver implementer");
+                } else {
+                    /// @solidity memory-safe-assembly
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * @dev Hook that is called before any token transfer. This includes minting and burning. If {ERC721Consecutive} is
+     * used, the hook may be called as part of a consecutive (batch) mint, as indicated by `batchSize` greater than 1.
+     *
+     * Calling conditions:
+     *
+     * - When `from` and `to` are both non-zero, ``from``'s tokens will be transferred to `to`.
+     * - When `from` is zero, the tokens will be minted for `to`.
+     * - When `to` is zero, ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     * - `batchSize` is non-zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 firstTokenId, uint256 batchSize) internal virtual {}
+
+    /**
+     * @dev Hook that is called after any token transfer. This includes minting and burning. If {ERC721Consecutive} is
+     * used, the hook may be called as part of a consecutive (batch) mint, as indicated by `batchSize` greater than 1.
+     *
+     * Calling conditions:
+     *
+     * - When `from` and `to` are both non-zero, ``from``'s tokens were transferred to `to`.
+     * - When `from` is zero, the tokens were minted for `to`.
+     * - When `to` is zero, ``from``'s tokens were burned.
+     * - `from` and `to` are never both zero.
+     * - `batchSize` is non-zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _afterTokenTransfer(address from, address to, uint256 firstTokenId, uint256 batchSize) internal virtual {}
+
+    /**
+     * @dev Unsafe write access to the balances, used by extensions that "mint" tokens using an {ownerOf} override.
+     *
+     * WARNING: Anyone calling this MUST ensure that the balances remain consistent with the ownership. The invariant
+     * being that for any address `a` the value returned by `balanceOf(a)` must be equal to the number of tokens such
+     * that `ownerOf(tokenId)` is `a`.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function __unsafe_increaseBalance(address account, uint256 amount) internal {
+        _balances[account] += amount;
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.8.0) (token/ERC721/extensions/ERC721Enumerable.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev This implements an optional extension of {ERC721} defined in the EIP that adds
+ * enumerability of all the token ids in the contract as well as all token ids owned by each
+ * account.
+ */
+abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
+    // Mapping from owner to list of owned token IDs
+    mapping(address => mapping(uint256 => uint256)) private _ownedTokens;
+
+    // Mapping from token ID to index of the owner tokens list
+    mapping(uint256 => uint256) private _ownedTokensIndex;
+
+    // Array with all token ids, used for enumeration
+    uint256[] private _allTokens;
+
+    // Mapping from token id to position in the allTokens array
+    mapping(uint256 => uint256) private _allTokensIndex;
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC721) returns (bool) {
+        return interfaceId == type(IERC721Enumerable).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev See {IERC721Enumerable-tokenOfOwnerByIndex}.
+     */
+    function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256) {
+        require(index < ERC721.balanceOf(owner), "ERC721Enumerable: owner index out of bounds");
+        return _ownedTokens[owner][index];
+    }
+
+    /**
+     * @dev See {IERC721Enumerable-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _allTokens.length;
+    }
+
+    /**
+     * @dev See {IERC721Enumerable-tokenByIndex}.
+     */
+    function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
+        require(index < ERC721Enumerable.totalSupply(), "ERC721Enumerable: global index out of bounds");
+        return _allTokens[index];
+    }
+
+    /**
+     * @dev See {ERC721-_beforeTokenTransfer}.
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 firstTokenId,
+        uint256 batchSize
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
+
+        if (batchSize > 1) {
+            // Will only trigger during construction. Batch transferring (minting) is not available afterwards.
+            revert("ERC721Enumerable: consecutive transfers not supported");
+        }
+
+        uint256 tokenId = firstTokenId;
+
+        if (from == address(0)) {
+            _addTokenToAllTokensEnumeration(tokenId);
+        } else if (from != to) {
+            _removeTokenFromOwnerEnumeration(from, tokenId);
+        }
+        if (to == address(0)) {
+            _removeTokenFromAllTokensEnumeration(tokenId);
+        } else if (to != from) {
+            _addTokenToOwnerEnumeration(to, tokenId);
+        }
+    }
+
+    /**
+     * @dev Private function to add a token to this extension's ownership-tracking data structures.
+     * @param to address representing the new owner of the given token ID
+     * @param tokenId uint256 ID of the token to be added to the tokens list of the given address
+     */
+    function _addTokenToOwnerEnumeration(address to, uint256 tokenId) private {
+        uint256 length = ERC721.balanceOf(to);
+        _ownedTokens[to][length] = tokenId;
+        _ownedTokensIndex[tokenId] = length;
+    }
+
+    /**
+     * @dev Private function to add a token to this extension's token tracking data structures.
+     * @param tokenId uint256 ID of the token to be added to the tokens list
+     */
+    function _addTokenToAllTokensEnumeration(uint256 tokenId) private {
+        _allTokensIndex[tokenId] = _allTokens.length;
+        _allTokens.push(tokenId);
+    }
+
+    /**
+     * @dev Private function to remove a token from this extension's ownership-tracking data structures. Note that
+     * while the token is not assigned a new owner, the `_ownedTokensIndex` mapping is _not_ updated: this allows for
+     * gas optimizations e.g. when performing a transfer operation (avoiding double writes).
+     * This has O(1) time complexity, but alters the order of the _ownedTokens array.
+     * @param from address representing the previous owner of the given token ID
+     * @param tokenId uint256 ID of the token to be removed from the tokens list of the given address
+     */
+    function _removeTokenFromOwnerEnumeration(address from, uint256 tokenId) private {
+        // To prevent a gap in from's tokens array, we store the last token in the index of the token to delete, and
+        // then delete the last slot (swap and pop).
+
+        uint256 lastTokenIndex = ERC721.balanceOf(from) - 1;
+        uint256 tokenIndex = _ownedTokensIndex[tokenId];
+
+        // When the token to delete is the last token, the swap operation is unnecessary
+        if (tokenIndex != lastTokenIndex) {
+            uint256 lastTokenId = _ownedTokens[from][lastTokenIndex];
+
+            _ownedTokens[from][tokenIndex] = lastTokenId; // Move the last token to the slot of the to-delete token
+            _ownedTokensIndex[lastTokenId] = tokenIndex; // Update the moved token's index
+        }
+
+        // This also deletes the contents at the last position of the array
+        delete _ownedTokensIndex[tokenId];
+        delete _ownedTokens[from][lastTokenIndex];
+    }
+
+    /**
+     * @dev Private function to remove a token from this extension's token tracking data structures.
+     * This has O(1) time complexity, but alters the order of the _allTokens array.
+     * @param tokenId uint256 ID of the token to be removed from the tokens list
+     */
+    function _removeTokenFromAllTokensEnumeration(uint256 tokenId) private {
+        // To prevent a gap in the tokens array, we store the last token in the index of the token to delete, and
+        // then delete the last slot (swap and pop).
+
+        uint256 lastTokenIndex = _allTokens.length - 1;
+        uint256 tokenIndex = _allTokensIndex[tokenId];
+
+        // When the token to delete is the last token, the swap operation is unnecessary. However, since this occurs so
+        // rarely (when the last minted token is burnt) that we still do the swap here to avoid the gas cost of adding
+        // an 'if' statement (like in _removeTokenFromOwnerEnumeration)
+        uint256 lastTokenId = _allTokens[lastTokenIndex];
+
+        _allTokens[tokenIndex] = lastTokenId; // Move the last token to the slot of the to-delete token
+        _allTokensIndex[lastTokenId] = tokenIndex; // Update the moved token's index
+
+        // This also deletes the contents at the last position of the array
+        delete _allTokensIndex[tokenId];
+        _allTokens.pop();
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.5.0) (token/ERC721/extensions/IERC721Enumerable.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional enumeration extension
+ * @dev See https://eips.ethereum.org/EIPS/eip-721
+ */
+interface IERC721Enumerable is IERC721 {
+    /**
+     * @dev Returns the total amount of tokens stored by the contract.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns a token ID owned by `owner` at a given `index` of its token list.
+     * Use along with {balanceOf} to enumerate all of ``owner``'s tokens.
+     */
+    function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256);
+
+    /**
+     * @dev Returns a token ID at a given `index` of all the tokens stored by the contract.
+     * Use along with {totalSupply} to enumerate all tokens.
+     */
+    function tokenByIndex(uint256 index) external view returns (uint256);
+}
+
+// OpenZeppelin Contracts v4.4.1 (token/ERC721/extensions/IERC721Metadata.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional metadata extension
+ * @dev See https://eips.ethereum.org/EIPS/eip-721
+ */
+interface IERC721Metadata is IERC721 {
+    /**
+     * @dev Returns the token collection name.
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @dev Returns the token collection symbol.
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the Uniform Resource Identifier (URI) for `tokenId` token.
+     */
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC721/IERC721.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Required interface of an ERC721 compliant contract.
+ */
+interface IERC721 is IERC165 {
+    /**
+     * @dev Emitted when `tokenId` token is transferred from `from` to `to`.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    /**
+     * @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.
+     */
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+
+    /**
+     * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+     */
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    /**
+     * @dev Returns the number of tokens in ``owner``'s account.
+     */
+    function balanceOf(address owner) external view returns (uint256 balance);
+
+    /**
+     * @dev Returns the owner of the `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
+     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+
+    /**
+     * @dev Transfers `tokenId` token from `from` to `to`.
+     *
+     * WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721
+     * or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must
+     * understand this adds an external call which potentially creates a reentrancy vulnerability.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address from, address to, uint256 tokenId) external;
+
+    /**
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
+     * The approval is cleared when the token is transferred.
+     *
+     * Only a single account can be approved at a time, so approving the zero address clears previous approvals.
+     *
+     * Requirements:
+     *
+     * - The caller must own the token or be an approved operator.
+     * - `tokenId` must exist.
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address to, uint256 tokenId) external;
+
+    /**
+     * @dev Approve or remove `operator` as an operator for the caller.
+     * Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.
+     *
+     * Requirements:
+     *
+     * - The `operator` cannot be the caller.
+     *
+     * Emits an {ApprovalForAll} event.
+     */
+    function setApprovalForAll(address operator, bool approved) external;
+
+    /**
+     * @dev Returns the account approved for `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function getApproved(uint256 tokenId) external view returns (address operator);
+
+    /**
+     * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.
+     *
+     * See {setApprovalForAll}
+     */
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+}
+
+// OpenZeppelin Contracts (last updated v4.6.0) (token/ERC721/IERC721Receiver.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title ERC721 token receiver interface
+ * @dev Interface for any contract that wants to support safeTransfers
+ * from ERC721 asset contracts.
+ */
+interface IERC721Receiver {
+    /**
+     * @dev Whenever an {IERC721} `tokenId` token is transferred to this contract via {IERC721-safeTransferFrom}
+     * by `operator` from `from`, this function is called.
+     *
+     * It must return its Solidity selector to confirm the token transfer.
+     * If any other value is returned or the interface is not implemented by the recipient, the transfer will be reverted.
+     *
+     * The selector can be obtained in Solidity with `IERC721Receiver.onERC721Received.selector`.
+     */
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external returns (bytes4);
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (utils/Address.sol)
+
+pragma solidity ^0.8.1;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     *
+     * Furthermore, `isContract` will also return true if the target contract within
+     * the same transaction is already scheduled for destruction by `SELFDESTRUCT`,
+     * which only has an effect at the end of a transaction.
+     * ====
+     *
+     * [IMPORTANT]
+     * ====
+     * You shouldn't rely on `isContract` to protect against flash loan attacks!
+     *
+     * Preventing calls from contracts is highly discouraged. It breaks composability, breaks support for smart wallets
+     * like Gnosis Safe, and does not provide security since it can be circumvented by calling from a contract
+     * constructor.
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize/address.code.length, which returns 0
+        // for contracts in construction, since the code is only stored at the end
+        // of the constructor execution.
+
+        return account.code.length > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.8.0/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain `call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal view returns (bytes memory) {
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Tool to verify that a low level call to smart-contract was successful, and revert (either by bubbling
+     * the revert reason or using the provided one) in case of unsuccessful call or if target was not a contract.
+     *
+     * _Available since v4.8._
+     */
+    function verifyCallResultFromTarget(
+        address target,
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) internal view returns (bytes memory) {
+        if (success) {
+            if (returndata.length == 0) {
+                // only check isContract if the call was successful and the return data is empty
+                // otherwise we already know that it was a contract
+                require(isContract(target), "Address: call to non-contract");
+            }
+            return returndata;
+        } else {
+            _revert(returndata, errorMessage);
+        }
+    }
+
+    /**
+     * @dev Tool to verify that a low level call was successful, and revert if it wasn't, either by bubbling the
+     * revert reason or using the provided one.
+     *
+     * _Available since v4.3._
+     */
+    function verifyCallResult(
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) internal pure returns (bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            _revert(returndata, errorMessage);
+        }
+    }
+
+    function _revert(bytes memory returndata, string memory errorMessage) private pure {
+        // Look for revert reason and bubble it up if present
+        if (returndata.length > 0) {
+            // The easiest way to bubble the revert reason is using memory via assembly
+            /// @solidity memory-safe-assembly
+            assembly {
+                let returndata_size := mload(returndata)
+                revert(add(32, returndata), returndata_size)
+            }
+        } else {
+            revert(errorMessage);
+        }
+    }
+}
+
+// OpenZeppelin Contracts v4.4.1 (utils/Context.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+}
+
+// OpenZeppelin Contracts v4.4.1 (utils/Counters.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title Counters
+ * @author Matt Condon (@shrugs)
+ * @dev Provides counters that can only be incremented, decremented or reset. This can be used e.g. to track the number
+ * of elements in a mapping, issuing ERC721 ids, or counting request ids.
+ *
+ * Include with `using Counters for Counters.Counter;`
+ */
+library Counters {
+    struct Counter {
+        // This variable should never be directly accessed by users of the library: interactions must be restricted to
+        // the library's function. As of Solidity v0.5.2, this cannot be enforced, though there is a proposal to add
+        // this feature: see https://github.com/ethereum/solidity/issues/4637
+        uint256 _value; // default: 0
+    }
+
+    function current(Counter storage counter) internal view returns (uint256) {
+        return counter._value;
+    }
+
+    function increment(Counter storage counter) internal {
+        unchecked {
+            counter._value += 1;
+        }
+    }
+
+    function decrement(Counter storage counter) internal {
+        uint256 value = counter._value;
+        require(value > 0, "Counter: decrement overflow");
+        unchecked {
+            counter._value = value - 1;
+        }
+    }
+
+    function reset(Counter storage counter) internal {
+        counter._value = 0;
+    }
+}
+
+// OpenZeppelin Contracts v4.4.1 (utils/introspection/ERC165.sol)
+
+pragma solidity ^0.8.0;
+
+
+/**
+ * @dev Implementation of the {IERC165} interface.
+ *
+ * Contracts that want to implement ERC165 should inherit from this contract and override {supportsInterface} to check
+ * for the additional interface id that will be supported. For example:
+ *
+ * ```solidity
+ * function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+ *     return interfaceId == type(MyInterface).interfaceId || super.supportsInterface(interfaceId);
+ * }
+ * ```
+ *
+ * Alternatively, {ERC165Storage} provides an easier to use but more expensive implementation.
+ */
+abstract contract ERC165 is IERC165 {
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IERC165).interfaceId;
+    }
+}
+
+// OpenZeppelin Contracts v4.4.1 (utils/introspection/IERC165.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[EIP].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (utils/math/Math.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Standard math utilities missing in the Solidity language.
+ */
+library Math {
+    enum Rounding {
+        Down, // Toward negative infinity
+        Up, // Toward infinity
+        Zero // Toward zero
+    }
+
+    /**
+     * @dev Returns the largest of two numbers.
+     */
+    function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a : b;
+    }
+
+    /**
+     * @dev Returns the smallest of two numbers.
+     */
+    function min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+
+    /**
+     * @dev Returns the average of two numbers. The result is rounded towards
+     * zero.
+     */
+    function average(uint256 a, uint256 b) internal pure returns (uint256) {
+        // (a + b) / 2 can overflow.
+        return (a & b) + (a ^ b) / 2;
+    }
+
+    /**
+     * @dev Returns the ceiling of the division of two numbers.
+     *
+     * This differs from standard division with `/` in that it rounds up instead
+     * of rounding down.
+     */
+    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+        // (a + b - 1) / b can overflow on addition, so we distribute.
+        return a == 0 ? 0 : (a - 1) / b + 1;
+    }
+
+    /**
+     * @notice Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+     * @dev Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv)
+     * with further edits by Uniswap Labs also under MIT license.
+     */
+    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {
+        unchecked {
+            // 512-bit multiply [prod1 prod0] = x * y. Compute the product mod 2^256 and mod 2^256 - 1, then use
+            // use the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256
+            // variables such that product = prod1 * 2^256 + prod0.
+            uint256 prod0; // Least significant 256 bits of the product
+            uint256 prod1; // Most significant 256 bits of the product
+            assembly {
+                let mm := mulmod(x, y, not(0))
+                prod0 := mul(x, y)
+                prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+            }
+
+            // Handle non-overflow cases, 256 by 256 division.
+            if (prod1 == 0) {
+                // Solidity will revert if denominator == 0, unlike the div opcode on its own.
+                // The surrounding unchecked block does not change this fact.
+                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.
+                return prod0 / denominator;
+            }
+
+            // Make sure the result is less than 2^256. Also prevents denominator == 0.
+            require(denominator > prod1, "Math: mulDiv overflow");
+
+            ///////////////////////////////////////////////
+            // 512 by 256 division.
+            ///////////////////////////////////////////////
+
+            // Make division exact by subtracting the remainder from [prod1 prod0].
+            uint256 remainder;
+            assembly {
+                // Compute remainder using mulmod.
+                remainder := mulmod(x, y, denominator)
+
+                // Subtract 256 bit number from 512 bit number.
+                prod1 := sub(prod1, gt(remainder, prod0))
+                prod0 := sub(prod0, remainder)
+            }
+
+            // Factor powers of two out of denominator and compute largest power of two divisor of denominator. Always >= 1.
+            // See https://cs.stackexchange.com/q/138556/92363.
+
+            // Does not overflow because the denominator cannot be zero at this stage in the function.
+            uint256 twos = denominator & (~denominator + 1);
+            assembly {
+                // Divide denominator by twos.
+                denominator := div(denominator, twos)
+
+                // Divide [prod1 prod0] by twos.
+                prod0 := div(prod0, twos)
+
+                // Flip twos such that it is 2^256 / twos. If twos is zero, then it becomes one.
+                twos := add(div(sub(0, twos), twos), 1)
+            }
+
+            // Shift in bits from prod1 into prod0.
+            prod0 |= prod1 * twos;
+
+            // Invert denominator mod 2^256. Now that denominator is an odd number, it has an inverse modulo 2^256 such
+            // that denominator * inv = 1 mod 2^256. Compute the inverse by starting with a seed that is correct for
+            // four bits. That is, denominator * inv = 1 mod 2^4.
+            uint256 inverse = (3 * denominator) ^ 2;
+
+            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also works
+            // in modular arithmetic, doubling the correct bits in each step.
+            inverse *= 2 - denominator * inverse; // inverse mod 2^8
+            inverse *= 2 - denominator * inverse; // inverse mod 2^16
+            inverse *= 2 - denominator * inverse; // inverse mod 2^32
+            inverse *= 2 - denominator * inverse; // inverse mod 2^64
+            inverse *= 2 - denominator * inverse; // inverse mod 2^128
+            inverse *= 2 - denominator * inverse; // inverse mod 2^256
+
+            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.
+            // This will give us the correct result modulo 2^256. Since the preconditions guarantee that the outcome is
+            // less than 2^256, this is the final result. We don't need to compute the high bits of the result and prod1
+            // is no longer required.
+            result = prod0 * inverse;
+            return result;
+        }
+    }
+
+    /**
+     * @notice Calculates x * y / denominator with full precision, following the selected rounding direction.
+     */
+    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {
+        uint256 result = mulDiv(x, y, denominator);
+        if (rounding == Rounding.Up && mulmod(x, y, denominator) > 0) {
+            result += 1;
+        }
+        return result;
+    }
+
+    /**
+     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded down.
+     *
+     * Inspired by Henry S. Warren, Jr.'s "Hacker's Delight" (Chapter 11).
+     */
+    function sqrt(uint256 a) internal pure returns (uint256) {
+        if (a == 0) {
+            return 0;
+        }
+
+        // For our first guess, we get the biggest power of 2 which is smaller than the square root of the target.
+        //
+        // We know that the "msb" (most significant bit) of our target number `a` is a power of 2 such that we have
+        // `msb(a) <= a < 2*msb(a)`. This value can be written `msb(a)=2**k` with `k=log2(a)`.
+        //
+        // This can be rewritten `2**log2(a) <= a < 2**(log2(a) + 1)`
+        // → `sqrt(2**k) <= sqrt(a) < sqrt(2**(k+1))`
+        // → `2**(k/2) <= sqrt(a) < 2**((k+1)/2) <= 2**(k/2 + 1)`
+        //
+        // Consequently, `2**(log2(a) / 2)` is a good first approximation of `sqrt(a)` with at least 1 correct bit.
+        uint256 result = 1 << (log2(a) >> 1);
+
+        // At this point `result` is an estimation with one bit of precision. We know the true value is a uint128,
+        // since it is the square root of a uint256. Newton's method converges quadratically (precision doubles at
+        // every iteration). We thus need at most 7 iteration to turn our partial result with one bit of precision
+        // into the expected uint128 result.
+        unchecked {
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            return min(result, a / result);
+        }
+    }
+
+    /**
+     * @notice Calculates sqrt(a), following the selected rounding direction.
+     */
+    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = sqrt(a);
+            return result + (rounding == Rounding.Up && result * result < a ? 1 : 0);
+        }
+    }
+
+    /**
+     * @dev Return the log in base 2, rounded down, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log2(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >> 128 > 0) {
+                value >>= 128;
+                result += 128;
+            }
+            if (value >> 64 > 0) {
+                value >>= 64;
+                result += 64;
+            }
+            if (value >> 32 > 0) {
+                value >>= 32;
+                result += 32;
+            }
+            if (value >> 16 > 0) {
+                value >>= 16;
+                result += 16;
+            }
+            if (value >> 8 > 0) {
+                value >>= 8;
+                result += 8;
+            }
+            if (value >> 4 > 0) {
+                value >>= 4;
+                result += 4;
+            }
+            if (value >> 2 > 0) {
+                value >>= 2;
+                result += 2;
+            }
+            if (value >> 1 > 0) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log2(value);
+            return result + (rounding == Rounding.Up && 1 << result < value ? 1 : 0);
+        }
+    }
+
+    /**
+     * @dev Return the log in base 10, rounded down, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log10(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >= 10 ** 64) {
+                value /= 10 ** 64;
+                result += 64;
+            }
+            if (value >= 10 ** 32) {
+                value /= 10 ** 32;
+                result += 32;
+            }
+            if (value >= 10 ** 16) {
+                value /= 10 ** 16;
+                result += 16;
+            }
+            if (value >= 10 ** 8) {
+                value /= 10 ** 8;
+                result += 8;
+            }
+            if (value >= 10 ** 4) {
+                value /= 10 ** 4;
+                result += 4;
+            }
+            if (value >= 10 ** 2) {
+                value /= 10 ** 2;
+                result += 2;
+            }
+            if (value >= 10 ** 1) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log10(value);
+            return result + (rounding == Rounding.Up && 10 ** result < value ? 1 : 0);
+        }
+    }
+
+    /**
+     * @dev Return the log in base 256, rounded down, of a positive value.
+     * Returns 0 if given 0.
+     *
+     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.
+     */
+    function log256(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >> 128 > 0) {
+                value >>= 128;
+                result += 16;
+            }
+            if (value >> 64 > 0) {
+                value >>= 64;
+                result += 8;
+            }
+            if (value >> 32 > 0) {
+                value >>= 32;
+                result += 4;
+            }
+            if (value >> 16 > 0) {
+                value >>= 16;
+                result += 2;
+            }
+            if (value >> 8 > 0) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log256(value);
+            return result + (rounding == Rounding.Up && 1 << (result << 3) < value ? 1 : 0);
+        }
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.8.0) (utils/math/SignedMath.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Standard signed math utilities missing in the Solidity language.
+ */
+library SignedMath {
+    /**
+     * @dev Returns the largest of two signed numbers.
+     */
+    function max(int256 a, int256 b) internal pure returns (int256) {
+        return a > b ? a : b;
+    }
+
+    /**
+     * @dev Returns the smallest of two signed numbers.
+     */
+    function min(int256 a, int256 b) internal pure returns (int256) {
+        return a < b ? a : b;
+    }
+
+    /**
+     * @dev Returns the average of two signed numbers without overflow.
+     * The result is rounded towards zero.
+     */
+    function average(int256 a, int256 b) internal pure returns (int256) {
+        // Formula from the book "Hacker's Delight"
+        int256 x = (a & b) + ((a ^ b) >> 1);
+        return x + (int256(uint256(x) >> 255) & (a ^ b));
+    }
+
+    /**
+     * @dev Returns the absolute unsigned value of a signed value.
+     */
+    function abs(int256 n) internal pure returns (uint256) {
+        unchecked {
+            // must be unchecked in order to support `n = type(int256).min`
+            return uint256(n >= 0 ? n : -n);
+        }
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (utils/Strings.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev String operations.
+ */
+library Strings {
+    bytes16 private constant _SYMBOLS = "0123456789abcdef";
+    uint8 private constant _ADDRESS_LENGTH = 20;
+
+    /**
+     * @dev Converts a `uint256` to its ASCII `string` decimal representation.
+     */
+    function toString(uint256 value) internal pure returns (string memory) {
+        unchecked {
+            uint256 length = Math.log10(value) + 1;
+            string memory buffer = new string(length);
+            uint256 ptr;
+            /// @solidity memory-safe-assembly
+            assembly {
+                ptr := add(buffer, add(32, length))
+            }
+            while (true) {
+                ptr--;
+                /// @solidity memory-safe-assembly
+                assembly {
+                    mstore8(ptr, byte(mod(value, 10), _SYMBOLS))
+                }
+                value /= 10;
+                if (value == 0) break;
+            }
+            return buffer;
+        }
+    }
+
+    /**
+     * @dev Converts a `int256` to its ASCII `string` decimal representation.
+     */
+    function toString(int256 value) internal pure returns (string memory) {
+        return string(abi.encodePacked(value < 0 ? "-" : "", toString(SignedMath.abs(value))));
+    }
+
+    /**
+     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.
+     */
+    function toHexString(uint256 value) internal pure returns (string memory) {
+        unchecked {
+            return toHexString(value, Math.log256(value) + 1);
+        }
+    }
+
+    /**
+     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.
+     */
+    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {
+        bytes memory buffer = new bytes(2 * length + 2);
+        buffer[0] = "0";
+        buffer[1] = "x";
+        for (uint256 i = 2 * length + 1; i > 1; --i) {
+            buffer[i] = _SYMBOLS[value & 0xf];
+            value >>= 4;
+        }
+        require(value == 0, "Strings: hex length insufficient");
+        return string(buffer);
+    }
+
+    /**
+     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation.
+     */
+    function toHexString(address addr) internal pure returns (string memory) {
+        return toHexString(uint256(uint160(addr)), _ADDRESS_LENGTH);
+    }
+
+    /**
+     * @dev Returns true if the two strings are equal.
+     */
+    function equal(string memory a, string memory b) internal pure returns (bool) {
+        return keccak256(bytes(a)) == keccak256(bytes(b));
+    }
+}
+
+pragma solidity 0.8.19;
+
+/// @notice Library to assist with calculation methods of the balances, ends, period amounts for a given plan
+/// used by both the Lockup and Vesting Plans
+library TimelockLibrary {
+  function min(uint256 a, uint256 b) internal pure returns (uint256 _min) {
+    _min = (a <= b) ? a : b;
+  }
+
+  /// @notice function to calculate the end date of a plan based on its start, amount, rate and period
+  function endDate(uint256 start, uint256 amount, uint256 rate, uint256 period) internal pure returns (uint256 end) {
+    end = (amount % rate == 0) ? (amount / rate) * period + start : ((amount / rate) * period) + period + start;
+  }
+
+  /// @notice function to calculate the end period and validate that the parameters passed in are valid
+  function validateEnd(
+    uint256 start,
+    uint256 cliff,
+    uint256 amount,
+    uint256 rate,
+    uint256 period
+  ) internal pure returns (uint256 end, bool valid) {
+    require(amount > 0, '0_amount');
+    require(rate > 0, '0_rate');
+    require(rate <= amount, 'rate > amount');
+    require(period > 0, '0_period');
+    end = (amount % rate == 0) ? (amount / rate) * period + start : ((amount / rate) * period) + period + start;
+    require(cliff <= end, 'cliff > end');
+    valid = true;
+  }
+
+  /// @notice function to calculate the unlocked (claimable) balance, still locked balance, and the most recent timestamp the unlock would take place
+  /// the most recent unlock time is based on the periods, so if the periods are 1, then the unlock time will be the same as the redemption time,
+  /// however if the period more than 1 second, the latest unlock will be a discrete time stamp
+  /// @param start is the start time of the plan
+  /// @param cliffDate is the timestamp of the cliff of the plan
+  /// @param amount is the total unclaimed amount tokens still in the vesting plan
+  /// @param rate is the amount of tokens that unlock per period
+  /// @param period is the seconds in each period, a 1 is a period of 1 second whereby tokens unlock every second
+  /// @param currentTime is the current time being evaluated, typically the block.timestamp, but used just to check the plan is past the start or cliff
+  /// @param redemptionTime is the time requested for the plan to be redeemed, this can be the same as the current time or prior to it for partial redemptions
+  function balanceAtTime(
+    uint256 start,
+    uint256 cliffDate,
+    uint256 amount,
+    uint256 rate,
+    uint256 period,
+    uint256 currentTime,
+    uint256 redemptionTime
+  ) internal pure returns (uint256 unlockedBalance, uint256 lockedBalance, uint256 unlockTime) {
+    if (start > currentTime || cliffDate > currentTime || redemptionTime <= start) {
+      lockedBalance = amount;
+      unlockTime = start;
+    } else {
+      uint256 periodsElapsed = (redemptionTime - start) / period;
+      uint256 calculatedBalance = periodsElapsed * rate;
+      unlockedBalance = min(calculatedBalance, amount);
+      lockedBalance = amount - unlockedBalance;
+      unlockTime = start + (period * periodsElapsed);
+    }
+  }
+
+  function calculateCombinedRate(
+    uint256 combinedAmount,
+    uint256 combinedRates,
+    uint256 start,
+    uint256 period,
+    uint256 targetEnd
+  ) internal pure returns (uint256 rate, uint256 end) {
+    uint256 numerator = combinedAmount * period;
+    uint256 denominator = (combinedAmount % combinedRates == 0) ? targetEnd - start : targetEnd - start - period;
+    rate = numerator / denominator;
+    end = endDate(start, combinedAmount, rate, period);
+  }
+
+  function calculateSegmentRates(
+    uint256 originalRate,
+    uint256 originalAmount,
+    uint256 planAmount,
+    uint256 segmentAmount,
+    uint256 start,
+    uint256 end,
+    uint256 period,
+    uint256 cliff
+  ) internal pure returns (uint256 planRate, uint256 segmentRate, uint256 planEnd, uint256 segmentEnd) {
+    planRate = (originalRate * ((planAmount * (10 ** 18)) / originalAmount)) / (10 ** 18);
+    segmentRate = (segmentAmount % (originalRate - planRate) == 0)
+      ? (segmentAmount * period) / (end - start)
+      : (segmentAmount * period) / (end - start - period);
+    bool validPlanEnd;
+    bool validSegmentEnd;
+    (planEnd, validPlanEnd) = validateEnd(start, cliff, planAmount, planRate, period);
+    (segmentEnd, validSegmentEnd) = validateEnd(start, cliff, segmentAmount, segmentRate, period);
+    require(validPlanEnd && validSegmentEnd, 'invalid end date');
+  }
+}
+
+pragma solidity 0.8.19;
+
+/// @notice Library to help safely transfer tokens and handle ETH wrapping and unwrapping of WETH
+library TransferHelper {
+  using SafeERC20 for IERC20;
+
+  /// @notice Internal function used for standard ERC20 transferFrom method
+  /// @notice it contains a pre and post balance check
+  /// @notice as well as a check on the msg.senders balance
+  /// @param token is the address of the ERC20 being transferred
+  /// @param from is the remitting address
+  /// @param to is the location where they are being delivered
+  function transferTokens(
+    address token,
+    address from,
+    address to,
+    uint256 amount
+  ) internal {
+    uint256 priorBalance = IERC20(token).balanceOf(address(to));
+    require(IERC20(token).balanceOf(from) >= amount, 'THL01');
+    SafeERC20.safeTransferFrom(IERC20(token), from, to, amount);
+    uint256 postBalance = IERC20(token).balanceOf(address(to));
+    require(postBalance - priorBalance == amount, 'THL02');
+  }
+
+  /// @notice Internal function is used with standard ERC20 transfer method
+  /// @notice this function ensures that the amount received is the amount sent with pre and post balance checking
+  /// @param token is the ERC20 contract address that is being transferred
+  /// @param to is the address of the recipient
+  /// @param amount is the amount of tokens that are being transferred
+  function withdrawTokens(
+    address token,
+    address to,
+    uint256 amount
+  ) internal {
+    uint256 priorBalance = IERC20(token).balanceOf(address(to));
+    SafeERC20.safeTransfer(IERC20(token), to, amount);
+    uint256 postBalance = IERC20(token).balanceOf(address(to));
+    require(postBalance - priorBalance == amount, 'THL02');
+  }
+
+}
+
+pragma solidity 0.8.19;
+
+/// @notice This contract is the storage contract for the Lockup Plans contracts.
+/// it contains the storage of the lockup plan object (Plan struct), as well as the events that the lockup plan contracts emit
+
+contract LockupStorage {
+  /// @dev the Plan is the storage in a struct of the tokens that are locked and being unlocked
+  /// @param token is the token address being timelocked
+  /// @param amount is the current amount of tokens locked in the lockup plan, both unclaimed unlocked and still locked tokens. This parameter is updated each time tokens are redeemed, reset to the new remaining locked and unclaimed amount
+  /// @param start is the start date when token unlock begins or began. This parameter gets updated each time tokens are redeemed and claimed, reset to the most recent redeem time
+  /// @param cliff is an optional field to add a single cliff date prior to which the tokens cannot be redeemed, this does not change
+  /// @param rate is the amount of tokens that unlock in a period. This parameter is constand for each plan. 
+  /// @param period is the length of time in between each discrete time when tokens unlock. If this is set to 1, then tokens unlocke every second. Otherwise the period is longer to allow for interval lockup plans. 
+  struct Plan {
+    address token;
+    uint256 amount;
+    uint256 start;
+    uint256 cliff;
+    uint256 rate;
+    uint256 period;
+  }
+
+  /// @dev a mapping of the planId to the Plan struct. This is also mapped of the NFT token ID to the Plan struct, as the planId is the NFT token Id. 
+  mapping(uint256 => Plan) public plans;
+
+  /// @dev this stores the original end date of a plan. This is only used when a token is segmented, which sometimes results in a new end that is longer than the original, 
+  /// the original end date is stored for the case of recombining those plans. 
+  mapping(uint256 => uint256) public segmentOriginalEnd;
+
+  ///@notice event emitted when a new lockup plan is created, emits the NFT and planId, as well as all of the info from the plan struct
+  event PlanCreated(
+    uint256 indexed id,
+    address indexed recipient,
+    address indexed token,
+    uint256 amount,
+    uint256 start,
+    uint256 cliff,
+    uint256 end,
+    uint256 rate,
+    uint256 period
+  );
+
+  /// @notice event emitted when a beneficiary redeems some or all of the tokens in their plan. 
+  /// It emits the id of the plan, as well as the amount redeemed, any remaining unvested or unclaimed tokens and the date that was the effective new start date, the reset date
+  event PlanRedeemed(uint256 indexed id, uint256 amountRedeemed, uint256 planRemainder, uint256 resetDate);
+
+  /// @notice this event is emitted when a plan owner segments a plan into a new plan. The event spits out all of the details that have changed for the original plan and the new segmented plan
+  event PlanSegmented(
+    uint256 indexed id,
+    uint256 indexed segmentId,
+    uint256 newPlanAmount,
+    uint256 newPlanRate,
+    uint256 segmentAmount,
+    uint256 segmentRate,
+    uint256 start,
+    uint256 cliff,
+    uint256 period,
+    uint256 newPlanEnd,
+    uint256 segmentEnd
+  );
+
+  /// @notice this event is emitted when two plans with the same parameters are combined, it emits the two combined plans ids, the surviving plan id, and the details of the surviving plan
+  event PlansCombined(
+    uint256 indexed id0,
+    uint256 indexed id1,
+    uint256 indexed survivingId,
+    uint256 amount,
+    uint256 rate,
+    uint256 start,
+    uint256 cliff,
+    uint256 period,
+    uint256 end
+  );
+
+  /// @notice public function to get the balance of a plan, this function is used by the contracts to calculate how much can be redeemed, and how to reset the start date
+  /// @param planId is the NFT token ID and plan Id
+  /// @param timeStamp is the effective current time stamp, can be polled for the future for estimating redeemable tokens
+  /// @param redemptionTime is the time of the request that the user is attemptint to redeem tokens, which can be prior to the timeStamp, though not beyond it.
+  function planBalanceOf(
+    uint256 planId,
+    uint256 timeStamp,
+    uint256 redemptionTime
+  ) public view returns (uint256 balance, uint256 remainder, uint256 latestUnlock) {
+    Plan memory plan = plans[planId];
+    (balance, remainder, latestUnlock) = TimelockLibrary.balanceAtTime(
+      plan.start,
+      plan.cliff,
+      plan.amount,
+      plan.rate,
+      plan.period,
+      timeStamp,
+      redemptionTime
+    );
+  }
+
+  /// @dev function to calculate the end date in seconds of a given vesting plan
+  /// @param planId is the NFT token ID
+  function planEnd(uint256 planId) external view returns (uint256 end) {
+    Plan memory plan = plans[planId];
+    end = TimelockLibrary.endDate(plan.start, plan.amount, plan.rate, plan.period);
+  }
+}
+
+pragma solidity 0.8.19;
+
+abstract contract PlanDelegator is ERC721Enumerable {
+  // mapping of tokenId to address who can delegate an NFT on behalf of the owner
+  /// @dev follows tokenApprovals logic
+  mapping(uint256 => address) private _approvedDelegators;
+
+  /// @dev operatorApprovals simialr to ERC721 standards
+  mapping(address => mapping(address => bool)) private _approvedOperatorDelegators;
+
+  /// @dev event that is emitted when a single plan delegator has been approved
+  event DelegatorApproved(uint256 indexed id, address owner, address delegator);
+
+  /// @dev event emit when the operator delegator has been approved to manage all delegation of a single address
+  event ApprovalForAllDelegation(address owner, address operator, bool approved);
+
+  /// @notice function to assign a single planId to a delegator. The delegator then has authority to call functions on other contracts such as delegate
+  /// @param delegator is the address of the delegator who can delegate on behalf of the nft owner
+  /// @param planId is the id of the vesting or lockup plan
+  function approveDelegator(address delegator, uint256 planId) public virtual {
+    address owner = ownerOf(planId);
+    require(msg.sender == owner || isApprovedForAllDelegation(owner, msg.sender), '!ownerOperator');
+    require(delegator != msg.sender, '!self approval');
+    _approveDelegator(delegator, planId);
+  }
+
+  /// @notice function that performs both the approveDelegator function and approves a spender
+  /// @param spender is the address who is approved to spend and is also a Delegator
+  /// @param planId is the vesting plan id
+  function approveSpenderDelegator(address spender, uint256 planId) public virtual {
+    address owner = ownerOf(planId);
+    require(
+      msg.sender == owner || (isApprovedForAllDelegation(owner, msg.sender) && isApprovedForAll(owner, msg.sender)),
+      '!ownerOperator'
+    );
+    require(spender != msg.sender, '!self approval');
+    _approveDelegator(spender, planId);
+    _approve(spender, planId);
+  }
+
+  /// @notice this function sets an address to be an operator delegator for the msg.sender, whereby the operator can delegate all tokens owned by the msg.sender
+  /// the operator can also approve other single plan delegators
+  /// @param operator address of the operator for the msg.sender
+  /// @param approved boolean for approved if true, and false if not
+  function setApprovalForAllDelegation(address operator, bool approved) public virtual {
+    _setApprovalForAllDelegation(msg.sender, operator, approved);
+  }
+
+  /// @notice functeion to set the approval operator for both delegation and for spending NFTs of the msg.sender
+  /// @param operator is the address who will be allowed to spend and delegate
+  /// @param approved is the bool determining if they are allowed or not
+  function setApprovalForOperator(address operator, bool approved) public virtual {
+    _setApprovalForAllDelegation(msg.sender, operator, approved);
+    _setApprovalForAll(msg.sender, operator, approved);
+  }
+
+  /// @notice internal function to update the storage of approvedDelegators and emit the event
+  function _approveDelegator(address delegator, uint256 planId) internal virtual {
+    _approvedDelegators[planId] = delegator;
+    emit DelegatorApproved(planId, ownerOf(planId), delegator);
+  }
+
+  /// @notice internal function to update the storage of approvedOperatorDelegators, and emit the event
+  function _setApprovalForAllDelegation(address owner, address operator, bool approved) internal virtual {
+    require(owner != operator, '!operator');
+    _approvedOperatorDelegators[owner][operator] = approved;
+    emit ApprovalForAllDelegation(owner, operator, approved);
+  }
+
+  /// @notice we call the beforeTokenTransfer hook to delete the approvedDelegators storage variable so that the Delegator approval does not travel with the NFT when transferred
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 firstTokenId,
+    uint256 batchSize
+  ) internal virtual override {
+    super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
+    delete _approvedDelegators[firstTokenId];
+  }
+
+  /// @notice function to get the approved delegator of a single planId
+  function getApprovedDelegator(uint256 planId) public view returns (address) {
+    _requireMinted(planId);
+    return _approvedDelegators[planId];
+  }
+
+  /// @notice function to evaluate if an operator is approved to manage delegations of an owner address
+  function isApprovedForAllDelegation(address owner, address operator) public view returns (bool) {
+    return _approvedOperatorDelegators[owner][operator];
+  }
+
+  /// @notice internal view function to determine if a delegator, typically the msg.sender is allowed to delegate a token, based on being either the Owner, Delegator or Operator.
+  function _isApprovedDelegatorOrOwner(address delegator, uint256 planId) internal view returns (bool) {
+    address owner = ownerOf(planId);
+    return (delegator == owner ||
+      isApprovedForAllDelegation(owner, delegator) ||
+      getApprovedDelegator(planId) == delegator);
+  }
+}
+
+pragma solidity 0.8.19;
+
+contract URIAdmin {
+    /// @dev baseURI is the URI directory where the metadata is stored
+  string public baseURI;
+  /// @dev bool to ensure uri has been set before admin can be deleted
+  bool internal uriSet;
+  /// @dev admin for setting the baseURI;
+  address internal uriAdmin;
+
+  /// @notice event for when a new URI is set for the NFT metadata linking
+  event URISet(string newURI);
+
+  /// @notice event for when the URI admin is deleted
+  event URIAdminDeleted(address _admin);
+
+
+  /// @notice function to set the base URI after the contract has been launched, only the admin can call
+  /// @param _uri is the new baseURI for the metadata
+  function updateBaseURI(string memory _uri) external {
+    require(msg.sender == uriAdmin, '!ADMIN');
+    baseURI = _uri;
+    uriSet = true;
+    emit URISet(_uri);
+  }
+
+  /// @notice function to delete the admin once the uri has been set
+  function deleteAdmin() external {
+    require(msg.sender == uriAdmin, '!ADMIN');
+    require(uriSet, '!SET');
+    delete uriAdmin;
+    emit URIAdminDeleted(msg.sender);
+  }
+}
+
+pragma solidity 0.8.19;
+
+
+interface IGovernanceToken {
+    function delegate(address delegatee) external;
+    function delegates(address wallet) external view returns (address delegate);
+}
+
+contract VotingVault {
+
+    address public token;
+    address public controller;
+
+    constructor(address _token, address beneficiary) {
+        controller = msg.sender;
+        token = _token;
+        address existingDelegate = IGovernanceToken(token).delegates(beneficiary);
+        if(existingDelegate != address(0)) IGovernanceToken(token).delegate(existingDelegate);
+        else IGovernanceToken(token).delegate(beneficiary);
+    }
+
+    modifier onlyController() {
+        require(msg.sender == controller);
+        _;
+    }
+
+    function delegateTokens(address delegatee) external onlyController {
+        uint256 balanceCheck = IERC20(token).balanceOf(address(this));
+        IGovernanceToken(token).delegate(delegatee);
+        // check to make sure delegate function is not malicious
+        require(balanceCheck == IERC20(token).balanceOf(address(this)), 'balance error');
+    }
+
+    function withdrawTokens(address to, uint256 amount) external onlyController {
+        TransferHelper.withdrawTokens(token, to, amount);
+        if (IERC20(token).balanceOf(address(this)) == 0) {
+            delete token;
+            delete controller;
+        }
+    }
+
+}

--- a/contracts/external/hedgey/VotingTokenLockupPlans.sol
+++ b/contracts/external/hedgey/VotingTokenLockupPlans.sol
@@ -1,841 +1,1564 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-/// @title TokenLockupPlans - An efficient way to allocate tokens to beneficiaries that unlock over time
-/// @notice This contract allows people to grant tokens to beneficiaries that unlock over time with the added functionalities;
-/// Owners of unlock plans can manage all of their token unlocks across all of their positions in a single contract.
-/// Each lockup plan is a unique NFT, leveraging the backbone of the ERC721 contract to represent a unique lockup plan
-/// 1. Not-Revokable: plans cannot be revoked, once granted the entire amount will be claimable by the beneficiary over time.
-/// 2. Transferable: Lockup plans can be transferred by the owner - opening up defi opportunities like NFT sales, borrowing and lending, and many others.
-/// 3. Governance optimized for on-chain voting: These are built to allow beneficiaries to vote with their unvested tokens on chain with the standard ERC20Votes contract, as well as on snapshot
-/// 4. Beneficiary Claims: Beneficiaries get to choose when to claim their tokens, and can claim partial amounts that are less than the amount they have unlocked for tax optimization
-/// 5. Segmenting plans: Beneficiaries can segment a single lockup into  smaller chunks for subdelegation of tokens, or to use in defi with smaller chunks
-/// 6. Combingin Plans: Beneficiaries can combine plans that have the same details in one larger chunk for easier bulk management
-contract VotingTokenLockupPlans is PlanDelegator, LockupStorage, ReentrancyGuard, URIAdmin {
-  /// @notice uses counters for incrementing token IDs which are the planIds
-  using Counters for Counters.Counter;
-  Counters.Counter private _planIds;
-
-  /// @dev Voting Vaults are external contracts that hold tokens for a lockup plan allowing an owner to delegate their tokens for on-chain governance
-  /// the lockup plan ID is mapped to the votingVault address so that it is one to one and unique to the NFT
-  mapping(uint256 => address) public votingVaults;
-
-  /// @notice event emitted when a new voting vault is generated and setup
-  event VotingVaultCreated(uint256 indexed id, address vaultAddress);
-
-  constructor(string memory name, string memory symbol) ERC721(name, symbol) {
-    uriAdmin = msg.sender;
-  }
-
-  function _baseURI() internal view override returns (string memory) {
-    return baseURI;
-  }
-
-  /****CORE EXTERNAL FUNCTIONS*********************************************************************************************************************************************/
-
-  /// @notice function to create a lockup plan.
-  /// @dev this function will pull the tokens into this contract for escrow, increment the planIds, mint an NFT to the recipient, and create the storage Plan and map it to the newly minted NFT token ID in storage
-  /// @param recipient the address of the recipient and beneficiary of the plan
-  /// @param token the address of the ERC20 token
-  /// @param amount the amount of tokens to be locked in the plan
-  /// @param start the start date of the lockup plan, unix time
-  /// @param cliff a cliff date which is a discrete date where tokens are not unlocked until this date, and then vest in a large single chunk on the cliff date
-  /// @param rate the amount of tokens that vest in a single period
-  /// @param period the amount of time in between each unlock time stamp, in seconds. A period of 1 means that tokens vest every second in a 'streaming' style.
-  function createPlan(
-    address recipient,
-    address token,
-    uint256 amount,
-    uint256 start,
-    uint256 cliff,
-    uint256 rate,
-    uint256 period
-  ) external nonReentrant returns (uint256 newPlanId) {
-    require(recipient != address(0), '0_recipient');
-    require(token != address(0), '0_token');
-    (uint256 end, bool valid) = TimelockLibrary.validateEnd(start, cliff, amount, rate, period);
-    require(valid);
-    _planIds.increment();
-    newPlanId = _planIds.current();
-    TransferHelper.transferTokens(token, msg.sender, address(this), amount);
-    plans[newPlanId] = Plan(token, amount, start, cliff, rate, period);
-    _safeMint(recipient, newPlanId);
-    emit PlanCreated(newPlanId, recipient, token, amount, start, cliff, end, rate, period);
-  }
-
-  /// @notice function for a beneficiary to redeem unlocked tokens from a group of plans
-  /// @dev this will call an internal function for processing the actual redemption of tokens, which will withdraw unlocked tokens and deliver them to the beneficiary
-  /// @dev this function will redeem all claimable and unlocked tokens up to the current block.timestamp
-  /// @param planIds is the array of the NFT planIds that are to be redeemed. If any have no redeemable balance they will be skipped.
-  function redeemPlans(uint256[] calldata planIds) external nonReentrant {
-    _redeemPlans(planIds, block.timestamp);
-  }
-
-  /// @notice function for a beneficiary to redeem unlocked tokens from a group of plans
-  /// @dev this will call an internal function for processing the actual redemption of tokens, which will withdraw unlocked tokens and deliver them to the beneficiary
-  /// @dev this function will redeem only a partial amount of tokens based on a redemption timestamp that is in the past. This allows holders to redeem less than their fully unlocked amount for various reasons
-  /// @param planIds is the array of the NFT planIds that are to be redeemed. If any have no redeemable balance they will be skipped.
-  /// @param redemptionTime is the timestamp which will calculate the amount of tokens redeemable and redeem them based on that timestamp
-  function partialRedeemPlans(uint256[] calldata planIds, uint256 redemptionTime) external nonReentrant {
-    require(redemptionTime < block.timestamp, '!future');
-    _redeemPlans(planIds, redemptionTime);
-  }
-
-  /// @notice this function will redeem all plans owned by a single wallet - useful for custodians or other intermeidaries that do not have the ability to lookup individual planIds
-  /// @dev this will iterate through all of the plans owned by the wallet based on the ERC721Enumerable backbone, and redeem each one with a redemption time of the current block.timestamp
-  function redeemAllPlans() external nonReentrant {
-    uint256 balance = balanceOf(msg.sender);
-    uint256[] memory planIds = new uint256[](balance);
-    for (uint256 i; i < balance; i++) {
-      uint256 planId = tokenOfOwnerByIndex(msg.sender, i);
-      planIds[i] = planId;
-    }
-    _redeemPlans(planIds, block.timestamp);
-  }
-
-  /// @notice function for an owner of a lockup plan to segment a single plan into multiple chunks; segments.
-  /// @dev the single plan can be divided up into many segments in this transaction, but care must be taken to ensure that the array is processed in a proper order
-  /// if the tokens are send in the wrong order the function will revert becuase the amount of the segment could be larger than the original plan.
-  /// this function iterates through the segment amounts and breaks up the same original plan into smaller sizes
-  /// each time a segment happens it is always with the single planId, which will generate a new NFT for each new segment, and the original plan is updated in storage
-  /// the original plan amount newPlanAmount + segmentAmount && original plan Rate = newPlanRate + segmentRate
-  /// IF The plan that is being segmented has a voting vault setup, it will generate a new voting vault for the segmented tokens, however it will not delegate those
-  /// @dev Segmenting plans where the segment amount is not divisible by the rate will result in a new End date that is 1 period farther than the original plan
-  /// @param planId is the plan that is going to be segmented
-  /// @param segmentAmounts is the array of amounts of each individual segment, which must each be smaller than the plan when it is being segmented.
-  function segmentPlan(
-    uint256 planId,
-    uint256[] memory segmentAmounts
-  ) external nonReentrant returns (uint256[] memory newPlanIds) {
-    newPlanIds = new uint256[](segmentAmounts.length);
-    for (uint256 i; i < segmentAmounts.length; i++) {
-      uint256 newPlanId = _segmentPlan(planId, segmentAmounts[i]);
-      newPlanIds[i] = newPlanId;
-    }
-  }
-
-  /// @notice this function combines the functionality of segmenting plans and then immediately delegating the new semgent plans to a delegate address
-  /// @dev this function does NOT delegate the original planId at all, it will only delegate the newly create segments
-  /// if the plan has a Voting Vault, it will create a new voting vault for each segment, and then delegate the tokens in the voting vault to the delegatee address
-  /// @param planId is the plan that will be segmented (and not delegated)
-  /// @param segmentAmounts is the array of each segment amount
-  /// @param delegatees is the array of delegatees that each new segment will be delegated to
-  function segmentAndDelegatePlans(
-    uint256 planId,
-    uint256[] memory segmentAmounts,
-    address[] memory delegatees
-  ) external nonReentrant returns (uint256[] memory newPlanIds) {
-    require(segmentAmounts.length == delegatees.length, '!length');
-    newPlanIds = new uint256[](segmentAmounts.length);
-    for (uint256 i; i < segmentAmounts.length; i++) {
-      uint256 newPlanId = _segmentPlan(planId, segmentAmounts[i]);
-      _delegate(newPlanId, delegatees[i]);
-      newPlanIds[i] = newPlanId;
-    }
-  }
-
-  /// @notice this function allows a beneficiary of two plans that share the same details to combine them into a single surviving plan
-  /// @dev the plans must have the same details except the amount and rate, but must share the same end date to be combined
-  /// if one of the plans has a voting vault, that plan will be the surviving plan and all tokens will be transferred to the surviving plan voting vault
-  /// @param planId0 is the planId of a first plan to be combined
-  /// @param planId1 is the planId of a second plan to be combined
-  function combinePlans(uint256 planId0, uint256 planId1) external nonReentrant returns (uint256 survivingPlanId) {
-    survivingPlanId = _combinePlans(planId0, planId1);
-  }
-
-  /****EXTERNAL VOTING FUNCTIONS*********************************************************************************************************************************************/
-  /// @notice functions for the owners of lockup plans to setup on chain voting vaults, and then delegate those tokens.
-  /// these are explicity for tokens that are of the ERC20Votes format, which have a delegate and delegates function.
-  /// tokens that do not have the standard delegate and delegates functionality for on-chain voting will revert when delegating or creating onchain voting vaults.
-
-  /// @notice function to setup a voting vault, this calls an internal voting function to set it up
-  // this will physically transfer tokens to the new voting vault contract once deployed
-  /// @param planId is the id of the lockup plan and NFT
-  function setupVoting(uint256 planId) external nonReentrant returns (address votingVault) {
-    votingVault = _setupVoting(planId);
-  }
-
-  /// @notice function for an owner of a lockup plan to delegate a single lockup plan to  single delegate
-  /// @dev this will call an internal delegate function for processing
-  /// if there is no voting vault setup, this function will automatically create a voting vault and then delegate the tokens to the delegatee
-  /// @param planId is the id of the lockup plan and NFT
-  function delegate(uint256 planId, address delegatee) external nonReentrant {
-    _delegate(planId, delegatee);
-  }
-
-  /// @notice this function allows an owner of multiple lockup plans to delegate multiple of them in a single transaction, each planId corresponding to a delegatee address
-  /// @param planIds is the ids of the lockup plan and NFT
-  /// @param delegatees is the array of addresses where each lockup plan will delegate the tokens to
-  function delegatePlans(uint256[] calldata planIds, address[] calldata delegatees) external nonReentrant {
-    require(planIds.length == delegatees.length, 'array error');
-    for (uint256 i; i < planIds.length; i++) {
-      _delegate(planIds[i], delegatees[i]);
-    }
-  }
-
-  /// @notice this function lets an owner delegate all of their lockup plans for a single token to a single delegatee
-  /// @dev this function will iterate through all of the owned lockup plans of the msg.sender, and if the token address matches the lockup plan token address, it will delegate that plan
-  /// @param token is the ERC20Votes token address of the tokens in the lockup plans
-  /// @param delegatee is the address of the delegate that the beneficiary is delegating their tokens to
-  function delegateAll(address token, address delegatee) external nonReentrant {
-    uint256 balance = balanceOf(msg.sender);
-    for (uint256 i; i < balance; i++) {
-      uint256 planId = tokenOfOwnerByIndex(msg.sender, i);
-      if (plans[planId].token == token) _delegate(planId, delegatee);
-    }
-  }
-
-  function transferAndDelegate(uint256 planId, address from, address to) external virtual nonReentrant {
-    safeTransferFrom(from, to, planId);
-    _delegate(planId, to);
-  }
-
-  /****CORE INTERNAL FUNCTIONS*********************************************************************************************************************************************/
-
-  /// @notice function that will intake an array of planIds and a redemption time, and then check the balances that are available to be redeemed
-  /// @dev if the nft has an available balance, it is then passed on to the _redeemPlan function for further processing
-  /// if there is no balance to be redeemed, the plan is skipped from being processed
-  /// @param planIds is the array of plans to be redeemed
-  /// @param redemptionTime is the requested redemption time, either the current block.timestamp or a timestamp from the past, but must be greater than the start date
-  function _redeemPlans(uint256[] memory planIds, uint256 redemptionTime) internal {
-    for (uint256 i; i < planIds.length; i++) {
-      (uint256 balance, uint256 remainder, uint256 latestUnlock) = planBalanceOf(
-        planIds[i],
-        block.timestamp,
-        redemptionTime
-      );
-      if (balance > 0) _redeemPlan(planIds[i], balance, remainder, latestUnlock);
-    }
-  }
-
-  /// @notice internal function that process the redemption for a single lockup plan
-  /// @dev this takes the inputs from the _redeemPlans and processes the redemption delivering the available balance of redeemable tokens to the beneficiary
-  /// if the plan has a voting vault then tokens will be redeemed and transferred from the voting vault to the beneficiary.
-  /// if the plan is fully redeemed, as defined that the balance == amount, then the plan is deleted and NFT burned
-  // if the plan is not fully redeemed, then the storage of start and amount are updated to reflect the remaining amount and most recent time redeemed for the new start date
-  /// @param planId is the id of the lockup plan and NFT
-  /// @param balance is the available redeemable balance
-  /// @param remainder is the amount of tokens that are still lcoked in the plan, and will be the new amount in the plan storage
-  /// @param latestUnlock is the most recent timestamp for when redemption occured. Because periods may be longer than 1 second,
-  /// the latestUnlock time may be the current block time, or the timestamp of the most recent period timestamp
-  function _redeemPlan(uint256 planId, uint256 balance, uint256 remainder, uint256 latestUnlock) internal {
-    require(ownerOf(planId) == msg.sender, '!owner');
-    address token = plans[planId].token;
-    address vault = votingVaults[planId];
-    if (remainder == 0) {
-      delete plans[planId];
-      delete votingVaults[planId];
-      _burn(planId);
-    } else {
-      plans[planId].amount = remainder;
-      plans[planId].start = latestUnlock;
-    }
-    if (vault == address(0)) {
-      TransferHelper.withdrawTokens(token, msg.sender, balance);
-    } else {
-      VotingVault(vault).withdrawTokens(msg.sender, balance);
-    }
-    emit PlanRedeemed(planId, balance, remainder, latestUnlock);
-  }
-
-  /// @notice the internal function for segmenting a single plan into two
-  /// @dev the function takes a plan, performs some checks that the segment amount cannot be 0 and must be strictly less than the original plan amount
-  /// then it will subtract the segmentamount from the original plan amount to get the new plan amount
-  /// then it will get a new pro-rata rate for the newplan based on the new plan amount divided by the original plan amount
-  /// while this pro-rata new rate is not perfect because of unitization (ie no decimal suppport), the segment rate is calculated by subtracting the new plan rate from the original plan rate
-  /// because the newplan amount and segment amount == original plan amount, and the new plan rate + segment rate == original plan rate, the beneficiary will still unlock the same number of tokens at approximatley the same rate
-  /// however because of uneven division, the end dates of each of the new rates may be different than the original rate. We check to make sure that the new end is farther than the original end
-  /// so that tokens do not unlock early, and then it is a valid segment.
-  /// finally a new NFT is minted with the Segment plan details
-  /// and the storage of the original plan amount and rate is updated with the newplan amount and rate.
-  /// at the end this checks if there is a voting vault setup for the original plan. If there is a voting vault setup, it will transfer tokens back from the original plan vault,
-  /// then setup a new voting vault for the segment plan, thereby transferring the segment tokens to the new segment voting vault
-  /// @param planId is the id of the lockup plan
-  /// @param segmentAmount is the amount of tokens to be segmented off from the original plan and created into a new segment plan
-  function _segmentPlan(uint256 planId, uint256 segmentAmount) internal returns (uint256 newPlanId) {
-    require(ownerOf(planId) == msg.sender, '!owner');
-    Plan memory plan = plans[planId];
-    require(segmentAmount < plan.amount, 'amount error');
-    require(segmentAmount > 0, '0_segment');
-    uint256 end = TimelockLibrary.endDate(plan.start, plan.amount, plan.rate, plan.period);
-    _planIds.increment();
-    newPlanId = _planIds.current();
-    uint256 planAmount = plan.amount - segmentAmount;
-    (uint256 planRate, uint256 segmentRate, uint256 planEnd, uint256 segmentEnd) = TimelockLibrary
-      .calculateSegmentRates(
-        plan.rate,
-        plan.amount,
-        planAmount,
-        segmentAmount,
-        plan.start,
-        end,
-        plan.period,
-        plan.cliff
-      );
-    uint256 endCheck = segmentOriginalEnd[planId] == 0 ? end : segmentOriginalEnd[planId];
-    require(planEnd >= endCheck, 'plan end error');
-    require(segmentEnd >= endCheck, 'segmentEnd error');
-    plans[planId].amount = planAmount;
-    plans[planId].rate = planRate;
-    _safeMint(msg.sender, newPlanId);
-    plans[newPlanId] = Plan(plan.token, segmentAmount, plan.start, plan.cliff, segmentRate, plan.period);
-    if (segmentOriginalEnd[planId] == 0) {
-      segmentOriginalEnd[planId] = end;
-      segmentOriginalEnd[newPlanId] = end;
-    } else {
-      segmentOriginalEnd[newPlanId] = segmentOriginalEnd[planId];
-    }
-    if (votingVaults[planId] != address(0)) {
-      VotingVault(votingVaults[planId]).withdrawTokens(address(this), segmentAmount);
-      _setupVoting(newPlanId);
-    }
-    emit PlanSegmented(
-      planId,
-      newPlanId,
-      planAmount,
-      planRate,
-      segmentAmount,
-      segmentRate,
-      plan.start,
-      plan.cliff,
-      plan.period,
-      planEnd,
-      segmentEnd
-    );
-  }
-
-  /// @notice this funtion allows the holder of two plans that have the same parameters to combine them into a single surviving plan
-  /// @dev all of the details of the plans must be the same except the amounts and rates may be different
-  /// this function will check that the owners are the same, the ERC20 tokens are the same, the start, cliff and periods are the same.
-  /// then it performs some checks on the end dates to ensure that either the end dates are the same, or if the user is combining previously segmented plans,
-  /// that the original end dates of those segments are the same.
-  /// if everything checks out, and the new end date of the combined plan will result in an end date equal to or later than the two plans, then they can be combined
-  /// combining plans will delete the plan1 and burn the NFT related to it
-  /// and then update the storage of the plan0 with the combined amount and combined rate
-  /// if One of the plans has a voting vault, then that plan will be the survivor and then tokens will be transferred and consolidated into that plan
-  /// if both have a voting vault, then plan0 will be the survivor and tokens consolidated to plan0 voting vault
-  /// if neither have a voting vault then nothing is done for voting vaults.
-  /// @param planId0 is the planId of the first plan in the combination
-  /// @param planId1 is the planId of a second plan to be combined
-  function _combinePlans(uint256 planId0, uint256 planId1) internal returns (uint256 survivingPlan) {
-    require(ownerOf(planId0) == msg.sender, '!owner');
-    require(ownerOf(planId1) == msg.sender, '!owner');
-    Plan memory plan0 = plans[planId0];
-    Plan memory plan1 = plans[planId1];
-    require(plan0.token == plan1.token, 'token error');
-    require(plan0.start == plan1.start, 'start error');
-    require(plan0.cliff == plan1.cliff, 'cliff error');
-    require(plan0.period == plan1.period, 'period error');
-    uint256 plan0End = TimelockLibrary.endDate(plan0.start, plan0.amount, plan0.rate, plan0.period);
-    uint256 plan1End = TimelockLibrary.endDate(plan1.start, plan1.amount, plan1.rate, plan1.period);
-    require(
-      plan0End == plan1End ||
-        (segmentOriginalEnd[planId0] == segmentOriginalEnd[planId1] && segmentOriginalEnd[planId0] != 0),
-      'end error'
-    );
-    address vault0 = votingVaults[planId0];
-    address vault1 = votingVaults[planId1];
-    survivingPlan = planId0;
-    if (vault0 != address(0)) {
-      plans[planId0].amount += plans[planId1].amount;
-      (uint256 survivorRate, uint256 survivorEnd) = TimelockLibrary.calculateCombinedRate(
-        plan0.amount + plan1.amount,
-        plan0.rate + plan1.rate,
-        plan0.start,
-        plan0.period,
-        plan0End
-      );
-      plans[planId0].rate = survivorRate;
-      if (survivorEnd < plan0End) {
-        require(
-          survivorEnd == segmentOriginalEnd[planId0] || survivorEnd == segmentOriginalEnd[planId1],
-          'original end error'
-        );
-      }
-      if (vault1 != address(0)) {
-        VotingVault(vault1).withdrawTokens(vault0, plan1.amount);
-      } else {
-        TransferHelper.withdrawTokens(plan0.token, vault0, plan1.amount);
-      }
-      delete plans[planId1];
-      _burn(planId1);
-      emit PlansCombined(
-        planId0,
-        planId1,
-        survivingPlan,
-        plans[planId0].amount,
-        plans[planId0].rate,
-        plan0.start,
-        plan0.cliff,
-        plan0.period,
-        survivorEnd
-      );
-    } else if (vault1 != address(0)) {
-      plans[planId1].amount += plans[planId0].amount;
-      (uint256 survivorRate, uint256 survivorEnd) = TimelockLibrary.calculateCombinedRate(
-        plan0.amount + plan1.amount,
-        plan0.rate + plan1.rate,
-        plan1.start,
-        plan1.period,
-        plan1End
-      );
-      plans[planId1].rate = survivorRate;
-      if (survivorEnd < plan1End) {
-        require(
-          survivorEnd == segmentOriginalEnd[planId0] || survivorEnd == segmentOriginalEnd[planId1],
-          'original end error'
-        );
-      }
-      TransferHelper.withdrawTokens(plan0.token, vault1, plan0.amount);
-      survivingPlan = planId1;
-      delete plans[planId0];
-      _burn(planId0);
-      emit PlansCombined(
-        planId0,
-        planId1,
-        survivingPlan,
-        plans[planId1].amount,
-        plans[planId1].rate,
-        plan1.start,
-        plan1.cliff,
-        plan1.period,
-        survivorEnd
-      );
-    } else {
-      plans[planId0].amount += plans[planId1].amount;
-      (uint256 survivorRate, uint256 survivorEnd) = TimelockLibrary.calculateCombinedRate(
-        plan0.amount + plan1.amount,
-        plan0.rate + plan1.rate,
-        plan0.start,
-        plan0.period,
-        plan0End
-      );
-      plans[planId0].rate = survivorRate;
-      if (survivorEnd < plan0End) {
-        require(
-          survivorEnd == segmentOriginalEnd[planId0] || survivorEnd == segmentOriginalEnd[planId1],
-          'original end error'
-        );
-      }
-      delete plans[planId1];
-      _burn(planId1);
-      emit PlansCombined(
-        planId0,
-        planId1,
-        survivingPlan,
-        plans[planId0].amount,
-        plans[planId0].rate,
-        plan0.start,
-        plan0.cliff,
-        plan0.period,
-        survivorEnd
-      );
-    }
-  }
-
-  /****INTERNAL VOTING & DELEGATION FUNCTIONS*********************************************************************************************************************************************/
-
-  /// @notice the internal function to setup a voting vault.
-  /// @dev this will check that no voting vault exists already and then deploy a new voting vault contract
-  // during the constructor setup of the voting vault, it will auto delegate the voting vault address to whatever the existing delegate of the  plan holder has delegated to
-  // if it has not delegated yet, it will self-delegate the tokens
-  /// then transfer the tokens remaining in the lockup plan to the voting vault physically
-  /// @param planId is the id of the lockup plan and NFT
-  function _setupVoting(uint256 planId) internal returns (address) {
-    require(_isApprovedDelegatorOrOwner(msg.sender, planId), '!delegator');
-    require(votingVaults[planId] == address(0), 'exists');
-    Plan memory plan = plans[planId];
-    VotingVault vault = new VotingVault(plan.token, ownerOf(planId));
-    votingVaults[planId] = address(vault);
-    TransferHelper.withdrawTokens(plan.token, address(vault), plan.amount);
-    emit VotingVaultCreated(planId, address(vault));
-    return address(vault);
-  }
-
-  /// @notice this internal function will physically delegate tokens held in a voting vault to a delegatee
-  /// @dev if a voting vautl has not been setup yet, then the function will call the internal _setupVoting function and setup a new voting vault
-  /// and then it will delegate the tokens held in the vault to the delegatee
-  /// @param planId is the id of the lockup plan and NFT
-  /// @param delegatee is the address of the delegatee where the tokens in the voting vault will be delegated to
-  function _delegate(uint256 planId, address delegatee) internal {
-    require(_isApprovedDelegatorOrOwner(msg.sender, planId), '!delegator');
-    address vault = votingVaults[planId];
-    if (votingVaults[planId] == address(0)) {
-      vault = _setupVoting(planId);
-    }
-    VotingVault(vault).delegateTokens(delegatee);
-  }
-
-  /****VIEW VOTING FUNCTIONS*********************************************************************************************************************************************/
-
-  /// @notice this function will pull all of the unclaimed tokens for a specific holder across all of their plans, based on a single ERC20 token
-  /// very useful for snapshot voting, and other view functionalities. This aggregates all balances, including any in voting vaults.
-  /// @param holder is the address of the beneficiary who owns the lockup plan(s)
-  /// @param token is the ERC20 address of the token that is stored across the lockup plans
-  function lockedBalances(address holder, address token) external view returns (uint256 lockedBalance) {
-    uint256 holdersBalance = balanceOf(holder);
-    for (uint256 i; i < holdersBalance; i++) {
-      uint256 planId = tokenOfOwnerByIndex(holder, i);
-      Plan memory plan = plans[planId];
-      if (token == plan.token) {
-        lockedBalance += plan.amount;
-      }
-    }
-  }
+interface IGovernanceToken {
+    function delegate(address delegatee) external;
+    function delegates(address wallet) external view returns (address delegate);
 }
 
-// OpenZeppelin Contracts (last updated v4.9.0) (security/ReentrancyGuard.sol)
+contract VotingVault {
+    address public token;
+    address public controller;
 
-pragma solidity ^0.8.0;
-
-/**
- * @dev Contract module that helps prevent reentrant calls to a function.
- *
- * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
- * available, which can be applied to functions to make sure there are no nested
- * (reentrant) calls to them.
- *
- * Note that because there is a single `nonReentrant` guard, functions marked as
- * `nonReentrant` may not call one another. This can be worked around by making
- * those functions `private`, and then adding `external` `nonReentrant` entry
- * points to them.
- *
- * TIP: If you would like to learn more about reentrancy and alternative ways
- * to protect against it, check out our blog post
- * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
- */
-abstract contract ReentrancyGuard {
-    // Booleans are more expensive than uint256 or any type that takes up a full
-    // word because each write operation emits an extra SLOAD to first read the
-    // slot's contents, replace the bits taken up by the boolean, and then write
-    // back. This is the compiler's defense against contract upgrades and
-    // pointer aliasing, and it cannot be disabled.
-
-    // The values being non-zero value makes deployment a bit more expensive,
-    // but in exchange the refund on every call to nonReentrant will be lower in
-    // amount. Since refunds are capped to a percentage of the total
-    // transaction's gas, it is best to keep them low in cases like this one, to
-    // increase the likelihood of the full refund coming into effect.
-    uint256 private constant _NOT_ENTERED = 1;
-    uint256 private constant _ENTERED = 2;
-
-    uint256 private _status;
-
-    constructor() {
-        _status = _NOT_ENTERED;
+    constructor(address _token, address beneficiary) {
+        controller = msg.sender;
+        token = _token;
+        address existingDelegate = IGovernanceToken(token).delegates(
+            beneficiary
+        );
+        if (existingDelegate != address(0))
+            IGovernanceToken(token).delegate(existingDelegate);
+        else IGovernanceToken(token).delegate(beneficiary);
     }
 
-    /**
-     * @dev Prevents a contract from calling itself, directly or indirectly.
-     * Calling a `nonReentrant` function from another `nonReentrant`
-     * function is not supported. It is possible to prevent this from happening
-     * by making the `nonReentrant` function external, and making it call a
-     * `private` function that does the actual work.
-     */
-    modifier nonReentrant() {
-        _nonReentrantBefore();
+    modifier onlyController() {
+        require(msg.sender == controller);
         _;
-        _nonReentrantAfter();
     }
 
-    function _nonReentrantBefore() private {
-        // On the first call to nonReentrant, _status will be _NOT_ENTERED
-        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
-
-        // Any calls to nonReentrant after this point will fail
-        _status = _ENTERED;
+    function delegateTokens(address delegatee) external onlyController {
+        uint256 balanceCheck = IERC20(token).balanceOf(address(this));
+        IGovernanceToken(token).delegate(delegatee);
+        // check to make sure delegate function is not malicious
+        require(
+            balanceCheck == IERC20(token).balanceOf(address(this)),
+            "balance error"
+        );
     }
 
-    function _nonReentrantAfter() private {
-        // By storing the original value once again, a refund is triggered (see
-        // https://eips.ethereum.org/EIPS/eip-2200)
-        _status = _NOT_ENTERED;
-    }
-
-    /**
-     * @dev Returns true if the reentrancy guard is currently set to "entered", which indicates there is a
-     * `nonReentrant` function in the call stack.
-     */
-    function _reentrancyGuardEntered() internal view returns (bool) {
-        return _status == _ENTERED;
+    function withdrawTokens(
+        address to,
+        uint256 amount
+    ) external onlyController {
+        TransferHelper.withdrawTokens(token, to, amount);
+        if (IERC20(token).balanceOf(address(this)) == 0) {
+            delete token;
+            delete controller;
+        }
     }
 }
 
-// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/extensions/IERC20Permit.sol)
+pragma solidity 0.8.19;
+
+contract URIAdmin {
+    /// @dev baseURI is the URI directory where the metadata is stored
+    string public baseURI;
+    /// @dev bool to ensure uri has been set before admin can be deleted
+    bool internal uriSet;
+    /// @dev admin for setting the baseURI;
+    address internal uriAdmin;
+
+    /// @notice event for when a new URI is set for the NFT metadata linking
+    event URISet(string newURI);
+
+    /// @notice event for when the URI admin is deleted
+    event URIAdminDeleted(address _admin);
+
+    /// @notice function to set the base URI after the contract has been launched, only the admin can call
+    /// @param _uri is the new baseURI for the metadata
+    function updateBaseURI(string memory _uri) external {
+        require(msg.sender == uriAdmin, "!ADMIN");
+        baseURI = _uri;
+        uriSet = true;
+        emit URISet(_uri);
+    }
+
+    /// @notice function to delete the admin once the uri has been set
+    function deleteAdmin() external {
+        require(msg.sender == uriAdmin, "!ADMIN");
+        require(uriSet, "!SET");
+        delete uriAdmin;
+        emit URIAdminDeleted(msg.sender);
+    }
+}
+
+pragma solidity 0.8.19;
+
+pragma solidity 0.8.19;
+
+/// @notice This contract is the storage contract for the Lockup Plans contracts.
+/// it contains the storage of the lockup plan object (Plan struct), as well as the events that the lockup plan contracts emit
+
+contract LockupStorage {
+    /// @dev the Plan is the storage in a struct of the tokens that are locked and being unlocked
+    /// @param token is the token address being timelocked
+    /// @param amount is the current amount of tokens locked in the lockup plan, both unclaimed unlocked and still locked tokens. This parameter is updated each time tokens are redeemed, reset to the new remaining locked and unclaimed amount
+    /// @param start is the start date when token unlock begins or began. This parameter gets updated each time tokens are redeemed and claimed, reset to the most recent redeem time
+    /// @param cliff is an optional field to add a single cliff date prior to which the tokens cannot be redeemed, this does not change
+    /// @param rate is the amount of tokens that unlock in a period. This parameter is constand for each plan.
+    /// @param period is the length of time in between each discrete time when tokens unlock. If this is set to 1, then tokens unlocke every second. Otherwise the period is longer to allow for interval lockup plans.
+    struct Plan {
+        address token;
+        uint256 amount;
+        uint256 start;
+        uint256 cliff;
+        uint256 rate;
+        uint256 period;
+    }
+
+    /// @dev a mapping of the planId to the Plan struct. This is also mapped of the NFT token ID to the Plan struct, as the planId is the NFT token Id.
+    mapping(uint256 => Plan) public plans;
+
+    /// @dev this stores the original end date of a plan. This is only used when a token is segmented, which sometimes results in a new end that is longer than the original,
+    /// the original end date is stored for the case of recombining those plans.
+    mapping(uint256 => uint256) public segmentOriginalEnd;
+
+    ///@notice event emitted when a new lockup plan is created, emits the NFT and planId, as well as all of the info from the plan struct
+    event PlanCreated(
+        uint256 indexed id,
+        address indexed recipient,
+        address indexed token,
+        uint256 amount,
+        uint256 start,
+        uint256 cliff,
+        uint256 end,
+        uint256 rate,
+        uint256 period
+    );
+
+    /// @notice event emitted when a beneficiary redeems some or all of the tokens in their plan.
+    /// It emits the id of the plan, as well as the amount redeemed, any remaining unvested or unclaimed tokens and the date that was the effective new start date, the reset date
+    event PlanRedeemed(
+        uint256 indexed id,
+        uint256 amountRedeemed,
+        uint256 planRemainder,
+        uint256 resetDate
+    );
+
+    /// @notice this event is emitted when a plan owner segments a plan into a new plan. The event spits out all of the details that have changed for the original plan and the new segmented plan
+    event PlanSegmented(
+        uint256 indexed id,
+        uint256 indexed segmentId,
+        uint256 newPlanAmount,
+        uint256 newPlanRate,
+        uint256 segmentAmount,
+        uint256 segmentRate,
+        uint256 start,
+        uint256 cliff,
+        uint256 period,
+        uint256 newPlanEnd,
+        uint256 segmentEnd
+    );
+
+    /// @notice this event is emitted when two plans with the same parameters are combined, it emits the two combined plans ids, the surviving plan id, and the details of the surviving plan
+    event PlansCombined(
+        uint256 indexed id0,
+        uint256 indexed id1,
+        uint256 indexed survivingId,
+        uint256 amount,
+        uint256 rate,
+        uint256 start,
+        uint256 cliff,
+        uint256 period,
+        uint256 end
+    );
+
+    /// @notice public function to get the balance of a plan, this function is used by the contracts to calculate how much can be redeemed, and how to reset the start date
+    /// @param planId is the NFT token ID and plan Id
+    /// @param timeStamp is the effective current time stamp, can be polled for the future for estimating redeemable tokens
+    /// @param redemptionTime is the time of the request that the user is attemptint to redeem tokens, which can be prior to the timeStamp, though not beyond it.
+    function planBalanceOf(
+        uint256 planId,
+        uint256 timeStamp,
+        uint256 redemptionTime
+    )
+        public
+        view
+        returns (uint256 balance, uint256 remainder, uint256 latestUnlock)
+    {
+        Plan memory plan = plans[planId];
+        (balance, remainder, latestUnlock) = TimelockLibrary.balanceAtTime(
+            plan.start,
+            plan.cliff,
+            plan.amount,
+            plan.rate,
+            plan.period,
+            timeStamp,
+            redemptionTime
+        );
+    }
+
+    /// @dev function to calculate the end date in seconds of a given vesting plan
+    /// @param planId is the NFT token ID
+    function planEnd(uint256 planId) external view returns (uint256 end) {
+        Plan memory plan = plans[planId];
+        end = TimelockLibrary.endDate(
+            plan.start,
+            plan.amount,
+            plan.rate,
+            plan.period
+        );
+    }
+}
+
+pragma solidity 0.8.19;
+
+/// @notice Library to help safely transfer tokens and handle ETH wrapping and unwrapping of WETH
+library TransferHelper {
+    using SafeERC20 for IERC20;
+
+    /// @notice Internal function used for standard ERC20 transferFrom method
+    /// @notice it contains a pre and post balance check
+    /// @notice as well as a check on the msg.senders balance
+    /// @param token is the address of the ERC20 being transferred
+    /// @param from is the remitting address
+    /// @param to is the location where they are being delivered
+    function transferTokens(
+        address token,
+        address from,
+        address to,
+        uint256 amount
+    ) internal {
+        uint256 priorBalance = IERC20(token).balanceOf(address(to));
+        require(IERC20(token).balanceOf(from) >= amount, "THL01");
+        SafeERC20.safeTransferFrom(IERC20(token), from, to, amount);
+        uint256 postBalance = IERC20(token).balanceOf(address(to));
+        require(postBalance - priorBalance == amount, "THL02");
+    }
+
+    /// @notice Internal function is used with standard ERC20 transfer method
+    /// @notice this function ensures that the amount received is the amount sent with pre and post balance checking
+    /// @param token is the ERC20 contract address that is being transferred
+    /// @param to is the address of the recipient
+    /// @param amount is the amount of tokens that are being transferred
+    function withdrawTokens(
+        address token,
+        address to,
+        uint256 amount
+    ) internal {
+        uint256 priorBalance = IERC20(token).balanceOf(address(to));
+        SafeERC20.safeTransfer(IERC20(token), to, amount);
+        uint256 postBalance = IERC20(token).balanceOf(address(to));
+        require(postBalance - priorBalance == amount, "THL02");
+    }
+}
+
+pragma solidity 0.8.19;
+
+/// @notice Library to assist with calculation methods of the balances, ends, period amounts for a given plan
+/// used by both the Lockup and Vesting Plans
+library TimelockLibrary {
+    function min(uint256 a, uint256 b) internal pure returns (uint256 _min) {
+        _min = (a <= b) ? a : b;
+    }
+
+    /// @notice function to calculate the end date of a plan based on its start, amount, rate and period
+    function endDate(
+        uint256 start,
+        uint256 amount,
+        uint256 rate,
+        uint256 period
+    ) internal pure returns (uint256 end) {
+        end = (amount % rate == 0)
+            ? (amount / rate) * period + start
+            : ((amount / rate) * period) + period + start;
+    }
+
+    /// @notice function to calculate the end period and validate that the parameters passed in are valid
+    function validateEnd(
+        uint256 start,
+        uint256 cliff,
+        uint256 amount,
+        uint256 rate,
+        uint256 period
+    ) internal pure returns (uint256 end, bool valid) {
+        require(amount > 0, "0_amount");
+        require(rate > 0, "0_rate");
+        require(rate <= amount, "rate > amount");
+        require(period > 0, "0_period");
+        end = (amount % rate == 0)
+            ? (amount / rate) * period + start
+            : ((amount / rate) * period) + period + start;
+        require(cliff <= end, "cliff > end");
+        valid = true;
+    }
+
+    /// @notice function to calculate the unlocked (claimable) balance, still locked balance, and the most recent timestamp the unlock would take place
+    /// the most recent unlock time is based on the periods, so if the periods are 1, then the unlock time will be the same as the redemption time,
+    /// however if the period more than 1 second, the latest unlock will be a discrete time stamp
+    /// @param start is the start time of the plan
+    /// @param cliffDate is the timestamp of the cliff of the plan
+    /// @param amount is the total unclaimed amount tokens still in the vesting plan
+    /// @param rate is the amount of tokens that unlock per period
+    /// @param period is the seconds in each period, a 1 is a period of 1 second whereby tokens unlock every second
+    /// @param currentTime is the current time being evaluated, typically the block.timestamp, but used just to check the plan is past the start or cliff
+    /// @param redemptionTime is the time requested for the plan to be redeemed, this can be the same as the current time or prior to it for partial redemptions
+    function balanceAtTime(
+        uint256 start,
+        uint256 cliffDate,
+        uint256 amount,
+        uint256 rate,
+        uint256 period,
+        uint256 currentTime,
+        uint256 redemptionTime
+    )
+        internal
+        pure
+        returns (
+            uint256 unlockedBalance,
+            uint256 lockedBalance,
+            uint256 unlockTime
+        )
+    {
+        if (
+            start > currentTime ||
+            cliffDate > currentTime ||
+            redemptionTime <= start
+        ) {
+            lockedBalance = amount;
+            unlockTime = start;
+        } else {
+            uint256 periodsElapsed = (redemptionTime - start) / period;
+            uint256 calculatedBalance = periodsElapsed * rate;
+            unlockedBalance = min(calculatedBalance, amount);
+            lockedBalance = amount - unlockedBalance;
+            unlockTime = start + (period * periodsElapsed);
+        }
+    }
+
+    function calculateCombinedRate(
+        uint256 combinedAmount,
+        uint256 combinedRates,
+        uint256 start,
+        uint256 period,
+        uint256 targetEnd
+    ) internal pure returns (uint256 rate, uint256 end) {
+        uint256 numerator = combinedAmount * period;
+        uint256 denominator = (combinedAmount % combinedRates == 0)
+            ? targetEnd - start
+            : targetEnd - start - period;
+        rate = numerator / denominator;
+        end = endDate(start, combinedAmount, rate, period);
+    }
+
+    function calculateSegmentRates(
+        uint256 originalRate,
+        uint256 originalAmount,
+        uint256 planAmount,
+        uint256 segmentAmount,
+        uint256 start,
+        uint256 end,
+        uint256 period,
+        uint256 cliff
+    )
+        internal
+        pure
+        returns (
+            uint256 planRate,
+            uint256 segmentRate,
+            uint256 planEnd,
+            uint256 segmentEnd
+        )
+    {
+        planRate =
+            (originalRate * ((planAmount * (10 ** 18)) / originalAmount)) /
+            (10 ** 18);
+        segmentRate = (segmentAmount % (originalRate - planRate) == 0)
+            ? (segmentAmount * period) / (end - start)
+            : (segmentAmount * period) / (end - start - period);
+        bool validPlanEnd;
+        bool validSegmentEnd;
+        (planEnd, validPlanEnd) = validateEnd(
+            start,
+            cliff,
+            planAmount,
+            planRate,
+            period
+        );
+        (segmentEnd, validSegmentEnd) = validateEnd(
+            start,
+            cliff,
+            segmentAmount,
+            segmentRate,
+            period
+        );
+        require(validPlanEnd && validSegmentEnd, "invalid end date");
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (utils/Strings.sol)
 
 pragma solidity ^0.8.0;
 
 /**
- * @dev Interface of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
- * https://eips.ethereum.org/EIPS/eip-2612[EIP-2612].
- *
- * Adds the {permit} method, which can be used to change an account's ERC20 allowance (see {IERC20-allowance}) by
- * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't
- * need to send a transaction, and thus is not required to hold Ether at all.
+ * @dev String operations.
  */
-interface IERC20Permit {
+library Strings {
+    bytes16 private constant _SYMBOLS = "0123456789abcdef";
+    uint8 private constant _ADDRESS_LENGTH = 20;
+
     /**
-     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,
-     * given ``owner``'s signed approval.
+     * @dev Converts a `uint256` to its ASCII `string` decimal representation.
+     */
+    function toString(uint256 value) internal pure returns (string memory) {
+        unchecked {
+            uint256 length = Math.log10(value) + 1;
+            string memory buffer = new string(length);
+            uint256 ptr;
+            /// @solidity memory-safe-assembly
+            assembly {
+                ptr := add(buffer, add(32, length))
+            }
+            while (true) {
+                ptr--;
+                /// @solidity memory-safe-assembly
+                assembly {
+                    mstore8(ptr, byte(mod(value, 10), _SYMBOLS))
+                }
+                value /= 10;
+                if (value == 0) break;
+            }
+            return buffer;
+        }
+    }
+
+    /**
+     * @dev Converts a `int256` to its ASCII `string` decimal representation.
+     */
+    function toString(int256 value) internal pure returns (string memory) {
+        return
+            string(
+                abi.encodePacked(
+                    value < 0 ? "-" : "",
+                    toString(SignedMath.abs(value))
+                )
+            );
+    }
+
+    /**
+     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.
+     */
+    function toHexString(uint256 value) internal pure returns (string memory) {
+        unchecked {
+            return toHexString(value, Math.log256(value) + 1);
+        }
+    }
+
+    /**
+     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.
+     */
+    function toHexString(
+        uint256 value,
+        uint256 length
+    ) internal pure returns (string memory) {
+        bytes memory buffer = new bytes(2 * length + 2);
+        buffer[0] = "0";
+        buffer[1] = "x";
+        for (uint256 i = 2 * length + 1; i > 1; --i) {
+            buffer[i] = _SYMBOLS[value & 0xf];
+            value >>= 4;
+        }
+        require(value == 0, "Strings: hex length insufficient");
+        return string(buffer);
+    }
+
+    /**
+     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation.
+     */
+    function toHexString(address addr) internal pure returns (string memory) {
+        return toHexString(uint256(uint160(addr)), _ADDRESS_LENGTH);
+    }
+
+    /**
+     * @dev Returns true if the two strings are equal.
+     */
+    function equal(
+        string memory a,
+        string memory b
+    ) internal pure returns (bool) {
+        return keccak256(bytes(a)) == keccak256(bytes(b));
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.8.0) (utils/math/SignedMath.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Standard signed math utilities missing in the Solidity language.
+ */
+library SignedMath {
+    /**
+     * @dev Returns the largest of two signed numbers.
+     */
+    function max(int256 a, int256 b) internal pure returns (int256) {
+        return a > b ? a : b;
+    }
+
+    /**
+     * @dev Returns the smallest of two signed numbers.
+     */
+    function min(int256 a, int256 b) internal pure returns (int256) {
+        return a < b ? a : b;
+    }
+
+    /**
+     * @dev Returns the average of two signed numbers without overflow.
+     * The result is rounded towards zero.
+     */
+    function average(int256 a, int256 b) internal pure returns (int256) {
+        // Formula from the book "Hacker's Delight"
+        int256 x = (a & b) + ((a ^ b) >> 1);
+        return x + (int256(uint256(x) >> 255) & (a ^ b));
+    }
+
+    /**
+     * @dev Returns the absolute unsigned value of a signed value.
+     */
+    function abs(int256 n) internal pure returns (uint256) {
+        unchecked {
+            // must be unchecked in order to support `n = type(int256).min`
+            return uint256(n >= 0 ? n : -n);
+        }
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (utils/math/Math.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Standard math utilities missing in the Solidity language.
+ */
+library Math {
+    enum Rounding {
+        Down, // Toward negative infinity
+        Up, // Toward infinity
+        Zero // Toward zero
+    }
+
+    /**
+     * @dev Returns the largest of two numbers.
+     */
+    function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a : b;
+    }
+
+    /**
+     * @dev Returns the smallest of two numbers.
+     */
+    function min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+
+    /**
+     * @dev Returns the average of two numbers. The result is rounded towards
+     * zero.
+     */
+    function average(uint256 a, uint256 b) internal pure returns (uint256) {
+        // (a + b) / 2 can overflow.
+        return (a & b) + (a ^ b) / 2;
+    }
+
+    /**
+     * @dev Returns the ceiling of the division of two numbers.
      *
-     * IMPORTANT: The same issues {IERC20-approve} has related to transaction
-     * ordering also apply here.
+     * This differs from standard division with `/` in that it rounds up instead
+     * of rounding down.
+     */
+    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+        // (a + b - 1) / b can overflow on addition, so we distribute.
+        return a == 0 ? 0 : (a - 1) / b + 1;
+    }
+
+    /**
+     * @notice Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+     * @dev Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv)
+     * with further edits by Uniswap Labs also under MIT license.
+     */
+    function mulDiv(
+        uint256 x,
+        uint256 y,
+        uint256 denominator
+    ) internal pure returns (uint256 result) {
+        unchecked {
+            // 512-bit multiply [prod1 prod0] = x * y. Compute the product mod 2^256 and mod 2^256 - 1, then use
+            // use the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256
+            // variables such that product = prod1 * 2^256 + prod0.
+            uint256 prod0; // Least significant 256 bits of the product
+            uint256 prod1; // Most significant 256 bits of the product
+            assembly {
+                let mm := mulmod(x, y, not(0))
+                prod0 := mul(x, y)
+                prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+            }
+
+            // Handle non-overflow cases, 256 by 256 division.
+            if (prod1 == 0) {
+                // Solidity will revert if denominator == 0, unlike the div opcode on its own.
+                // The surrounding unchecked block does not change this fact.
+                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.
+                return prod0 / denominator;
+            }
+
+            // Make sure the result is less than 2^256. Also prevents denominator == 0.
+            require(denominator > prod1, "Math: mulDiv overflow");
+
+            ///////////////////////////////////////////////
+            // 512 by 256 division.
+            ///////////////////////////////////////////////
+
+            // Make division exact by subtracting the remainder from [prod1 prod0].
+            uint256 remainder;
+            assembly {
+                // Compute remainder using mulmod.
+                remainder := mulmod(x, y, denominator)
+
+                // Subtract 256 bit number from 512 bit number.
+                prod1 := sub(prod1, gt(remainder, prod0))
+                prod0 := sub(prod0, remainder)
+            }
+
+            // Factor powers of two out of denominator and compute largest power of two divisor of denominator. Always >= 1.
+            // See https://cs.stackexchange.com/q/138556/92363.
+
+            // Does not overflow because the denominator cannot be zero at this stage in the function.
+            uint256 twos = denominator & (~denominator + 1);
+            assembly {
+                // Divide denominator by twos.
+                denominator := div(denominator, twos)
+
+                // Divide [prod1 prod0] by twos.
+                prod0 := div(prod0, twos)
+
+                // Flip twos such that it is 2^256 / twos. If twos is zero, then it becomes one.
+                twos := add(div(sub(0, twos), twos), 1)
+            }
+
+            // Shift in bits from prod1 into prod0.
+            prod0 |= prod1 * twos;
+
+            // Invert denominator mod 2^256. Now that denominator is an odd number, it has an inverse modulo 2^256 such
+            // that denominator * inv = 1 mod 2^256. Compute the inverse by starting with a seed that is correct for
+            // four bits. That is, denominator * inv = 1 mod 2^4.
+            uint256 inverse = (3 * denominator) ^ 2;
+
+            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also works
+            // in modular arithmetic, doubling the correct bits in each step.
+            inverse *= 2 - denominator * inverse; // inverse mod 2^8
+            inverse *= 2 - denominator * inverse; // inverse mod 2^16
+            inverse *= 2 - denominator * inverse; // inverse mod 2^32
+            inverse *= 2 - denominator * inverse; // inverse mod 2^64
+            inverse *= 2 - denominator * inverse; // inverse mod 2^128
+            inverse *= 2 - denominator * inverse; // inverse mod 2^256
+
+            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.
+            // This will give us the correct result modulo 2^256. Since the preconditions guarantee that the outcome is
+            // less than 2^256, this is the final result. We don't need to compute the high bits of the result and prod1
+            // is no longer required.
+            result = prod0 * inverse;
+            return result;
+        }
+    }
+
+    /**
+     * @notice Calculates x * y / denominator with full precision, following the selected rounding direction.
+     */
+    function mulDiv(
+        uint256 x,
+        uint256 y,
+        uint256 denominator,
+        Rounding rounding
+    ) internal pure returns (uint256) {
+        uint256 result = mulDiv(x, y, denominator);
+        if (rounding == Rounding.Up && mulmod(x, y, denominator) > 0) {
+            result += 1;
+        }
+        return result;
+    }
+
+    /**
+     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded down.
      *
-     * Emits an {Approval} event.
+     * Inspired by Henry S. Warren, Jr.'s "Hacker's Delight" (Chapter 11).
+     */
+    function sqrt(uint256 a) internal pure returns (uint256) {
+        if (a == 0) {
+            return 0;
+        }
+
+        // For our first guess, we get the biggest power of 2 which is smaller than the square root of the target.
+        //
+        // We know that the "msb" (most significant bit) of our target number `a` is a power of 2 such that we have
+        // `msb(a) <= a < 2*msb(a)`. This value can be written `msb(a)=2**k` with `k=log2(a)`.
+        //
+        // This can be rewritten `2**log2(a) <= a < 2**(log2(a) + 1)`
+        // → `sqrt(2**k) <= sqrt(a) < sqrt(2**(k+1))`
+        // → `2**(k/2) <= sqrt(a) < 2**((k+1)/2) <= 2**(k/2 + 1)`
+        //
+        // Consequently, `2**(log2(a) / 2)` is a good first approximation of `sqrt(a)` with at least 1 correct bit.
+        uint256 result = 1 << (log2(a) >> 1);
+
+        // At this point `result` is an estimation with one bit of precision. We know the true value is a uint128,
+        // since it is the square root of a uint256. Newton's method converges quadratically (precision doubles at
+        // every iteration). We thus need at most 7 iteration to turn our partial result with one bit of precision
+        // into the expected uint128 result.
+        unchecked {
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            result = (result + a / result) >> 1;
+            return min(result, a / result);
+        }
+    }
+
+    /**
+     * @notice Calculates sqrt(a), following the selected rounding direction.
+     */
+    function sqrt(
+        uint256 a,
+        Rounding rounding
+    ) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = sqrt(a);
+            return
+                result +
+                (rounding == Rounding.Up && result * result < a ? 1 : 0);
+        }
+    }
+
+    /**
+     * @dev Return the log in base 2, rounded down, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log2(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >> 128 > 0) {
+                value >>= 128;
+                result += 128;
+            }
+            if (value >> 64 > 0) {
+                value >>= 64;
+                result += 64;
+            }
+            if (value >> 32 > 0) {
+                value >>= 32;
+                result += 32;
+            }
+            if (value >> 16 > 0) {
+                value >>= 16;
+                result += 16;
+            }
+            if (value >> 8 > 0) {
+                value >>= 8;
+                result += 8;
+            }
+            if (value >> 4 > 0) {
+                value >>= 4;
+                result += 4;
+            }
+            if (value >> 2 > 0) {
+                value >>= 2;
+                result += 2;
+            }
+            if (value >> 1 > 0) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log2(
+        uint256 value,
+        Rounding rounding
+    ) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log2(value);
+            return
+                result +
+                (rounding == Rounding.Up && 1 << result < value ? 1 : 0);
+        }
+    }
+
+    /**
+     * @dev Return the log in base 10, rounded down, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log10(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >= 10 ** 64) {
+                value /= 10 ** 64;
+                result += 64;
+            }
+            if (value >= 10 ** 32) {
+                value /= 10 ** 32;
+                result += 32;
+            }
+            if (value >= 10 ** 16) {
+                value /= 10 ** 16;
+                result += 16;
+            }
+            if (value >= 10 ** 8) {
+                value /= 10 ** 8;
+                result += 8;
+            }
+            if (value >= 10 ** 4) {
+                value /= 10 ** 4;
+                result += 4;
+            }
+            if (value >= 10 ** 2) {
+                value /= 10 ** 2;
+                result += 2;
+            }
+            if (value >= 10 ** 1) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log10(
+        uint256 value,
+        Rounding rounding
+    ) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log10(value);
+            return
+                result +
+                (rounding == Rounding.Up && 10 ** result < value ? 1 : 0);
+        }
+    }
+
+    /**
+     * @dev Return the log in base 256, rounded down, of a positive value.
+     * Returns 0 if given 0.
+     *
+     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.
+     */
+    function log256(uint256 value) internal pure returns (uint256) {
+        uint256 result = 0;
+        unchecked {
+            if (value >> 128 > 0) {
+                value >>= 128;
+                result += 16;
+            }
+            if (value >> 64 > 0) {
+                value >>= 64;
+                result += 8;
+            }
+            if (value >> 32 > 0) {
+                value >>= 32;
+                result += 4;
+            }
+            if (value >> 16 > 0) {
+                value >>= 16;
+                result += 2;
+            }
+            if (value >> 8 > 0) {
+                result += 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.
+     * Returns 0 if given 0.
+     */
+    function log256(
+        uint256 value,
+        Rounding rounding
+    ) internal pure returns (uint256) {
+        unchecked {
+            uint256 result = log256(value);
+            return
+                result +
+                (rounding == Rounding.Up && 1 << (result << 3) < value ? 1 : 0);
+        }
+    }
+}
+
+// OpenZeppelin Contracts v4.4.1 (utils/introspection/IERC165.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[EIP].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+// OpenZeppelin Contracts v4.4.1 (utils/introspection/ERC165.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Implementation of the {IERC165} interface.
+ *
+ * Contracts that want to implement ERC165 should inherit from this contract and override {supportsInterface} to check
+ * for the additional interface id that will be supported. For example:
+ *
+ * ```solidity
+ * function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+ *     return interfaceId == type(MyInterface).interfaceId || super.supportsInterface(interfaceId);
+ * }
+ * ```
+ *
+ * Alternatively, {ERC165Storage} provides an easier to use but more expensive implementation.
+ */
+abstract contract ERC165 is IERC165 {
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return interfaceId == type(IERC165).interfaceId;
+    }
+}
+
+// OpenZeppelin Contracts v4.4.1 (utils/Counters.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title Counters
+ * @author Matt Condon (@shrugs)
+ * @dev Provides counters that can only be incremented, decremented or reset. This can be used e.g. to track the number
+ * of elements in a mapping, issuing ERC721 ids, or counting request ids.
+ *
+ * Include with `using Counters for Counters.Counter;`
+ */
+library Counters {
+    struct Counter {
+        // This variable should never be directly accessed by users of the library: interactions must be restricted to
+        // the library's function. As of Solidity v0.5.2, this cannot be enforced, though there is a proposal to add
+        // this feature: see https://github.com/ethereum/solidity/issues/4637
+        uint256 _value; // default: 0
+    }
+
+    function current(Counter storage counter) internal view returns (uint256) {
+        return counter._value;
+    }
+
+    function increment(Counter storage counter) internal {
+        unchecked {
+            counter._value += 1;
+        }
+    }
+
+    function decrement(Counter storage counter) internal {
+        uint256 value = counter._value;
+        require(value > 0, "Counter: decrement overflow");
+        unchecked {
+            counter._value = value - 1;
+        }
+    }
+
+    function reset(Counter storage counter) internal {
+        counter._value = 0;
+    }
+}
+
+// OpenZeppelin Contracts v4.4.1 (utils/Context.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (utils/Address.sol)
+
+pragma solidity ^0.8.1;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     *
+     * Furthermore, `isContract` will also return true if the target contract within
+     * the same transaction is already scheduled for destruction by `SELFDESTRUCT`,
+     * which only has an effect at the end of a transaction.
+     * ====
+     *
+     * [IMPORTANT]
+     * ====
+     * You shouldn't rely on `isContract` to protect against flash loan attacks!
+     *
+     * Preventing calls from contracts is highly discouraged. It breaks composability, breaks support for smart wallets
+     * like Gnosis Safe, and does not provide security since it can be circumvented by calling from a contract
+     * constructor.
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize/address.code.length, which returns 0
+        // for contracts in construction, since the code is only stored at the end
+        // of the constructor execution.
+
+        return account.code.length > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.8.0/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(
+            address(this).balance >= amount,
+            "Address: insufficient balance"
+        );
+
+        (bool success, ) = recipient.call{value: amount}("");
+        require(
+            success,
+            "Address: unable to send value, recipient may have reverted"
+        );
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain `call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
      *
      * Requirements:
      *
-     * - `spender` cannot be the zero address.
-     * - `deadline` must be a timestamp in the future.
-     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`
-     * over the EIP712-formatted function arguments.
-     * - the signature must use ``owner``'s current nonce (see {nonces}).
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
      *
-     * For more information on the signature format, see the
-     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP
-     * section].
+     * _Available since v3.1._
      */
-    function permit(
-        address owner,
-        address spender,
+    function functionCall(
+        address target,
+        bytes memory data
+    ) internal returns (bytes memory) {
+        return
+            functionCallWithValue(
+                target,
+                data,
+                0,
+                "Address: low-level call failed"
+            );
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value
+    ) internal returns (bytes memory) {
+        return
+            functionCallWithValue(
+                target,
+                data,
+                value,
+                "Address: low-level call with value failed"
+            );
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
         uint256 value,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external;
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        require(
+            address(this).balance >= value,
+            "Address: insufficient balance for call"
+        );
+        (bool success, bytes memory returndata) = target.call{value: value}(
+            data
+        );
+        return
+            verifyCallResultFromTarget(
+                target,
+                success,
+                returndata,
+                errorMessage
+            );
+    }
 
     /**
-     * @dev Returns the current nonce for `owner`. This value must be
-     * included whenever a signature is generated for {permit}.
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
      *
-     * Every successful call to {permit} increases ``owner``'s nonce by one. This
-     * prevents a signature from being used multiple times.
+     * _Available since v3.3._
      */
-    function nonces(address owner) external view returns (uint256);
+    function functionStaticCall(
+        address target,
+        bytes memory data
+    ) internal view returns (bytes memory) {
+        return
+            functionStaticCall(
+                target,
+                data,
+                "Address: low-level static call failed"
+            );
+    }
 
     /**
-     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
      */
-    // solhint-disable-next-line func-name-mixedcase
-    function DOMAIN_SEPARATOR() external view returns (bytes32);
+    function functionStaticCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal view returns (bytes memory) {
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return
+            verifyCallResultFromTarget(
+                target,
+                success,
+                returndata,
+                errorMessage
+            );
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(
+        address target,
+        bytes memory data
+    ) internal returns (bytes memory) {
+        return
+            functionDelegateCall(
+                target,
+                data,
+                "Address: low-level delegate call failed"
+            );
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return
+            verifyCallResultFromTarget(
+                target,
+                success,
+                returndata,
+                errorMessage
+            );
+    }
+
+    /**
+     * @dev Tool to verify that a low level call to smart-contract was successful, and revert (either by bubbling
+     * the revert reason or using the provided one) in case of unsuccessful call or if target was not a contract.
+     *
+     * _Available since v4.8._
+     */
+    function verifyCallResultFromTarget(
+        address target,
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) internal view returns (bytes memory) {
+        if (success) {
+            if (returndata.length == 0) {
+                // only check isContract if the call was successful and the return data is empty
+                // otherwise we already know that it was a contract
+                require(isContract(target), "Address: call to non-contract");
+            }
+            return returndata;
+        } else {
+            _revert(returndata, errorMessage);
+        }
+    }
+
+    /**
+     * @dev Tool to verify that a low level call was successful, and revert if it wasn't, either by bubbling the
+     * revert reason or using the provided one.
+     *
+     * _Available since v4.3._
+     */
+    function verifyCallResult(
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) internal pure returns (bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            _revert(returndata, errorMessage);
+        }
+    }
+
+    function _revert(
+        bytes memory returndata,
+        string memory errorMessage
+    ) private pure {
+        // Look for revert reason and bubble it up if present
+        if (returndata.length > 0) {
+            // The easiest way to bubble the revert reason is using memory via assembly
+            /// @solidity memory-safe-assembly
+            assembly {
+                let returndata_size := mload(returndata)
+                revert(add(32, returndata), returndata_size)
+            }
+        } else {
+            revert(errorMessage);
+        }
+    }
 }
 
-// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/IERC20.sol)
+// OpenZeppelin Contracts (last updated v4.6.0) (token/ERC721/IERC721Receiver.sol)
 
 pragma solidity ^0.8.0;
 
 /**
- * @dev Interface of the ERC20 standard as defined in the EIP.
+ * @title ERC721 token receiver interface
+ * @dev Interface for any contract that wants to support safeTransfers
+ * from ERC721 asset contracts.
  */
-interface IERC20 {
+interface IERC721Receiver {
     /**
-     * @dev Emitted when `value` tokens are moved from one account (`from`) to
-     * another (`to`).
+     * @dev Whenever an {IERC721} `tokenId` token is transferred to this contract via {IERC721-safeTransferFrom}
+     * by `operator` from `from`, this function is called.
      *
-     * Note that `value` may be zero.
+     * It must return its Solidity selector to confirm the token transfer.
+     * If any other value is returned or the interface is not implemented by the recipient, the transfer will be reverted.
+     *
+     * The selector can be obtained in Solidity with `IERC721Receiver.onERC721Received.selector`.
      */
-    event Transfer(address indexed from, address indexed to, uint256 value);
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external returns (bytes4);
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC721/IERC721.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Required interface of an ERC721 compliant contract.
+ */
+interface IERC721 is IERC165 {
+    /**
+     * @dev Emitted when `tokenId` token is transferred from `from` to `to`.
+     */
+    event Transfer(
+        address indexed from,
+        address indexed to,
+        uint256 indexed tokenId
+    );
 
     /**
-     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
-     * a call to {approve}. `value` is the new allowance.
+     * @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.
      */
-    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Approval(
+        address indexed owner,
+        address indexed approved,
+        uint256 indexed tokenId
+    );
 
     /**
-     * @dev Returns the amount of tokens in existence.
+     * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+     */
+    event ApprovalForAll(
+        address indexed owner,
+        address indexed operator,
+        bool approved
+    );
+
+    /**
+     * @dev Returns the number of tokens in ``owner``'s account.
+     */
+    function balanceOf(address owner) external view returns (uint256 balance);
+
+    /**
+     * @dev Returns the owner of the `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes calldata data
+    ) external;
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
+     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external;
+
+    /**
+     * @dev Transfers `tokenId` token from `from` to `to`.
+     *
+     * WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721
+     * or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must
+     * understand this adds an external call which potentially creates a reentrancy vulnerability.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address from, address to, uint256 tokenId) external;
+
+    /**
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
+     * The approval is cleared when the token is transferred.
+     *
+     * Only a single account can be approved at a time, so approving the zero address clears previous approvals.
+     *
+     * Requirements:
+     *
+     * - The caller must own the token or be an approved operator.
+     * - `tokenId` must exist.
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address to, uint256 tokenId) external;
+
+    /**
+     * @dev Approve or remove `operator` as an operator for the caller.
+     * Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.
+     *
+     * Requirements:
+     *
+     * - The `operator` cannot be the caller.
+     *
+     * Emits an {ApprovalForAll} event.
+     */
+    function setApprovalForAll(address operator, bool approved) external;
+
+    /**
+     * @dev Returns the account approved for `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function getApproved(
+        uint256 tokenId
+    ) external view returns (address operator);
+
+    /**
+     * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.
+     *
+     * See {setApprovalForAll}
+     */
+    function isApprovedForAll(
+        address owner,
+        address operator
+    ) external view returns (bool);
+}
+
+// OpenZeppelin Contracts v4.4.1 (token/ERC721/extensions/IERC721Metadata.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional metadata extension
+ * @dev See https://eips.ethereum.org/EIPS/eip-721
+ */
+interface IERC721Metadata is IERC721 {
+    /**
+     * @dev Returns the token collection name.
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @dev Returns the token collection symbol.
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the Uniform Resource Identifier (URI) for `tokenId` token.
+     */
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}
+
+// OpenZeppelin Contracts (last updated v4.5.0) (token/ERC721/extensions/IERC721Enumerable.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @title ERC-721 Non-Fungible Token Standard, optional enumeration extension
+ * @dev See https://eips.ethereum.org/EIPS/eip-721
+ */
+interface IERC721Enumerable is IERC721 {
+    /**
+     * @dev Returns the total amount of tokens stored by the contract.
      */
     function totalSupply() external view returns (uint256);
 
     /**
-     * @dev Returns the amount of tokens owned by `account`.
+     * @dev Returns a token ID owned by `owner` at a given `index` of its token list.
+     * Use along with {balanceOf} to enumerate all of ``owner``'s tokens.
      */
-    function balanceOf(address account) external view returns (uint256);
-
-    /**
-     * @dev Moves `amount` tokens from the caller's account to `to`.
-     *
-     * Returns a boolean value indicating whether the operation succeeded.
-     *
-     * Emits a {Transfer} event.
-     */
-    function transfer(address to, uint256 amount) external returns (bool);
-
-    /**
-     * @dev Returns the remaining number of tokens that `spender` will be
-     * allowed to spend on behalf of `owner` through {transferFrom}. This is
-     * zero by default.
-     *
-     * This value changes when {approve} or {transferFrom} are called.
-     */
-    function allowance(address owner, address spender) external view returns (uint256);
-
-    /**
-     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
-     *
-     * Returns a boolean value indicating whether the operation succeeded.
-     *
-     * IMPORTANT: Beware that changing an allowance with this method brings the risk
-     * that someone may use both the old and the new allowance by unfortunate
-     * transaction ordering. One possible solution to mitigate this race
-     * condition is to first reduce the spender's allowance to 0 and set the
-     * desired value afterwards:
-     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-     *
-     * Emits an {Approval} event.
-     */
-    function approve(address spender, uint256 amount) external returns (bool);
-
-    /**
-     * @dev Moves `amount` tokens from `from` to `to` using the
-     * allowance mechanism. `amount` is then deducted from the caller's
-     * allowance.
-     *
-     * Returns a boolean value indicating whether the operation succeeded.
-     *
-     * Emits a {Transfer} event.
-     */
-    function transferFrom(address from, address to, uint256 amount) external returns (bool);
-}
-
-// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/utils/SafeERC20.sol)
-
-pragma solidity ^0.8.0;
-
-/**
- * @title SafeERC20
- * @dev Wrappers around ERC20 operations that throw on failure (when the token
- * contract returns false). Tokens that return no value (and instead revert or
- * throw on failure) are also supported, non-reverting calls are assumed to be
- * successful.
- * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
- * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
- */
-library SafeERC20 {
-    using Address for address;
-
-    /**
-     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,
-     * non-reverting calls are assumed to be successful.
-     */
-    function safeTransfer(IERC20 token, address to, uint256 value) internal {
-        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
-    }
-
-    /**
-     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the
-     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.
-     */
-    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {
-        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
-    }
-
-    /**
-     * @dev Deprecated. This function has issues similar to the ones found in
-     * {IERC20-approve}, and its usage is discouraged.
-     *
-     * Whenever possible, use {safeIncreaseAllowance} and
-     * {safeDecreaseAllowance} instead.
-     */
-    function safeApprove(IERC20 token, address spender, uint256 value) internal {
-        // safeApprove should only be called when setting an initial allowance,
-        // or when resetting it to zero. To increase and decrease it, use
-        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
-        require(
-            (value == 0) || (token.allowance(address(this), spender) == 0),
-            "SafeERC20: approve from non-zero to non-zero allowance"
-        );
-        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
-    }
-
-    /**
-     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,
-     * non-reverting calls are assumed to be successful.
-     */
-    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {
-        uint256 oldAllowance = token.allowance(address(this), spender);
-        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, oldAllowance + value));
-    }
-
-    /**
-     * @dev Decrease the calling contract's allowance toward `spender` by `value`. If `token` returns no value,
-     * non-reverting calls are assumed to be successful.
-     */
-    function safeDecreaseAllowance(IERC20 token, address spender, uint256 value) internal {
-        unchecked {
-            uint256 oldAllowance = token.allowance(address(this), spender);
-            require(oldAllowance >= value, "SafeERC20: decreased allowance below zero");
-            _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, oldAllowance - value));
-        }
-    }
-
-    /**
-     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,
-     * non-reverting calls are assumed to be successful. Compatible with tokens that require the approval to be set to
-     * 0 before setting it to a non-zero value.
-     */
-    function forceApprove(IERC20 token, address spender, uint256 value) internal {
-        bytes memory approvalCall = abi.encodeWithSelector(token.approve.selector, spender, value);
-
-        if (!_callOptionalReturnBool(token, approvalCall)) {
-            _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, 0));
-            _callOptionalReturn(token, approvalCall);
-        }
-    }
-
-    /**
-     * @dev Use a ERC-2612 signature to set the `owner` approval toward `spender` on `token`.
-     * Revert on invalid signature.
-     */
-    function safePermit(
-        IERC20Permit token,
+    function tokenOfOwnerByIndex(
         address owner,
-        address spender,
-        uint256 value,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) internal {
-        uint256 nonceBefore = token.nonces(owner);
-        token.permit(owner, spender, value, deadline, v, r, s);
-        uint256 nonceAfter = token.nonces(owner);
-        require(nonceAfter == nonceBefore + 1, "SafeERC20: permit did not succeed");
-    }
+        uint256 index
+    ) external view returns (uint256);
 
     /**
-     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
-     * on the return value: the return value is optional (but if data is returned, it must not be false).
-     * @param token The token targeted by the call.
-     * @param data The call data (encoded using abi.encode or one of its variants).
+     * @dev Returns a token ID at a given `index` of all the tokens stored by the contract.
+     * Use along with {totalSupply} to enumerate all tokens.
      */
-    function _callOptionalReturn(IERC20 token, bytes memory data) private {
-        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
-        // we're implementing it ourselves. We use {Address-functionCall} to perform this call, which verifies that
-        // the target address contains contract code and also asserts for success in the low-level call.
-
-        bytes memory returndata = address(token).functionCall(data, "SafeERC20: low-level call failed");
-        require(returndata.length == 0 || abi.decode(returndata, (bool)), "SafeERC20: ERC20 operation did not succeed");
-    }
-
-    /**
-     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
-     * on the return value: the return value is optional (but if data is returned, it must not be false).
-     * @param token The token targeted by the call.
-     * @param data The call data (encoded using abi.encode or one of its variants).
-     *
-     * This is a variant of {_callOptionalReturn} that silents catches all reverts and returns a bool instead.
-     */
-    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {
-        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
-        // we're implementing it ourselves. We cannot use {Address-functionCall} here since this should return false
-        // and not revert is the subcall reverts.
-
-        (bool success, bytes memory returndata) = address(token).call(data);
-        return
-            success && (returndata.length == 0 || abi.decode(returndata, (bool))) && Address.isContract(address(token));
-    }
+    function tokenByIndex(uint256 index) external view returns (uint256);
 }
 
 // OpenZeppelin Contracts (last updated v4.9.0) (token/ERC721/ERC721.sol)
@@ -880,7 +1603,9 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165, IERC165) returns (bool) {
         return
             interfaceId == type(IERC721).interfaceId ||
             interfaceId == type(IERC721Metadata).interfaceId ||
@@ -890,15 +1615,22 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     /**
      * @dev See {IERC721-balanceOf}.
      */
-    function balanceOf(address owner) public view virtual override returns (uint256) {
-        require(owner != address(0), "ERC721: address zero is not a valid owner");
+    function balanceOf(
+        address owner
+    ) public view virtual override returns (uint256) {
+        require(
+            owner != address(0),
+            "ERC721: address zero is not a valid owner"
+        );
         return _balances[owner];
     }
 
     /**
      * @dev See {IERC721-ownerOf}.
      */
-    function ownerOf(uint256 tokenId) public view virtual override returns (address) {
+    function ownerOf(
+        uint256 tokenId
+    ) public view virtual override returns (address) {
         address owner = _ownerOf(tokenId);
         require(owner != address(0), "ERC721: invalid token ID");
         return owner;
@@ -921,11 +1653,16 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     /**
      * @dev See {IERC721Metadata-tokenURI}.
      */
-    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+    function tokenURI(
+        uint256 tokenId
+    ) public view virtual override returns (string memory) {
         _requireMinted(tokenId);
 
         string memory baseURI = _baseURI();
-        return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
+        return
+            bytes(baseURI).length > 0
+                ? string(abi.encodePacked(baseURI, tokenId.toString()))
+                : "";
     }
 
     /**
@@ -955,7 +1692,9 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     /**
      * @dev See {IERC721-getApproved}.
      */
-    function getApproved(uint256 tokenId) public view virtual override returns (address) {
+    function getApproved(
+        uint256 tokenId
+    ) public view virtual override returns (address) {
         _requireMinted(tokenId);
 
         return _tokenApprovals[tokenId];
@@ -964,23 +1703,36 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     /**
      * @dev See {IERC721-setApprovalForAll}.
      */
-    function setApprovalForAll(address operator, bool approved) public virtual override {
+    function setApprovalForAll(
+        address operator,
+        bool approved
+    ) public virtual override {
         _setApprovalForAll(_msgSender(), operator, approved);
     }
 
     /**
      * @dev See {IERC721-isApprovedForAll}.
      */
-    function isApprovedForAll(address owner, address operator) public view virtual override returns (bool) {
+    function isApprovedForAll(
+        address owner,
+        address operator
+    ) public view virtual override returns (bool) {
         return _operatorApprovals[owner][operator];
     }
 
     /**
      * @dev See {IERC721-transferFrom}.
      */
-    function transferFrom(address from, address to, uint256 tokenId) public virtual override {
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {
         //solhint-disable-next-line max-line-length
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: caller is not token owner or approved");
+        require(
+            _isApprovedOrOwner(_msgSender(), tokenId),
+            "ERC721: caller is not token owner or approved"
+        );
 
         _transfer(from, to, tokenId);
     }
@@ -988,15 +1740,27 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
     /**
      * @dev See {IERC721-safeTransferFrom}.
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId) public virtual override {
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {
         safeTransferFrom(from, to, tokenId, "");
     }
 
     /**
      * @dev See {IERC721-safeTransferFrom}.
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public virtual override {
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "ERC721: caller is not token owner or approved");
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) public virtual override {
+        require(
+            _isApprovedOrOwner(_msgSender(), tokenId),
+            "ERC721: caller is not token owner or approved"
+        );
         _safeTransfer(from, to, tokenId, data);
     }
 
@@ -1018,9 +1782,17 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      *
      * Emits a {Transfer} event.
      */
-    function _safeTransfer(address from, address to, uint256 tokenId, bytes memory data) internal virtual {
+    function _safeTransfer(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) internal virtual {
         _transfer(from, to, tokenId);
-        require(_checkOnERC721Received(from, to, tokenId, data), "ERC721: transfer to non ERC721Receiver implementer");
+        require(
+            _checkOnERC721Received(from, to, tokenId, data),
+            "ERC721: transfer to non ERC721Receiver implementer"
+        );
     }
 
     /**
@@ -1049,9 +1821,14 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      *
      * - `tokenId` must exist.
      */
-    function _isApprovedOrOwner(address spender, uint256 tokenId) internal view virtual returns (bool) {
+    function _isApprovedOrOwner(
+        address spender,
+        uint256 tokenId
+    ) internal view virtual returns (bool) {
         address owner = ERC721.ownerOf(tokenId);
-        return (spender == owner || isApprovedForAll(owner, spender) || getApproved(tokenId) == spender);
+        return (spender == owner ||
+            isApprovedForAll(owner, spender) ||
+            getApproved(tokenId) == spender);
     }
 
     /**
@@ -1072,7 +1849,11 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * @dev Same as {xref-ERC721-_safeMint-address-uint256-}[`_safeMint`], with an additional `data` parameter which is
      * forwarded in {IERC721Receiver-onERC721Received} to contract recipients.
      */
-    function _safeMint(address to, uint256 tokenId, bytes memory data) internal virtual {
+    function _safeMint(
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) internal virtual {
         _mint(to, tokenId);
         require(
             _checkOnERC721Received(address(0), to, tokenId, data),
@@ -1161,14 +1942,24 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      *
      * Emits a {Transfer} event.
      */
-    function _transfer(address from, address to, uint256 tokenId) internal virtual {
-        require(ERC721.ownerOf(tokenId) == from, "ERC721: transfer from incorrect owner");
+    function _transfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual {
+        require(
+            ERC721.ownerOf(tokenId) == from,
+            "ERC721: transfer from incorrect owner"
+        );
         require(to != address(0), "ERC721: transfer to the zero address");
 
         _beforeTokenTransfer(from, to, tokenId, 1);
 
         // Check that tokenId was not transferred by `_beforeTokenTransfer` hook
-        require(ERC721.ownerOf(tokenId) == from, "ERC721: transfer from incorrect owner");
+        require(
+            ERC721.ownerOf(tokenId) == from,
+            "ERC721: transfer from incorrect owner"
+        );
 
         // Clear approvals from the previous owner
         delete _tokenApprovals[tokenId];
@@ -1204,7 +1995,11 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      *
      * Emits an {ApprovalForAll} event.
      */
-    function _setApprovalForAll(address owner, address operator, bool approved) internal virtual {
+    function _setApprovalForAll(
+        address owner,
+        address operator,
+        bool approved
+    ) internal virtual {
         require(owner != operator, "ERC721: approve to caller");
         _operatorApprovals[owner][operator] = approved;
         emit ApprovalForAll(owner, operator, approved);
@@ -1234,11 +2029,20 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
         bytes memory data
     ) private returns (bool) {
         if (to.isContract()) {
-            try IERC721Receiver(to).onERC721Received(_msgSender(), from, tokenId, data) returns (bytes4 retval) {
+            try
+                IERC721Receiver(to).onERC721Received(
+                    _msgSender(),
+                    from,
+                    tokenId,
+                    data
+                )
+            returns (bytes4 retval) {
                 return retval == IERC721Receiver.onERC721Received.selector;
             } catch (bytes memory reason) {
                 if (reason.length == 0) {
-                    revert("ERC721: transfer to non ERC721Receiver implementer");
+                    revert(
+                        "ERC721: transfer to non ERC721Receiver implementer"
+                    );
                 } else {
                     /// @solidity memory-safe-assembly
                     assembly {
@@ -1265,7 +2069,12 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      *
      * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
      */
-    function _beforeTokenTransfer(address from, address to, uint256 firstTokenId, uint256 batchSize) internal virtual {}
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 firstTokenId,
+        uint256 batchSize
+    ) internal virtual {}
 
     /**
      * @dev Hook that is called after any token transfer. This includes minting and burning. If {ERC721Consecutive} is
@@ -1281,7 +2090,12 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      *
      * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
      */
-    function _afterTokenTransfer(address from, address to, uint256 firstTokenId, uint256 batchSize) internal virtual {}
+    function _afterTokenTransfer(
+        address from,
+        address to,
+        uint256 firstTokenId,
+        uint256 batchSize
+    ) internal virtual {}
 
     /**
      * @dev Unsafe write access to the balances, used by extensions that "mint" tokens using an {ownerOf} override.
@@ -1291,7 +2105,10 @@ contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
      * that `ownerOf(tokenId)` is `a`.
      */
     // solhint-disable-next-line func-name-mixedcase
-    function __unsafe_increaseBalance(address account, uint256 amount) internal {
+    function __unsafe_increaseBalance(
+        address account,
+        uint256 amount
+    ) internal {
         _balances[account] += amount;
     }
 }
@@ -1321,15 +2138,25 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC721) returns (bool) {
-        return interfaceId == type(IERC721Enumerable).interfaceId || super.supportsInterface(interfaceId);
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165, ERC721) returns (bool) {
+        return
+            interfaceId == type(IERC721Enumerable).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /**
      * @dev See {IERC721Enumerable-tokenOfOwnerByIndex}.
      */
-    function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256) {
-        require(index < ERC721.balanceOf(owner), "ERC721Enumerable: owner index out of bounds");
+    function tokenOfOwnerByIndex(
+        address owner,
+        uint256 index
+    ) public view virtual override returns (uint256) {
+        require(
+            index < ERC721.balanceOf(owner),
+            "ERC721Enumerable: owner index out of bounds"
+        );
         return _ownedTokens[owner][index];
     }
 
@@ -1343,8 +2170,13 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
     /**
      * @dev See {IERC721Enumerable-tokenByIndex}.
      */
-    function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
-        require(index < ERC721Enumerable.totalSupply(), "ERC721Enumerable: global index out of bounds");
+    function tokenByIndex(
+        uint256 index
+    ) public view virtual override returns (uint256) {
+        require(
+            index < ERC721Enumerable.totalSupply(),
+            "ERC721Enumerable: global index out of bounds"
+        );
         return _allTokens[index];
     }
 
@@ -1406,7 +2238,10 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
      * @param from address representing the previous owner of the given token ID
      * @param tokenId uint256 ID of the token to be removed from the tokens list of the given address
      */
-    function _removeTokenFromOwnerEnumeration(address from, uint256 tokenId) private {
+    function _removeTokenFromOwnerEnumeration(
+        address from,
+        uint256 tokenId
+    ) private {
         // To prevent a gap in from's tokens array, we store the last token in the index of the token to delete, and
         // then delete the last slot (swap and pop).
 
@@ -1452,1460 +2287,1159 @@ abstract contract ERC721Enumerable is ERC721, IERC721Enumerable {
     }
 }
 
-// OpenZeppelin Contracts (last updated v4.5.0) (token/ERC721/extensions/IERC721Enumerable.sol)
+// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/utils/SafeERC20.sol)
 
 pragma solidity ^0.8.0;
 
 /**
- * @title ERC-721 Non-Fungible Token Standard, optional enumeration extension
- * @dev See https://eips.ethereum.org/EIPS/eip-721
+ * @title SafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
  */
-interface IERC721Enumerable is IERC721 {
+library SafeERC20 {
+    using Address for address;
+
     /**
-     * @dev Returns the total amount of tokens stored by the contract.
+     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     */
+    function safeTransfer(IERC20 token, address to, uint256 value) internal {
+        _callOptionalReturn(
+            token,
+            abi.encodeWithSelector(token.transfer.selector, to, value)
+        );
+    }
+
+    /**
+     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the
+     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.
+     */
+    function safeTransferFrom(
+        IERC20 token,
+        address from,
+        address to,
+        uint256 value
+    ) internal {
+        _callOptionalReturn(
+            token,
+            abi.encodeWithSelector(token.transferFrom.selector, from, to, value)
+        );
+    }
+
+    /**
+     * @dev Deprecated. This function has issues similar to the ones found in
+     * {IERC20-approve}, and its usage is discouraged.
+     *
+     * Whenever possible, use {safeIncreaseAllowance} and
+     * {safeDecreaseAllowance} instead.
+     */
+    function safeApprove(
+        IERC20 token,
+        address spender,
+        uint256 value
+    ) internal {
+        // safeApprove should only be called when setting an initial allowance,
+        // or when resetting it to zero. To increase and decrease it, use
+        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
+        require(
+            (value == 0) || (token.allowance(address(this), spender) == 0),
+            "SafeERC20: approve from non-zero to non-zero allowance"
+        );
+        _callOptionalReturn(
+            token,
+            abi.encodeWithSelector(token.approve.selector, spender, value)
+        );
+    }
+
+    /**
+     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     */
+    function safeIncreaseAllowance(
+        IERC20 token,
+        address spender,
+        uint256 value
+    ) internal {
+        uint256 oldAllowance = token.allowance(address(this), spender);
+        _callOptionalReturn(
+            token,
+            abi.encodeWithSelector(
+                token.approve.selector,
+                spender,
+                oldAllowance + value
+            )
+        );
+    }
+
+    /**
+     * @dev Decrease the calling contract's allowance toward `spender` by `value`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     */
+    function safeDecreaseAllowance(
+        IERC20 token,
+        address spender,
+        uint256 value
+    ) internal {
+        unchecked {
+            uint256 oldAllowance = token.allowance(address(this), spender);
+            require(
+                oldAllowance >= value,
+                "SafeERC20: decreased allowance below zero"
+            );
+            _callOptionalReturn(
+                token,
+                abi.encodeWithSelector(
+                    token.approve.selector,
+                    spender,
+                    oldAllowance - value
+                )
+            );
+        }
+    }
+
+    /**
+     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful. Compatible with tokens that require the approval to be set to
+     * 0 before setting it to a non-zero value.
+     */
+    function forceApprove(
+        IERC20 token,
+        address spender,
+        uint256 value
+    ) internal {
+        bytes memory approvalCall = abi.encodeWithSelector(
+            token.approve.selector,
+            spender,
+            value
+        );
+
+        if (!_callOptionalReturnBool(token, approvalCall)) {
+            _callOptionalReturn(
+                token,
+                abi.encodeWithSelector(token.approve.selector, spender, 0)
+            );
+            _callOptionalReturn(token, approvalCall);
+        }
+    }
+
+    /**
+     * @dev Use a ERC-2612 signature to set the `owner` approval toward `spender` on `token`.
+     * Revert on invalid signature.
+     */
+    function safePermit(
+        IERC20Permit token,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal {
+        uint256 nonceBefore = token.nonces(owner);
+        token.permit(owner, spender, value, deadline, v, r, s);
+        uint256 nonceAfter = token.nonces(owner);
+        require(
+            nonceAfter == nonceBefore + 1,
+            "SafeERC20: permit did not succeed"
+        );
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(IERC20 token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {Address-functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = address(token).functionCall(
+            data,
+            "SafeERC20: low-level call failed"
+        );
+        require(
+            returndata.length == 0 || abi.decode(returndata, (bool)),
+            "SafeERC20: ERC20 operation did not succeed"
+        );
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     *
+     * This is a variant of {_callOptionalReturn} that silents catches all reverts and returns a bool instead.
+     */
+    function _callOptionalReturnBool(
+        IERC20 token,
+        bytes memory data
+    ) private returns (bool) {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We cannot use {Address-functionCall} here since this should return false
+        // and not revert is the subcall reverts.
+
+        (bool success, bytes memory returndata) = address(token).call(data);
+        return
+            success &&
+            (returndata.length == 0 || abi.decode(returndata, (bool))) &&
+            Address.isContract(address(token));
+    }
+}
+
+// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/IERC20.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+
+    /**
+     * @dev Returns the amount of tokens in existence.
      */
     function totalSupply() external view returns (uint256);
 
     /**
-     * @dev Returns a token ID owned by `owner` at a given `index` of its token list.
-     * Use along with {balanceOf} to enumerate all of ``owner``'s tokens.
+     * @dev Returns the amount of tokens owned by `account`.
      */
-    function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
 
     /**
-     * @dev Returns a token ID at a given `index` of all the tokens stored by the contract.
-     * Use along with {totalSupply} to enumerate all tokens.
-     */
-    function tokenByIndex(uint256 index) external view returns (uint256);
-}
-
-// OpenZeppelin Contracts v4.4.1 (token/ERC721/extensions/IERC721Metadata.sol)
-
-pragma solidity ^0.8.0;
-
-/**
- * @title ERC-721 Non-Fungible Token Standard, optional metadata extension
- * @dev See https://eips.ethereum.org/EIPS/eip-721
- */
-interface IERC721Metadata is IERC721 {
-    /**
-     * @dev Returns the token collection name.
-     */
-    function name() external view returns (string memory);
-
-    /**
-     * @dev Returns the token collection symbol.
-     */
-    function symbol() external view returns (string memory);
-
-    /**
-     * @dev Returns the Uniform Resource Identifier (URI) for `tokenId` token.
-     */
-    function tokenURI(uint256 tokenId) external view returns (string memory);
-}
-
-// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC721/IERC721.sol)
-
-pragma solidity ^0.8.0;
-
-/**
- * @dev Required interface of an ERC721 compliant contract.
- */
-interface IERC721 is IERC165 {
-    /**
-     * @dev Emitted when `tokenId` token is transferred from `from` to `to`.
-     */
-    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
-
-    /**
-     * @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.
-     */
-    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
-
-    /**
-     * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
-     */
-    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
-
-    /**
-     * @dev Returns the number of tokens in ``owner``'s account.
-     */
-    function balanceOf(address owner) external view returns (uint256 balance);
-
-    /**
-     * @dev Returns the owner of the `tokenId` token.
+     * @dev Moves `amount` tokens from the caller's account to `to`.
      *
-     * Requirements:
-     *
-     * - `tokenId` must exist.
-     */
-    function ownerOf(uint256 tokenId) external view returns (address owner);
-
-    /**
-     * @dev Safely transfers `tokenId` token from `from` to `to`.
-     *
-     * Requirements:
-     *
-     * - `from` cannot be the zero address.
-     * - `to` cannot be the zero address.
-     * - `tokenId` token must exist and be owned by `from`.
-     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
-     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * Returns a boolean value indicating whether the operation succeeded.
      *
      * Emits a {Transfer} event.
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
+    function transfer(address to, uint256 amount) external returns (bool);
 
     /**
-     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
-     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
      *
-     * Requirements:
-     *
-     * - `from` cannot be the zero address.
-     * - `to` cannot be the zero address.
-     * - `tokenId` token must exist and be owned by `from`.
-     * - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}.
-     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
-     *
-     * Emits a {Transfer} event.
+     * This value changes when {approve} or {transferFrom} are called.
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+    function allowance(
+        address owner,
+        address spender
+    ) external view returns (uint256);
 
     /**
-     * @dev Transfers `tokenId` token from `from` to `to`.
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
      *
-     * WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721
-     * or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must
-     * understand this adds an external call which potentially creates a reentrancy vulnerability.
+     * Returns a boolean value indicating whether the operation succeeded.
      *
-     * Requirements:
-     *
-     * - `from` cannot be the zero address.
-     * - `to` cannot be the zero address.
-     * - `tokenId` token must be owned by `from`.
-     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
-     *
-     * Emits a {Transfer} event.
-     */
-    function transferFrom(address from, address to, uint256 tokenId) external;
-
-    /**
-     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
-     * The approval is cleared when the token is transferred.
-     *
-     * Only a single account can be approved at a time, so approving the zero address clears previous approvals.
-     *
-     * Requirements:
-     *
-     * - The caller must own the token or be an approved operator.
-     * - `tokenId` must exist.
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
      *
      * Emits an {Approval} event.
      */
-    function approve(address to, uint256 tokenId) external;
+    function approve(address spender, uint256 amount) external returns (bool);
 
     /**
-     * @dev Approve or remove `operator` as an operator for the caller.
-     * Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.
+     * @dev Moves `amount` tokens from `from` to `to` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
      *
-     * Requirements:
+     * Returns a boolean value indicating whether the operation succeeded.
      *
-     * - The `operator` cannot be the caller.
-     *
-     * Emits an {ApprovalForAll} event.
+     * Emits a {Transfer} event.
      */
-    function setApprovalForAll(address operator, bool approved) external;
-
-    /**
-     * @dev Returns the account approved for `tokenId` token.
-     *
-     * Requirements:
-     *
-     * - `tokenId` must exist.
-     */
-    function getApproved(uint256 tokenId) external view returns (address operator);
-
-    /**
-     * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.
-     *
-     * See {setApprovalForAll}
-     */
-    function isApprovedForAll(address owner, address operator) external view returns (bool);
-}
-
-// OpenZeppelin Contracts (last updated v4.6.0) (token/ERC721/IERC721Receiver.sol)
-
-pragma solidity ^0.8.0;
-
-/**
- * @title ERC721 token receiver interface
- * @dev Interface for any contract that wants to support safeTransfers
- * from ERC721 asset contracts.
- */
-interface IERC721Receiver {
-    /**
-     * @dev Whenever an {IERC721} `tokenId` token is transferred to this contract via {IERC721-safeTransferFrom}
-     * by `operator` from `from`, this function is called.
-     *
-     * It must return its Solidity selector to confirm the token transfer.
-     * If any other value is returned or the interface is not implemented by the recipient, the transfer will be reverted.
-     *
-     * The selector can be obtained in Solidity with `IERC721Receiver.onERC721Received.selector`.
-     */
-    function onERC721Received(
-        address operator,
+    function transferFrom(
         address from,
-        uint256 tokenId,
-        bytes calldata data
-    ) external returns (bytes4);
+        address to,
+        uint256 amount
+    ) external returns (bool);
 }
 
-// OpenZeppelin Contracts (last updated v4.9.0) (utils/Address.sol)
+// OpenZeppelin Contracts (last updated v4.9.0) (token/ERC20/extensions/IERC20Permit.sol)
 
-pragma solidity ^0.8.1;
+pragma solidity ^0.8.0;
 
 /**
- * @dev Collection of functions related to the address type
+ * @dev Interface of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
+ * https://eips.ethereum.org/EIPS/eip-2612[EIP-2612].
+ *
+ * Adds the {permit} method, which can be used to change an account's ERC20 allowance (see {IERC20-allowance}) by
+ * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't
+ * need to send a transaction, and thus is not required to hold Ether at all.
  */
-library Address {
+interface IERC20Permit {
     /**
-     * @dev Returns true if `account` is a contract.
+     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,
+     * given ``owner``'s signed approval.
      *
-     * [IMPORTANT]
-     * ====
-     * It is unsafe to assume that an address for which this function returns
-     * false is an externally-owned account (EOA) and not a contract.
+     * IMPORTANT: The same issues {IERC20-approve} has related to transaction
+     * ordering also apply here.
      *
-     * Among others, `isContract` will return false for the following
-     * types of addresses:
-     *
-     *  - an externally-owned account
-     *  - a contract in construction
-     *  - an address where a contract will be created
-     *  - an address where a contract lived, but was destroyed
-     *
-     * Furthermore, `isContract` will also return true if the target contract within
-     * the same transaction is already scheduled for destruction by `SELFDESTRUCT`,
-     * which only has an effect at the end of a transaction.
-     * ====
-     *
-     * [IMPORTANT]
-     * ====
-     * You shouldn't rely on `isContract` to protect against flash loan attacks!
-     *
-     * Preventing calls from contracts is highly discouraged. It breaks composability, breaks support for smart wallets
-     * like Gnosis Safe, and does not provide security since it can be circumvented by calling from a contract
-     * constructor.
-     * ====
-     */
-    function isContract(address account) internal view returns (bool) {
-        // This method relies on extcodesize/address.code.length, which returns 0
-        // for contracts in construction, since the code is only stored at the end
-        // of the constructor execution.
-
-        return account.code.length > 0;
-    }
-
-    /**
-     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
-     * `recipient`, forwarding all available gas and reverting on errors.
-     *
-     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
-     * of certain opcodes, possibly making contracts go over the 2300 gas limit
-     * imposed by `transfer`, making them unable to receive funds via
-     * `transfer`. {sendValue} removes this limitation.
-     *
-     * https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/[Learn more].
-     *
-     * IMPORTANT: because control is transferred to `recipient`, care must be
-     * taken to not create reentrancy vulnerabilities. Consider using
-     * {ReentrancyGuard} or the
-     * https://solidity.readthedocs.io/en/v0.8.0/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
-     */
-    function sendValue(address payable recipient, uint256 amount) internal {
-        require(address(this).balance >= amount, "Address: insufficient balance");
-
-        (bool success, ) = recipient.call{value: amount}("");
-        require(success, "Address: unable to send value, recipient may have reverted");
-    }
-
-    /**
-     * @dev Performs a Solidity function call using a low level `call`. A
-     * plain `call` is an unsafe replacement for a function call: use this
-     * function instead.
-     *
-     * If `target` reverts with a revert reason, it is bubbled up by this
-     * function (like regular Solidity function calls).
-     *
-     * Returns the raw returned data. To convert to the expected return value,
-     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     * Emits an {Approval} event.
      *
      * Requirements:
      *
-     * - `target` must be a contract.
-     * - calling `target` with `data` must not revert.
+     * - `spender` cannot be the zero address.
+     * - `deadline` must be a timestamp in the future.
+     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`
+     * over the EIP712-formatted function arguments.
+     * - the signature must use ``owner``'s current nonce (see {nonces}).
      *
-     * _Available since v3.1._
+     * For more information on the signature format, see the
+     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP
+     * section].
      */
-    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
-        return functionCallWithValue(target, data, 0, "Address: low-level call failed");
-    }
-
-    /**
-     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
-     * `errorMessage` as a fallback revert reason when `target` reverts.
-     *
-     * _Available since v3.1._
-     */
-    function functionCall(
-        address target,
-        bytes memory data,
-        string memory errorMessage
-    ) internal returns (bytes memory) {
-        return functionCallWithValue(target, data, 0, errorMessage);
-    }
-
-    /**
-     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
-     * but also transferring `value` wei to `target`.
-     *
-     * Requirements:
-     *
-     * - the calling contract must have an ETH balance of at least `value`.
-     * - the called Solidity function must be `payable`.
-     *
-     * _Available since v3.1._
-     */
-    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
-        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
-    }
-
-    /**
-     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
-     * with `errorMessage` as a fallback revert reason when `target` reverts.
-     *
-     * _Available since v3.1._
-     */
-    function functionCallWithValue(
-        address target,
-        bytes memory data,
+    function permit(
+        address owner,
+        address spender,
         uint256 value,
-        string memory errorMessage
-    ) internal returns (bytes memory) {
-        require(address(this).balance >= value, "Address: insufficient balance for call");
-        (bool success, bytes memory returndata) = target.call{value: value}(data);
-        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
-    }
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
 
     /**
-     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
-     * but performing a static call.
+     * @dev Returns the current nonce for `owner`. This value must be
+     * included whenever a signature is generated for {permit}.
      *
-     * _Available since v3.3._
+     * Every successful call to {permit} increases ``owner``'s nonce by one. This
+     * prevents a signature from being used multiple times.
      */
-    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
-        return functionStaticCall(target, data, "Address: low-level static call failed");
-    }
+    function nonces(address owner) external view returns (uint256);
 
     /**
-     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
-     * but performing a static call.
-     *
-     * _Available since v3.3._
+     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.
      */
-    function functionStaticCall(
-        address target,
-        bytes memory data,
-        string memory errorMessage
-    ) internal view returns (bytes memory) {
-        (bool success, bytes memory returndata) = target.staticcall(data);
-        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
-    }
-
-    /**
-     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
-     * but performing a delegate call.
-     *
-     * _Available since v3.4._
-     */
-    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
-        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
-    }
-
-    /**
-     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
-     * but performing a delegate call.
-     *
-     * _Available since v3.4._
-     */
-    function functionDelegateCall(
-        address target,
-        bytes memory data,
-        string memory errorMessage
-    ) internal returns (bytes memory) {
-        (bool success, bytes memory returndata) = target.delegatecall(data);
-        return verifyCallResultFromTarget(target, success, returndata, errorMessage);
-    }
-
-    /**
-     * @dev Tool to verify that a low level call to smart-contract was successful, and revert (either by bubbling
-     * the revert reason or using the provided one) in case of unsuccessful call or if target was not a contract.
-     *
-     * _Available since v4.8._
-     */
-    function verifyCallResultFromTarget(
-        address target,
-        bool success,
-        bytes memory returndata,
-        string memory errorMessage
-    ) internal view returns (bytes memory) {
-        if (success) {
-            if (returndata.length == 0) {
-                // only check isContract if the call was successful and the return data is empty
-                // otherwise we already know that it was a contract
-                require(isContract(target), "Address: call to non-contract");
-            }
-            return returndata;
-        } else {
-            _revert(returndata, errorMessage);
-        }
-    }
-
-    /**
-     * @dev Tool to verify that a low level call was successful, and revert if it wasn't, either by bubbling the
-     * revert reason or using the provided one.
-     *
-     * _Available since v4.3._
-     */
-    function verifyCallResult(
-        bool success,
-        bytes memory returndata,
-        string memory errorMessage
-    ) internal pure returns (bytes memory) {
-        if (success) {
-            return returndata;
-        } else {
-            _revert(returndata, errorMessage);
-        }
-    }
-
-    function _revert(bytes memory returndata, string memory errorMessage) private pure {
-        // Look for revert reason and bubble it up if present
-        if (returndata.length > 0) {
-            // The easiest way to bubble the revert reason is using memory via assembly
-            /// @solidity memory-safe-assembly
-            assembly {
-                let returndata_size := mload(returndata)
-                revert(add(32, returndata), returndata_size)
-            }
-        } else {
-            revert(errorMessage);
-        }
-    }
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
 }
 
-// OpenZeppelin Contracts v4.4.1 (utils/Context.sol)
+// OpenZeppelin Contracts (last updated v4.9.0) (security/ReentrancyGuard.sol)
 
 pragma solidity ^0.8.0;
 
 /**
- * @dev Provides information about the current execution context, including the
- * sender of the transaction and its data. While these are generally available
- * via msg.sender and msg.data, they should not be accessed in such a direct
- * manner, since when dealing with meta-transactions the account sending and
- * paying for execution may not be the actual sender (as far as an application
- * is concerned).
+ * @dev Contract module that helps prevent reentrant calls to a function.
  *
- * This contract is only required for intermediate, library-like contracts.
- */
-abstract contract Context {
-    function _msgSender() internal view virtual returns (address) {
-        return msg.sender;
-    }
-
-    function _msgData() internal view virtual returns (bytes calldata) {
-        return msg.data;
-    }
-}
-
-// OpenZeppelin Contracts v4.4.1 (utils/Counters.sol)
-
-pragma solidity ^0.8.0;
-
-/**
- * @title Counters
- * @author Matt Condon (@shrugs)
- * @dev Provides counters that can only be incremented, decremented or reset. This can be used e.g. to track the number
- * of elements in a mapping, issuing ERC721 ids, or counting request ids.
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
  *
- * Include with `using Counters for Counters.Counter;`
- */
-library Counters {
-    struct Counter {
-        // This variable should never be directly accessed by users of the library: interactions must be restricted to
-        // the library's function. As of Solidity v0.5.2, this cannot be enforced, though there is a proposal to add
-        // this feature: see https://github.com/ethereum/solidity/issues/4637
-        uint256 _value; // default: 0
-    }
-
-    function current(Counter storage counter) internal view returns (uint256) {
-        return counter._value;
-    }
-
-    function increment(Counter storage counter) internal {
-        unchecked {
-            counter._value += 1;
-        }
-    }
-
-    function decrement(Counter storage counter) internal {
-        uint256 value = counter._value;
-        require(value > 0, "Counter: decrement overflow");
-        unchecked {
-            counter._value = value - 1;
-        }
-    }
-
-    function reset(Counter storage counter) internal {
-        counter._value = 0;
-    }
-}
-
-// OpenZeppelin Contracts v4.4.1 (utils/introspection/ERC165.sol)
-
-pragma solidity ^0.8.0;
-
-
-/**
- * @dev Implementation of the {IERC165} interface.
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
  *
- * Contracts that want to implement ERC165 should inherit from this contract and override {supportsInterface} to check
- * for the additional interface id that will be supported. For example:
- *
- * ```solidity
- * function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
- *     return interfaceId == type(MyInterface).interfaceId || super.supportsInterface(interfaceId);
- * }
- * ```
- *
- * Alternatively, {ERC165Storage} provides an easier to use but more expensive implementation.
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
  */
-abstract contract ERC165 is IERC165 {
+abstract contract ReentrancyGuard {
+    // Booleans are more expensive than uint256 or any type that takes up a full
+    // word because each write operation emits an extra SLOAD to first read the
+    // slot's contents, replace the bits taken up by the boolean, and then write
+    // back. This is the compiler's defense against contract upgrades and
+    // pointer aliasing, and it cannot be disabled.
+
+    // The values being non-zero value makes deployment a bit more expensive,
+    // but in exchange the refund on every call to nonReentrant will be lower in
+    // amount. Since refunds are capped to a percentage of the total
+    // transaction's gas, it is best to keep them low in cases like this one, to
+    // increase the likelihood of the full refund coming into effect.
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+
+    uint256 private _status;
+
+    constructor() {
+        _status = _NOT_ENTERED;
+    }
+
     /**
-     * @dev See {IERC165-supportsInterface}.
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and making it call a
+     * `private` function that does the actual work.
      */
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == type(IERC165).interfaceId;
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+
+    function _nonReentrantBefore() private {
+        // On the first call to nonReentrant, _status will be _NOT_ENTERED
+        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+
+        // Any calls to nonReentrant after this point will fail
+        _status = _ENTERED;
+    }
+
+    function _nonReentrantAfter() private {
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = _NOT_ENTERED;
+    }
+
+    /**
+     * @dev Returns true if the reentrancy guard is currently set to "entered", which indicates there is a
+     * `nonReentrant` function in the call stack.
+     */
+    function _reentrancyGuardEntered() internal view returns (bool) {
+        return _status == _ENTERED;
     }
 }
-
-// OpenZeppelin Contracts v4.4.1 (utils/introspection/IERC165.sol)
-
-pragma solidity ^0.8.0;
-
-/**
- * @dev Interface of the ERC165 standard, as defined in the
- * https://eips.ethereum.org/EIPS/eip-165[EIP].
- *
- * Implementers can declare support of contract interfaces, which can then be
- * queried by others ({ERC165Checker}).
- *
- * For an implementation, see {ERC165}.
- */
-interface IERC165 {
-    /**
-     * @dev Returns true if this contract implements the interface defined by
-     * `interfaceId`. See the corresponding
-     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
-     * to learn more about how these ids are created.
-     *
-     * This function call must use less than 30 000 gas.
-     */
-    function supportsInterface(bytes4 interfaceId) external view returns (bool);
-}
-
-// OpenZeppelin Contracts (last updated v4.9.0) (utils/math/Math.sol)
-
-pragma solidity ^0.8.0;
-
-/**
- * @dev Standard math utilities missing in the Solidity language.
- */
-library Math {
-    enum Rounding {
-        Down, // Toward negative infinity
-        Up, // Toward infinity
-        Zero // Toward zero
-    }
-
-    /**
-     * @dev Returns the largest of two numbers.
-     */
-    function max(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a > b ? a : b;
-    }
-
-    /**
-     * @dev Returns the smallest of two numbers.
-     */
-    function min(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a < b ? a : b;
-    }
-
-    /**
-     * @dev Returns the average of two numbers. The result is rounded towards
-     * zero.
-     */
-    function average(uint256 a, uint256 b) internal pure returns (uint256) {
-        // (a + b) / 2 can overflow.
-        return (a & b) + (a ^ b) / 2;
-    }
-
-    /**
-     * @dev Returns the ceiling of the division of two numbers.
-     *
-     * This differs from standard division with `/` in that it rounds up instead
-     * of rounding down.
-     */
-    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
-        // (a + b - 1) / b can overflow on addition, so we distribute.
-        return a == 0 ? 0 : (a - 1) / b + 1;
-    }
-
-    /**
-     * @notice Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
-     * @dev Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv)
-     * with further edits by Uniswap Labs also under MIT license.
-     */
-    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {
-        unchecked {
-            // 512-bit multiply [prod1 prod0] = x * y. Compute the product mod 2^256 and mod 2^256 - 1, then use
-            // use the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256
-            // variables such that product = prod1 * 2^256 + prod0.
-            uint256 prod0; // Least significant 256 bits of the product
-            uint256 prod1; // Most significant 256 bits of the product
-            assembly {
-                let mm := mulmod(x, y, not(0))
-                prod0 := mul(x, y)
-                prod1 := sub(sub(mm, prod0), lt(mm, prod0))
-            }
-
-            // Handle non-overflow cases, 256 by 256 division.
-            if (prod1 == 0) {
-                // Solidity will revert if denominator == 0, unlike the div opcode on its own.
-                // The surrounding unchecked block does not change this fact.
-                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.
-                return prod0 / denominator;
-            }
-
-            // Make sure the result is less than 2^256. Also prevents denominator == 0.
-            require(denominator > prod1, "Math: mulDiv overflow");
-
-            ///////////////////////////////////////////////
-            // 512 by 256 division.
-            ///////////////////////////////////////////////
-
-            // Make division exact by subtracting the remainder from [prod1 prod0].
-            uint256 remainder;
-            assembly {
-                // Compute remainder using mulmod.
-                remainder := mulmod(x, y, denominator)
-
-                // Subtract 256 bit number from 512 bit number.
-                prod1 := sub(prod1, gt(remainder, prod0))
-                prod0 := sub(prod0, remainder)
-            }
-
-            // Factor powers of two out of denominator and compute largest power of two divisor of denominator. Always >= 1.
-            // See https://cs.stackexchange.com/q/138556/92363.
-
-            // Does not overflow because the denominator cannot be zero at this stage in the function.
-            uint256 twos = denominator & (~denominator + 1);
-            assembly {
-                // Divide denominator by twos.
-                denominator := div(denominator, twos)
-
-                // Divide [prod1 prod0] by twos.
-                prod0 := div(prod0, twos)
-
-                // Flip twos such that it is 2^256 / twos. If twos is zero, then it becomes one.
-                twos := add(div(sub(0, twos), twos), 1)
-            }
-
-            // Shift in bits from prod1 into prod0.
-            prod0 |= prod1 * twos;
-
-            // Invert denominator mod 2^256. Now that denominator is an odd number, it has an inverse modulo 2^256 such
-            // that denominator * inv = 1 mod 2^256. Compute the inverse by starting with a seed that is correct for
-            // four bits. That is, denominator * inv = 1 mod 2^4.
-            uint256 inverse = (3 * denominator) ^ 2;
-
-            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also works
-            // in modular arithmetic, doubling the correct bits in each step.
-            inverse *= 2 - denominator * inverse; // inverse mod 2^8
-            inverse *= 2 - denominator * inverse; // inverse mod 2^16
-            inverse *= 2 - denominator * inverse; // inverse mod 2^32
-            inverse *= 2 - denominator * inverse; // inverse mod 2^64
-            inverse *= 2 - denominator * inverse; // inverse mod 2^128
-            inverse *= 2 - denominator * inverse; // inverse mod 2^256
-
-            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.
-            // This will give us the correct result modulo 2^256. Since the preconditions guarantee that the outcome is
-            // less than 2^256, this is the final result. We don't need to compute the high bits of the result and prod1
-            // is no longer required.
-            result = prod0 * inverse;
-            return result;
-        }
-    }
-
-    /**
-     * @notice Calculates x * y / denominator with full precision, following the selected rounding direction.
-     */
-    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {
-        uint256 result = mulDiv(x, y, denominator);
-        if (rounding == Rounding.Up && mulmod(x, y, denominator) > 0) {
-            result += 1;
-        }
-        return result;
-    }
-
-    /**
-     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded down.
-     *
-     * Inspired by Henry S. Warren, Jr.'s "Hacker's Delight" (Chapter 11).
-     */
-    function sqrt(uint256 a) internal pure returns (uint256) {
-        if (a == 0) {
-            return 0;
-        }
-
-        // For our first guess, we get the biggest power of 2 which is smaller than the square root of the target.
-        //
-        // We know that the "msb" (most significant bit) of our target number `a` is a power of 2 such that we have
-        // `msb(a) <= a < 2*msb(a)`. This value can be written `msb(a)=2**k` with `k=log2(a)`.
-        //
-        // This can be rewritten `2**log2(a) <= a < 2**(log2(a) + 1)`
-        // → `sqrt(2**k) <= sqrt(a) < sqrt(2**(k+1))`
-        // → `2**(k/2) <= sqrt(a) < 2**((k+1)/2) <= 2**(k/2 + 1)`
-        //
-        // Consequently, `2**(log2(a) / 2)` is a good first approximation of `sqrt(a)` with at least 1 correct bit.
-        uint256 result = 1 << (log2(a) >> 1);
-
-        // At this point `result` is an estimation with one bit of precision. We know the true value is a uint128,
-        // since it is the square root of a uint256. Newton's method converges quadratically (precision doubles at
-        // every iteration). We thus need at most 7 iteration to turn our partial result with one bit of precision
-        // into the expected uint128 result.
-        unchecked {
-            result = (result + a / result) >> 1;
-            result = (result + a / result) >> 1;
-            result = (result + a / result) >> 1;
-            result = (result + a / result) >> 1;
-            result = (result + a / result) >> 1;
-            result = (result + a / result) >> 1;
-            result = (result + a / result) >> 1;
-            return min(result, a / result);
-        }
-    }
-
-    /**
-     * @notice Calculates sqrt(a), following the selected rounding direction.
-     */
-    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {
-        unchecked {
-            uint256 result = sqrt(a);
-            return result + (rounding == Rounding.Up && result * result < a ? 1 : 0);
-        }
-    }
-
-    /**
-     * @dev Return the log in base 2, rounded down, of a positive value.
-     * Returns 0 if given 0.
-     */
-    function log2(uint256 value) internal pure returns (uint256) {
-        uint256 result = 0;
-        unchecked {
-            if (value >> 128 > 0) {
-                value >>= 128;
-                result += 128;
-            }
-            if (value >> 64 > 0) {
-                value >>= 64;
-                result += 64;
-            }
-            if (value >> 32 > 0) {
-                value >>= 32;
-                result += 32;
-            }
-            if (value >> 16 > 0) {
-                value >>= 16;
-                result += 16;
-            }
-            if (value >> 8 > 0) {
-                value >>= 8;
-                result += 8;
-            }
-            if (value >> 4 > 0) {
-                value >>= 4;
-                result += 4;
-            }
-            if (value >> 2 > 0) {
-                value >>= 2;
-                result += 2;
-            }
-            if (value >> 1 > 0) {
-                result += 1;
-            }
-        }
-        return result;
-    }
-
-    /**
-     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.
-     * Returns 0 if given 0.
-     */
-    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {
-        unchecked {
-            uint256 result = log2(value);
-            return result + (rounding == Rounding.Up && 1 << result < value ? 1 : 0);
-        }
-    }
-
-    /**
-     * @dev Return the log in base 10, rounded down, of a positive value.
-     * Returns 0 if given 0.
-     */
-    function log10(uint256 value) internal pure returns (uint256) {
-        uint256 result = 0;
-        unchecked {
-            if (value >= 10 ** 64) {
-                value /= 10 ** 64;
-                result += 64;
-            }
-            if (value >= 10 ** 32) {
-                value /= 10 ** 32;
-                result += 32;
-            }
-            if (value >= 10 ** 16) {
-                value /= 10 ** 16;
-                result += 16;
-            }
-            if (value >= 10 ** 8) {
-                value /= 10 ** 8;
-                result += 8;
-            }
-            if (value >= 10 ** 4) {
-                value /= 10 ** 4;
-                result += 4;
-            }
-            if (value >= 10 ** 2) {
-                value /= 10 ** 2;
-                result += 2;
-            }
-            if (value >= 10 ** 1) {
-                result += 1;
-            }
-        }
-        return result;
-    }
-
-    /**
-     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.
-     * Returns 0 if given 0.
-     */
-    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {
-        unchecked {
-            uint256 result = log10(value);
-            return result + (rounding == Rounding.Up && 10 ** result < value ? 1 : 0);
-        }
-    }
-
-    /**
-     * @dev Return the log in base 256, rounded down, of a positive value.
-     * Returns 0 if given 0.
-     *
-     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.
-     */
-    function log256(uint256 value) internal pure returns (uint256) {
-        uint256 result = 0;
-        unchecked {
-            if (value >> 128 > 0) {
-                value >>= 128;
-                result += 16;
-            }
-            if (value >> 64 > 0) {
-                value >>= 64;
-                result += 8;
-            }
-            if (value >> 32 > 0) {
-                value >>= 32;
-                result += 4;
-            }
-            if (value >> 16 > 0) {
-                value >>= 16;
-                result += 2;
-            }
-            if (value >> 8 > 0) {
-                result += 1;
-            }
-        }
-        return result;
-    }
-
-    /**
-     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.
-     * Returns 0 if given 0.
-     */
-    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {
-        unchecked {
-            uint256 result = log256(value);
-            return result + (rounding == Rounding.Up && 1 << (result << 3) < value ? 1 : 0);
-        }
-    }
-}
-
-// OpenZeppelin Contracts (last updated v4.8.0) (utils/math/SignedMath.sol)
-
-pragma solidity ^0.8.0;
-
-/**
- * @dev Standard signed math utilities missing in the Solidity language.
- */
-library SignedMath {
-    /**
-     * @dev Returns the largest of two signed numbers.
-     */
-    function max(int256 a, int256 b) internal pure returns (int256) {
-        return a > b ? a : b;
-    }
-
-    /**
-     * @dev Returns the smallest of two signed numbers.
-     */
-    function min(int256 a, int256 b) internal pure returns (int256) {
-        return a < b ? a : b;
-    }
-
-    /**
-     * @dev Returns the average of two signed numbers without overflow.
-     * The result is rounded towards zero.
-     */
-    function average(int256 a, int256 b) internal pure returns (int256) {
-        // Formula from the book "Hacker's Delight"
-        int256 x = (a & b) + ((a ^ b) >> 1);
-        return x + (int256(uint256(x) >> 255) & (a ^ b));
-    }
-
-    /**
-     * @dev Returns the absolute unsigned value of a signed value.
-     */
-    function abs(int256 n) internal pure returns (uint256) {
-        unchecked {
-            // must be unchecked in order to support `n = type(int256).min`
-            return uint256(n >= 0 ? n : -n);
-        }
-    }
-}
-
-// OpenZeppelin Contracts (last updated v4.9.0) (utils/Strings.sol)
-
-pragma solidity ^0.8.0;
-
-/**
- * @dev String operations.
- */
-library Strings {
-    bytes16 private constant _SYMBOLS = "0123456789abcdef";
-    uint8 private constant _ADDRESS_LENGTH = 20;
-
-    /**
-     * @dev Converts a `uint256` to its ASCII `string` decimal representation.
-     */
-    function toString(uint256 value) internal pure returns (string memory) {
-        unchecked {
-            uint256 length = Math.log10(value) + 1;
-            string memory buffer = new string(length);
-            uint256 ptr;
-            /// @solidity memory-safe-assembly
-            assembly {
-                ptr := add(buffer, add(32, length))
-            }
-            while (true) {
-                ptr--;
-                /// @solidity memory-safe-assembly
-                assembly {
-                    mstore8(ptr, byte(mod(value, 10), _SYMBOLS))
-                }
-                value /= 10;
-                if (value == 0) break;
-            }
-            return buffer;
-        }
-    }
-
-    /**
-     * @dev Converts a `int256` to its ASCII `string` decimal representation.
-     */
-    function toString(int256 value) internal pure returns (string memory) {
-        return string(abi.encodePacked(value < 0 ? "-" : "", toString(SignedMath.abs(value))));
-    }
-
-    /**
-     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.
-     */
-    function toHexString(uint256 value) internal pure returns (string memory) {
-        unchecked {
-            return toHexString(value, Math.log256(value) + 1);
-        }
-    }
-
-    /**
-     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.
-     */
-    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {
-        bytes memory buffer = new bytes(2 * length + 2);
-        buffer[0] = "0";
-        buffer[1] = "x";
-        for (uint256 i = 2 * length + 1; i > 1; --i) {
-            buffer[i] = _SYMBOLS[value & 0xf];
-            value >>= 4;
-        }
-        require(value == 0, "Strings: hex length insufficient");
-        return string(buffer);
-    }
-
-    /**
-     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal representation.
-     */
-    function toHexString(address addr) internal pure returns (string memory) {
-        return toHexString(uint256(uint160(addr)), _ADDRESS_LENGTH);
-    }
-
-    /**
-     * @dev Returns true if the two strings are equal.
-     */
-    function equal(string memory a, string memory b) internal pure returns (bool) {
-        return keccak256(bytes(a)) == keccak256(bytes(b));
-    }
-}
-
-pragma solidity 0.8.19;
-
-/// @notice Library to assist with calculation methods of the balances, ends, period amounts for a given plan
-/// used by both the Lockup and Vesting Plans
-library TimelockLibrary {
-  function min(uint256 a, uint256 b) internal pure returns (uint256 _min) {
-    _min = (a <= b) ? a : b;
-  }
-
-  /// @notice function to calculate the end date of a plan based on its start, amount, rate and period
-  function endDate(uint256 start, uint256 amount, uint256 rate, uint256 period) internal pure returns (uint256 end) {
-    end = (amount % rate == 0) ? (amount / rate) * period + start : ((amount / rate) * period) + period + start;
-  }
-
-  /// @notice function to calculate the end period and validate that the parameters passed in are valid
-  function validateEnd(
-    uint256 start,
-    uint256 cliff,
-    uint256 amount,
-    uint256 rate,
-    uint256 period
-  ) internal pure returns (uint256 end, bool valid) {
-    require(amount > 0, '0_amount');
-    require(rate > 0, '0_rate');
-    require(rate <= amount, 'rate > amount');
-    require(period > 0, '0_period');
-    end = (amount % rate == 0) ? (amount / rate) * period + start : ((amount / rate) * period) + period + start;
-    require(cliff <= end, 'cliff > end');
-    valid = true;
-  }
-
-  /// @notice function to calculate the unlocked (claimable) balance, still locked balance, and the most recent timestamp the unlock would take place
-  /// the most recent unlock time is based on the periods, so if the periods are 1, then the unlock time will be the same as the redemption time,
-  /// however if the period more than 1 second, the latest unlock will be a discrete time stamp
-  /// @param start is the start time of the plan
-  /// @param cliffDate is the timestamp of the cliff of the plan
-  /// @param amount is the total unclaimed amount tokens still in the vesting plan
-  /// @param rate is the amount of tokens that unlock per period
-  /// @param period is the seconds in each period, a 1 is a period of 1 second whereby tokens unlock every second
-  /// @param currentTime is the current time being evaluated, typically the block.timestamp, but used just to check the plan is past the start or cliff
-  /// @param redemptionTime is the time requested for the plan to be redeemed, this can be the same as the current time or prior to it for partial redemptions
-  function balanceAtTime(
-    uint256 start,
-    uint256 cliffDate,
-    uint256 amount,
-    uint256 rate,
-    uint256 period,
-    uint256 currentTime,
-    uint256 redemptionTime
-  ) internal pure returns (uint256 unlockedBalance, uint256 lockedBalance, uint256 unlockTime) {
-    if (start > currentTime || cliffDate > currentTime || redemptionTime <= start) {
-      lockedBalance = amount;
-      unlockTime = start;
-    } else {
-      uint256 periodsElapsed = (redemptionTime - start) / period;
-      uint256 calculatedBalance = periodsElapsed * rate;
-      unlockedBalance = min(calculatedBalance, amount);
-      lockedBalance = amount - unlockedBalance;
-      unlockTime = start + (period * periodsElapsed);
-    }
-  }
-
-  function calculateCombinedRate(
-    uint256 combinedAmount,
-    uint256 combinedRates,
-    uint256 start,
-    uint256 period,
-    uint256 targetEnd
-  ) internal pure returns (uint256 rate, uint256 end) {
-    uint256 numerator = combinedAmount * period;
-    uint256 denominator = (combinedAmount % combinedRates == 0) ? targetEnd - start : targetEnd - start - period;
-    rate = numerator / denominator;
-    end = endDate(start, combinedAmount, rate, period);
-  }
-
-  function calculateSegmentRates(
-    uint256 originalRate,
-    uint256 originalAmount,
-    uint256 planAmount,
-    uint256 segmentAmount,
-    uint256 start,
-    uint256 end,
-    uint256 period,
-    uint256 cliff
-  ) internal pure returns (uint256 planRate, uint256 segmentRate, uint256 planEnd, uint256 segmentEnd) {
-    planRate = (originalRate * ((planAmount * (10 ** 18)) / originalAmount)) / (10 ** 18);
-    segmentRate = (segmentAmount % (originalRate - planRate) == 0)
-      ? (segmentAmount * period) / (end - start)
-      : (segmentAmount * period) / (end - start - period);
-    bool validPlanEnd;
-    bool validSegmentEnd;
-    (planEnd, validPlanEnd) = validateEnd(start, cliff, planAmount, planRate, period);
-    (segmentEnd, validSegmentEnd) = validateEnd(start, cliff, segmentAmount, segmentRate, period);
-    require(validPlanEnd && validSegmentEnd, 'invalid end date');
-  }
-}
-
-pragma solidity 0.8.19;
-
-/// @notice Library to help safely transfer tokens and handle ETH wrapping and unwrapping of WETH
-library TransferHelper {
-  using SafeERC20 for IERC20;
-
-  /// @notice Internal function used for standard ERC20 transferFrom method
-  /// @notice it contains a pre and post balance check
-  /// @notice as well as a check on the msg.senders balance
-  /// @param token is the address of the ERC20 being transferred
-  /// @param from is the remitting address
-  /// @param to is the location where they are being delivered
-  function transferTokens(
-    address token,
-    address from,
-    address to,
-    uint256 amount
-  ) internal {
-    uint256 priorBalance = IERC20(token).balanceOf(address(to));
-    require(IERC20(token).balanceOf(from) >= amount, 'THL01');
-    SafeERC20.safeTransferFrom(IERC20(token), from, to, amount);
-    uint256 postBalance = IERC20(token).balanceOf(address(to));
-    require(postBalance - priorBalance == amount, 'THL02');
-  }
-
-  /// @notice Internal function is used with standard ERC20 transfer method
-  /// @notice this function ensures that the amount received is the amount sent with pre and post balance checking
-  /// @param token is the ERC20 contract address that is being transferred
-  /// @param to is the address of the recipient
-  /// @param amount is the amount of tokens that are being transferred
-  function withdrawTokens(
-    address token,
-    address to,
-    uint256 amount
-  ) internal {
-    uint256 priorBalance = IERC20(token).balanceOf(address(to));
-    SafeERC20.safeTransfer(IERC20(token), to, amount);
-    uint256 postBalance = IERC20(token).balanceOf(address(to));
-    require(postBalance - priorBalance == amount, 'THL02');
-  }
-
-}
-
-pragma solidity 0.8.19;
-
-/// @notice This contract is the storage contract for the Lockup Plans contracts.
-/// it contains the storage of the lockup plan object (Plan struct), as well as the events that the lockup plan contracts emit
-
-contract LockupStorage {
-  /// @dev the Plan is the storage in a struct of the tokens that are locked and being unlocked
-  /// @param token is the token address being timelocked
-  /// @param amount is the current amount of tokens locked in the lockup plan, both unclaimed unlocked and still locked tokens. This parameter is updated each time tokens are redeemed, reset to the new remaining locked and unclaimed amount
-  /// @param start is the start date when token unlock begins or began. This parameter gets updated each time tokens are redeemed and claimed, reset to the most recent redeem time
-  /// @param cliff is an optional field to add a single cliff date prior to which the tokens cannot be redeemed, this does not change
-  /// @param rate is the amount of tokens that unlock in a period. This parameter is constand for each plan. 
-  /// @param period is the length of time in between each discrete time when tokens unlock. If this is set to 1, then tokens unlocke every second. Otherwise the period is longer to allow for interval lockup plans. 
-  struct Plan {
-    address token;
-    uint256 amount;
-    uint256 start;
-    uint256 cliff;
-    uint256 rate;
-    uint256 period;
-  }
-
-  /// @dev a mapping of the planId to the Plan struct. This is also mapped of the NFT token ID to the Plan struct, as the planId is the NFT token Id. 
-  mapping(uint256 => Plan) public plans;
-
-  /// @dev this stores the original end date of a plan. This is only used when a token is segmented, which sometimes results in a new end that is longer than the original, 
-  /// the original end date is stored for the case of recombining those plans. 
-  mapping(uint256 => uint256) public segmentOriginalEnd;
-
-  ///@notice event emitted when a new lockup plan is created, emits the NFT and planId, as well as all of the info from the plan struct
-  event PlanCreated(
-    uint256 indexed id,
-    address indexed recipient,
-    address indexed token,
-    uint256 amount,
-    uint256 start,
-    uint256 cliff,
-    uint256 end,
-    uint256 rate,
-    uint256 period
-  );
-
-  /// @notice event emitted when a beneficiary redeems some or all of the tokens in their plan. 
-  /// It emits the id of the plan, as well as the amount redeemed, any remaining unvested or unclaimed tokens and the date that was the effective new start date, the reset date
-  event PlanRedeemed(uint256 indexed id, uint256 amountRedeemed, uint256 planRemainder, uint256 resetDate);
-
-  /// @notice this event is emitted when a plan owner segments a plan into a new plan. The event spits out all of the details that have changed for the original plan and the new segmented plan
-  event PlanSegmented(
-    uint256 indexed id,
-    uint256 indexed segmentId,
-    uint256 newPlanAmount,
-    uint256 newPlanRate,
-    uint256 segmentAmount,
-    uint256 segmentRate,
-    uint256 start,
-    uint256 cliff,
-    uint256 period,
-    uint256 newPlanEnd,
-    uint256 segmentEnd
-  );
-
-  /// @notice this event is emitted when two plans with the same parameters are combined, it emits the two combined plans ids, the surviving plan id, and the details of the surviving plan
-  event PlansCombined(
-    uint256 indexed id0,
-    uint256 indexed id1,
-    uint256 indexed survivingId,
-    uint256 amount,
-    uint256 rate,
-    uint256 start,
-    uint256 cliff,
-    uint256 period,
-    uint256 end
-  );
-
-  /// @notice public function to get the balance of a plan, this function is used by the contracts to calculate how much can be redeemed, and how to reset the start date
-  /// @param planId is the NFT token ID and plan Id
-  /// @param timeStamp is the effective current time stamp, can be polled for the future for estimating redeemable tokens
-  /// @param redemptionTime is the time of the request that the user is attemptint to redeem tokens, which can be prior to the timeStamp, though not beyond it.
-  function planBalanceOf(
-    uint256 planId,
-    uint256 timeStamp,
-    uint256 redemptionTime
-  ) public view returns (uint256 balance, uint256 remainder, uint256 latestUnlock) {
-    Plan memory plan = plans[planId];
-    (balance, remainder, latestUnlock) = TimelockLibrary.balanceAtTime(
-      plan.start,
-      plan.cliff,
-      plan.amount,
-      plan.rate,
-      plan.period,
-      timeStamp,
-      redemptionTime
-    );
-  }
-
-  /// @dev function to calculate the end date in seconds of a given vesting plan
-  /// @param planId is the NFT token ID
-  function planEnd(uint256 planId) external view returns (uint256 end) {
-    Plan memory plan = plans[planId];
-    end = TimelockLibrary.endDate(plan.start, plan.amount, plan.rate, plan.period);
-  }
-}
-
-pragma solidity 0.8.19;
 
 abstract contract PlanDelegator is ERC721Enumerable {
-  // mapping of tokenId to address who can delegate an NFT on behalf of the owner
-  /// @dev follows tokenApprovals logic
-  mapping(uint256 => address) private _approvedDelegators;
+    // mapping of tokenId to address who can delegate an NFT on behalf of the owner
+    /// @dev follows tokenApprovals logic
+    mapping(uint256 => address) private _approvedDelegators;
 
-  /// @dev operatorApprovals simialr to ERC721 standards
-  mapping(address => mapping(address => bool)) private _approvedOperatorDelegators;
+    /// @dev operatorApprovals simialr to ERC721 standards
+    mapping(address => mapping(address => bool))
+        private _approvedOperatorDelegators;
 
-  /// @dev event that is emitted when a single plan delegator has been approved
-  event DelegatorApproved(uint256 indexed id, address owner, address delegator);
-
-  /// @dev event emit when the operator delegator has been approved to manage all delegation of a single address
-  event ApprovalForAllDelegation(address owner, address operator, bool approved);
-
-  /// @notice function to assign a single planId to a delegator. The delegator then has authority to call functions on other contracts such as delegate
-  /// @param delegator is the address of the delegator who can delegate on behalf of the nft owner
-  /// @param planId is the id of the vesting or lockup plan
-  function approveDelegator(address delegator, uint256 planId) public virtual {
-    address owner = ownerOf(planId);
-    require(msg.sender == owner || isApprovedForAllDelegation(owner, msg.sender), '!ownerOperator');
-    require(delegator != msg.sender, '!self approval');
-    _approveDelegator(delegator, planId);
-  }
-
-  /// @notice function that performs both the approveDelegator function and approves a spender
-  /// @param spender is the address who is approved to spend and is also a Delegator
-  /// @param planId is the vesting plan id
-  function approveSpenderDelegator(address spender, uint256 planId) public virtual {
-    address owner = ownerOf(planId);
-    require(
-      msg.sender == owner || (isApprovedForAllDelegation(owner, msg.sender) && isApprovedForAll(owner, msg.sender)),
-      '!ownerOperator'
+    /// @dev event that is emitted when a single plan delegator has been approved
+    event DelegatorApproved(
+        uint256 indexed id,
+        address owner,
+        address delegator
     );
-    require(spender != msg.sender, '!self approval');
-    _approveDelegator(spender, planId);
-    _approve(spender, planId);
-  }
 
-  /// @notice this function sets an address to be an operator delegator for the msg.sender, whereby the operator can delegate all tokens owned by the msg.sender
-  /// the operator can also approve other single plan delegators
-  /// @param operator address of the operator for the msg.sender
-  /// @param approved boolean for approved if true, and false if not
-  function setApprovalForAllDelegation(address operator, bool approved) public virtual {
-    _setApprovalForAllDelegation(msg.sender, operator, approved);
-  }
+    /// @dev event emit when the operator delegator has been approved to manage all delegation of a single address
+    event ApprovalForAllDelegation(
+        address owner,
+        address operator,
+        bool approved
+    );
 
-  /// @notice functeion to set the approval operator for both delegation and for spending NFTs of the msg.sender
-  /// @param operator is the address who will be allowed to spend and delegate
-  /// @param approved is the bool determining if they are allowed or not
-  function setApprovalForOperator(address operator, bool approved) public virtual {
-    _setApprovalForAllDelegation(msg.sender, operator, approved);
-    _setApprovalForAll(msg.sender, operator, approved);
-  }
+    /// @notice function to assign a single planId to a delegator. The delegator then has authority to call functions on other contracts such as delegate
+    /// @param delegator is the address of the delegator who can delegate on behalf of the nft owner
+    /// @param planId is the id of the vesting or lockup plan
+    function approveDelegator(
+        address delegator,
+        uint256 planId
+    ) public virtual {
+        address owner = ownerOf(planId);
+        require(
+            msg.sender == owner ||
+                isApprovedForAllDelegation(owner, msg.sender),
+            "!ownerOperator"
+        );
+        require(delegator != msg.sender, "!self approval");
+        _approveDelegator(delegator, planId);
+    }
 
-  /// @notice internal function to update the storage of approvedDelegators and emit the event
-  function _approveDelegator(address delegator, uint256 planId) internal virtual {
-    _approvedDelegators[planId] = delegator;
-    emit DelegatorApproved(planId, ownerOf(planId), delegator);
-  }
+    /// @notice function that performs both the approveDelegator function and approves a spender
+    /// @param spender is the address who is approved to spend and is also a Delegator
+    /// @param planId is the vesting plan id
+    function approveSpenderDelegator(
+        address spender,
+        uint256 planId
+    ) public virtual {
+        address owner = ownerOf(planId);
+        require(
+            msg.sender == owner ||
+                (isApprovedForAllDelegation(owner, msg.sender) &&
+                    isApprovedForAll(owner, msg.sender)),
+            "!ownerOperator"
+        );
+        require(spender != msg.sender, "!self approval");
+        _approveDelegator(spender, planId);
+        _approve(spender, planId);
+    }
 
-  /// @notice internal function to update the storage of approvedOperatorDelegators, and emit the event
-  function _setApprovalForAllDelegation(address owner, address operator, bool approved) internal virtual {
-    require(owner != operator, '!operator');
-    _approvedOperatorDelegators[owner][operator] = approved;
-    emit ApprovalForAllDelegation(owner, operator, approved);
-  }
+    /// @notice this function sets an address to be an operator delegator for the msg.sender, whereby the operator can delegate all tokens owned by the msg.sender
+    /// the operator can also approve other single plan delegators
+    /// @param operator address of the operator for the msg.sender
+    /// @param approved boolean for approved if true, and false if not
+    function setApprovalForAllDelegation(
+        address operator,
+        bool approved
+    ) public virtual {
+        _setApprovalForAllDelegation(msg.sender, operator, approved);
+    }
 
-  /// @notice we call the beforeTokenTransfer hook to delete the approvedDelegators storage variable so that the Delegator approval does not travel with the NFT when transferred
-  function _beforeTokenTransfer(
-    address from,
-    address to,
-    uint256 firstTokenId,
-    uint256 batchSize
-  ) internal virtual override {
-    super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
-    delete _approvedDelegators[firstTokenId];
-  }
+    /// @notice functeion to set the approval operator for both delegation and for spending NFTs of the msg.sender
+    /// @param operator is the address who will be allowed to spend and delegate
+    /// @param approved is the bool determining if they are allowed or not
+    function setApprovalForOperator(
+        address operator,
+        bool approved
+    ) public virtual {
+        _setApprovalForAllDelegation(msg.sender, operator, approved);
+        _setApprovalForAll(msg.sender, operator, approved);
+    }
 
-  /// @notice function to get the approved delegator of a single planId
-  function getApprovedDelegator(uint256 planId) public view returns (address) {
-    _requireMinted(planId);
-    return _approvedDelegators[planId];
-  }
+    /// @notice internal function to update the storage of approvedDelegators and emit the event
+    function _approveDelegator(
+        address delegator,
+        uint256 planId
+    ) internal virtual {
+        _approvedDelegators[planId] = delegator;
+        emit DelegatorApproved(planId, ownerOf(planId), delegator);
+    }
 
-  /// @notice function to evaluate if an operator is approved to manage delegations of an owner address
-  function isApprovedForAllDelegation(address owner, address operator) public view returns (bool) {
-    return _approvedOperatorDelegators[owner][operator];
-  }
+    /// @notice internal function to update the storage of approvedOperatorDelegators, and emit the event
+    function _setApprovalForAllDelegation(
+        address owner,
+        address operator,
+        bool approved
+    ) internal virtual {
+        require(owner != operator, "!operator");
+        _approvedOperatorDelegators[owner][operator] = approved;
+        emit ApprovalForAllDelegation(owner, operator, approved);
+    }
 
-  /// @notice internal view function to determine if a delegator, typically the msg.sender is allowed to delegate a token, based on being either the Owner, Delegator or Operator.
-  function _isApprovedDelegatorOrOwner(address delegator, uint256 planId) internal view returns (bool) {
-    address owner = ownerOf(planId);
-    return (delegator == owner ||
-      isApprovedForAllDelegation(owner, delegator) ||
-      getApprovedDelegator(planId) == delegator);
-  }
+    /// @notice we call the beforeTokenTransfer hook to delete the approvedDelegators storage variable so that the Delegator approval does not travel with the NFT when transferred
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 firstTokenId,
+        uint256 batchSize
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
+        delete _approvedDelegators[firstTokenId];
+    }
+
+    /// @notice function to get the approved delegator of a single planId
+    function getApprovedDelegator(
+        uint256 planId
+    ) public view returns (address) {
+        _requireMinted(planId);
+        return _approvedDelegators[planId];
+    }
+
+    /// @notice function to evaluate if an operator is approved to manage delegations of an owner address
+    function isApprovedForAllDelegation(
+        address owner,
+        address operator
+    ) public view returns (bool) {
+        return _approvedOperatorDelegators[owner][operator];
+    }
+
+    /// @notice internal view function to determine if a delegator, typically the msg.sender is allowed to delegate a token, based on being either the Owner, Delegator or Operator.
+    function _isApprovedDelegatorOrOwner(
+        address delegator,
+        uint256 planId
+    ) internal view returns (bool) {
+        address owner = ownerOf(planId);
+        return (delegator == owner ||
+            isApprovedForAllDelegation(owner, delegator) ||
+            getApprovedDelegator(planId) == delegator);
+    }
 }
 
 pragma solidity 0.8.19;
 
-contract URIAdmin {
-    /// @dev baseURI is the URI directory where the metadata is stored
-  string public baseURI;
-  /// @dev bool to ensure uri has been set before admin can be deleted
-  bool internal uriSet;
-  /// @dev admin for setting the baseURI;
-  address internal uriAdmin;
+/// @title TokenLockupPlans - An efficient way to allocate tokens to beneficiaries that unlock over time
+/// @notice This contract allows people to grant tokens to beneficiaries that unlock over time with the added functionalities;
+/// Owners of unlock plans can manage all of their token unlocks across all of their positions in a single contract.
+/// Each lockup plan is a unique NFT, leveraging the backbone of the ERC721 contract to represent a unique lockup plan
+/// 1. Not-Revokable: plans cannot be revoked, once granted the entire amount will be claimable by the beneficiary over time.
+/// 2. Transferable: Lockup plans can be transferred by the owner - opening up defi opportunities like NFT sales, borrowing and lending, and many others.
+/// 3. Governance optimized for on-chain voting: These are built to allow beneficiaries to vote with their unvested tokens on chain with the standard ERC20Votes contract, as well as on snapshot
+/// 4. Beneficiary Claims: Beneficiaries get to choose when to claim their tokens, and can claim partial amounts that are less than the amount they have unlocked for tax optimization
+/// 5. Segmenting plans: Beneficiaries can segment a single lockup into  smaller chunks for subdelegation of tokens, or to use in defi with smaller chunks
+/// 6. Combingin Plans: Beneficiaries can combine plans that have the same details in one larger chunk for easier bulk management
+contract VotingTokenLockupPlans is
+    PlanDelegator,
+    LockupStorage,
+    ReentrancyGuard,
+    URIAdmin
+{
+    /// @notice uses counters for incrementing token IDs which are the planIds
+    using Counters for Counters.Counter;
+    Counters.Counter private _planIds;
 
-  /// @notice event for when a new URI is set for the NFT metadata linking
-  event URISet(string newURI);
+    /// @dev Voting Vaults are external contracts that hold tokens for a lockup plan allowing an owner to delegate their tokens for on-chain governance
+    /// the lockup plan ID is mapped to the votingVault address so that it is one to one and unique to the NFT
+    mapping(uint256 => address) public votingVaults;
 
-  /// @notice event for when the URI admin is deleted
-  event URIAdminDeleted(address _admin);
+    /// @notice event emitted when a new voting vault is generated and setup
+    event VotingVaultCreated(uint256 indexed id, address vaultAddress);
 
-
-  /// @notice function to set the base URI after the contract has been launched, only the admin can call
-  /// @param _uri is the new baseURI for the metadata
-  function updateBaseURI(string memory _uri) external {
-    require(msg.sender == uriAdmin, '!ADMIN');
-    baseURI = _uri;
-    uriSet = true;
-    emit URISet(_uri);
-  }
-
-  /// @notice function to delete the admin once the uri has been set
-  function deleteAdmin() external {
-    require(msg.sender == uriAdmin, '!ADMIN');
-    require(uriSet, '!SET');
-    delete uriAdmin;
-    emit URIAdminDeleted(msg.sender);
-  }
-}
-
-pragma solidity 0.8.19;
-
-
-interface IGovernanceToken {
-    function delegate(address delegatee) external;
-    function delegates(address wallet) external view returns (address delegate);
-}
-
-contract VotingVault {
-
-    address public token;
-    address public controller;
-
-    constructor(address _token, address beneficiary) {
-        controller = msg.sender;
-        token = _token;
-        address existingDelegate = IGovernanceToken(token).delegates(beneficiary);
-        if(existingDelegate != address(0)) IGovernanceToken(token).delegate(existingDelegate);
-        else IGovernanceToken(token).delegate(beneficiary);
+    constructor(string memory name, string memory symbol) ERC721(name, symbol) {
+        uriAdmin = msg.sender;
     }
 
-    modifier onlyController() {
-        require(msg.sender == controller);
-        _;
+    function _baseURI() internal view override returns (string memory) {
+        return baseURI;
     }
 
-    function delegateTokens(address delegatee) external onlyController {
-        uint256 balanceCheck = IERC20(token).balanceOf(address(this));
-        IGovernanceToken(token).delegate(delegatee);
-        // check to make sure delegate function is not malicious
-        require(balanceCheck == IERC20(token).balanceOf(address(this)), 'balance error');
+    /****CORE EXTERNAL FUNCTIONS*********************************************************************************************************************************************/
+
+    /// @notice function to create a lockup plan.
+    /// @dev this function will pull the tokens into this contract for escrow, increment the planIds, mint an NFT to the recipient, and create the storage Plan and map it to the newly minted NFT token ID in storage
+    /// @param recipient the address of the recipient and beneficiary of the plan
+    /// @param token the address of the ERC20 token
+    /// @param amount the amount of tokens to be locked in the plan
+    /// @param start the start date of the lockup plan, unix time
+    /// @param cliff a cliff date which is a discrete date where tokens are not unlocked until this date, and then vest in a large single chunk on the cliff date
+    /// @param rate the amount of tokens that vest in a single period
+    /// @param period the amount of time in between each unlock time stamp, in seconds. A period of 1 means that tokens vest every second in a 'streaming' style.
+    function createPlan(
+        address recipient,
+        address token,
+        uint256 amount,
+        uint256 start,
+        uint256 cliff,
+        uint256 rate,
+        uint256 period
+    ) external nonReentrant returns (uint256 newPlanId) {
+        require(recipient != address(0), "0_recipient");
+        require(token != address(0), "0_token");
+        (uint256 end, bool valid) = TimelockLibrary.validateEnd(
+            start,
+            cliff,
+            amount,
+            rate,
+            period
+        );
+        require(valid);
+        _planIds.increment();
+        newPlanId = _planIds.current();
+        TransferHelper.transferTokens(token, msg.sender, address(this), amount);
+        plans[newPlanId] = Plan(token, amount, start, cliff, rate, period);
+        _safeMint(recipient, newPlanId);
+        emit PlanCreated(
+            newPlanId,
+            recipient,
+            token,
+            amount,
+            start,
+            cliff,
+            end,
+            rate,
+            period
+        );
     }
 
-    function withdrawTokens(address to, uint256 amount) external onlyController {
-        TransferHelper.withdrawTokens(token, to, amount);
-        if (IERC20(token).balanceOf(address(this)) == 0) {
-            delete token;
-            delete controller;
+    /// @notice function for a beneficiary to redeem unlocked tokens from a group of plans
+    /// @dev this will call an internal function for processing the actual redemption of tokens, which will withdraw unlocked tokens and deliver them to the beneficiary
+    /// @dev this function will redeem all claimable and unlocked tokens up to the current block.timestamp
+    /// @param planIds is the array of the NFT planIds that are to be redeemed. If any have no redeemable balance they will be skipped.
+    function redeemPlans(uint256[] calldata planIds) external nonReentrant {
+        _redeemPlans(planIds, block.timestamp);
+    }
+
+    /// @notice function for a beneficiary to redeem unlocked tokens from a group of plans
+    /// @dev this will call an internal function for processing the actual redemption of tokens, which will withdraw unlocked tokens and deliver them to the beneficiary
+    /// @dev this function will redeem only a partial amount of tokens based on a redemption timestamp that is in the past. This allows holders to redeem less than their fully unlocked amount for various reasons
+    /// @param planIds is the array of the NFT planIds that are to be redeemed. If any have no redeemable balance they will be skipped.
+    /// @param redemptionTime is the timestamp which will calculate the amount of tokens redeemable and redeem them based on that timestamp
+    function partialRedeemPlans(
+        uint256[] calldata planIds,
+        uint256 redemptionTime
+    ) external nonReentrant {
+        require(redemptionTime < block.timestamp, "!future");
+        _redeemPlans(planIds, redemptionTime);
+    }
+
+    /// @notice this function will redeem all plans owned by a single wallet - useful for custodians or other intermeidaries that do not have the ability to lookup individual planIds
+    /// @dev this will iterate through all of the plans owned by the wallet based on the ERC721Enumerable backbone, and redeem each one with a redemption time of the current block.timestamp
+    function redeemAllPlans() external nonReentrant {
+        uint256 balance = balanceOf(msg.sender);
+        uint256[] memory planIds = new uint256[](balance);
+        for (uint256 i; i < balance; i++) {
+            uint256 planId = tokenOfOwnerByIndex(msg.sender, i);
+            planIds[i] = planId;
+        }
+        _redeemPlans(planIds, block.timestamp);
+    }
+
+    /// @notice function for an owner of a lockup plan to segment a single plan into multiple chunks; segments.
+    /// @dev the single plan can be divided up into many segments in this transaction, but care must be taken to ensure that the array is processed in a proper order
+    /// if the tokens are send in the wrong order the function will revert becuase the amount of the segment could be larger than the original plan.
+    /// this function iterates through the segment amounts and breaks up the same original plan into smaller sizes
+    /// each time a segment happens it is always with the single planId, which will generate a new NFT for each new segment, and the original plan is updated in storage
+    /// the original plan amount newPlanAmount + segmentAmount && original plan Rate = newPlanRate + segmentRate
+    /// IF The plan that is being segmented has a voting vault setup, it will generate a new voting vault for the segmented tokens, however it will not delegate those
+    /// @dev Segmenting plans where the segment amount is not divisible by the rate will result in a new End date that is 1 period farther than the original plan
+    /// @param planId is the plan that is going to be segmented
+    /// @param segmentAmounts is the array of amounts of each individual segment, which must each be smaller than the plan when it is being segmented.
+    function segmentPlan(
+        uint256 planId,
+        uint256[] memory segmentAmounts
+    ) external nonReentrant returns (uint256[] memory newPlanIds) {
+        newPlanIds = new uint256[](segmentAmounts.length);
+        for (uint256 i; i < segmentAmounts.length; i++) {
+            uint256 newPlanId = _segmentPlan(planId, segmentAmounts[i]);
+            newPlanIds[i] = newPlanId;
         }
     }
 
+    /// @notice this function combines the functionality of segmenting plans and then immediately delegating the new semgent plans to a delegate address
+    /// @dev this function does NOT delegate the original planId at all, it will only delegate the newly create segments
+    /// if the plan has a Voting Vault, it will create a new voting vault for each segment, and then delegate the tokens in the voting vault to the delegatee address
+    /// @param planId is the plan that will be segmented (and not delegated)
+    /// @param segmentAmounts is the array of each segment amount
+    /// @param delegatees is the array of delegatees that each new segment will be delegated to
+    function segmentAndDelegatePlans(
+        uint256 planId,
+        uint256[] memory segmentAmounts,
+        address[] memory delegatees
+    ) external nonReentrant returns (uint256[] memory newPlanIds) {
+        require(segmentAmounts.length == delegatees.length, "!length");
+        newPlanIds = new uint256[](segmentAmounts.length);
+        for (uint256 i; i < segmentAmounts.length; i++) {
+            uint256 newPlanId = _segmentPlan(planId, segmentAmounts[i]);
+            _delegate(newPlanId, delegatees[i]);
+            newPlanIds[i] = newPlanId;
+        }
+    }
+
+    /// @notice this function allows a beneficiary of two plans that share the same details to combine them into a single surviving plan
+    /// @dev the plans must have the same details except the amount and rate, but must share the same end date to be combined
+    /// if one of the plans has a voting vault, that plan will be the surviving plan and all tokens will be transferred to the surviving plan voting vault
+    /// @param planId0 is the planId of a first plan to be combined
+    /// @param planId1 is the planId of a second plan to be combined
+    function combinePlans(
+        uint256 planId0,
+        uint256 planId1
+    ) external nonReentrant returns (uint256 survivingPlanId) {
+        survivingPlanId = _combinePlans(planId0, planId1);
+    }
+
+    /****EXTERNAL VOTING FUNCTIONS*********************************************************************************************************************************************/
+    /// @notice functions for the owners of lockup plans to setup on chain voting vaults, and then delegate those tokens.
+    /// these are explicity for tokens that are of the ERC20Votes format, which have a delegate and delegates function.
+    /// tokens that do not have the standard delegate and delegates functionality for on-chain voting will revert when delegating or creating onchain voting vaults.
+
+    /// @notice function to setup a voting vault, this calls an internal voting function to set it up
+    // this will physically transfer tokens to the new voting vault contract once deployed
+    /// @param planId is the id of the lockup plan and NFT
+    function setupVoting(
+        uint256 planId
+    ) external nonReentrant returns (address votingVault) {
+        votingVault = _setupVoting(planId);
+    }
+
+    /// @notice function for an owner of a lockup plan to delegate a single lockup plan to  single delegate
+    /// @dev this will call an internal delegate function for processing
+    /// if there is no voting vault setup, this function will automatically create a voting vault and then delegate the tokens to the delegatee
+    /// @param planId is the id of the lockup plan and NFT
+    function delegate(uint256 planId, address delegatee) external nonReentrant {
+        _delegate(planId, delegatee);
+    }
+
+    /// @notice this function allows an owner of multiple lockup plans to delegate multiple of them in a single transaction, each planId corresponding to a delegatee address
+    /// @param planIds is the ids of the lockup plan and NFT
+    /// @param delegatees is the array of addresses where each lockup plan will delegate the tokens to
+    function delegatePlans(
+        uint256[] calldata planIds,
+        address[] calldata delegatees
+    ) external nonReentrant {
+        require(planIds.length == delegatees.length, "array error");
+        for (uint256 i; i < planIds.length; i++) {
+            _delegate(planIds[i], delegatees[i]);
+        }
+    }
+
+    /// @notice this function lets an owner delegate all of their lockup plans for a single token to a single delegatee
+    /// @dev this function will iterate through all of the owned lockup plans of the msg.sender, and if the token address matches the lockup plan token address, it will delegate that plan
+    /// @param token is the ERC20Votes token address of the tokens in the lockup plans
+    /// @param delegatee is the address of the delegate that the beneficiary is delegating their tokens to
+    function delegateAll(
+        address token,
+        address delegatee
+    ) external nonReentrant {
+        uint256 balance = balanceOf(msg.sender);
+        for (uint256 i; i < balance; i++) {
+            uint256 planId = tokenOfOwnerByIndex(msg.sender, i);
+            if (plans[planId].token == token) _delegate(planId, delegatee);
+        }
+    }
+
+    function transferAndDelegate(
+        uint256 planId,
+        address from,
+        address to
+    ) external virtual nonReentrant {
+        safeTransferFrom(from, to, planId);
+        _delegate(planId, to);
+    }
+
+    /****CORE INTERNAL FUNCTIONS*********************************************************************************************************************************************/
+
+    /// @notice function that will intake an array of planIds and a redemption time, and then check the balances that are available to be redeemed
+    /// @dev if the nft has an available balance, it is then passed on to the _redeemPlan function for further processing
+    /// if there is no balance to be redeemed, the plan is skipped from being processed
+    /// @param planIds is the array of plans to be redeemed
+    /// @param redemptionTime is the requested redemption time, either the current block.timestamp or a timestamp from the past, but must be greater than the start date
+    function _redeemPlans(
+        uint256[] memory planIds,
+        uint256 redemptionTime
+    ) internal {
+        for (uint256 i; i < planIds.length; i++) {
+            (
+                uint256 balance,
+                uint256 remainder,
+                uint256 latestUnlock
+            ) = planBalanceOf(planIds[i], block.timestamp, redemptionTime);
+            if (balance > 0)
+                _redeemPlan(planIds[i], balance, remainder, latestUnlock);
+        }
+    }
+
+    /// @notice internal function that process the redemption for a single lockup plan
+    /// @dev this takes the inputs from the _redeemPlans and processes the redemption delivering the available balance of redeemable tokens to the beneficiary
+    /// if the plan has a voting vault then tokens will be redeemed and transferred from the voting vault to the beneficiary.
+    /// if the plan is fully redeemed, as defined that the balance == amount, then the plan is deleted and NFT burned
+    // if the plan is not fully redeemed, then the storage of start and amount are updated to reflect the remaining amount and most recent time redeemed for the new start date
+    /// @param planId is the id of the lockup plan and NFT
+    /// @param balance is the available redeemable balance
+    /// @param remainder is the amount of tokens that are still lcoked in the plan, and will be the new amount in the plan storage
+    /// @param latestUnlock is the most recent timestamp for when redemption occured. Because periods may be longer than 1 second,
+    /// the latestUnlock time may be the current block time, or the timestamp of the most recent period timestamp
+    function _redeemPlan(
+        uint256 planId,
+        uint256 balance,
+        uint256 remainder,
+        uint256 latestUnlock
+    ) internal {
+        require(ownerOf(planId) == msg.sender, "!owner");
+        address token = plans[planId].token;
+        address vault = votingVaults[planId];
+        if (remainder == 0) {
+            delete plans[planId];
+            delete votingVaults[planId];
+            _burn(planId);
+        } else {
+            plans[planId].amount = remainder;
+            plans[planId].start = latestUnlock;
+        }
+        if (vault == address(0)) {
+            TransferHelper.withdrawTokens(token, msg.sender, balance);
+        } else {
+            VotingVault(vault).withdrawTokens(msg.sender, balance);
+        }
+        emit PlanRedeemed(planId, balance, remainder, latestUnlock);
+    }
+
+    /// @notice the internal function for segmenting a single plan into two
+    /// @dev the function takes a plan, performs some checks that the segment amount cannot be 0 and must be strictly less than the original plan amount
+    /// then it will subtract the segmentamount from the original plan amount to get the new plan amount
+    /// then it will get a new pro-rata rate for the newplan based on the new plan amount divided by the original plan amount
+    /// while this pro-rata new rate is not perfect because of unitization (ie no decimal suppport), the segment rate is calculated by subtracting the new plan rate from the original plan rate
+    /// because the newplan amount and segment amount == original plan amount, and the new plan rate + segment rate == original plan rate, the beneficiary will still unlock the same number of tokens at approximatley the same rate
+    /// however because of uneven division, the end dates of each of the new rates may be different than the original rate. We check to make sure that the new end is farther than the original end
+    /// so that tokens do not unlock early, and then it is a valid segment.
+    /// finally a new NFT is minted with the Segment plan details
+    /// and the storage of the original plan amount and rate is updated with the newplan amount and rate.
+    /// at the end this checks if there is a voting vault setup for the original plan. If there is a voting vault setup, it will transfer tokens back from the original plan vault,
+    /// then setup a new voting vault for the segment plan, thereby transferring the segment tokens to the new segment voting vault
+    /// @param planId is the id of the lockup plan
+    /// @param segmentAmount is the amount of tokens to be segmented off from the original plan and created into a new segment plan
+    function _segmentPlan(
+        uint256 planId,
+        uint256 segmentAmount
+    ) internal returns (uint256 newPlanId) {
+        require(ownerOf(planId) == msg.sender, "!owner");
+        Plan memory plan = plans[planId];
+        require(segmentAmount < plan.amount, "amount error");
+        require(segmentAmount > 0, "0_segment");
+        uint256 end = TimelockLibrary.endDate(
+            plan.start,
+            plan.amount,
+            plan.rate,
+            plan.period
+        );
+        _planIds.increment();
+        newPlanId = _planIds.current();
+        uint256 planAmount = plan.amount - segmentAmount;
+        (
+            uint256 planRate,
+            uint256 segmentRate,
+            uint256 planEnd,
+            uint256 segmentEnd
+        ) = TimelockLibrary.calculateSegmentRates(
+                plan.rate,
+                plan.amount,
+                planAmount,
+                segmentAmount,
+                plan.start,
+                end,
+                plan.period,
+                plan.cliff
+            );
+        uint256 endCheck = segmentOriginalEnd[planId] == 0
+            ? end
+            : segmentOriginalEnd[planId];
+        require(planEnd >= endCheck, "plan end error");
+        require(segmentEnd >= endCheck, "segmentEnd error");
+        plans[planId].amount = planAmount;
+        plans[planId].rate = planRate;
+        _safeMint(msg.sender, newPlanId);
+        plans[newPlanId] = Plan(
+            plan.token,
+            segmentAmount,
+            plan.start,
+            plan.cliff,
+            segmentRate,
+            plan.period
+        );
+        if (segmentOriginalEnd[planId] == 0) {
+            segmentOriginalEnd[planId] = end;
+            segmentOriginalEnd[newPlanId] = end;
+        } else {
+            segmentOriginalEnd[newPlanId] = segmentOriginalEnd[planId];
+        }
+        if (votingVaults[planId] != address(0)) {
+            VotingVault(votingVaults[planId]).withdrawTokens(
+                address(this),
+                segmentAmount
+            );
+            _setupVoting(newPlanId);
+        }
+        emit PlanSegmented(
+            planId,
+            newPlanId,
+            planAmount,
+            planRate,
+            segmentAmount,
+            segmentRate,
+            plan.start,
+            plan.cliff,
+            plan.period,
+            planEnd,
+            segmentEnd
+        );
+    }
+
+    /// @notice this funtion allows the holder of two plans that have the same parameters to combine them into a single surviving plan
+    /// @dev all of the details of the plans must be the same except the amounts and rates may be different
+    /// this function will check that the owners are the same, the ERC20 tokens are the same, the start, cliff and periods are the same.
+    /// then it performs some checks on the end dates to ensure that either the end dates are the same, or if the user is combining previously segmented plans,
+    /// that the original end dates of those segments are the same.
+    /// if everything checks out, and the new end date of the combined plan will result in an end date equal to or later than the two plans, then they can be combined
+    /// combining plans will delete the plan1 and burn the NFT related to it
+    /// and then update the storage of the plan0 with the combined amount and combined rate
+    /// if One of the plans has a voting vault, then that plan will be the survivor and then tokens will be transferred and consolidated into that plan
+    /// if both have a voting vault, then plan0 will be the survivor and tokens consolidated to plan0 voting vault
+    /// if neither have a voting vault then nothing is done for voting vaults.
+    /// @param planId0 is the planId of the first plan in the combination
+    /// @param planId1 is the planId of a second plan to be combined
+    function _combinePlans(
+        uint256 planId0,
+        uint256 planId1
+    ) internal returns (uint256 survivingPlan) {
+        require(ownerOf(planId0) == msg.sender, "!owner");
+        require(ownerOf(planId1) == msg.sender, "!owner");
+        Plan memory plan0 = plans[planId0];
+        Plan memory plan1 = plans[planId1];
+        require(plan0.token == plan1.token, "token error");
+        require(plan0.start == plan1.start, "start error");
+        require(plan0.cliff == plan1.cliff, "cliff error");
+        require(plan0.period == plan1.period, "period error");
+        uint256 plan0End = TimelockLibrary.endDate(
+            plan0.start,
+            plan0.amount,
+            plan0.rate,
+            plan0.period
+        );
+        uint256 plan1End = TimelockLibrary.endDate(
+            plan1.start,
+            plan1.amount,
+            plan1.rate,
+            plan1.period
+        );
+        require(
+            plan0End == plan1End ||
+                (segmentOriginalEnd[planId0] == segmentOriginalEnd[planId1] &&
+                    segmentOriginalEnd[planId0] != 0),
+            "end error"
+        );
+        address vault0 = votingVaults[planId0];
+        address vault1 = votingVaults[planId1];
+        survivingPlan = planId0;
+        if (vault0 != address(0)) {
+            plans[planId0].amount += plans[planId1].amount;
+            (uint256 survivorRate, uint256 survivorEnd) = TimelockLibrary
+                .calculateCombinedRate(
+                    plan0.amount + plan1.amount,
+                    plan0.rate + plan1.rate,
+                    plan0.start,
+                    plan0.period,
+                    plan0End
+                );
+            plans[planId0].rate = survivorRate;
+            if (survivorEnd < plan0End) {
+                require(
+                    survivorEnd == segmentOriginalEnd[planId0] ||
+                        survivorEnd == segmentOriginalEnd[planId1],
+                    "original end error"
+                );
+            }
+            if (vault1 != address(0)) {
+                VotingVault(vault1).withdrawTokens(vault0, plan1.amount);
+            } else {
+                TransferHelper.withdrawTokens(
+                    plan0.token,
+                    vault0,
+                    plan1.amount
+                );
+            }
+            delete plans[planId1];
+            _burn(planId1);
+            emit PlansCombined(
+                planId0,
+                planId1,
+                survivingPlan,
+                plans[planId0].amount,
+                plans[planId0].rate,
+                plan0.start,
+                plan0.cliff,
+                plan0.period,
+                survivorEnd
+            );
+        } else if (vault1 != address(0)) {
+            plans[planId1].amount += plans[planId0].amount;
+            (uint256 survivorRate, uint256 survivorEnd) = TimelockLibrary
+                .calculateCombinedRate(
+                    plan0.amount + plan1.amount,
+                    plan0.rate + plan1.rate,
+                    plan1.start,
+                    plan1.period,
+                    plan1End
+                );
+            plans[planId1].rate = survivorRate;
+            if (survivorEnd < plan1End) {
+                require(
+                    survivorEnd == segmentOriginalEnd[planId0] ||
+                        survivorEnd == segmentOriginalEnd[planId1],
+                    "original end error"
+                );
+            }
+            TransferHelper.withdrawTokens(plan0.token, vault1, plan0.amount);
+            survivingPlan = planId1;
+            delete plans[planId0];
+            _burn(planId0);
+            emit PlansCombined(
+                planId0,
+                planId1,
+                survivingPlan,
+                plans[planId1].amount,
+                plans[planId1].rate,
+                plan1.start,
+                plan1.cliff,
+                plan1.period,
+                survivorEnd
+            );
+        } else {
+            plans[planId0].amount += plans[planId1].amount;
+            (uint256 survivorRate, uint256 survivorEnd) = TimelockLibrary
+                .calculateCombinedRate(
+                    plan0.amount + plan1.amount,
+                    plan0.rate + plan1.rate,
+                    plan0.start,
+                    plan0.period,
+                    plan0End
+                );
+            plans[planId0].rate = survivorRate;
+            if (survivorEnd < plan0End) {
+                require(
+                    survivorEnd == segmentOriginalEnd[planId0] ||
+                        survivorEnd == segmentOriginalEnd[planId1],
+                    "original end error"
+                );
+            }
+            delete plans[planId1];
+            _burn(planId1);
+            emit PlansCombined(
+                planId0,
+                planId1,
+                survivingPlan,
+                plans[planId0].amount,
+                plans[planId0].rate,
+                plan0.start,
+                plan0.cliff,
+                plan0.period,
+                survivorEnd
+            );
+        }
+    }
+
+    /****INTERNAL VOTING & DELEGATION FUNCTIONS*********************************************************************************************************************************************/
+
+    /// @notice the internal function to setup a voting vault.
+    /// @dev this will check that no voting vault exists already and then deploy a new voting vault contract
+    // during the constructor setup of the voting vault, it will auto delegate the voting vault address to whatever the existing delegate of the  plan holder has delegated to
+    // if it has not delegated yet, it will self-delegate the tokens
+    /// then transfer the tokens remaining in the lockup plan to the voting vault physically
+    /// @param planId is the id of the lockup plan and NFT
+    function _setupVoting(uint256 planId) internal returns (address) {
+        require(_isApprovedDelegatorOrOwner(msg.sender, planId), "!delegator");
+        require(votingVaults[planId] == address(0), "exists");
+        Plan memory plan = plans[planId];
+        VotingVault vault = new VotingVault(plan.token, ownerOf(planId));
+        votingVaults[planId] = address(vault);
+        TransferHelper.withdrawTokens(plan.token, address(vault), plan.amount);
+        emit VotingVaultCreated(planId, address(vault));
+        return address(vault);
+    }
+
+    /// @notice this internal function will physically delegate tokens held in a voting vault to a delegatee
+    /// @dev if a voting vautl has not been setup yet, then the function will call the internal _setupVoting function and setup a new voting vault
+    /// and then it will delegate the tokens held in the vault to the delegatee
+    /// @param planId is the id of the lockup plan and NFT
+    /// @param delegatee is the address of the delegatee where the tokens in the voting vault will be delegated to
+    function _delegate(uint256 planId, address delegatee) internal {
+        require(_isApprovedDelegatorOrOwner(msg.sender, planId), "!delegator");
+        address vault = votingVaults[planId];
+        if (votingVaults[planId] == address(0)) {
+            vault = _setupVoting(planId);
+        }
+        VotingVault(vault).delegateTokens(delegatee);
+    }
+
+    /****VIEW VOTING FUNCTIONS*********************************************************************************************************************************************/
+
+    /// @notice this function will pull all of the unclaimed tokens for a specific holder across all of their plans, based on a single ERC20 token
+    /// very useful for snapshot voting, and other view functionalities. This aggregates all balances, including any in voting vaults.
+    /// @param holder is the address of the beneficiary who owns the lockup plan(s)
+    /// @param token is the ERC20 address of the token that is stored across the lockup plans
+    function lockedBalances(
+        address holder,
+        address token
+    ) external view returns (uint256 lockedBalance) {
+        uint256 holdersBalance = balanceOf(holder);
+        for (uint256 i; i < holdersBalance; i++) {
+            uint256 planId = tokenOfOwnerByIndex(holder, i);
+            Plan memory plan = plans[planId];
+            if (token == plan.token) {
+                lockedBalance += plan.amount;
+            }
+        }
+    }
 }

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -51,6 +51,31 @@ interface IPublicSaleV1 {
     error SaleNotEnded();
 
     /**
+     * @notice Thrown when Hedgey vesting amount is zero
+     */
+    error InvalidAmount();
+
+    /**
+     * @notice Thrown when Hedgey vesting rate is zero
+     */
+    error InvalidRate();
+
+    /**
+     * @notice Thrown when Hedgey vesting rate exceeds amount
+     */
+    error RateExceedsAmount();
+
+    /**
+     * @notice Thrown when Hedgey vesting period is zero
+     */
+    error InvalidPeriod();
+
+    /**
+     * @notice Thrown when Hedgey vesting cliff exceeds end time
+     */
+    error CliffExceedsEnd();
+
+    /**
      * @notice Thrown when attempting to settle an already settled account
      */
     error AlreadySettled();
@@ -93,6 +118,24 @@ interface IPublicSaleV1 {
     // --- Structs ---
 
     /**
+     * @notice Parameters for initializing hedgey lockup plan
+     * @param enabled Whether to use hedgey lockup plan
+     * @param start the start date of the lockup plan, unix time
+     * @param cliff a cliff date which is a discrete date where tokens are not unlocked until this date, and then vest in a large single chunk on the cliff date
+     * @param rate the amount of tokens that vest in a single period
+     * @param period the amount of time in between each unlock time stamp, in seconds. A period of 1 means that tokens vest every second in a 'streaming' style.
+     * @param votingTokenLockupPlans the address of the voting token lockup plans contract
+     */
+    struct HedgeyLockupParams {
+        bool enabled;
+        uint256 start;
+        uint256 cliff;
+        uint256 rate;
+        uint256 period;
+        address votingTokenLockupPlans;
+    }
+
+    /**
      * @notice Parameters for initializing the public sale contract
      * @param saleStartTimestamp Unix timestamp when the sale begins
      * @param saleEndTimestamp Unix timestamp when the sale ends
@@ -109,6 +152,7 @@ interface IPublicSaleV1 {
      * @param maximumTotalCommitment Maximum total commitments allowed
      * @param saleTokenPrice Price per sale token in commitment token units (with PRECISION decimals)
      * @param protocolFee Fee percentage taken from proceeds (with PRECISION decimals)
+     * @param hedgeyLockupParams Parameters for initializing hedgey lockup plan
      */
     struct InitializerParams {
         uint48 saleStartTimestamp;
@@ -126,6 +170,7 @@ interface IPublicSaleV1 {
         uint256 maximumTotalCommitment;
         uint256 saleTokenPrice;
         uint256 protocolFee;
+        HedgeyLockupParams hedgeyLockupParams;
     }
 
     // --- Enums ---

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -393,7 +393,10 @@ interface IPublicSaleV1 {
      * @notice Returns the Hedgey lockup rate
      * @return ratePercentage Rate of percentage of tokens that vest per period
      */
-    function hedgeyLockupRatePercentage() external view returns (uint256 ratePercentage);
+    function hedgeyLockupRatePercentage()
+        external
+        view
+        returns (uint256 ratePercentage);
 
     /**
      * @notice Returns the Hedgey lockup period
@@ -405,7 +408,10 @@ interface IPublicSaleV1 {
      * @notice Returns the Hedgey voting token lockup plans contract address
      * @return votingTokenLockupPlans Address of the VotingTokenLockupPlans contract
      */
-    function hedgeyVotingTokenLockupPlans() external view returns (address votingTokenLockupPlans);
+    function hedgeyVotingTokenLockupPlans()
+        external
+        view
+        returns (address votingTokenLockupPlans);
 
     // --- State-Changing Functions ---
 

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -115,11 +115,6 @@ interface IPublicSaleV1 {
      */
     error InvalidCommitmentToken();
 
-    /**
-     * @notice Thrown when using attempting to setup hedgey lockup with native asset as commitment token
-     */
-    error InvalidHedgeyNativeAsset();
-
     // --- Structs ---
 
     /**

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -115,6 +115,11 @@ interface IPublicSaleV1 {
      */
     error InvalidCommitmentToken();
 
+    /**
+     * @notice Thrown when using attempting to setup hedgey lockup with native asset as commitment token
+     */
+    error InvalidHedgeyNativeAsset();
+
     // --- Structs ---
 
     /**
@@ -122,7 +127,7 @@ interface IPublicSaleV1 {
      * @param enabled Whether to use hedgey lockup plan
      * @param start the start date of the lockup plan, unix time
      * @param cliff a cliff date which is a discrete date where tokens are not unlocked until this date, and then vest in a large single chunk on the cliff date
-     * @param rate the amount of tokens that vest in a single period
+     * @param ratePercentage the percentage of the total token amount that vest in a single period
      * @param period the amount of time in between each unlock time stamp, in seconds. A period of 1 means that tokens vest every second in a 'streaming' style.
      * @param votingTokenLockupPlans the address of the voting token lockup plans contract
      */
@@ -130,7 +135,7 @@ interface IPublicSaleV1 {
         bool enabled;
         uint256 start;
         uint256 cliff;
-        uint256 rate;
+        uint256 ratePercentage;
         uint256 period;
         address votingTokenLockupPlans;
     }
@@ -365,6 +370,42 @@ interface IPublicSaleV1 {
      * @return hasSettled True if settled, false otherwise
      */
     function settled(address account_) external view returns (bool hasSettled);
+
+    /**
+     * @notice Returns whether Hedgey lockup is enabled
+     * @return enabled True if Hedgey lockup is enabled, false otherwise
+     */
+    function hedgeyLockupEnabled() external view returns (bool enabled);
+
+    /**
+     * @notice Returns the Hedgey lockup start time
+     * @return start Start time of the lockup plan
+     */
+    function hedgeyLockupStart() external view returns (uint256 start);
+
+    /**
+     * @notice Returns the Hedgey lockup cliff time
+     * @return cliff Cliff time of the lockup plan
+     */
+    function hedgeyLockupCliff() external view returns (uint256 cliff);
+
+    /**
+     * @notice Returns the Hedgey lockup rate
+     * @return ratePercentage Rate of percentage of tokens that vest per period
+     */
+    function hedgeyLockupRatePercentage() external view returns (uint256 ratePercentage);
+
+    /**
+     * @notice Returns the Hedgey lockup period
+     * @return period Duration of each vesting period in seconds
+     */
+    function hedgeyLockupPeriod() external view returns (uint256 period);
+
+    /**
+     * @notice Returns the Hedgey voting token lockup plans contract address
+     * @return votingTokenLockupPlans Address of the VotingTokenLockupPlans contract
+     */
+    function hedgeyVotingTokenLockupPlans() external view returns (address votingTokenLockupPlans);
 
     // --- State-Changing Functions ---
 

--- a/contracts/mocks/hedgey/VotingTokenLockupPlans.sol
+++ b/contracts/mocks/hedgey/VotingTokenLockupPlans.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
+// solhint-disable-file
 pragma solidity 0.8.19;
 
 interface IGovernanceToken {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -15,9 +15,9 @@ const config: HardhatUserConfig = {
           },
         },
       },
-      {
-        // 0.8.19 compiler is only used for the VotingTokenLockupPlans contract,
-        // which is only used for testing purposes.
+    ],
+    overrides: {
+      'contracts/mocks/hedgey/VotingTokenLockupPlans.sol': {
         version: '0.8.19',
         settings: {
           optimizer: {
@@ -27,7 +27,7 @@ const config: HardhatUserConfig = {
           viaIR: true,
         },
       },
-    ],
+    },
   },
   networks: {
     sepolia: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -15,6 +15,15 @@ const config: HardhatUserConfig = {
           },
         },
       },
+      {
+        version: '0.8.19',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
     ],
   },
   networks: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -16,12 +16,15 @@ const config: HardhatUserConfig = {
         },
       },
       {
+        // 0.8.19 compiler is only used for the VotingTokenLockupPlans contract,
+        // which is only used for testing purposes.
         version: '0.8.19',
         settings: {
           optimizer: {
             enabled: true,
             runs: 200,
           },
+          viaIR: true,
         },
       },
     ],

--- a/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -36,7 +36,10 @@ async function runExecuteTxAndCheckBalanceDeltasTests(
       if (t.token === 'native') {
         return ethers.provider.getBalance(t.addressToCheck);
       } else {
-        const token = await ethers.getContractAt('@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20', t.token);
+        const token = await ethers.getContractAt(
+          '@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20',
+          t.token,
+        );
         const balance = await token.balanceOf(t.addressToCheck);
         return balance;
       }
@@ -56,7 +59,10 @@ async function runExecuteTxAndCheckBalanceDeltasTests(
     if (transfer.token === 'native') {
       finalBalance = await ethers.provider.getBalance(transfer.addressToCheck);
     } else {
-      const token = await ethers.getContractAt('@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20', transfer.token);
+      const token = await ethers.getContractAt(
+        '@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20',
+        transfer.token,
+      );
       finalBalance = await token.balanceOf(transfer.addressToCheck);
     }
 

--- a/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -5,8 +5,8 @@ import { ethers } from 'hardhat';
 import {
   ERC1967Proxy__factory,
   IDeploymentBlock__factory,
-  IERC165__factory,
   IERC20__factory,
+  IERC165__factory,
   IVersion__factory,
   IVotes__factory,
   IVotesERC20StakedV1__factory,
@@ -36,7 +36,7 @@ async function runExecuteTxAndCheckBalanceDeltasTests(
       if (t.token === 'native') {
         return ethers.provider.getBalance(t.addressToCheck);
       } else {
-        const token = await ethers.getContractAt('IERC20', t.token);
+        const token = await ethers.getContractAt('@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20', t.token);
         const balance = await token.balanceOf(t.addressToCheck);
         return balance;
       }
@@ -56,7 +56,7 @@ async function runExecuteTxAndCheckBalanceDeltasTests(
     if (transfer.token === 'native') {
       finalBalance = await ethers.provider.getBalance(transfer.addressToCheck);
     } else {
-      const token = await ethers.getContractAt('IERC20', transfer.token);
+      const token = await ethers.getContractAt('@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20', transfer.token);
       finalBalance = await token.balanceOf(transfer.addressToCheck);
     }
 
@@ -302,9 +302,9 @@ describe('VotesERC20StakedV1', () => {
         IERC165__factory,
         IVotesERC20StakedV1__factory,
         IVersion__factory,
-        IERC20__factory,
         IVotes__factory,
         IDeploymentBlock__factory,
+        IERC20__factory,
       ],
     });
   });

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -428,29 +428,6 @@ describe('PublicSaleV1', () => {
       );
     });
 
-    it('should revert when Hedgey lockup is enabled with native asset as commitment token', async () => {
-      const currentTime = await time.latest();
-      const invalidHedgeyParams = {
-        ...defaultParams,
-        commitmentToken: TEST_CONSTANTS.NATIVE_ASSET,
-        hedgeyLockupParams: {
-          enabled: true,
-          start: BigInt(currentTime),
-          cliff: BigInt(currentTime + 1_000_000),
-          ratePercentage: ethers.parseEther('0.0025'),
-          period: 10_000,
-          votingTokenLockupPlans: await votingTokenLockupPlans.getAddress(),
-        },
-      };
-
-      await expect(
-        deployPublicSaleProxy(deployer, invalidHedgeyParams),
-      ).to.be.revertedWithCustomError(
-        PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
-        'InvalidHedgeyNativeAsset',
-      );
-    });
-
     it('should revert when Hedgey lockup rate exceeds amount', async () => {
       const currentTime = await time.latest();
       const invalidHedgeyParams = {

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -1771,7 +1771,7 @@ describe('PublicSaleV1 - Shared Tests', () => {
             enabled: false,
             start: 0,
             cliff: 0,
-            rate: 0,
+            ratePercentage: 0,
             period: 0,
             votingTokenLockupPlans: ethers.ZeroAddress,
           },
@@ -1806,7 +1806,7 @@ describe('PublicSaleV1 - Shared Tests', () => {
         // Use the saved params to ensure timestamps match
         return ethers.AbiCoder.defaultAbiCoder().encode(
           [
-            'tuple(uint48 saleStartTimestamp, uint48 saleEndTimestamp, address owner, address saleTokenHolder, address commitmentToken, address saleToken, address kycVerifier, address saleProceedsReceiver, address protocolFeeReceiver, uint256 minimumCommitment, uint256 maximumCommitment, uint256 minimumTotalCommitment, uint256 maximumTotalCommitment, uint256 saleTokenPrice, uint256 protocolFee)',
+            'tuple(uint48 saleStartTimestamp, uint48 saleEndTimestamp, address owner, address saleTokenHolder, address commitmentToken, address saleToken, address kycVerifier, address saleProceedsReceiver, address protocolFeeReceiver, uint256 minimumCommitment, uint256 maximumCommitment, uint256 minimumTotalCommitment, uint256 maximumTotalCommitment, uint256 saleTokenPrice, uint256 protocolFee, tuple(bool enabled, uint256 start, uint256 cliff, uint256 ratePercentage, uint256 period, address votingTokenLockupPlans) hedgeyLockupParams)',
           ],
           [savedInitParams],
         );

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -15,6 +15,8 @@ import {
   IVersion__factory,
   IDeploymentBlock__factory,
   IERC165__factory,
+  VotingTokenLockupPlans,
+  VotingTokenLockupPlans__factory,
 } from '../../../../typechain-types';
 import { runDeploymentBlockTests } from '../../shared/deploymentBlockTests';
 import { runInitializerEventEmitterTests } from '../../shared/initializerEventEmitterTests';
@@ -84,6 +86,7 @@ interface DeployTestSaleOptions {
   minimumCommitment?: bigint;
   maximumCommitment?: bigint;
   saleTokenPrice?: bigint;
+  hedgeyLockupParams?: IPublicSaleV1.HedgeyLockupParamsStruct;
 }
 
 async function deployTestSale(
@@ -113,6 +116,7 @@ async function deployTestSale(
     ...(options.minimumCommitment && { minimumCommitment: options.minimumCommitment }),
     ...(options.maximumCommitment && { maximumCommitment: options.maximumCommitment }),
     ...(options.saleTokenPrice && { saleTokenPrice: options.saleTokenPrice }),
+    ...(options.hedgeyLockupParams && { hedgeyLockupParams: options.hedgeyLockupParams }),
   };
 
   // Calculate and mint required sale tokens
@@ -182,6 +186,37 @@ async function expectSaleState(sale: PublicSaleV1, expectedState: SaleState): Pr
   expect(await sale.saleState()).to.equal(BigInt(expectedState));
 }
 
+function getLockupPlanCreatedEvent(
+  receipt: any,
+  votingTokenLockupPlans: VotingTokenLockupPlans
+): any | null {
+  const planCreatedEvent = receipt?.logs?.find((log: any) => {
+    try {
+      const parsed = votingTokenLockupPlans.interface.parseLog(log);
+      return parsed?.name === 'PlanCreated';
+    } catch {
+      return false;
+    }
+  });
+
+  if (planCreatedEvent) {
+    const parsedEvent = votingTokenLockupPlans.interface.parseLog(planCreatedEvent);
+    return {
+      planId: parsedEvent?.args?.[0],
+      recipient: parsedEvent?.args?.[1],
+      token: parsedEvent?.args?.[2],
+      amount: parsedEvent?.args?.[3],
+      start: parsedEvent?.args?.[4],
+      cliff: parsedEvent?.args?.[5],
+      end: parsedEvent?.args?.[6],
+      rate: parsedEvent?.args?.[7],
+      period: parsedEvent?.args?.[8]
+    };
+  }
+
+  return null;
+}
+
 describe('PublicSaleV1', () => {
   let deployer: SignerWithAddress;
   let owner: SignerWithAddress;
@@ -197,6 +232,7 @@ describe('PublicSaleV1', () => {
   let saleToken: MockERC20;
   let commitmentToken: MockERC20;
   let kycVerifier: MockKYCVerifier;
+  let votingTokenLockupPlans: VotingTokenLockupPlans; // Hedgey contract
 
   let defaultParams: IPublicSaleV1.InitializerParamsStruct;
 
@@ -221,6 +257,9 @@ describe('PublicSaleV1', () => {
     commitmentToken = await MockERC20Factory.deploy('Commitment Token', 'COMMIT', 18);
     kycVerifier = await MockKYCVerifierFactory.deploy();
 
+    // Deploy Hedgey VotingTokenLockupPlans contract
+    votingTokenLockupPlans = await new VotingTokenLockupPlans__factory(deployer).deploy('VotingTokenLockupPlans', 'VTLP');
+
     // Mint tokens to sale token holder
     await saleToken.mint(saleTokenHolder.address, ethers.parseEther('1000000'));
 
@@ -242,6 +281,14 @@ describe('PublicSaleV1', () => {
       maximumTotalCommitment: ethers.parseEther('100000'),
       saleTokenPrice: ethers.parseEther('0.1'), // 0.1 commitment token per sale token
       protocolFee: ethers.parseEther('0.02'), // 2%
+      hedgeyLockupParams: {
+        enabled: false,
+        start: 0,
+        cliff: 0,
+        ratePercentage: 0,
+        period: 0,
+        votingTokenLockupPlans: ethers.ZeroAddress,
+      },
     };
 
     // Enable KYC for test accounts
@@ -271,6 +318,12 @@ describe('PublicSaleV1', () => {
       );
       expect(await publicSale.saleTokenPrice()).to.equal(defaultParams.saleTokenPrice);
       expect(await publicSale.protocolFee()).to.equal(defaultParams.protocolFee);
+      expect(await publicSale.hedgeyLockupEnabled()).to.equal(defaultParams.hedgeyLockupParams.enabled);
+      expect(await publicSale.hedgeyLockupStart()).to.equal(defaultParams.hedgeyLockupParams.start);
+      expect(await publicSale.hedgeyLockupCliff()).to.equal(defaultParams.hedgeyLockupParams.cliff);
+      expect(await publicSale.hedgeyLockupRatePercentage()).to.equal(defaultParams.hedgeyLockupParams.ratePercentage);
+      expect(await publicSale.hedgeyLockupPeriod()).to.equal(defaultParams.hedgeyLockupParams.period);
+      expect(await publicSale.hedgeyVotingTokenLockupPlans()).to.equal(defaultParams.hedgeyLockupParams.votingTokenLockupPlans);
 
       // Verify sale tokens were transferred to the contract
       const expectedSaleTokenAmount =
@@ -339,6 +392,107 @@ describe('PublicSaleV1', () => {
       await expect(deployPublicSaleProxy(deployer, invalidParams)).to.be.revertedWithCustomError(
         PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
         'InvalidProtocolFee',
+      );
+    });
+
+    it('should revert when Hedgey lockup is enabled with invalid parameters', async () => {
+      const currentTime = await time.latest();
+      const invalidHedgeyParams = {
+        ...defaultParams,
+        hedgeyLockupParams: {
+          enabled: true,
+          start: BigInt(currentTime),
+          cliff: BigInt(currentTime + 1_000_000), 
+          ratePercentage: 0, // Invalid: rate cannot be zero
+          period: 10_000,
+          votingTokenLockupPlans: await votingTokenLockupPlans.getAddress(),
+        },
+      };
+
+      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+        PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
+        'InvalidRate',
+      );
+    });
+
+    it('should revert when Hedgey lockup is enabled with native asset as commitment token', async () => {
+      const currentTime = await time.latest();
+      const invalidHedgeyParams = {
+        ...defaultParams,
+        commitmentToken: TEST_CONSTANTS.NATIVE_ASSET,
+        hedgeyLockupParams: {
+          enabled: true,
+          start: BigInt(currentTime),
+          cliff: BigInt(currentTime + 1_000_000),
+          ratePercentage: ethers.parseEther('0.0025'),
+          period: 10_000,
+          votingTokenLockupPlans: await votingTokenLockupPlans.getAddress(),
+        },
+      };
+
+      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+        PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
+        'InvalidHedgeyNativeAsset',
+      );
+    });
+
+    it('should revert when Hedgey lockup rate exceeds amount', async () => {
+      const currentTime = await time.latest();
+      const invalidHedgeyParams = {
+        ...defaultParams,
+        hedgeyLockupParams: {
+          enabled: true,
+          start: BigInt(currentTime),
+          cliff: BigInt(currentTime + 1_000_000),
+          ratePercentage: ethers.parseEther('1.1'), // Rate exceeds the calculated amount
+          period: 10_000,
+          votingTokenLockupPlans: await votingTokenLockupPlans.getAddress(),
+        },
+      };
+
+      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+        PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
+        'RateExceedsAmount',
+      );
+    });
+
+    it('should revert when Hedgey lockup period is zero', async () => {
+      const currentTime = await time.latest();
+      const invalidHedgeyParams = {
+        ...defaultParams,
+        hedgeyLockupParams: {
+          enabled: true,
+          start: BigInt(currentTime),
+          cliff: BigInt(currentTime + 1_000_000),
+          ratePercentage: ethers.parseEther('0.0025'),
+          period: 0, // Invalid: period cannot be zero
+          votingTokenLockupPlans: await votingTokenLockupPlans.getAddress(),
+        },
+      };
+
+      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+        PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
+        'InvalidPeriod',
+      );
+    });
+
+    it('should revert when Hedgey lockup cliff exceeds end time', async () => {
+      const currentTime = await time.latest();
+      const invalidHedgeyParams = {
+        ...defaultParams,
+        hedgeyLockupParams: {
+          enabled: true,
+          start: BigInt(currentTime),
+          cliff: BigInt(currentTime + 4_000_001), // calculated end period should be 4_000_000
+          ratePercentage: ethers.parseEther('0.0025'),
+          period: 10_000,
+          votingTokenLockupPlans: await votingTokenLockupPlans.getAddress(),
+        },
+      };
+
+      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+        PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
+        'CliffExceedsEnd',
       );
     });
 
@@ -727,7 +881,151 @@ describe('PublicSaleV1', () => {
     });
   });
 
-  describe('User Settlement - Success Case', () => {
+  describe('User Settlement - Success Case with Hedgey Lockup', () => {
+    let hedgeySale: PublicSaleV1;
+    let lockupStartTime: number;
+
+    beforeEach(async () => {
+      lockupStartTime = await time.latest();
+      
+      const hedgeyParams = {
+        ...defaultParams,
+        hedgeyLockupParams: {
+          enabled: true,
+          start: BigInt(lockupStartTime),
+          cliff: BigInt(lockupStartTime + 1_000_000),
+          ratePercentage: ethers.parseEther('0.0025'),
+          period: 10_000,
+          votingTokenLockupPlans: await votingTokenLockupPlans.getAddress(),
+        },
+      };
+
+      hedgeySale = await deployTestSale(deployer, saleToken, saleTokenHolder, hedgeyParams, {
+        startOffset: 60,
+      });
+      await moveToSaleStart(hedgeySale);
+
+      // Setup commitments
+      await mintAndApproveCommitmentTokens(
+        commitmentToken,
+        hedgeySale,
+        [alice, bob],
+        [ethers.parseEther('50000'), ethers.parseEther('50000')],
+      );
+
+      // Make enough commitments to succeed
+      await hedgeySale
+        .connect(alice)
+        .increaseCommitmentERC20(defaultParams.minimumCommitment, ethers.getBytes('0x'), 0n);
+      await hedgeySale
+        .connect(bob)
+        .increaseCommitmentERC20(defaultParams.maximumCommitment, ethers.getBytes('0x'), 0n);
+
+      // Reach minimum total commitment
+      await reachMinimumTotalCommitment(
+        hedgeySale,
+        commitmentToken,
+        BigInt(defaultParams.minimumTotalCommitment),
+        BigInt(defaultParams.maximumCommitment),
+        [
+          { user: alice, amount: BigInt(defaultParams.minimumCommitment) },
+          { user: bob, amount: BigInt(defaultParams.maximumCommitment) },
+        ],
+      );
+
+      // Move to end of sale
+      await moveToSaleEnd(hedgeySale);
+    });
+
+    it('should create Hedgey lockup plan instead of direct transfer when enabled', async () => {
+      const commitment = await hedgeySale.commitments(alice.address);
+      const expectedSaleTokens =
+        (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
+      // Get initial balances
+      const initialSaleTokenBalance = await saleToken.balanceOf(await hedgeySale.getAddress());
+      const initialHedgeyBalance = await saleToken.balanceOf(await votingTokenLockupPlans.getAddress());
+
+      // Capture the PlanCreated event from the Hedgey contract
+      const tx = await hedgeySale.connect(alice).settle(alice.address);
+      const receipt = await tx.wait();
+      
+      // Extract and log the PlanCreated event
+      const lockupPlanId = (getLockupPlanCreatedEvent(receipt, votingTokenLockupPlans)).planId;
+      
+      const lockupPlan = await votingTokenLockupPlans.plans(lockupPlanId);
+      
+      expect(lockupPlan.token).to.equal(await saleToken.getAddress());
+      expect(lockupPlan.amount).to.equal(expectedSaleTokens);
+      expect(lockupPlan.start).to.equal(BigInt(lockupStartTime));
+      expect(lockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
+      expect(lockupPlan.period).to.equal(BigInt(10_000));
+      expect(lockupPlan.rate).to.equal(expectedSaleTokens * ethers.parseEther('0.0025') / TEST_CONSTANTS.PRECISION);
+
+      // verify correct end time
+      expect(await votingTokenLockupPlans.planEnd(lockupPlanId)).to.equal(BigInt(lockupStartTime + 4_000_000));
+
+      // Verify sale tokens were transferred to Hedgey contract
+      expect(await saleToken.balanceOf(await hedgeySale.getAddress())).to.equal(
+        initialSaleTokenBalance - expectedSaleTokens,
+      );
+      expect(await saleToken.balanceOf(await votingTokenLockupPlans.getAddress())).to.equal(
+        initialHedgeyBalance + expectedSaleTokens,
+      );
+
+      // Verify user didn't receive tokens directly
+      expect(await saleToken.balanceOf(alice.address)).to.equal(0);
+      expect(await hedgeySale.settled(alice.address)).to.be.true;
+    });
+
+    it('should create Hedgey lockup plans for multiple users', async () => {
+      const aliceCommitment = await hedgeySale.commitments(alice.address);
+      const bobCommitment = await hedgeySale.commitments(bob.address);
+
+      const aliceExpectedSaleTokens =
+        (BigInt(aliceCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+      const bobExpectedSaleTokens =
+        (BigInt(bobCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+      
+      // Settle and get lockup plan IDs
+      const aliceLockupPlanId = (getLockupPlanCreatedEvent((await (await hedgeySale.connect(alice).settle(alice.address)).wait()), votingTokenLockupPlans)).planId;
+      const bobLockupPlanId = (getLockupPlanCreatedEvent((await (await hedgeySale.connect(bob).settle(bob.address)).wait()), votingTokenLockupPlans)).planId;
+
+      // Get lockup plan objects
+      const aliceLockupPlan = await votingTokenLockupPlans.plans(aliceLockupPlanId);
+      const bobLockupPlan = await votingTokenLockupPlans.plans(bobLockupPlanId);
+
+      // Verify lockup plans
+      expect(aliceLockupPlan.token).to.equal(await saleToken.getAddress());
+      expect(aliceLockupPlan.amount).to.equal(aliceExpectedSaleTokens);
+      expect(aliceLockupPlan.start).to.equal(BigInt(lockupStartTime));
+      expect(aliceLockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
+      expect(aliceLockupPlan.period).to.equal(BigInt(10_000));
+
+      expect(bobLockupPlan.token).to.equal(await saleToken.getAddress());
+      expect(bobLockupPlan.amount).to.equal(bobExpectedSaleTokens);
+      expect(bobLockupPlan.start).to.equal(BigInt(lockupStartTime));
+      expect(bobLockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
+      expect(bobLockupPlan.period).to.equal(BigInt(10_000));
+
+      // verify correct end time
+      expect(await votingTokenLockupPlans.planEnd(aliceLockupPlanId)).to.equal(BigInt(lockupStartTime + 4_000_000));
+      expect(await votingTokenLockupPlans.planEnd(bobLockupPlanId)).to.equal(BigInt(lockupStartTime + 4_000_000));
+    });
+
+    it('should emit SuccessfulSaleSettled event when Hedgey is enabled', async () => {
+      const commitment = await hedgeySale.commitments(alice.address);
+      const expectedSaleTokens =
+        (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
+      // The event should not be emitted when Hedgey lockup is enabled
+      await expect(hedgeySale.connect(alice).settle(alice.address))
+        .to.emit(hedgeySale, 'SuccessfulSaleSettled')
+        .withArgs(alice.address, alice.address, expectedSaleTokens);
+    });
+  });
+
+  describe('User Settlement - Success Case without Hedgey Lockup', () => {
     beforeEach(async () => {
       publicSale = await deployTestSale(deployer, saleToken, saleTokenHolder, defaultParams, {
         startOffset: 60,
@@ -766,7 +1064,7 @@ describe('PublicSaleV1', () => {
       await moveToSaleEnd(publicSale);
     });
 
-    it('should allow user to settle and receive sale tokens', async () => {
+    it('should allow user to settle and receive sale tokens directly', async () => {
       const commitment = await publicSale.commitments(alice.address);
       const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
@@ -1412,6 +1710,14 @@ describe('PublicSaleV1 - Shared Tests', () => {
       maximumTotalCommitment: ethers.parseEther('100000'),
       saleTokenPrice: ethers.parseEther('0.1'),
       protocolFee: ethers.parseEther('0.02'),
+      hedgeyLockupParams: {
+        enabled: false,
+        start: 0,
+        cliff: 0,
+        ratePercentage: 0,
+        period: 0,
+        votingTokenLockupPlans: ethers.ZeroAddress,
+      },
     };
 
     // Enable KYC
@@ -1461,6 +1767,14 @@ describe('PublicSaleV1 - Shared Tests', () => {
           maximumTotalCommitment: ethers.parseEther('100000'),
           saleTokenPrice: ethers.parseEther('0.1'),
           protocolFee: ethers.parseEther('0.02'),
+          hedgeyLockupParams: {
+            enabled: false,
+            start: 0,
+            cliff: 0,
+            rate: 0,
+            period: 0,
+            votingTokenLockupPlans: ethers.ZeroAddress,
+          },
         };
 
         // Calculate required sale token amount

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -188,7 +188,7 @@ async function expectSaleState(sale: PublicSaleV1, expectedState: SaleState): Pr
 
 function getLockupPlanCreatedEvent(
   receipt: any,
-  votingTokenLockupPlans: VotingTokenLockupPlans
+  votingTokenLockupPlans: VotingTokenLockupPlans,
 ): any | null {
   const planCreatedEvent = receipt?.logs?.find((log: any) => {
     try {
@@ -210,7 +210,7 @@ function getLockupPlanCreatedEvent(
       cliff: parsedEvent?.args?.[5],
       end: parsedEvent?.args?.[6],
       rate: parsedEvent?.args?.[7],
-      period: parsedEvent?.args?.[8]
+      period: parsedEvent?.args?.[8],
     };
   }
 
@@ -258,7 +258,10 @@ describe('PublicSaleV1', () => {
     kycVerifier = await MockKYCVerifierFactory.deploy();
 
     // Deploy Hedgey VotingTokenLockupPlans contract
-    votingTokenLockupPlans = await new VotingTokenLockupPlans__factory(deployer).deploy('VotingTokenLockupPlans', 'VTLP');
+    votingTokenLockupPlans = await new VotingTokenLockupPlans__factory(deployer).deploy(
+      'VotingTokenLockupPlans',
+      'VTLP',
+    );
 
     // Mint tokens to sale token holder
     await saleToken.mint(saleTokenHolder.address, ethers.parseEther('1000000'));
@@ -318,12 +321,20 @@ describe('PublicSaleV1', () => {
       );
       expect(await publicSale.saleTokenPrice()).to.equal(defaultParams.saleTokenPrice);
       expect(await publicSale.protocolFee()).to.equal(defaultParams.protocolFee);
-      expect(await publicSale.hedgeyLockupEnabled()).to.equal(defaultParams.hedgeyLockupParams.enabled);
+      expect(await publicSale.hedgeyLockupEnabled()).to.equal(
+        defaultParams.hedgeyLockupParams.enabled,
+      );
       expect(await publicSale.hedgeyLockupStart()).to.equal(defaultParams.hedgeyLockupParams.start);
       expect(await publicSale.hedgeyLockupCliff()).to.equal(defaultParams.hedgeyLockupParams.cliff);
-      expect(await publicSale.hedgeyLockupRatePercentage()).to.equal(defaultParams.hedgeyLockupParams.ratePercentage);
-      expect(await publicSale.hedgeyLockupPeriod()).to.equal(defaultParams.hedgeyLockupParams.period);
-      expect(await publicSale.hedgeyVotingTokenLockupPlans()).to.equal(defaultParams.hedgeyLockupParams.votingTokenLockupPlans);
+      expect(await publicSale.hedgeyLockupRatePercentage()).to.equal(
+        defaultParams.hedgeyLockupParams.ratePercentage,
+      );
+      expect(await publicSale.hedgeyLockupPeriod()).to.equal(
+        defaultParams.hedgeyLockupParams.period,
+      );
+      expect(await publicSale.hedgeyVotingTokenLockupPlans()).to.equal(
+        defaultParams.hedgeyLockupParams.votingTokenLockupPlans,
+      );
 
       // Verify sale tokens were transferred to the contract
       const expectedSaleTokenAmount =
@@ -402,14 +413,16 @@ describe('PublicSaleV1', () => {
         hedgeyLockupParams: {
           enabled: true,
           start: BigInt(currentTime),
-          cliff: BigInt(currentTime + 1_000_000), 
+          cliff: BigInt(currentTime + 1_000_000),
           ratePercentage: 0, // Invalid: rate cannot be zero
           period: 10_000,
           votingTokenLockupPlans: await votingTokenLockupPlans.getAddress(),
         },
       };
 
-      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+      await expect(
+        deployPublicSaleProxy(deployer, invalidHedgeyParams),
+      ).to.be.revertedWithCustomError(
         PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
         'InvalidRate',
       );
@@ -430,7 +443,9 @@ describe('PublicSaleV1', () => {
         },
       };
 
-      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+      await expect(
+        deployPublicSaleProxy(deployer, invalidHedgeyParams),
+      ).to.be.revertedWithCustomError(
         PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
         'InvalidHedgeyNativeAsset',
       );
@@ -450,7 +465,9 @@ describe('PublicSaleV1', () => {
         },
       };
 
-      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+      await expect(
+        deployPublicSaleProxy(deployer, invalidHedgeyParams),
+      ).to.be.revertedWithCustomError(
         PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
         'RateExceedsAmount',
       );
@@ -470,7 +487,9 @@ describe('PublicSaleV1', () => {
         },
       };
 
-      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+      await expect(
+        deployPublicSaleProxy(deployer, invalidHedgeyParams),
+      ).to.be.revertedWithCustomError(
         PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
         'InvalidPeriod',
       );
@@ -490,7 +509,9 @@ describe('PublicSaleV1', () => {
         },
       };
 
-      await expect(deployPublicSaleProxy(deployer, invalidHedgeyParams)).to.be.revertedWithCustomError(
+      await expect(
+        deployPublicSaleProxy(deployer, invalidHedgeyParams),
+      ).to.be.revertedWithCustomError(
         PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
         'CliffExceedsEnd',
       );
@@ -887,7 +908,7 @@ describe('PublicSaleV1', () => {
 
     beforeEach(async () => {
       lockupStartTime = await time.latest();
-      
+
       const hedgeyParams = {
         ...defaultParams,
         hedgeyLockupParams: {
@@ -944,26 +965,32 @@ describe('PublicSaleV1', () => {
 
       // Get initial balances
       const initialSaleTokenBalance = await saleToken.balanceOf(await hedgeySale.getAddress());
-      const initialHedgeyBalance = await saleToken.balanceOf(await votingTokenLockupPlans.getAddress());
+      const initialHedgeyBalance = await saleToken.balanceOf(
+        await votingTokenLockupPlans.getAddress(),
+      );
 
       // Capture the PlanCreated event from the Hedgey contract
       const tx = await hedgeySale.connect(alice).settle(alice.address);
       const receipt = await tx.wait();
-      
+
       // Extract and log the PlanCreated event
-      const lockupPlanId = (getLockupPlanCreatedEvent(receipt, votingTokenLockupPlans)).planId;
-      
+      const lockupPlanId = getLockupPlanCreatedEvent(receipt, votingTokenLockupPlans).planId;
+
       const lockupPlan = await votingTokenLockupPlans.plans(lockupPlanId);
-      
+
       expect(lockupPlan.token).to.equal(await saleToken.getAddress());
       expect(lockupPlan.amount).to.equal(expectedSaleTokens);
       expect(lockupPlan.start).to.equal(BigInt(lockupStartTime));
       expect(lockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
       expect(lockupPlan.period).to.equal(BigInt(10_000));
-      expect(lockupPlan.rate).to.equal(expectedSaleTokens * ethers.parseEther('0.0025') / TEST_CONSTANTS.PRECISION);
+      expect(lockupPlan.rate).to.equal(
+        (expectedSaleTokens * ethers.parseEther('0.0025')) / TEST_CONSTANTS.PRECISION,
+      );
 
       // verify correct end time
-      expect(await votingTokenLockupPlans.planEnd(lockupPlanId)).to.equal(BigInt(lockupStartTime + 4_000_000));
+      expect(await votingTokenLockupPlans.planEnd(lockupPlanId)).to.equal(
+        BigInt(lockupStartTime + 4_000_000),
+      );
 
       // Verify sale tokens were transferred to Hedgey contract
       expect(await saleToken.balanceOf(await hedgeySale.getAddress())).to.equal(
@@ -986,10 +1013,16 @@ describe('PublicSaleV1', () => {
         (BigInt(aliceCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
       const bobExpectedSaleTokens =
         (BigInt(bobCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
-      
+
       // Settle and get lockup plan IDs
-      const aliceLockupPlanId = (getLockupPlanCreatedEvent((await (await hedgeySale.connect(alice).settle(alice.address)).wait()), votingTokenLockupPlans)).planId;
-      const bobLockupPlanId = (getLockupPlanCreatedEvent((await (await hedgeySale.connect(bob).settle(bob.address)).wait()), votingTokenLockupPlans)).planId;
+      const aliceLockupPlanId = getLockupPlanCreatedEvent(
+        await (await hedgeySale.connect(alice).settle(alice.address)).wait(),
+        votingTokenLockupPlans,
+      ).planId;
+      const bobLockupPlanId = getLockupPlanCreatedEvent(
+        await (await hedgeySale.connect(bob).settle(bob.address)).wait(),
+        votingTokenLockupPlans,
+      ).planId;
 
       // Get lockup plan objects
       const aliceLockupPlan = await votingTokenLockupPlans.plans(aliceLockupPlanId);
@@ -1009,8 +1042,12 @@ describe('PublicSaleV1', () => {
       expect(bobLockupPlan.period).to.equal(BigInt(10_000));
 
       // verify correct end time
-      expect(await votingTokenLockupPlans.planEnd(aliceLockupPlanId)).to.equal(BigInt(lockupStartTime + 4_000_000));
-      expect(await votingTokenLockupPlans.planEnd(bobLockupPlanId)).to.equal(BigInt(lockupStartTime + 4_000_000));
+      expect(await votingTokenLockupPlans.planEnd(aliceLockupPlanId)).to.equal(
+        BigInt(lockupStartTime + 4_000_000),
+      );
+      expect(await votingTokenLockupPlans.planEnd(bobLockupPlanId)).to.equal(
+        BigInt(lockupStartTime + 4_000_000),
+      );
     });
 
     it('should emit SuccessfulSaleSettled event when Hedgey is enabled', async () => {

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -203,14 +203,6 @@ function getLockupPlanCreatedEvent(
     const parsedEvent = votingTokenLockupPlans.interface.parseLog(planCreatedEvent);
     return {
       planId: parsedEvent?.args?.[0],
-      recipient: parsedEvent?.args?.[1],
-      token: parsedEvent?.args?.[2],
-      amount: parsedEvent?.args?.[3],
-      start: parsedEvent?.args?.[4],
-      cliff: parsedEvent?.args?.[5],
-      end: parsedEvent?.args?.[6],
-      rate: parsedEvent?.args?.[7],
-      period: parsedEvent?.args?.[8],
     };
   }
 


### PR DESCRIPTION
This PR adds Hedgey integration to the Public Sale contract. A boolean passed in upon contract initialization indicates whether the Hedgey integration is used. If true - upon successful sale settlement, the Hedgey VotingTokenLockupPlans contract will be called to create a lockup plan for the buyer, and the buyer's corresponding sale token amount will be transferred to the Hedgey contract. If false upon a successful sale settlement - the buyer will simply be transferred their purchased sale token amount as before.

Added HedgeyLockupParams struct to initialization data:

`    struct HedgeyLockupParams {
        bool enabled;
        uint256 start;
        uint256 cliff;
        uint256 ratePercentage;
        uint256 period;
        address votingTokenLockupPlans;
    }
` 
The `ratePercentage` is different than the `rate` that is passed in to Hedgey, as it is different depending on the lockup amount. `ratePercentage` is represented as a percentage (divide the amount by 10**18) of the lockup amount that unlocks on each `period`.

So if ratePercentage is 0.001 * 10**18, and period is 10,000, then 0.1% of the lockup amount will unlock every 10,000 seconds.

`VotingTokenLockupPlans.sol` in the mocks/hedgey folder is a flattened version of the production Hedgey contract, but is functionally equivalent. This was done since Hedgey doesn't have a contracts npm package, but to still support integration testing.