### PR TITLE
Remove ownable public sale

### DIFF
--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -561,7 +561,7 @@ contract PublicSaleV1 is
     /**
      * @inheritdoc IPublicSaleV1
      */
-    function settle(address recipient_) public virtual override {
+    function buyerSettle(address recipient_) public virtual override {
         PublicSaleStorage storage $ = _getPublicSaleStorage();
 
         if ($.settled[msg.sender]) revert AlreadySettled();
@@ -603,7 +603,11 @@ contract PublicSaleV1 is
                 IERC20($.saleToken).safeTransfer(recipient_, saleTokenAmount);
             }
 
-            emit SuccessfulSaleSettled(msg.sender, recipient_, saleTokenAmount);
+            emit SuccessfulSaleBuyerSettled(
+                msg.sender,
+                recipient_,
+                saleTokenAmount
+            );
         } else if (state == SaleState.FAILED) {
             // sale failed, refund the caller their commitment tokens
             uint256 commitmentTokenAmount = $.commitments[msg.sender];
@@ -614,7 +618,7 @@ contract PublicSaleV1 is
                 commitmentTokenAmount
             );
 
-            emit FailedSaleSettled(
+            emit FailedSaleBuyerSettled(
                 msg.sender,
                 recipient_,
                 commitmentTokenAmount

--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -19,9 +19,6 @@ import {InitializerEventEmitter} from "../../InitializerEventEmitter.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {
-    Ownable2StepUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
-import {
     SafeERC20
 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -36,8 +33,7 @@ contract PublicSaleV1 is
     IVersion,
     DeploymentBlockInitializable,
     InitializerEventEmitter,
-    ERC165,
-    Ownable2StepUpgradeable
+    ERC165
 {
     using SafeERC20 for IERC20;
 
@@ -157,7 +153,6 @@ contract PublicSaleV1 is
         if (params_.protocolFee > PRECISION) revert InvalidProtocolFee();
 
         __InitializerEventEmitter_init(abi.encode(params_));
-        __Ownable_init(params_.owner);
         __DeploymentBlockInitializable_init();
 
         // if hedgey lockup is enabled, validate the params
@@ -632,7 +627,7 @@ contract PublicSaleV1 is
     /**
      * @inheritdoc IPublicSaleV1
      */
-    function ownerSettle() public virtual override onlyOwner {
+    function ownerSettle() public virtual override {
         PublicSaleStorage storage $ = _getPublicSaleStorage();
 
         if ($.ownerSettled) revert AlreadySettled();

--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -586,7 +586,7 @@ contract PublicSaleV1 is
                 );
 
                 // create hedgey lockup plan for the caller
-                IVotingTokenLockupPlans(
+                uint256 hedgeyLockupPlanId = IVotingTokenLockupPlans(
                     $.hedgeyLockupParams.votingTokenLockupPlans
                 ).createPlan(
                         recipient_,
@@ -598,16 +598,23 @@ contract PublicSaleV1 is
                             $.hedgeyLockupParams.ratePercentage) / PRECISION,
                         $.hedgeyLockupParams.period
                     );
+
+                emit SuccessfulSaleBuyerSettledHedgey(
+                    msg.sender,
+                    recipient_,
+                    saleTokenAmount,
+                    hedgeyLockupPlanId
+                );
             } else {
                 // send the caller their purchased sale tokens
                 IERC20($.saleToken).safeTransfer(recipient_, saleTokenAmount);
-            }
 
-            emit SuccessfulSaleBuyerSettled(
-                msg.sender,
-                recipient_,
-                saleTokenAmount
-            );
+                emit SuccessfulSaleBuyerSettled(
+                    msg.sender,
+                    recipient_,
+                    saleTokenAmount
+                );
+            }
         } else if (state == SaleState.FAILED) {
             // sale failed, refund the caller their commitment tokens
             uint256 commitmentTokenAmount = $.commitments[msg.sender];

--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -47,7 +47,7 @@ contract PublicSaleV1 is
      * @custom:storage-location erc7201:Decent.PublicSale.main
      */
     struct PublicSaleStorage {
-        bool ownerSettled;
+        bool sellerSettled;
         uint48 saleStartTimestamp;
         uint48 saleEndTimestamp;
         address commitmentToken;
@@ -229,9 +229,9 @@ contract PublicSaleV1 is
     /**
      * @inheritdoc IPublicSaleV1
      */
-    function ownerSettled() external view virtual override returns (bool) {
+    function sellerSettled() external view virtual override returns (bool) {
         PublicSaleStorage storage $ = _getPublicSaleStorage();
-        return $.ownerSettled;
+        return $.sellerSettled;
     }
 
     /**
@@ -627,12 +627,12 @@ contract PublicSaleV1 is
     /**
      * @inheritdoc IPublicSaleV1
      */
-    function ownerSettle() public virtual override {
+    function sellerSettle() public virtual override {
         PublicSaleStorage storage $ = _getPublicSaleStorage();
 
-        if ($.ownerSettled) revert AlreadySettled();
+        if ($.sellerSettled) revert AlreadySettled();
 
-        $.ownerSettled = true;
+        $.sellerSettled = true;
 
         SaleState state = saleState();
 
@@ -664,7 +664,7 @@ contract PublicSaleV1 is
                 _protocolFee
             );
 
-            emit SuccessfulSaleOwnerSettled(
+            emit SuccessfulSaleSellerSettled(
                 msg.sender,
                 saleProceeds,
                 _protocolFee
@@ -680,7 +680,7 @@ contract PublicSaleV1 is
                 saleTokenAmount
             );
 
-            emit FailedSaleOwnerSettled(msg.sender, saleTokenAmount);
+            emit FailedSaleSellerSettled(msg.sender, saleTokenAmount);
         } else {
             revert SaleNotEnded();
         }

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -221,24 +221,24 @@ interface IPublicSaleV1 {
     );
 
     /**
-     * @notice Emitted when owner settlement is performed after successful sale
-     * @param caller Address that called ownerSettle
+     * @notice Emitted when seller settlement is performed after successful sale
+     * @param caller Address that called sellerSettle
      * @param saleProceeds Amount sent to saleProceedsReceiver
      * @param protocolFee Amount sent to protocolFeeReceiver
      */
-    event SuccessfulSaleOwnerSettled(
+    event SuccessfulSaleSellerSettled(
         address indexed caller,
         uint256 saleProceeds,
         uint256 protocolFee
     );
 
     /**
-     * @notice Emitted when owner settlement is performed after failed sale
-     * @param caller Address that called ownerSettle
+     * @notice Emitted when seller settlement is performed after failed sale
+     * @param seller Address that called sellerSettle
      * @param saleTokenAmount Amount of sale tokens returned
      */
-    event FailedSaleOwnerSettled(
-        address indexed caller,
+    event FailedSaleSellerSettled(
+        address indexed seller,
         uint256 saleTokenAmount
     );
 
@@ -259,10 +259,10 @@ interface IPublicSaleV1 {
     function saleState() external view returns (SaleState state);
 
     /**
-     * @notice Returns whether the owner has settled
-     * @return settled True if owner has settled, false otherwise
+     * @notice Returns whether the seller has settled
+     * @return settled True if seller has settled, false otherwise
      */
-    function ownerSettled() external view returns (bool settled);
+    function sellerSettled() external view returns (bool settled);
 
     /**
      * @notice Returns the sale start timestamp
@@ -440,8 +440,8 @@ interface IPublicSaleV1 {
     function settle(address recipient_) external;
 
     /**
-     * @notice Settle sale proceeds and fees
+     * @notice Seller settles sale proceeds and fees
      * @dev Can be called by anyone after sale has ended
      */
-    function ownerSettle() external;
+    function sellerSettle() external;
 }

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -202,7 +202,7 @@ interface IPublicSaleV1 {
      * @param recipient Address receiving the sale tokens
      * @param saleTokenAmount Amount of sale tokens received
      */
-    event SuccessfulSaleSettled(
+    event SuccessfulSaleBuyerSettled(
         address indexed account,
         address indexed recipient,
         uint256 saleTokenAmount
@@ -214,7 +214,7 @@ interface IPublicSaleV1 {
      * @param recipient Address receiving the refunded commitment
      * @param commitmentTokenAmount Amount of commitment tokens refunded
      */
-    event FailedSaleSettled(
+    event FailedSaleBuyerSettled(
         address indexed account,
         address indexed recipient,
         uint256 commitmentTokenAmount
@@ -433,11 +433,11 @@ interface IPublicSaleV1 {
     ) external;
 
     /**
-     * @notice Settles user's commitment after sale ends
+     * @notice Buyer settles user's commitment after sale ends
      * @param recipient_ Address to receive tokens (sale tokens if successful, commitment tokens if failed)
      * @dev Can only be called after sale has ended
      */
-    function settle(address recipient_) external;
+    function buyerSettle(address recipient_) external;
 
     /**
      * @notice Seller settles sale proceeds and fees

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -209,6 +209,19 @@ interface IPublicSaleV1 {
     );
 
     /**
+     * @notice Emitted when a user settles after successful sale
+     * @param account Address of the user
+     * @param recipient Address receiving the sale tokens
+     * @param saleTokenAmount Amount of sale tokens received
+     */
+    event SuccessfulSaleBuyerSettledHedgey(
+        address indexed account,
+        address indexed recipient,
+        uint256 saleTokenAmount,
+        uint256 indexed hedgeyLockupPlanId
+    );
+
+    /**
      * @notice Emitted when a user settles after failed sale
      * @param account Address of the user
      * @param recipient Address receiving the refunded commitment

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -139,7 +139,6 @@ interface IPublicSaleV1 {
      * @notice Parameters for initializing the public sale contract
      * @param saleStartTimestamp Unix timestamp when the sale begins
      * @param saleEndTimestamp Unix timestamp when the sale ends
-     * @param owner Address that will own the contract and can call ownerSettle
      * @param saleTokenHolder Address holding the sale tokens to be distributed
      * @param commitmentToken Address of the token users commit (use NATIVE_ASSET constant for ETH)
      * @param saleToken Address of the token being sold
@@ -157,7 +156,6 @@ interface IPublicSaleV1 {
     struct InitializerParams {
         uint48 saleStartTimestamp;
         uint48 saleEndTimestamp;
-        address owner;
         address saleTokenHolder;
         address commitmentToken;
         address saleToken;
@@ -223,24 +221,24 @@ interface IPublicSaleV1 {
     );
 
     /**
-     * @notice Emitted when owner settles after successful sale
-     * @param owner Address of the contract owner
+     * @notice Emitted when owner settlement is performed after successful sale
+     * @param caller Address that called ownerSettle
      * @param saleProceeds Amount sent to saleProceedsReceiver
      * @param protocolFee Amount sent to protocolFeeReceiver
      */
     event SuccessfulSaleOwnerSettled(
-        address indexed owner,
+        address indexed caller,
         uint256 saleProceeds,
         uint256 protocolFee
     );
 
     /**
-     * @notice Emitted when owner settles after failed sale
-     * @param owner Address of the contract owner
+     * @notice Emitted when owner settlement is performed after failed sale
+     * @param caller Address that called ownerSettle
      * @param saleTokenAmount Amount of sale tokens returned
      */
     event FailedSaleOwnerSettled(
-        address indexed owner,
+        address indexed caller,
         uint256 saleTokenAmount
     );
 
@@ -442,8 +440,8 @@ interface IPublicSaleV1 {
     function settle(address recipient_) external;
 
     /**
-     * @notice Owner settles the sale proceeds and fees
-     * @dev Can only be called by owner after sale has ended
+     * @notice Settle sale proceeds and fees
+     * @dev Can be called by anyone after sale has ended
      */
     function ownerSettle() external;
 }

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -945,7 +945,7 @@ describe('PublicSaleV1', () => {
       );
 
       // Capture the PlanCreated event from the Hedgey contract
-      const tx = await hedgeySale.connect(alice).settle(alice.address);
+      const tx = await hedgeySale.connect(alice).buyerSettle(alice.address);
       const receipt = await tx.wait();
 
       // Extract and log the PlanCreated event
@@ -991,11 +991,11 @@ describe('PublicSaleV1', () => {
 
       // Settle and get lockup plan IDs
       const aliceLockupPlanId = getLockupPlanCreatedEvent(
-        await (await hedgeySale.connect(alice).settle(alice.address)).wait(),
+        await (await hedgeySale.connect(alice).buyerSettle(alice.address)).wait(),
         votingTokenLockupPlans,
       ).planId;
       const bobLockupPlanId = getLockupPlanCreatedEvent(
-        await (await hedgeySale.connect(bob).settle(bob.address)).wait(),
+        await (await hedgeySale.connect(bob).buyerSettle(bob.address)).wait(),
         votingTokenLockupPlans,
       ).planId;
 
@@ -1025,14 +1025,14 @@ describe('PublicSaleV1', () => {
       );
     });
 
-    it('should emit SuccessfulSaleSettled event when Hedgey is enabled', async () => {
+    it('should emit SuccessfulSaleBuyerSettled event when Hedgey is enabled', async () => {
       const commitment = await hedgeySale.commitments(alice.address);
       const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
 
       // The event should not be emitted when Hedgey lockup is enabled
-      await expect(hedgeySale.connect(alice).settle(alice.address))
-        .to.emit(hedgeySale, 'SuccessfulSaleSettled')
+      await expect(hedgeySale.connect(alice).buyerSettle(alice.address))
+        .to.emit(hedgeySale, 'SuccessfulSaleBuyerSettled')
         .withArgs(alice.address, alice.address, expectedSaleTokens);
     });
   });
@@ -1081,8 +1081,8 @@ describe('PublicSaleV1', () => {
       const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
 
-      await expect(publicSale.connect(alice).settle(alice.address))
-        .to.emit(publicSale, 'SuccessfulSaleSettled')
+      await expect(publicSale.connect(alice).buyerSettle(alice.address))
+        .to.emit(publicSale, 'SuccessfulSaleBuyerSettled')
         .withArgs(alice.address, alice.address, expectedSaleTokens);
 
       expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokens);
@@ -1094,7 +1094,7 @@ describe('PublicSaleV1', () => {
       const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
 
-      await publicSale.connect(alice).settle(alice.address);
+      await publicSale.connect(alice).buyerSettle(alice.address);
       expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokens);
     });
 
@@ -1103,7 +1103,7 @@ describe('PublicSaleV1', () => {
       const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
 
-      await publicSale.connect(alice).settle(bob.address);
+      await publicSale.connect(alice).buyerSettle(bob.address);
 
       expect(await saleToken.balanceOf(bob.address)).to.equal(expectedSaleTokens);
       expect(await saleToken.balanceOf(alice.address)).to.equal(0);
@@ -1111,9 +1111,9 @@ describe('PublicSaleV1', () => {
     });
 
     it('should revert when user settles twice', async () => {
-      await publicSale.connect(alice).settle(alice.address);
+      await publicSale.connect(alice).buyerSettle(alice.address);
 
-      await expect(publicSale.connect(alice).settle(alice.address)).to.be.revertedWithCustomError(
+      await expect(publicSale.connect(alice).buyerSettle(alice.address)).to.be.revertedWithCustomError(
         publicSale,
         'AlreadySettled',
       );
@@ -1121,7 +1121,7 @@ describe('PublicSaleV1', () => {
 
     it('should revert when user has no commitment', async () => {
       await expect(
-        publicSale.connect(nonCommitter).settle(nonCommitter.address),
+        publicSale.connect(nonCommitter).buyerSettle(nonCommitter.address),
       ).to.be.revertedWithCustomError(publicSale, 'ZeroCommitment');
     });
 
@@ -1143,7 +1143,7 @@ describe('PublicSaleV1', () => {
         .connect(alice)
         .increaseCommitmentERC20(defaultParams.minimumCommitment, ethers.getBytes('0x'), 0n);
 
-      await expect(activeSale.connect(alice).settle(alice.address)).to.be.revertedWithCustomError(
+      await expect(activeSale.connect(alice).buyerSettle(alice.address)).to.be.revertedWithCustomError(
         activeSale,
         'SaleNotEnded',
       );
@@ -1172,8 +1172,8 @@ describe('PublicSaleV1', () => {
       const commitment = await publicSale.commitments(alice.address);
       const initialBalance = await commitmentToken.balanceOf(alice.address);
 
-      await expect(publicSale.connect(alice).settle(alice.address))
-        .to.emit(publicSale, 'FailedSaleSettled')
+      await expect(publicSale.connect(alice).buyerSettle(alice.address))
+        .to.emit(publicSale, 'FailedSaleBuyerSettled')
         .withArgs(alice.address, alice.address, commitment);
 
       expect(await commitmentToken.balanceOf(alice.address)).to.equal(initialBalance + commitment);
@@ -1181,14 +1181,14 @@ describe('PublicSaleV1', () => {
     });
 
     it('should not transfer any sale tokens when sale fails', async () => {
-      await publicSale.connect(alice).settle(alice.address);
+      await publicSale.connect(alice).buyerSettle(alice.address);
       expect(await saleToken.balanceOf(alice.address)).to.equal(0);
     });
 
     it('should allow settlement to different recipient for refund', async () => {
       const commitment = await publicSale.commitments(alice.address);
 
-      await publicSale.connect(alice).settle(bob.address);
+      await publicSale.connect(alice).buyerSettle(bob.address);
 
       expect(await commitmentToken.balanceOf(bob.address)).to.equal(commitment);
       expect(await commitmentToken.balanceOf(alice.address)).to.equal(
@@ -1241,7 +1241,7 @@ describe('PublicSaleV1', () => {
         (BigInt(totalBalance) * BigInt(defaultParams.protocolFee)) / TEST_CONSTANTS.PRECISION;
       const saleProceedsAmount = BigInt(totalBalance) - protocolFeeAmount;
 
-      await expect((publicSale as any).connect(seller).sellerSettle())
+      await expect(publicSale.connect(seller).sellerSettle())
         .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
         .withArgs(seller.address, saleProceedsAmount, protocolFeeAmount);
 
@@ -1251,7 +1251,7 @@ describe('PublicSaleV1', () => {
       expect(await commitmentToken.balanceOf(protocolFeeReceiver.address)).to.equal(
         protocolFeeAmount,
       );
-      expect(await (publicSale as any).sellerSettled()).to.be.true;
+      expect(await publicSale.sellerSettled()).to.be.true;
     });
 
     it('should handle different protocol fee percentages', async () => {
@@ -1289,7 +1289,7 @@ describe('PublicSaleV1', () => {
       const protocolFeeAmount =
         (totalBalance * ethers.parseEther('0.1')) / TEST_CONSTANTS.PRECISION;
 
-      await (customSale as any).connect(seller).sellerSettle();
+      await customSale.connect(seller).sellerSettle();
 
       expect(await commitmentToken.balanceOf(protocolFeeReceiver.address)).to.equal(
         protocolFeeAmount,
@@ -1297,16 +1297,16 @@ describe('PublicSaleV1', () => {
     });
 
     it('should revert when owner settles twice', async () => {
-      await (publicSale as any).connect(seller).sellerSettle();
+      await publicSale.connect(seller).sellerSettle();
 
-      await expect((publicSale as any).connect(seller).sellerSettle()).to.be.revertedWithCustomError(
+      await expect(publicSale.connect(seller).sellerSettle()).to.be.revertedWithCustomError(
         publicSale,
         'AlreadySettled',
       );
     });
 
     it('should allow anyone to settle', async () => {
-      await expect((publicSale as any).connect(alice).sellerSettle()).to.not.be.reverted;
+      await expect(publicSale.connect(alice).sellerSettle()).to.not.be.reverted;
     });
   });
 
@@ -1333,7 +1333,7 @@ describe('PublicSaleV1', () => {
     it('should return all sale tokens and collected fees', async () => {
       const saleTokenBalance = await saleToken.balanceOf(await publicSale.getAddress());
 
-      await expect((publicSale as any).connect(seller).sellerSettle())
+      await expect(publicSale.connect(seller).sellerSettle())
         .to.emit(publicSale, 'FailedSaleSellerSettled')
         .withArgs(seller.address, saleTokenBalance);
 
@@ -1417,7 +1417,7 @@ describe('PublicSaleV1', () => {
       const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / ethers.parseEther('0.000001');
 
-      await extremeSale.connect(alice).settle(alice.address);
+      await extremeSale.connect(alice).buyerSettle(alice.address);
 
       expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokens);
     });
@@ -1598,8 +1598,8 @@ describe('PublicSaleV1', () => {
       const expectedSaleTokens =
         (BigInt(aliceCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
 
-      await expect(publicSale.connect(alice).settle(alice.address))
-        .to.emit(publicSale, 'SuccessfulSaleSettled')
+      await expect(publicSale.connect(alice).buyerSettle(alice.address))
+        .to.emit(publicSale, 'SuccessfulSaleBuyerSettled')
         .withArgs(alice.address, alice.address, expectedSaleTokens);
 
       // Owner settlement
@@ -1608,7 +1608,7 @@ describe('PublicSaleV1', () => {
         (BigInt(totalBalance) * BigInt(defaultParams.protocolFee)) / TEST_CONSTANTS.PRECISION;
       const saleProceedsAmount = BigInt(totalBalance) - protocolFeeAmount;
 
-      await expect((publicSale as any).connect(seller).sellerSettle())
+      await expect(publicSale.connect(seller).sellerSettle())
         .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
         .withArgs(seller.address, saleProceedsAmount, protocolFeeAmount);
     });
@@ -1620,7 +1620,7 @@ describe('PublicSaleV1', () => {
     });
 
     it('should return all correct values from view functions', async () => {
-      expect(await (publicSale as any).sellerSettled()).to.be.false;
+      expect(await publicSale.sellerSettled()).to.be.false;
       expect(await publicSale.saleStartTimestamp()).to.equal(defaultParams.saleStartTimestamp);
       expect(await publicSale.saleEndTimestamp()).to.equal(defaultParams.saleEndTimestamp);
       expect(await publicSale.commitmentToken()).to.equal(defaultParams.commitmentToken);

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -1025,15 +1025,34 @@ describe('PublicSaleV1', () => {
       );
     });
 
-    it('should emit SuccessfulSaleBuyerSettled event when Hedgey is enabled', async () => {
+    it('should emit SuccessfulSaleBuyerSettledHedgey event when Hedgey is enabled', async () => {
       const commitment = await hedgeySale.commitments(alice.address);
       const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
 
       // The event should not be emitted when Hedgey lockup is enabled
-      await expect(hedgeySale.connect(alice).buyerSettle(alice.address))
-        .to.emit(hedgeySale, 'SuccessfulSaleBuyerSettled')
-        .withArgs(alice.address, alice.address, expectedSaleTokens);
+      const tx2 = await hedgeySale.connect(alice).buyerSettle(alice.address);
+      const receipt2 = await tx2.wait();
+
+      // Read plan id from Hedgey PlanCreated
+      const planCreated = getLockupPlanCreatedEvent(receipt2, votingTokenLockupPlans);
+      const planId = planCreated?.planId;
+
+      // Find SuccessfulSaleBuyerSettledHedgey event emitted by PublicSale
+      const saleLog = (receipt2?.logs ?? []).find((l: any) => {
+        try {
+          const parsed = hedgeySale.interface.parseLog(l);
+          return parsed?.name === 'SuccessfulSaleBuyerSettledHedgey';
+        } catch {
+          return false;
+        }
+      });
+      const parsed = saleLog ? hedgeySale.interface.parseLog(saleLog) : null;
+      expect(parsed).to.not.equal(null);
+      expect(parsed?.args?.[0]).to.equal(alice.address);
+      expect(parsed?.args?.[1]).to.equal(alice.address);
+      expect(parsed?.args?.[2]).to.equal(expectedSaleTokens);
+      expect(parsed?.args?.[3]).to.equal(planId);
     });
   });
 
@@ -1113,10 +1132,9 @@ describe('PublicSaleV1', () => {
     it('should revert when user settles twice', async () => {
       await publicSale.connect(alice).buyerSettle(alice.address);
 
-      await expect(publicSale.connect(alice).buyerSettle(alice.address)).to.be.revertedWithCustomError(
-        publicSale,
-        'AlreadySettled',
-      );
+      await expect(
+        publicSale.connect(alice).buyerSettle(alice.address),
+      ).to.be.revertedWithCustomError(publicSale, 'AlreadySettled');
     });
 
     it('should revert when user has no commitment', async () => {
@@ -1143,10 +1161,9 @@ describe('PublicSaleV1', () => {
         .connect(alice)
         .increaseCommitmentERC20(defaultParams.minimumCommitment, ethers.getBytes('0x'), 0n);
 
-      await expect(activeSale.connect(alice).buyerSettle(alice.address)).to.be.revertedWithCustomError(
-        activeSale,
-        'SaleNotEnded',
-      );
+      await expect(
+        activeSale.connect(alice).buyerSettle(alice.address),
+      ).to.be.revertedWithCustomError(activeSale, 'SaleNotEnded');
     });
   });
 
@@ -1674,7 +1691,7 @@ describe('PublicSaleV1 - Shared Tests', () => {
 
     // Setup default parameters
     const currentTime = await time.latest();
-      defaultParams = {
+    defaultParams = {
       saleStartTimestamp: currentTime + 3600,
       saleEndTimestamp: currentTime + 86400,
       saleTokenHolder: saleTokenHolder.address,

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -219,7 +219,7 @@ function getLockupPlanCreatedEvent(
 
 describe('PublicSaleV1', () => {
   let deployer: SignerWithAddress;
-  let owner: SignerWithAddress;
+  let seller: SignerWithAddress;
   let alice: SignerWithAddress;
   let bob: SignerWithAddress;
   let charlie: SignerWithAddress;
@@ -239,7 +239,7 @@ describe('PublicSaleV1', () => {
   beforeEach(async () => {
     [
       deployer,
-      owner,
+      seller,
       alice,
       bob,
       charlie,
@@ -1241,9 +1241,9 @@ describe('PublicSaleV1', () => {
         (BigInt(totalBalance) * BigInt(defaultParams.protocolFee)) / TEST_CONSTANTS.PRECISION;
       const saleProceedsAmount = BigInt(totalBalance) - protocolFeeAmount;
 
-      await expect(publicSale.connect(owner).ownerSettle())
-        .to.emit(publicSale, 'SuccessfulSaleOwnerSettled')
-        .withArgs(owner.address, saleProceedsAmount, protocolFeeAmount);
+      await expect((publicSale as any).connect(seller).sellerSettle())
+        .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
+        .withArgs(seller.address, saleProceedsAmount, protocolFeeAmount);
 
       expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(
         saleProceedsAmount,
@@ -1251,7 +1251,7 @@ describe('PublicSaleV1', () => {
       expect(await commitmentToken.balanceOf(protocolFeeReceiver.address)).to.equal(
         protocolFeeAmount,
       );
-      expect(await publicSale.ownerSettled()).to.be.true;
+      expect(await (publicSale as any).sellerSettled()).to.be.true;
     });
 
     it('should handle different protocol fee percentages', async () => {
@@ -1289,7 +1289,7 @@ describe('PublicSaleV1', () => {
       const protocolFeeAmount =
         (totalBalance * ethers.parseEther('0.1')) / TEST_CONSTANTS.PRECISION;
 
-      await customSale.connect(owner).ownerSettle();
+      await (customSale as any).connect(seller).sellerSettle();
 
       expect(await commitmentToken.balanceOf(protocolFeeReceiver.address)).to.equal(
         protocolFeeAmount,
@@ -1297,16 +1297,16 @@ describe('PublicSaleV1', () => {
     });
 
     it('should revert when owner settles twice', async () => {
-      await publicSale.connect(owner).ownerSettle();
+      await (publicSale as any).connect(seller).sellerSettle();
 
-      await expect(publicSale.connect(owner).ownerSettle()).to.be.revertedWithCustomError(
+      await expect((publicSale as any).connect(seller).sellerSettle()).to.be.revertedWithCustomError(
         publicSale,
         'AlreadySettled',
       );
     });
 
     it('should allow anyone to settle', async () => {
-      await expect(publicSale.connect(alice).ownerSettle()).to.not.be.reverted;
+      await expect((publicSale as any).connect(alice).sellerSettle()).to.not.be.reverted;
     });
   });
 
@@ -1333,9 +1333,9 @@ describe('PublicSaleV1', () => {
     it('should return all sale tokens and collected fees', async () => {
       const saleTokenBalance = await saleToken.balanceOf(await publicSale.getAddress());
 
-      await expect(publicSale.connect(owner).ownerSettle())
-        .to.emit(publicSale, 'FailedSaleOwnerSettled')
-        .withArgs(owner.address, saleTokenBalance);
+      await expect((publicSale as any).connect(seller).sellerSettle())
+        .to.emit(publicSale, 'FailedSaleSellerSettled')
+        .withArgs(seller.address, saleTokenBalance);
 
       expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(saleTokenBalance);
       expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(0);
@@ -1608,9 +1608,9 @@ describe('PublicSaleV1', () => {
         (BigInt(totalBalance) * BigInt(defaultParams.protocolFee)) / TEST_CONSTANTS.PRECISION;
       const saleProceedsAmount = BigInt(totalBalance) - protocolFeeAmount;
 
-      await expect(publicSale.connect(owner).ownerSettle())
-        .to.emit(publicSale, 'SuccessfulSaleOwnerSettled')
-        .withArgs(owner.address, saleProceedsAmount, protocolFeeAmount);
+      await expect((publicSale as any).connect(seller).sellerSettle())
+        .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
+        .withArgs(seller.address, saleProceedsAmount, protocolFeeAmount);
     });
   });
 
@@ -1620,7 +1620,7 @@ describe('PublicSaleV1', () => {
     });
 
     it('should return all correct values from view functions', async () => {
-      expect(await publicSale.ownerSettled()).to.be.false;
+      expect(await (publicSale as any).sellerSettled()).to.be.false;
       expect(await publicSale.saleStartTimestamp()).to.equal(defaultParams.saleStartTimestamp);
       expect(await publicSale.saleEndTimestamp()).to.equal(defaultParams.saleEndTimestamp);
       expect(await publicSale.commitmentToken()).to.equal(defaultParams.commitmentToken);

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -271,7 +271,6 @@ describe('PublicSaleV1', () => {
     defaultParams = {
       saleStartTimestamp: BigInt(currentTime + 3600), // 1 hour from now
       saleEndTimestamp: BigInt(currentTime + 86400), // 24 hours from now
-      owner: owner.address,
       saleTokenHolder: saleTokenHolder.address,
       commitmentToken: await commitmentToken.getAddress(),
       saleToken: await saleToken.getAddress(),
@@ -305,7 +304,6 @@ describe('PublicSaleV1', () => {
       // Verify all parameters are set correctly
       expect(await publicSale.saleStartTimestamp()).to.equal(defaultParams.saleStartTimestamp);
       expect(await publicSale.saleEndTimestamp()).to.equal(defaultParams.saleEndTimestamp);
-      expect(await publicSale.owner()).to.equal(defaultParams.owner);
       expect(await publicSale.commitmentToken()).to.equal(defaultParams.commitmentToken);
       expect(await publicSale.saleToken()).to.equal(defaultParams.saleToken);
       expect(await publicSale.kycVerifier()).to.equal(defaultParams.kycVerifier);
@@ -1307,11 +1305,8 @@ describe('PublicSaleV1', () => {
       );
     });
 
-    it('should revert when non-owner tries to settle', async () => {
-      await expect(publicSale.connect(alice).ownerSettle()).to.be.revertedWithCustomError(
-        publicSale,
-        'OwnableUnauthorizedAccount',
-      );
+    it('should allow anyone to settle', async () => {
+      await expect(publicSale.connect(alice).ownerSettle()).to.not.be.reverted;
     });
   });
 
@@ -1457,34 +1452,6 @@ describe('PublicSaleV1', () => {
           .connect(alice)
           .increaseCommitmentERC20(ethers.parseEther('100'), ethers.getBytes('0x'), 0n),
       ).to.be.revertedWithCustomError(kycVerifier, 'InvalidSignature');
-    });
-  });
-
-  describe('Access Control', () => {
-    beforeEach(async () => {
-      publicSale = await deployPublicSaleProxy(deployer, defaultParams);
-      await time.increaseTo(Number(defaultParams.saleEndTimestamp) + 1);
-    });
-
-    it('should only allow owner to call ownerSettle', async () => {
-      await expect(publicSale.connect(alice).ownerSettle()).to.be.revertedWithCustomError(
-        publicSale,
-        'OwnableUnauthorizedAccount',
-      );
-
-      await expect(publicSale.connect(owner).ownerSettle()).to.not.be.reverted;
-    });
-
-    it('should allow ownership transfer using Ownable2Step pattern', async () => {
-      // Start transfer
-      await publicSale.connect(owner).transferOwnership(alice.address);
-      expect(await publicSale.owner()).to.equal(owner.address);
-      expect(await publicSale.pendingOwner()).to.equal(alice.address);
-
-      // Accept transfer
-      await publicSale.connect(alice).acceptOwnership();
-      expect(await publicSale.owner()).to.equal(alice.address);
-      expect(await publicSale.pendingOwner()).to.equal(ethers.ZeroAddress);
     });
   });
 
@@ -1681,7 +1648,6 @@ describe('PublicSaleV1', () => {
 // Run shared test suites
 describe('PublicSaleV1 - Shared Tests', () => {
   let deployer: SignerWithAddress;
-  let owner: SignerWithAddress;
   let saleProceedsReceiver: SignerWithAddress;
   let protocolFeeReceiver: SignerWithAddress;
   let saleTokenHolder: SignerWithAddress;
@@ -1692,7 +1658,7 @@ describe('PublicSaleV1 - Shared Tests', () => {
   let defaultParams: IPublicSaleV1.InitializerParamsStruct;
 
   beforeEach(async () => {
-    [deployer, owner, saleProceedsReceiver, protocolFeeReceiver, saleTokenHolder] =
+    [deployer, saleProceedsReceiver, protocolFeeReceiver, saleTokenHolder] =
       await ethers.getSigners();
 
     // Deploy mock contracts
@@ -1708,10 +1674,9 @@ describe('PublicSaleV1 - Shared Tests', () => {
 
     // Setup default parameters
     const currentTime = await time.latest();
-    defaultParams = {
+      defaultParams = {
       saleStartTimestamp: currentTime + 3600,
       saleEndTimestamp: currentTime + 86400,
-      owner: owner.address,
       saleTokenHolder: saleTokenHolder.address,
       commitmentToken: await commitmentToken.getAddress(),
       saleToken: await saleToken.getAddress(),
@@ -1768,7 +1733,6 @@ describe('PublicSaleV1 - Shared Tests', () => {
         const initParams = {
           saleStartTimestamp: currentTime + 3600,
           saleEndTimestamp: currentTime + 86400,
-          owner: owner.address,
           saleTokenHolder: saleTokenHolder.address,
           commitmentToken: await commitmentToken.getAddress(),
           saleToken: await saleToken.getAddress(),
@@ -1820,7 +1784,7 @@ describe('PublicSaleV1 - Shared Tests', () => {
         // Use the saved params to ensure timestamps match
         return ethers.AbiCoder.defaultAbiCoder().encode(
           [
-            'tuple(uint48 saleStartTimestamp, uint48 saleEndTimestamp, address owner, address saleTokenHolder, address commitmentToken, address saleToken, address kycVerifier, address saleProceedsReceiver, address protocolFeeReceiver, uint256 minimumCommitment, uint256 maximumCommitment, uint256 minimumTotalCommitment, uint256 maximumTotalCommitment, uint256 saleTokenPrice, uint256 protocolFee, tuple(bool enabled, uint256 start, uint256 cliff, uint256 ratePercentage, uint256 period, address votingTokenLockupPlans) hedgeyLockupParams)',
+            'tuple(uint48 saleStartTimestamp, uint48 saleEndTimestamp, address saleTokenHolder, address commitmentToken, address saleToken, address kycVerifier, address saleProceedsReceiver, address protocolFeeReceiver, uint256 minimumCommitment, uint256 maximumCommitment, uint256 minimumTotalCommitment, uint256 maximumTotalCommitment, uint256 saleTokenPrice, uint256 protocolFee, tuple(bool enabled, uint256 start, uint256 cliff, uint256 ratePercentage, uint256 period, address votingTokenLockupPlans) hedgeyLockupParams)',
           ],
           [savedInitParams],
         );


### PR DESCRIPTION
This PR: 
- Removes `Ownable2StepUpgradeable` inheritance from `PublicSaleV1`
- Replaces references to `owner` with `seller`
- Adds reference to `buyer` in functions and events.
- Creates a new event `SuccessfulSaleBuyerSettledHedgey` that emits the created lockup plan ID