### PR TITLE
add sale token protocol fee

### DIFF
--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -192,10 +192,13 @@ contract PublicSaleV1 is
         $.saleTokenProtocolFee = params_.saleTokenProtocolFee;
         $.hedgeyLockupParams = params_.hedgeyLockupParams;
 
+        // calculate the amount of sale tokens for this contract to escrow
+        // this is the maximum amount of sale tokens that can be sold plus the sale token protocol fee
         uint256 saleTokenEscrowAmount = (params_.maximumTotalCommitment *
-            PRECISION) / params_.saleTokenPrice;
+            (PRECISION + params_.saleTokenProtocolFee)) /
+            params_.saleTokenPrice;
 
-        // transfer sale token from holder to this contract
+        // transfer sale tokens from holder to this contract
         IERC20(params_.saleToken).safeTransferFrom(
             params_.saleTokenHolder,
             address(this),
@@ -597,10 +600,9 @@ contract PublicSaleV1 is
         SaleState state = saleState();
 
         if (state == SaleState.SUCCEEDED) {
-            // calculate the amount of sale tokens to transfer to the recipient,
-            // subtracting out the sale token protocol fee
-            uint256 saleTokenAmount = ($.commitments[msg.sender] *
-                (PRECISION - $.saleTokenProtocolFee)) / $.saleTokenPrice;
+            // calculate the amount of sale tokens purchased by the buyer
+            uint256 saleTokenAmount = ($.commitments[msg.sender] * PRECISION) /
+                $.saleTokenPrice;
 
             if ($.hedgeyLockupParams.enabled) {
                 // approve hedgey lockup plan to transfer the sale token
@@ -713,13 +715,17 @@ contract PublicSaleV1 is
                 saleTokenProtocolFeeAmount
             );
 
-            uint256 unsoldSaleTokenAmount = (($.maximumTotalCommitment -
-                $.totalCommitments) * PRECISION) / $.saleTokenPrice;
+            uint256 saleTokenEscrowAmount = ($.maximumTotalCommitment *
+                (PRECISION + $.saleTokenProtocolFee)) / $.saleTokenPrice;
+
+            uint256 leftoverSaleTokenAmount = saleTokenEscrowAmount -
+                saleTokenSold -
+                saleTokenProtocolFeeAmount;
 
             // send unsold sale tokens to saleProceedsReceiver
             IERC20($.saleToken).safeTransfer(
                 $.saleProceedsReceiver,
-                unsoldSaleTokenAmount
+                leftoverSaleTokenAmount
             );
 
             emit SuccessfulSaleSellerSettled(
@@ -727,10 +733,11 @@ contract PublicSaleV1 is
                 commitmentTokenProtocolFeeAmount,
                 commitmentTokenAmountToSeller,
                 saleTokenProtocolFeeAmount,
-                unsoldSaleTokenAmount
+                leftoverSaleTokenAmount
             );
         } else if (state == SaleState.FAILED) {
             // transfer entire balance of sale tokens to saleProceedsReceiver
+            // no protocol fees taken on failed sale
             uint256 saleTokenAmount = IERC20($.saleToken).balanceOf(
                 address(this)
             );

--- a/contracts/deployables/public-sale/PublicSaleV1.sol
+++ b/contracts/deployables/public-sale/PublicSaleV1.sol
@@ -60,7 +60,8 @@ contract PublicSaleV1 is
         uint256 minimumTotalCommitment;
         uint256 maximumTotalCommitment;
         uint256 saleTokenPrice;
-        uint256 protocolFee;
+        uint256 commitmentTokenProtocolFee;
+        uint256 saleTokenProtocolFee;
         uint256 totalCommitments;
         HedgeyLockupParams hedgeyLockupParams;
         mapping(address account => uint256 commitmentAmount) commitments;
@@ -150,7 +151,10 @@ contract PublicSaleV1 is
         if (params_.minimumTotalCommitment > params_.maximumTotalCommitment)
             revert InvalidTotalCommitmentAmounts();
 
-        if (params_.protocolFee > PRECISION) revert InvalidProtocolFee();
+        if (
+            params_.commitmentTokenProtocolFee > PRECISION ||
+            params_.saleTokenProtocolFee > PRECISION
+        ) revert InvalidProtocolFee();
 
         __InitializerEventEmitter_init(abi.encode(params_));
         __DeploymentBlockInitializable_init();
@@ -184,7 +188,8 @@ contract PublicSaleV1 is
         $.minimumTotalCommitment = params_.minimumTotalCommitment;
         $.maximumTotalCommitment = params_.maximumTotalCommitment;
         $.saleTokenPrice = params_.saleTokenPrice;
-        $.protocolFee = params_.protocolFee;
+        $.commitmentTokenProtocolFee = params_.commitmentTokenProtocolFee;
+        $.saleTokenProtocolFee = params_.saleTokenProtocolFee;
         $.hedgeyLockupParams = params_.hedgeyLockupParams;
 
         uint256 saleTokenEscrowAmount = (params_.maximumTotalCommitment *
@@ -387,11 +392,30 @@ contract PublicSaleV1 is
     /**
      * @inheritdoc IPublicSaleV1
      */
-    function protocolFee() external view virtual override returns (uint256) {
+    function commitmentTokenProtocolFee()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         PublicSaleStorage storage $ = _getPublicSaleStorage();
-        return $.protocolFee;
+        return $.commitmentTokenProtocolFee;
     }
 
+    /**
+     * @inheritdoc IPublicSaleV1
+     */
+    function saleTokenProtocolFee()
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        PublicSaleStorage storage $ = _getPublicSaleStorage();
+        return $.saleTokenProtocolFee;
+    }
     /**
      * @inheritdoc IPublicSaleV1
      */
@@ -573,10 +597,10 @@ contract PublicSaleV1 is
         SaleState state = saleState();
 
         if (state == SaleState.SUCCEEDED) {
-            // sale succeeded
-
-            uint256 saleTokenAmount = ($.commitments[msg.sender] * PRECISION) /
-                $.saleTokenPrice;
+            // calculate the amount of sale tokens to transfer to the recipient,
+            // subtracting out the sale token protocol fee
+            uint256 saleTokenAmount = ($.commitments[msg.sender] *
+                (PRECISION - $.saleTokenProtocolFee)) / $.saleTokenPrice;
 
             if ($.hedgeyLockupParams.enabled) {
                 // approve hedgey lockup plan to transfer the sale token
@@ -648,37 +672,62 @@ contract PublicSaleV1 is
         SaleState state = saleState();
 
         if (state == SaleState.SUCCEEDED) {
-            uint256 commitmentTokenAmount;
+            uint256 commitmentTokenBalance;
             if ($.commitmentToken == NATIVE_ASSET) {
-                commitmentTokenAmount = address(this).balance;
+                commitmentTokenBalance = address(this).balance;
             } else {
-                commitmentTokenAmount = IERC20($.commitmentToken).balanceOf(
+                commitmentTokenBalance = IERC20($.commitmentToken).balanceOf(
                     address(this)
                 );
             }
 
-            uint256 _protocolFee = (commitmentTokenAmount * $.protocolFee) /
-                PRECISION;
-            uint256 saleProceeds = commitmentTokenAmount - _protocolFee;
+            uint256 commitmentTokenProtocolFeeAmount = (commitmentTokenBalance *
+                $.commitmentTokenProtocolFee) / PRECISION;
+
+            // send commitment token protocol fee to protocolFeeReceiver
+            _transferTokenOrNative(
+                $.commitmentToken,
+                $.protocolFeeReceiver,
+                commitmentTokenProtocolFeeAmount
+            );
+
+            uint256 commitmentTokenAmountToSeller = commitmentTokenBalance -
+                commitmentTokenProtocolFeeAmount;
 
             // send (commitments - protocol fee) to saleProceedsReceiver
             _transferTokenOrNative(
                 $.commitmentToken,
                 $.saleProceedsReceiver,
-                saleProceeds
+                commitmentTokenAmountToSeller
             );
 
-            // send protocol fee to protocolFeeReceiver
-            _transferTokenOrNative(
-                $.commitmentToken,
+            uint256 saleTokenSold = ($.totalCommitments * PRECISION) /
+                $.saleTokenPrice;
+
+            uint256 saleTokenProtocolFeeAmount = (saleTokenSold *
+                $.saleTokenProtocolFee) / PRECISION;
+
+            // send sale token protocol fee to protocolFeeReceiver
+            IERC20($.saleToken).safeTransfer(
                 $.protocolFeeReceiver,
-                _protocolFee
+                saleTokenProtocolFeeAmount
+            );
+
+            uint256 unsoldSaleTokenAmount = (($.maximumTotalCommitment -
+                $.totalCommitments) * PRECISION) / $.saleTokenPrice;
+
+            // send unsold sale tokens to saleProceedsReceiver
+            IERC20($.saleToken).safeTransfer(
+                $.saleProceedsReceiver,
+                unsoldSaleTokenAmount
             );
 
             emit SuccessfulSaleSellerSettled(
                 msg.sender,
-                saleProceeds,
-                _protocolFee
+                commitmentTokenProtocolFeeAmount,
+                commitmentTokenAmountToSeller,
+                saleTokenProtocolFeeAmount,
+                unsoldSaleTokenAmount
             );
         } else if (state == SaleState.FAILED) {
             // transfer entire balance of sale tokens to saleProceedsReceiver

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -241,14 +241,14 @@ interface IPublicSaleV1 {
      * @param commitmentTokenProtocolFeeAmount Commitment token amount taken as protocol fee
      * @param commitmentTokenAmountToSeller Commitment token amount sent to saleProceedsReceiver
      * @param saleTokenProtocolFeeAmount Sale tokena amount taken as protocol fee
-     * @param unsoldSaleTokenAmount Sale token amount sent to saleProceedsReceiver
+     * @param leftoverSaleTokenAmount Sale token amount leftover after sale
      */
     event SuccessfulSaleSellerSettled(
         address indexed caller,
         uint256 commitmentTokenProtocolFeeAmount,
         uint256 commitmentTokenAmountToSeller,
         uint256 saleTokenProtocolFeeAmount,
-        uint256 unsoldSaleTokenAmount
+        uint256 leftoverSaleTokenAmount
     );
 
     /**

--- a/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/IPublicSaleV1.sol
@@ -150,7 +150,8 @@ interface IPublicSaleV1 {
      * @param minimumTotalCommitment Minimum total commitments for successful sale
      * @param maximumTotalCommitment Maximum total commitments allowed
      * @param saleTokenPrice Price per sale token in commitment token units (with PRECISION decimals)
-     * @param protocolFee Fee percentage taken from proceeds (with PRECISION decimals)
+     * @param commitmentTokenProtocolFee Fee percentage taken from commitment token proceeds (with PRECISION decimals)
+     * @param saleTokenProtocolFee Fee percentage taken from sale token (with PRECISION decimals)
      * @param hedgeyLockupParams Parameters for initializing hedgey lockup plan
      */
     struct InitializerParams {
@@ -167,7 +168,8 @@ interface IPublicSaleV1 {
         uint256 minimumTotalCommitment;
         uint256 maximumTotalCommitment;
         uint256 saleTokenPrice;
-        uint256 protocolFee;
+        uint256 commitmentTokenProtocolFee;
+        uint256 saleTokenProtocolFee;
         HedgeyLockupParams hedgeyLockupParams;
     }
 
@@ -236,13 +238,17 @@ interface IPublicSaleV1 {
     /**
      * @notice Emitted when seller settlement is performed after successful sale
      * @param caller Address that called sellerSettle
-     * @param saleProceeds Amount sent to saleProceedsReceiver
-     * @param protocolFee Amount sent to protocolFeeReceiver
+     * @param commitmentTokenProtocolFeeAmount Commitment token amount taken as protocol fee
+     * @param commitmentTokenAmountToSeller Commitment token amount sent to saleProceedsReceiver
+     * @param saleTokenProtocolFeeAmount Sale tokena amount taken as protocol fee
+     * @param unsoldSaleTokenAmount Sale token amount sent to saleProceedsReceiver
      */
     event SuccessfulSaleSellerSettled(
         address indexed caller,
-        uint256 saleProceeds,
-        uint256 protocolFee
+        uint256 commitmentTokenProtocolFeeAmount,
+        uint256 commitmentTokenAmountToSeller,
+        uint256 saleTokenProtocolFeeAmount,
+        uint256 unsoldSaleTokenAmount
     );
 
     /**
@@ -350,10 +356,16 @@ interface IPublicSaleV1 {
     function saleTokenPrice() external view returns (uint256 price);
 
     /**
-     * @notice Returns the protocol fee
+     * @notice Returns the commitment token protocol fee
      * @return fee Fee percentage (with PRECISION decimals)
      */
-    function protocolFee() external view returns (uint256 fee);
+    function commitmentTokenProtocolFee() external view returns (uint256 fee);
+
+    /**
+     * @notice Returns the sale token protocol fee
+     * @return fee Fee percentage (with PRECISION decimals)
+     */
+    function saleTokenProtocolFee() external view returns (uint256 fee);
 
     /**
      * @notice Returns the total commitments in the sale

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -50,7 +50,8 @@ async function deployPublicSaleProxy(
 
   // Calculate required sale token amount
   const saleTokenAmount =
-    (BigInt(params.maximumTotalCommitment) * ethers.parseEther('1')) /
+    (BigInt(params.maximumTotalCommitment) *
+      (TEST_CONSTANTS.PRECISION + BigInt(params.saleTokenProtocolFee))) /
     BigInt(params.saleTokenPrice);
 
   // Deploy implementation
@@ -125,7 +126,8 @@ async function deployTestSale(
 
   // Calculate and mint required sale tokens
   const requiredSaleTokens =
-    (BigInt(params.maximumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
+    (BigInt(params.maximumTotalCommitment) *
+      (TEST_CONSTANTS.PRECISION + BigInt(params.saleTokenProtocolFee))) /
     BigInt(params.saleTokenPrice);
   await saleToken.mint(saleTokenHolder.address, requiredSaleTokens);
 
@@ -268,7 +270,7 @@ describe('PublicSaleV1', () => {
     );
 
     // Mint tokens to sale token holder
-    await saleToken.mint(saleTokenHolder.address, ethers.parseEther('1000000'));
+    await saleToken.mint(saleTokenHolder.address, ethers.parseEther('1050000'));
 
     // Setup default parameters
     const currentTime = await time.latest();
@@ -344,8 +346,10 @@ describe('PublicSaleV1', () => {
 
       // Verify sale tokens were transferred to the contract
       const expectedSaleTokenAmount =
-        (BigInt(defaultParams.maximumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
+        (BigInt(defaultParams.maximumTotalCommitment) *
+          (TEST_CONSTANTS.PRECISION + BigInt(defaultParams.saleTokenProtocolFee))) /
         BigInt(defaultParams.saleTokenPrice);
+
       expect(await saleToken.balanceOf(await publicSale.getAddress())).to.equal(
         expectedSaleTokenAmount,
       );
@@ -955,13 +959,8 @@ describe('PublicSaleV1', () => {
 
     it('should create Hedgey lockup plan instead of direct transfer when enabled', async () => {
       const commitment = await hedgeySale.commitments(alice.address);
-      const expectedSaleTokensBeforeFee =
+      const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
-
-      const expectedSaleTokensAfterFee =
-        (BigInt(expectedSaleTokensBeforeFee) *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
       // Get initial balances
       const initialSaleTokenBalance = await saleToken.balanceOf(await hedgeySale.getAddress());
@@ -979,12 +978,12 @@ describe('PublicSaleV1', () => {
       const lockupPlan = await votingTokenLockupPlans.plans(lockupPlanId);
 
       expect(lockupPlan.token).to.equal(await saleToken.getAddress());
-      expect(lockupPlan.amount).to.equal(expectedSaleTokensAfterFee);
+      expect(lockupPlan.amount).to.equal(expectedSaleTokens);
       expect(lockupPlan.start).to.equal(BigInt(lockupStartTime));
       expect(lockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
       expect(lockupPlan.period).to.equal(BigInt(10_000));
       expect(lockupPlan.rate).to.equal(
-        (expectedSaleTokensAfterFee * ethers.parseEther('0.0025')) / TEST_CONSTANTS.PRECISION,
+        (expectedSaleTokens * ethers.parseEther('0.0025')) / TEST_CONSTANTS.PRECISION,
       );
 
       // verify correct end time
@@ -994,10 +993,10 @@ describe('PublicSaleV1', () => {
 
       // Verify sale tokens were transferred to Hedgey contract
       expect(await saleToken.balanceOf(await hedgeySale.getAddress())).to.equal(
-        initialSaleTokenBalance - expectedSaleTokensAfterFee,
+        initialSaleTokenBalance - expectedSaleTokens,
       );
       expect(await saleToken.balanceOf(await votingTokenLockupPlans.getAddress())).to.equal(
-        initialHedgeyBalance + expectedSaleTokensAfterFee,
+        initialHedgeyBalance + expectedSaleTokens,
       );
 
       // Verify user didn't receive tokens directly
@@ -1009,21 +1008,11 @@ describe('PublicSaleV1', () => {
       const aliceCommitment = await hedgeySale.commitments(alice.address);
       const bobCommitment = await hedgeySale.commitments(bob.address);
 
-      const aliceExpectedSaleTokensBeforeFee =
+      const aliceExpectedSaleTokens =
         (BigInt(aliceCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
 
-      const aliceExpectedSaleTokensAfterFee =
-        (BigInt(aliceExpectedSaleTokensBeforeFee) *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
-
-      const bobExpectedSaleTokensBeforeFee =
+      const bobExpectedSaleTokens =
         (BigInt(bobCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
-
-      const bobExpectedSaleTokensAfterFee =
-        (BigInt(bobExpectedSaleTokensBeforeFee) *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
       // Settle and get lockup plan IDs
       const aliceLockupPlanId = getLockupPlanCreatedEvent(
@@ -1041,13 +1030,13 @@ describe('PublicSaleV1', () => {
 
       // Verify lockup plans
       expect(aliceLockupPlan.token).to.equal(await saleToken.getAddress());
-      expect(aliceLockupPlan.amount).to.equal(aliceExpectedSaleTokensAfterFee);
+      expect(aliceLockupPlan.amount).to.equal(aliceExpectedSaleTokens);
       expect(aliceLockupPlan.start).to.equal(BigInt(lockupStartTime));
       expect(aliceLockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
       expect(aliceLockupPlan.period).to.equal(BigInt(10_000));
 
       expect(bobLockupPlan.token).to.equal(await saleToken.getAddress());
-      expect(bobLockupPlan.amount).to.equal(bobExpectedSaleTokensAfterFee);
+      expect(bobLockupPlan.amount).to.equal(bobExpectedSaleTokens);
       expect(bobLockupPlan.start).to.equal(BigInt(lockupStartTime));
       expect(bobLockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
       expect(bobLockupPlan.period).to.equal(BigInt(10_000));
@@ -1063,13 +1052,8 @@ describe('PublicSaleV1', () => {
 
     it('should emit SuccessfulSaleBuyerSettledHedgey event when Hedgey is enabled', async () => {
       const commitment = await hedgeySale.commitments(alice.address);
-      const expectedSaleTokensBeforeFee =
+      const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
-
-      const expectedSaleTokensAfterFee =
-        (BigInt(expectedSaleTokensBeforeFee) *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
       // The event should not be emitted when Hedgey lockup is enabled
       const tx2 = await hedgeySale.connect(alice).buyerSettle(alice.address);
@@ -1092,7 +1076,7 @@ describe('PublicSaleV1', () => {
       expect(parsed).to.not.equal(null);
       expect(parsed?.args?.[0]).to.equal(alice.address);
       expect(parsed?.args?.[1]).to.equal(alice.address);
-      expect(parsed?.args?.[2]).to.equal(expectedSaleTokensAfterFee);
+      expect(parsed?.args?.[2]).to.equal(expectedSaleTokens);
       expect(parsed?.args?.[3]).to.equal(planId);
     });
   });
@@ -1138,35 +1122,25 @@ describe('PublicSaleV1', () => {
 
     it('should allow user to settle and receive sale tokens directly', async () => {
       const commitment = await publicSale.commitments(alice.address);
-      const expectedSaleTokensBeforeFee =
+      const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
-
-      const expectedSaleTokensAfterFee =
-        (BigInt(expectedSaleTokensBeforeFee) *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
       await expect(publicSale.connect(alice).buyerSettle(alice.address))
         .to.emit(publicSale, 'SuccessfulSaleBuyerSettled')
-        .withArgs(alice.address, alice.address, expectedSaleTokensAfterFee);
+        .withArgs(alice.address, alice.address, expectedSaleTokens);
 
-      expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokensAfterFee);
+      expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokens);
       expect(await publicSale.settled(alice.address)).to.be.true;
     });
 
     it('should allow settlement to different recipient address', async () => {
       const commitment = await publicSale.commitments(alice.address);
-      const expectedSaleTokensBeforeFee =
+      const expectedSaleTokens =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
-
-      const expectedSaleTokensAfterFee =
-        (BigInt(expectedSaleTokensBeforeFee) *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
       await publicSale.connect(alice).buyerSettle(bob.address);
 
-      expect(await saleToken.balanceOf(bob.address)).to.equal(expectedSaleTokensAfterFee);
+      expect(await saleToken.balanceOf(bob.address)).to.equal(expectedSaleTokens);
       expect(await saleToken.balanceOf(alice.address)).to.equal(0);
       expect(await publicSale.settled(alice.address)).to.be.true;
     });
@@ -1295,23 +1269,23 @@ describe('PublicSaleV1', () => {
     });
 
     it('should distribute proceeds and protocol fees correctly', async () => {
-      const commitmentTokenTotalBalance = await commitmentToken.balanceOf(
-        await publicSale.getAddress(),
-      );
+      const totalCommitments = await publicSale.totalCommitments();
       const commitmentTokenProtocolFeeAmount =
-        (BigInt(commitmentTokenTotalBalance) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
+        (BigInt(totalCommitments) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
         TEST_CONSTANTS.PRECISION;
-      const commitmentTokenAmountToSeller =
-        commitmentTokenTotalBalance - commitmentTokenProtocolFeeAmount;
+      const commitmentTokenAmountToSeller = totalCommitments - commitmentTokenProtocolFeeAmount;
       const saleTokenTotalBalance = await saleToken.balanceOf(await publicSale.getAddress());
 
       const saleTokenSold =
-        (BigInt(defaultParams.minimumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
+        (BigInt(totalCommitments) * TEST_CONSTANTS.PRECISION) /
         BigInt(defaultParams.saleTokenPrice);
+
       const saleTokenProtocolFeeAmount =
         (BigInt(saleTokenSold) * BigInt(defaultParams.saleTokenProtocolFee)) /
         TEST_CONSTANTS.PRECISION;
-      const unsoldSaleTokenAmount = BigInt(saleTokenTotalBalance) - saleTokenSold;
+
+      const leftoverSaleTokenAmount =
+        saleTokenTotalBalance - saleTokenSold - saleTokenProtocolFeeAmount;
 
       await expect(publicSale.connect(seller).sellerSettle())
         .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
@@ -1320,7 +1294,7 @@ describe('PublicSaleV1', () => {
           commitmentTokenProtocolFeeAmount,
           commitmentTokenAmountToSeller,
           saleTokenProtocolFeeAmount,
-          unsoldSaleTokenAmount,
+          leftoverSaleTokenAmount,
         );
 
       expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(
@@ -1330,7 +1304,7 @@ describe('PublicSaleV1', () => {
         commitmentTokenProtocolFeeAmount,
       );
       expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(
-        unsoldSaleTokenAmount,
+        leftoverSaleTokenAmount,
       );
       expect(await saleToken.balanceOf(protocolFeeReceiver.address)).to.equal(
         saleTokenProtocolFeeAmount,
@@ -1358,23 +1332,20 @@ describe('PublicSaleV1', () => {
 
       await moveToSaleEnd(customSale);
 
-      const commitmentTokenTotalBalance = await commitmentToken.balanceOf(
-        await customSale.getAddress(),
-      );
+      const totalCommitments = await customSale.totalCommitments();
       const commitmentTokenProtocolFeeAmount =
-        (BigInt(commitmentTokenTotalBalance) * ethers.parseEther('0.1')) / TEST_CONSTANTS.PRECISION;
-      const commitmentTokenAmountToSeller =
-        commitmentTokenTotalBalance - commitmentTokenProtocolFeeAmount;
+        (BigInt(totalCommitments) * ethers.parseEther('0.1')) / TEST_CONSTANTS.PRECISION;
+      const commitmentTokenAmountToSeller = totalCommitments - commitmentTokenProtocolFeeAmount;
+
       const saleTokenSold =
-        (commitmentTokenTotalBalance * TEST_CONSTANTS.PRECISION) /
-        BigInt(defaultParams.saleTokenPrice);
+        (totalCommitments * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
       const saleTokenProtocolFeeAmount =
         (BigInt(saleTokenSold) * ethers.parseEther('0.05')) / TEST_CONSTANTS.PRECISION;
-      const unsoldSaleTokenAmount =
-        BigInt(
-          (BigInt(defaultParams.maximumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
-            BigInt(defaultParams.saleTokenPrice),
-        ) - saleTokenSold;
+
+      const saleTokenEscrowAmount = await saleToken.balanceOf(await customSale.getAddress());
+      const leftoverSaleTokenAmount =
+        saleTokenEscrowAmount - saleTokenSold - saleTokenProtocolFeeAmount;
 
       await customSale.connect(seller).sellerSettle();
 
@@ -1385,7 +1356,7 @@ describe('PublicSaleV1', () => {
         commitmentTokenAmountToSeller,
       );
       expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(
-        unsoldSaleTokenAmount,
+        leftoverSaleTokenAmount,
       );
       expect(await saleToken.balanceOf(protocolFeeReceiver.address)).to.equal(
         saleTokenProtocolFeeAmount,
@@ -1472,24 +1443,16 @@ describe('PublicSaleV1', () => {
       await publicSale.connect(alice).buyerSettle(alice.address);
       await publicSale.connect(bob).buyerSettle(bob.address);
 
-      const aliceExpectedSaleTokensBeforeFee =
+      const aliceExpectedSaleTokens =
         (BigInt(ethers.parseEther('250')) * TEST_CONSTANTS.PRECISION) /
         BigInt(defaultParams.saleTokenPrice);
-      const aliceExpectedSaleTokensAfterFee =
-        (aliceExpectedSaleTokensBeforeFee *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
-      const bobExpectedSaleTokensBeforeFee =
+      const bobExpectedSaleTokens =
         (BigInt(ethers.parseEther('750')) * TEST_CONSTANTS.PRECISION) /
         BigInt(defaultParams.saleTokenPrice);
-      const bobExpectedSaleTokensAfterFee =
-        (bobExpectedSaleTokensBeforeFee *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
-      expect(await saleToken.balanceOf(alice.address)).to.equal(aliceExpectedSaleTokensAfterFee);
-      expect(await saleToken.balanceOf(bob.address)).to.equal(bobExpectedSaleTokensAfterFee);
+      expect(await saleToken.balanceOf(alice.address)).to.equal(aliceExpectedSaleTokens);
+      expect(await saleToken.balanceOf(bob.address)).to.equal(bobExpectedSaleTokens);
 
       const commitmentTokenProtocolFeeAmount =
         (BigInt(totalCommitments) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
@@ -1498,10 +1461,13 @@ describe('PublicSaleV1', () => {
 
       const saleTokenSold =
         (totalCommitments * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
       const saleTokenProtocolFeeAmount =
         (BigInt(saleTokenSold) * BigInt(defaultParams.saleTokenProtocolFee)) /
         TEST_CONSTANTS.PRECISION;
-      const unsoldSaleTokenAmount = BigInt(escrowedSaleTokenAmount) - saleTokenSold;
+
+      const leftoverSaleTokenAmount =
+        escrowedSaleTokenAmount - saleTokenSold - saleTokenProtocolFeeAmount;
 
       await expect(publicSale.connect(seller).sellerSettle())
         .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
@@ -1510,7 +1476,7 @@ describe('PublicSaleV1', () => {
           commitmentTokenProtocolFeeAmount,
           commitmentTokenAmountToSeller,
           saleTokenProtocolFeeAmount,
-          unsoldSaleTokenAmount,
+          leftoverSaleTokenAmount,
         );
 
       expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(
@@ -1520,7 +1486,7 @@ describe('PublicSaleV1', () => {
         commitmentTokenProtocolFeeAmount,
       );
       expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(
-        unsoldSaleTokenAmount,
+        leftoverSaleTokenAmount,
       );
       expect(await saleToken.balanceOf(protocolFeeReceiver.address)).to.equal(
         saleTokenProtocolFeeAmount,
@@ -1568,24 +1534,16 @@ describe('PublicSaleV1', () => {
       await publicSale.connect(alice).buyerSettle(alice.address);
       await publicSale.connect(bob).buyerSettle(bob.address);
 
-      const aliceExpectedSaleTokensBeforeFee =
+      const aliceExpectedSaleTokens =
         (BigInt(ethers.parseEther('1000')) * TEST_CONSTANTS.PRECISION) /
         BigInt(defaultParams.saleTokenPrice);
-      const aliceExpectedSaleTokensAfterFee =
-        (aliceExpectedSaleTokensBeforeFee *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
-      const bobExpectedSaleTokensBeforeFee =
+      const bobExpectedSaleTokens =
         (BigInt(ethers.parseEther('1000')) * TEST_CONSTANTS.PRECISION) /
         BigInt(defaultParams.saleTokenPrice);
-      const bobExpectedSaleTokensAfterFee =
-        (bobExpectedSaleTokensBeforeFee *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
-      expect(await saleToken.balanceOf(alice.address)).to.equal(aliceExpectedSaleTokensAfterFee);
-      expect(await saleToken.balanceOf(bob.address)).to.equal(bobExpectedSaleTokensAfterFee);
+      expect(await saleToken.balanceOf(alice.address)).to.equal(aliceExpectedSaleTokens);
+      expect(await saleToken.balanceOf(bob.address)).to.equal(bobExpectedSaleTokens);
 
       const commitmentTokenProtocolFeeAmount =
         (BigInt(totalCommitments) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
@@ -1594,10 +1552,13 @@ describe('PublicSaleV1', () => {
 
       const saleTokenSold =
         (totalCommitments * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
       const saleTokenProtocolFeeAmount =
         (BigInt(saleTokenSold) * BigInt(defaultParams.saleTokenProtocolFee)) /
         TEST_CONSTANTS.PRECISION;
-      const unsoldSaleTokenAmount = BigInt(escrowedSaleTokenAmount) - saleTokenSold;
+
+      const leftoverSaleTokenAmount =
+        escrowedSaleTokenAmount - saleTokenSold - saleTokenProtocolFeeAmount;
 
       await expect(publicSale.connect(seller).sellerSettle())
         .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
@@ -1606,7 +1567,7 @@ describe('PublicSaleV1', () => {
           commitmentTokenProtocolFeeAmount,
           commitmentTokenAmountToSeller,
           saleTokenProtocolFeeAmount,
-          unsoldSaleTokenAmount,
+          leftoverSaleTokenAmount,
         );
 
       expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(
@@ -1616,7 +1577,7 @@ describe('PublicSaleV1', () => {
         commitmentTokenProtocolFeeAmount,
       );
       expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(
-        unsoldSaleTokenAmount,
+        leftoverSaleTokenAmount,
       );
       expect(await saleToken.balanceOf(protocolFeeReceiver.address)).to.equal(
         saleTokenProtocolFeeAmount,
@@ -1626,91 +1587,6 @@ describe('PublicSaleV1', () => {
       // all users have settled, verify that public sale has no remaining commitment or sale tokens
       expect(await saleToken.balanceOf(await publicSale.getAddress())).to.equal(0);
       expect(await commitmentToken.balanceOf(await publicSale.getAddress())).to.equal(0);
-    });
-  });
-
-  describe('Token Decimal & Precision Testing', () => {
-    it('should handle saleToken: 6 decimals, commitmentToken: 18 decimals', async () => {
-      // Deploy tokens with different decimals
-      const saleToken6 = await new MockERC20__factory(deployer).deploy('Sale6', 'S6', 6);
-      const commitToken18 = await new MockERC20__factory(deployer).deploy('Commit18', 'C18', 18);
-
-      // Calculate required escrow
-      // The contract expects: (maximumTotalCommitment * TEST_CONSTANTS.PRECISION) / saleTokenPrice
-      // = (10k * 10^18 * 10^18) / 10^18 = 10k * 10^18
-      // This is the raw amount the contract will try to transfer
-      const requiredEscrowRaw = ethers.parseEther('10000'); // 10k * 10^18
-      await saleToken6.mint(saleTokenHolder.address, requiredEscrowRaw); // Mint the raw amount
-
-      const currentTime = await time.latest();
-      const customParams = {
-        ...defaultParams,
-        saleToken: await saleToken6.getAddress(),
-        commitmentToken: await commitToken18.getAddress(),
-        saleTokenPrice: ethers.parseEther('1'), // 1:1 ratio in terms of value
-        maximumTotalCommitment: ethers.parseEther('10000'), // 10k commitment tokens
-        saleStartTimestamp: BigInt(currentTime + 3600),
-        saleEndTimestamp: BigInt(currentTime + 86400),
-      };
-
-      const customSale = await deployPublicSaleProxy(deployer, customParams);
-      await time.increaseTo(Number(customParams.saleStartTimestamp));
-
-      // Verify the escrow amount calculation
-      const escrowAmount = await saleToken6.balanceOf(await customSale.getAddress());
-      // The contract transfers the raw amount calculated as (maxTotalCommit * TEST_CONSTANTS.PRECISION) / price
-      // = (10k * 10^18 * 10^18) / 10^18 = 10k * 10^18
-      const expectedEscrow = ethers.parseEther('10000'); // This is the raw amount
-      expect(escrowAmount).to.equal(expectedEscrow);
-    });
-
-    it('should handle extreme price values', async () => {
-      const extremeSale = await deployTestSale(
-        deployer,
-        saleToken,
-        saleTokenHolder,
-        defaultParams,
-        {
-          saleTokenPrice: ethers.parseEther('0.000001'), // Very low price
-        },
-      );
-      await moveToSaleStart(extremeSale);
-
-      // Setup alice with commitment tokens
-      await mintAndApproveCommitmentTokens(
-        commitmentToken,
-        extremeSale,
-        [alice],
-        [BigInt(defaultParams.maximumCommitment)],
-      );
-
-      // Alice makes a commitment
-      await extremeSale
-        .connect(alice)
-        .increaseCommitmentERC20(defaultParams.maximumCommitment, ethers.getBytes('0x'), 0n);
-
-      // Reach minimum total commitment with other users
-      await reachMinimumTotalCommitment(
-        extremeSale,
-        commitmentToken,
-        BigInt(defaultParams.minimumTotalCommitment),
-        BigInt(defaultParams.maximumCommitment),
-        [{ user: alice, amount: BigInt(defaultParams.maximumCommitment) }],
-      );
-
-      await moveToSaleEnd(extremeSale);
-
-      const commitment = await extremeSale.commitments(alice.address);
-      const expectedSaleTokensBeforeFee =
-        (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / ethers.parseEther('0.000001');
-      const expectedSaleTokensAfterFee =
-        (BigInt(expectedSaleTokensBeforeFee) *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
-
-      await extremeSale.connect(alice).buyerSettle(alice.address);
-
-      expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokensAfterFee);
     });
   });
 
@@ -1862,6 +1738,8 @@ describe('PublicSaleV1', () => {
     });
 
     it('should emit all settlement events correctly', async () => {
+      const escrowedSaleTokenAmount = await saleToken.balanceOf(await publicSale.getAddress());
+
       // Setup successful sale - need multiple users
       await mintAndApproveCommitmentTokens(
         commitmentToken,
@@ -1886,37 +1764,27 @@ describe('PublicSaleV1', () => {
 
       // User settlement
       const aliceCommitment = await publicSale.commitments(alice.address);
-      const aliceExpectedSaleTokensBeforeFee =
+      const aliceExpectedSaleTokens =
         (BigInt(aliceCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
-
-      const aliceExpectedSaleTokensAfterFee =
-        (BigInt(aliceExpectedSaleTokensBeforeFee) *
-          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
-        TEST_CONSTANTS.PRECISION;
 
       await expect(publicSale.connect(alice).buyerSettle(alice.address))
         .to.emit(publicSale, 'SuccessfulSaleBuyerSettled')
-        .withArgs(alice.address, alice.address, aliceExpectedSaleTokensAfterFee);
+        .withArgs(alice.address, alice.address, aliceExpectedSaleTokens);
 
       // Owner settlement
-      const commitmentTokenTotalBalance = await commitmentToken.balanceOf(
-        await publicSale.getAddress(),
-      );
+      const totalCommitments = await publicSale.totalCommitments();
       const commitmentTokenProtocolFeeAmount =
-        (BigInt(commitmentTokenTotalBalance) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
+        (BigInt(totalCommitments) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
         TEST_CONSTANTS.PRECISION;
-      const commitmentTokenAmountToSeller =
-        commitmentTokenTotalBalance - commitmentTokenProtocolFeeAmount;
+      const commitmentTokenAmountToSeller = totalCommitments - commitmentTokenProtocolFeeAmount;
       const saleTokenSold =
         (BigInt(defaultParams.minimumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
         BigInt(defaultParams.saleTokenPrice);
       const saleTokenProtocolFeeAmount =
         (BigInt(saleTokenSold) * BigInt(defaultParams.saleTokenProtocolFee)) /
         TEST_CONSTANTS.PRECISION;
-      const unsoldSaleTokenAmount =
-        (BigInt(defaultParams.maximumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
-          BigInt(defaultParams.saleTokenPrice) -
-        saleTokenSold;
+      const leftoverSaleTokenAmount =
+        escrowedSaleTokenAmount - saleTokenSold - saleTokenProtocolFeeAmount;
 
       await expect(publicSale.connect(seller).sellerSettle())
         .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
@@ -1925,7 +1793,7 @@ describe('PublicSaleV1', () => {
           commitmentTokenProtocolFeeAmount,
           commitmentTokenAmountToSeller,
           saleTokenProtocolFeeAmount,
-          unsoldSaleTokenAmount,
+          leftoverSaleTokenAmount,
         );
     });
   });
@@ -1989,7 +1857,7 @@ describe('PublicSaleV1 - Shared Tests', () => {
     kycVerifier = await MockKYCVerifierFactory.deploy();
 
     // Mint tokens to sale token holder
-    await saleToken.mint(saleTokenHolder.address, ethers.parseEther('1000000'));
+    await saleToken.mint(saleTokenHolder.address, ethers.parseEther('1050000'));
 
     // Setup default parameters
     const currentTime = await time.latest();
@@ -2078,7 +1946,8 @@ describe('PublicSaleV1 - Shared Tests', () => {
 
         // Calculate required sale token amount
         const saleTokenAmount =
-          (BigInt(initParams.maximumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
+          (BigInt(initParams.maximumTotalCommitment) *
+            (TEST_CONSTANTS.PRECISION + BigInt(initParams.saleTokenProtocolFee))) /
           BigInt(initParams.saleTokenPrice);
 
         // Mint tokens to saleTokenHolder

--- a/test/unit/deployables/public-sale/PublicSaleV1.test.ts
+++ b/test/unit/deployables/public-sale/PublicSaleV1.test.ts
@@ -82,7 +82,8 @@ interface DeployTestSaleOptions {
   maximumTotalCommitment?: bigint;
   minimumTotalCommitment?: bigint;
   commitmentToken?: string;
-  protocolFee?: bigint;
+  commitmentTokenProtocolFee?: bigint;
+  saleTokenProtocolFee?: bigint;
   minimumCommitment?: bigint;
   maximumCommitment?: bigint;
   saleTokenPrice?: bigint;
@@ -112,7 +113,10 @@ async function deployTestSale(
       minimumTotalCommitment: options.minimumTotalCommitment,
     }),
     ...(options.commitmentToken && { commitmentToken: options.commitmentToken }),
-    ...(options.protocolFee !== undefined && { protocolFee: options.protocolFee }),
+    ...(options.commitmentTokenProtocolFee && {
+      commitmentTokenProtocolFee: options.commitmentTokenProtocolFee,
+    }),
+    ...(options.saleTokenProtocolFee && { saleTokenProtocolFee: options.saleTokenProtocolFee }),
     ...(options.minimumCommitment && { minimumCommitment: options.minimumCommitment }),
     ...(options.maximumCommitment && { maximumCommitment: options.maximumCommitment }),
     ...(options.saleTokenPrice && { saleTokenPrice: options.saleTokenPrice }),
@@ -282,7 +286,8 @@ describe('PublicSaleV1', () => {
       minimumTotalCommitment: ethers.parseEther('10000'),
       maximumTotalCommitment: ethers.parseEther('100000'),
       saleTokenPrice: ethers.parseEther('0.1'), // 0.1 commitment token per sale token
-      protocolFee: ethers.parseEther('0.02'), // 2%
+      commitmentTokenProtocolFee: ethers.parseEther('0.02'), // 2%
+      saleTokenProtocolFee: ethers.parseEther('0.05'), // 5%
       hedgeyLockupParams: {
         enabled: false,
         start: 0,
@@ -318,7 +323,10 @@ describe('PublicSaleV1', () => {
         defaultParams.maximumTotalCommitment,
       );
       expect(await publicSale.saleTokenPrice()).to.equal(defaultParams.saleTokenPrice);
-      expect(await publicSale.protocolFee()).to.equal(defaultParams.protocolFee);
+      expect(await publicSale.commitmentTokenProtocolFee()).to.equal(
+        defaultParams.commitmentTokenProtocolFee,
+      );
+      expect(await publicSale.saleTokenProtocolFee()).to.equal(defaultParams.saleTokenProtocolFee);
       expect(await publicSale.hedgeyLockupEnabled()).to.equal(
         defaultParams.hedgeyLockupParams.enabled,
       );
@@ -392,10 +400,22 @@ describe('PublicSaleV1', () => {
       );
     });
 
-    it('should revert when protocolFee > TEST_CONSTANTS.PRECISION', async () => {
+    it('should revert when commitmentTokenProtocolFee > TEST_CONSTANTS.PRECISION', async () => {
       const invalidParams = {
         ...defaultParams,
-        protocolFee: TEST_CONSTANTS.PRECISION + 1n,
+        commitmentTokenProtocolFee: TEST_CONSTANTS.PRECISION + 1n,
+      };
+
+      await expect(deployPublicSaleProxy(deployer, invalidParams)).to.be.revertedWithCustomError(
+        PublicSaleV1__factory.connect(ethers.ZeroAddress, deployer),
+        'InvalidProtocolFee',
+      );
+    });
+
+    it('should revert when saleTokenProtocolFee > TEST_CONSTANTS.PRECISION', async () => {
+      const invalidParams = {
+        ...defaultParams,
+        saleTokenProtocolFee: TEST_CONSTANTS.PRECISION + 1n,
       };
 
       await expect(deployPublicSaleProxy(deployer, invalidParams)).to.be.revertedWithCustomError(
@@ -935,8 +955,13 @@ describe('PublicSaleV1', () => {
 
     it('should create Hedgey lockup plan instead of direct transfer when enabled', async () => {
       const commitment = await hedgeySale.commitments(alice.address);
-      const expectedSaleTokens =
+      const expectedSaleTokensBeforeFee =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
+      const expectedSaleTokensAfterFee =
+        (BigInt(expectedSaleTokensBeforeFee) *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
 
       // Get initial balances
       const initialSaleTokenBalance = await saleToken.balanceOf(await hedgeySale.getAddress());
@@ -954,12 +979,12 @@ describe('PublicSaleV1', () => {
       const lockupPlan = await votingTokenLockupPlans.plans(lockupPlanId);
 
       expect(lockupPlan.token).to.equal(await saleToken.getAddress());
-      expect(lockupPlan.amount).to.equal(expectedSaleTokens);
+      expect(lockupPlan.amount).to.equal(expectedSaleTokensAfterFee);
       expect(lockupPlan.start).to.equal(BigInt(lockupStartTime));
       expect(lockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
       expect(lockupPlan.period).to.equal(BigInt(10_000));
       expect(lockupPlan.rate).to.equal(
-        (expectedSaleTokens * ethers.parseEther('0.0025')) / TEST_CONSTANTS.PRECISION,
+        (expectedSaleTokensAfterFee * ethers.parseEther('0.0025')) / TEST_CONSTANTS.PRECISION,
       );
 
       // verify correct end time
@@ -969,10 +994,10 @@ describe('PublicSaleV1', () => {
 
       // Verify sale tokens were transferred to Hedgey contract
       expect(await saleToken.balanceOf(await hedgeySale.getAddress())).to.equal(
-        initialSaleTokenBalance - expectedSaleTokens,
+        initialSaleTokenBalance - expectedSaleTokensAfterFee,
       );
       expect(await saleToken.balanceOf(await votingTokenLockupPlans.getAddress())).to.equal(
-        initialHedgeyBalance + expectedSaleTokens,
+        initialHedgeyBalance + expectedSaleTokensAfterFee,
       );
 
       // Verify user didn't receive tokens directly
@@ -984,10 +1009,21 @@ describe('PublicSaleV1', () => {
       const aliceCommitment = await hedgeySale.commitments(alice.address);
       const bobCommitment = await hedgeySale.commitments(bob.address);
 
-      const aliceExpectedSaleTokens =
+      const aliceExpectedSaleTokensBeforeFee =
         (BigInt(aliceCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
-      const bobExpectedSaleTokens =
+
+      const aliceExpectedSaleTokensAfterFee =
+        (BigInt(aliceExpectedSaleTokensBeforeFee) *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
+
+      const bobExpectedSaleTokensBeforeFee =
         (BigInt(bobCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
+      const bobExpectedSaleTokensAfterFee =
+        (BigInt(bobExpectedSaleTokensBeforeFee) *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
 
       // Settle and get lockup plan IDs
       const aliceLockupPlanId = getLockupPlanCreatedEvent(
@@ -1005,13 +1041,13 @@ describe('PublicSaleV1', () => {
 
       // Verify lockup plans
       expect(aliceLockupPlan.token).to.equal(await saleToken.getAddress());
-      expect(aliceLockupPlan.amount).to.equal(aliceExpectedSaleTokens);
+      expect(aliceLockupPlan.amount).to.equal(aliceExpectedSaleTokensAfterFee);
       expect(aliceLockupPlan.start).to.equal(BigInt(lockupStartTime));
       expect(aliceLockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
       expect(aliceLockupPlan.period).to.equal(BigInt(10_000));
 
       expect(bobLockupPlan.token).to.equal(await saleToken.getAddress());
-      expect(bobLockupPlan.amount).to.equal(bobExpectedSaleTokens);
+      expect(bobLockupPlan.amount).to.equal(bobExpectedSaleTokensAfterFee);
       expect(bobLockupPlan.start).to.equal(BigInt(lockupStartTime));
       expect(bobLockupPlan.cliff).to.equal(BigInt(lockupStartTime + 1_000_000));
       expect(bobLockupPlan.period).to.equal(BigInt(10_000));
@@ -1027,8 +1063,13 @@ describe('PublicSaleV1', () => {
 
     it('should emit SuccessfulSaleBuyerSettledHedgey event when Hedgey is enabled', async () => {
       const commitment = await hedgeySale.commitments(alice.address);
-      const expectedSaleTokens =
+      const expectedSaleTokensBeforeFee =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
+      const expectedSaleTokensAfterFee =
+        (BigInt(expectedSaleTokensBeforeFee) *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
 
       // The event should not be emitted when Hedgey lockup is enabled
       const tx2 = await hedgeySale.connect(alice).buyerSettle(alice.address);
@@ -1051,7 +1092,7 @@ describe('PublicSaleV1', () => {
       expect(parsed).to.not.equal(null);
       expect(parsed?.args?.[0]).to.equal(alice.address);
       expect(parsed?.args?.[1]).to.equal(alice.address);
-      expect(parsed?.args?.[2]).to.equal(expectedSaleTokens);
+      expect(parsed?.args?.[2]).to.equal(expectedSaleTokensAfterFee);
       expect(parsed?.args?.[3]).to.equal(planId);
     });
   });
@@ -1097,34 +1138,35 @@ describe('PublicSaleV1', () => {
 
     it('should allow user to settle and receive sale tokens directly', async () => {
       const commitment = await publicSale.commitments(alice.address);
-      const expectedSaleTokens =
+      const expectedSaleTokensBeforeFee =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
+      const expectedSaleTokensAfterFee =
+        (BigInt(expectedSaleTokensBeforeFee) *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
 
       await expect(publicSale.connect(alice).buyerSettle(alice.address))
         .to.emit(publicSale, 'SuccessfulSaleBuyerSettled')
-        .withArgs(alice.address, alice.address, expectedSaleTokens);
+        .withArgs(alice.address, alice.address, expectedSaleTokensAfterFee);
 
-      expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokens);
+      expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokensAfterFee);
       expect(await publicSale.settled(alice.address)).to.be.true;
-    });
-
-    it('should calculate sale token amount with correct precision', async () => {
-      const commitment = await publicSale.commitments(alice.address);
-      const expectedSaleTokens =
-        (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
-
-      await publicSale.connect(alice).buyerSettle(alice.address);
-      expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokens);
     });
 
     it('should allow settlement to different recipient address', async () => {
       const commitment = await publicSale.commitments(alice.address);
-      const expectedSaleTokens =
+      const expectedSaleTokensBeforeFee =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
+      const expectedSaleTokensAfterFee =
+        (BigInt(expectedSaleTokensBeforeFee) *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
 
       await publicSale.connect(alice).buyerSettle(bob.address);
 
-      expect(await saleToken.balanceOf(bob.address)).to.equal(expectedSaleTokens);
+      expect(await saleToken.balanceOf(bob.address)).to.equal(expectedSaleTokensAfterFee);
       expect(await saleToken.balanceOf(alice.address)).to.equal(0);
       expect(await publicSale.settled(alice.address)).to.be.true;
     });
@@ -1253,20 +1295,45 @@ describe('PublicSaleV1', () => {
     });
 
     it('should distribute proceeds and protocol fees correctly', async () => {
-      const totalBalance = await commitmentToken.balanceOf(await publicSale.getAddress());
-      const protocolFeeAmount =
-        (BigInt(totalBalance) * BigInt(defaultParams.protocolFee)) / TEST_CONSTANTS.PRECISION;
-      const saleProceedsAmount = BigInt(totalBalance) - protocolFeeAmount;
+      const commitmentTokenTotalBalance = await commitmentToken.balanceOf(
+        await publicSale.getAddress(),
+      );
+      const commitmentTokenProtocolFeeAmount =
+        (BigInt(commitmentTokenTotalBalance) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
+        TEST_CONSTANTS.PRECISION;
+      const commitmentTokenAmountToSeller =
+        commitmentTokenTotalBalance - commitmentTokenProtocolFeeAmount;
+      const saleTokenTotalBalance = await saleToken.balanceOf(await publicSale.getAddress());
+
+      const saleTokenSold =
+        (BigInt(defaultParams.minimumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
+        BigInt(defaultParams.saleTokenPrice);
+      const saleTokenProtocolFeeAmount =
+        (BigInt(saleTokenSold) * BigInt(defaultParams.saleTokenProtocolFee)) /
+        TEST_CONSTANTS.PRECISION;
+      const unsoldSaleTokenAmount = BigInt(saleTokenTotalBalance) - saleTokenSold;
 
       await expect(publicSale.connect(seller).sellerSettle())
         .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
-        .withArgs(seller.address, saleProceedsAmount, protocolFeeAmount);
+        .withArgs(
+          seller.address,
+          commitmentTokenProtocolFeeAmount,
+          commitmentTokenAmountToSeller,
+          saleTokenProtocolFeeAmount,
+          unsoldSaleTokenAmount,
+        );
 
       expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(
-        saleProceedsAmount,
+        commitmentTokenAmountToSeller,
       );
       expect(await commitmentToken.balanceOf(protocolFeeReceiver.address)).to.equal(
-        protocolFeeAmount,
+        commitmentTokenProtocolFeeAmount,
+      );
+      expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(
+        unsoldSaleTokenAmount,
+      );
+      expect(await saleToken.balanceOf(protocolFeeReceiver.address)).to.equal(
+        saleTokenProtocolFeeAmount,
       );
       expect(await publicSale.sellerSettled()).to.be.true;
     });
@@ -1274,42 +1341,54 @@ describe('PublicSaleV1', () => {
     it('should handle different protocol fee percentages', async () => {
       // Deploy with different protocol fee
       const customSale = await deployTestSale(deployer, saleToken, saleTokenHolder, defaultParams, {
-        protocolFee: ethers.parseEther('0.1'), // 10%
+        commitmentTokenProtocolFee: ethers.parseEther('0.1'), // 10%
+        saleTokenProtocolFee: ethers.parseEther('0.05'), // 5%
         startOffset: 60,
       });
       await moveToSaleStart(customSale);
 
-      // Multiple users commit to reach minimum total
-      const signers = await ethers.getSigners();
-      const commitmentPerUser = defaultParams.maximumCommitment;
-      const numUsers = Number(
-        BigInt(defaultParams.minimumTotalCommitment) / BigInt(commitmentPerUser),
-      );
-
-      const users = signers.slice(2, 2 + numUsers); // Skip deployer and owner
-      await mintAndApproveCommitmentTokens(
-        commitmentToken,
+      // Reach minimum total commitment
+      await reachMinimumTotalCommitment(
         customSale,
-        users,
-        Array(numUsers).fill(BigInt(commitmentPerUser)),
+        commitmentToken,
+        BigInt(defaultParams.minimumTotalCommitment),
+        BigInt(defaultParams.maximumCommitment),
+        [],
       );
-
-      for (const user of users) {
-        await customSale
-          .connect(user)
-          .increaseCommitmentERC20(commitmentPerUser, ethers.getBytes('0x'), 0n);
-      }
 
       await moveToSaleEnd(customSale);
 
-      const totalBalance = await commitmentToken.balanceOf(await customSale.getAddress());
-      const protocolFeeAmount =
-        (totalBalance * ethers.parseEther('0.1')) / TEST_CONSTANTS.PRECISION;
+      const commitmentTokenTotalBalance = await commitmentToken.balanceOf(
+        await customSale.getAddress(),
+      );
+      const commitmentTokenProtocolFeeAmount =
+        (BigInt(commitmentTokenTotalBalance) * ethers.parseEther('0.1')) / TEST_CONSTANTS.PRECISION;
+      const commitmentTokenAmountToSeller =
+        commitmentTokenTotalBalance - commitmentTokenProtocolFeeAmount;
+      const saleTokenSold =
+        (commitmentTokenTotalBalance * TEST_CONSTANTS.PRECISION) /
+        BigInt(defaultParams.saleTokenPrice);
+      const saleTokenProtocolFeeAmount =
+        (BigInt(saleTokenSold) * ethers.parseEther('0.05')) / TEST_CONSTANTS.PRECISION;
+      const unsoldSaleTokenAmount =
+        BigInt(
+          (BigInt(defaultParams.maximumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
+            BigInt(defaultParams.saleTokenPrice),
+        ) - saleTokenSold;
 
       await customSale.connect(seller).sellerSettle();
 
       expect(await commitmentToken.balanceOf(protocolFeeReceiver.address)).to.equal(
-        protocolFeeAmount,
+        commitmentTokenProtocolFeeAmount,
+      );
+      expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(
+        commitmentTokenAmountToSeller,
+      );
+      expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(
+        unsoldSaleTokenAmount,
+      );
+      expect(await saleToken.balanceOf(protocolFeeReceiver.address)).to.equal(
+        saleTokenProtocolFeeAmount,
       );
     });
 
@@ -1356,6 +1435,197 @@ describe('PublicSaleV1', () => {
 
       expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(saleTokenBalance);
       expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(0);
+    });
+  });
+
+  describe('Full Settlement - Success Case - Minimum total commitment', () => {
+    beforeEach(async () => {
+      publicSale = await deployTestSale(deployer, saleToken, saleTokenHolder, defaultParams, {
+        startOffset: 60,
+        minimumTotalCommitment: ethers.parseEther('1000'),
+      });
+      await moveToSaleStart(publicSale);
+
+      // Setup successful sale
+      await mintAndApproveCommitmentTokens(
+        commitmentToken,
+        publicSale,
+        [alice, bob],
+        [ethers.parseEther('50000'), ethers.parseEther('50000')],
+      );
+
+      await publicSale
+        .connect(alice)
+        .increaseCommitmentERC20(ethers.parseEther('250'), ethers.getBytes('0x'), 0n);
+      await publicSale
+        .connect(bob)
+        .increaseCommitmentERC20(ethers.parseEther('750'), ethers.getBytes('0x'), 0n);
+
+      // Move to end of sale
+      await moveToSaleEnd(publicSale);
+    });
+
+    it('should distribute proceeds and protocol fees correctly', async () => {
+      const totalCommitments = await publicSale.totalCommitments();
+      const escrowedSaleTokenAmount = await saleToken.balanceOf(await publicSale.getAddress());
+
+      await publicSale.connect(alice).buyerSettle(alice.address);
+      await publicSale.connect(bob).buyerSettle(bob.address);
+
+      const aliceExpectedSaleTokensBeforeFee =
+        (BigInt(ethers.parseEther('250')) * TEST_CONSTANTS.PRECISION) /
+        BigInt(defaultParams.saleTokenPrice);
+      const aliceExpectedSaleTokensAfterFee =
+        (aliceExpectedSaleTokensBeforeFee *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
+
+      const bobExpectedSaleTokensBeforeFee =
+        (BigInt(ethers.parseEther('750')) * TEST_CONSTANTS.PRECISION) /
+        BigInt(defaultParams.saleTokenPrice);
+      const bobExpectedSaleTokensAfterFee =
+        (bobExpectedSaleTokensBeforeFee *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
+
+      expect(await saleToken.balanceOf(alice.address)).to.equal(aliceExpectedSaleTokensAfterFee);
+      expect(await saleToken.balanceOf(bob.address)).to.equal(bobExpectedSaleTokensAfterFee);
+
+      const commitmentTokenProtocolFeeAmount =
+        (BigInt(totalCommitments) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
+        TEST_CONSTANTS.PRECISION;
+      const commitmentTokenAmountToSeller = totalCommitments - commitmentTokenProtocolFeeAmount;
+
+      const saleTokenSold =
+        (totalCommitments * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+      const saleTokenProtocolFeeAmount =
+        (BigInt(saleTokenSold) * BigInt(defaultParams.saleTokenProtocolFee)) /
+        TEST_CONSTANTS.PRECISION;
+      const unsoldSaleTokenAmount = BigInt(escrowedSaleTokenAmount) - saleTokenSold;
+
+      await expect(publicSale.connect(seller).sellerSettle())
+        .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
+        .withArgs(
+          seller.address,
+          commitmentTokenProtocolFeeAmount,
+          commitmentTokenAmountToSeller,
+          saleTokenProtocolFeeAmount,
+          unsoldSaleTokenAmount,
+        );
+
+      expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(
+        commitmentTokenAmountToSeller,
+      );
+      expect(await commitmentToken.balanceOf(protocolFeeReceiver.address)).to.equal(
+        commitmentTokenProtocolFeeAmount,
+      );
+      expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(
+        unsoldSaleTokenAmount,
+      );
+      expect(await saleToken.balanceOf(protocolFeeReceiver.address)).to.equal(
+        saleTokenProtocolFeeAmount,
+      );
+      expect(await publicSale.sellerSettled()).to.be.true;
+
+      // all users have settled, verify that public sale has no remaining commitment or sale tokens
+      expect(await saleToken.balanceOf(await publicSale.getAddress())).to.equal(0);
+      expect(await commitmentToken.balanceOf(await publicSale.getAddress())).to.equal(0);
+    });
+  });
+
+  describe('Full Settlement - Success Case - Maximum total commitment', () => {
+    beforeEach(async () => {
+      publicSale = await deployTestSale(deployer, saleToken, saleTokenHolder, defaultParams, {
+        startOffset: 60,
+        minimumTotalCommitment: ethers.parseEther('1000'),
+        maximumTotalCommitment: ethers.parseEther('2000'),
+      });
+      await moveToSaleStart(publicSale);
+
+      // Setup successful sale
+      await mintAndApproveCommitmentTokens(
+        commitmentToken,
+        publicSale,
+        [alice, bob],
+        [ethers.parseEther('50000'), ethers.parseEther('50000')],
+      );
+
+      await publicSale
+        .connect(alice)
+        .increaseCommitmentERC20(ethers.parseEther('1000'), ethers.getBytes('0x'), 0n);
+      await publicSale
+        .connect(bob)
+        .increaseCommitmentERC20(ethers.parseEther('1000'), ethers.getBytes('0x'), 0n);
+
+      // Move to end of sale
+      await moveToSaleEnd(publicSale);
+    });
+
+    it('should distribute proceeds and protocol fees correctly', async () => {
+      const totalCommitments = await publicSale.totalCommitments();
+      const escrowedSaleTokenAmount = await saleToken.balanceOf(await publicSale.getAddress());
+
+      await publicSale.connect(alice).buyerSettle(alice.address);
+      await publicSale.connect(bob).buyerSettle(bob.address);
+
+      const aliceExpectedSaleTokensBeforeFee =
+        (BigInt(ethers.parseEther('1000')) * TEST_CONSTANTS.PRECISION) /
+        BigInt(defaultParams.saleTokenPrice);
+      const aliceExpectedSaleTokensAfterFee =
+        (aliceExpectedSaleTokensBeforeFee *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
+
+      const bobExpectedSaleTokensBeforeFee =
+        (BigInt(ethers.parseEther('1000')) * TEST_CONSTANTS.PRECISION) /
+        BigInt(defaultParams.saleTokenPrice);
+      const bobExpectedSaleTokensAfterFee =
+        (bobExpectedSaleTokensBeforeFee *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
+
+      expect(await saleToken.balanceOf(alice.address)).to.equal(aliceExpectedSaleTokensAfterFee);
+      expect(await saleToken.balanceOf(bob.address)).to.equal(bobExpectedSaleTokensAfterFee);
+
+      const commitmentTokenProtocolFeeAmount =
+        (BigInt(totalCommitments) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
+        TEST_CONSTANTS.PRECISION;
+      const commitmentTokenAmountToSeller = totalCommitments - commitmentTokenProtocolFeeAmount;
+
+      const saleTokenSold =
+        (totalCommitments * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+      const saleTokenProtocolFeeAmount =
+        (BigInt(saleTokenSold) * BigInt(defaultParams.saleTokenProtocolFee)) /
+        TEST_CONSTANTS.PRECISION;
+      const unsoldSaleTokenAmount = BigInt(escrowedSaleTokenAmount) - saleTokenSold;
+
+      await expect(publicSale.connect(seller).sellerSettle())
+        .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
+        .withArgs(
+          seller.address,
+          commitmentTokenProtocolFeeAmount,
+          commitmentTokenAmountToSeller,
+          saleTokenProtocolFeeAmount,
+          unsoldSaleTokenAmount,
+        );
+
+      expect(await commitmentToken.balanceOf(saleProceedsReceiver.address)).to.equal(
+        commitmentTokenAmountToSeller,
+      );
+      expect(await commitmentToken.balanceOf(protocolFeeReceiver.address)).to.equal(
+        commitmentTokenProtocolFeeAmount,
+      );
+      expect(await saleToken.balanceOf(saleProceedsReceiver.address)).to.equal(
+        unsoldSaleTokenAmount,
+      );
+      expect(await saleToken.balanceOf(protocolFeeReceiver.address)).to.equal(
+        saleTokenProtocolFeeAmount,
+      );
+      expect(await publicSale.sellerSettled()).to.be.true;
+
+      // all users have settled, verify that public sale has no remaining commitment or sale tokens
+      expect(await saleToken.balanceOf(await publicSale.getAddress())).to.equal(0);
+      expect(await commitmentToken.balanceOf(await publicSale.getAddress())).to.equal(0);
     });
   });
 
@@ -1431,12 +1701,16 @@ describe('PublicSaleV1', () => {
       await moveToSaleEnd(extremeSale);
 
       const commitment = await extremeSale.commitments(alice.address);
-      const expectedSaleTokens =
+      const expectedSaleTokensBeforeFee =
         (BigInt(commitment) * TEST_CONSTANTS.PRECISION) / ethers.parseEther('0.000001');
+      const expectedSaleTokensAfterFee =
+        (BigInt(expectedSaleTokensBeforeFee) *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
 
       await extremeSale.connect(alice).buyerSettle(alice.address);
 
-      expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokens);
+      expect(await saleToken.balanceOf(alice.address)).to.equal(expectedSaleTokensAfterFee);
     });
   });
 
@@ -1612,22 +1886,47 @@ describe('PublicSaleV1', () => {
 
       // User settlement
       const aliceCommitment = await publicSale.commitments(alice.address);
-      const expectedSaleTokens =
+      const aliceExpectedSaleTokensBeforeFee =
         (BigInt(aliceCommitment) * TEST_CONSTANTS.PRECISION) / BigInt(defaultParams.saleTokenPrice);
+
+      const aliceExpectedSaleTokensAfterFee =
+        (BigInt(aliceExpectedSaleTokensBeforeFee) *
+          (TEST_CONSTANTS.PRECISION - BigInt(defaultParams.saleTokenProtocolFee))) /
+        TEST_CONSTANTS.PRECISION;
 
       await expect(publicSale.connect(alice).buyerSettle(alice.address))
         .to.emit(publicSale, 'SuccessfulSaleBuyerSettled')
-        .withArgs(alice.address, alice.address, expectedSaleTokens);
+        .withArgs(alice.address, alice.address, aliceExpectedSaleTokensAfterFee);
 
       // Owner settlement
-      const totalBalance = await commitmentToken.balanceOf(await publicSale.getAddress());
-      const protocolFeeAmount =
-        (BigInt(totalBalance) * BigInt(defaultParams.protocolFee)) / TEST_CONSTANTS.PRECISION;
-      const saleProceedsAmount = BigInt(totalBalance) - protocolFeeAmount;
+      const commitmentTokenTotalBalance = await commitmentToken.balanceOf(
+        await publicSale.getAddress(),
+      );
+      const commitmentTokenProtocolFeeAmount =
+        (BigInt(commitmentTokenTotalBalance) * BigInt(defaultParams.commitmentTokenProtocolFee)) /
+        TEST_CONSTANTS.PRECISION;
+      const commitmentTokenAmountToSeller =
+        commitmentTokenTotalBalance - commitmentTokenProtocolFeeAmount;
+      const saleTokenSold =
+        (BigInt(defaultParams.minimumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
+        BigInt(defaultParams.saleTokenPrice);
+      const saleTokenProtocolFeeAmount =
+        (BigInt(saleTokenSold) * BigInt(defaultParams.saleTokenProtocolFee)) /
+        TEST_CONSTANTS.PRECISION;
+      const unsoldSaleTokenAmount =
+        (BigInt(defaultParams.maximumTotalCommitment) * TEST_CONSTANTS.PRECISION) /
+          BigInt(defaultParams.saleTokenPrice) -
+        saleTokenSold;
 
       await expect(publicSale.connect(seller).sellerSettle())
         .to.emit(publicSale, 'SuccessfulSaleSellerSettled')
-        .withArgs(seller.address, saleProceedsAmount, protocolFeeAmount);
+        .withArgs(
+          seller.address,
+          commitmentTokenProtocolFeeAmount,
+          commitmentTokenAmountToSeller,
+          saleTokenProtocolFeeAmount,
+          unsoldSaleTokenAmount,
+        );
     });
   });
 
@@ -1654,7 +1953,10 @@ describe('PublicSaleV1', () => {
         defaultParams.maximumTotalCommitment,
       );
       expect(await publicSale.saleTokenPrice()).to.equal(defaultParams.saleTokenPrice);
-      expect(await publicSale.protocolFee()).to.equal(defaultParams.protocolFee);
+      expect(await publicSale.commitmentTokenProtocolFee()).to.equal(
+        defaultParams.commitmentTokenProtocolFee,
+      );
+      expect(await publicSale.saleTokenProtocolFee()).to.equal(defaultParams.saleTokenProtocolFee);
       expect(await publicSale.totalCommitments()).to.equal(0);
       expect(await publicSale.commitments(alice.address)).to.equal(0);
       expect(await publicSale.settled(alice.address)).to.be.false;
@@ -1705,7 +2007,8 @@ describe('PublicSaleV1 - Shared Tests', () => {
       minimumTotalCommitment: ethers.parseEther('10000'),
       maximumTotalCommitment: ethers.parseEther('100000'),
       saleTokenPrice: ethers.parseEther('0.1'),
-      protocolFee: ethers.parseEther('0.02'),
+      commitmentTokenProtocolFee: ethers.parseEther('0.02'),
+      saleTokenProtocolFee: ethers.parseEther('0.05'),
       hedgeyLockupParams: {
         enabled: false,
         start: 0,
@@ -1761,7 +2064,8 @@ describe('PublicSaleV1 - Shared Tests', () => {
           minimumTotalCommitment: ethers.parseEther('10000'),
           maximumTotalCommitment: ethers.parseEther('100000'),
           saleTokenPrice: ethers.parseEther('0.1'),
-          protocolFee: ethers.parseEther('0.02'),
+          commitmentTokenProtocolFee: ethers.parseEther('0.02'),
+          saleTokenProtocolFee: ethers.parseEther('0.05'),
           hedgeyLockupParams: {
             enabled: false,
             start: 0,
@@ -1801,7 +2105,7 @@ describe('PublicSaleV1 - Shared Tests', () => {
         // Use the saved params to ensure timestamps match
         return ethers.AbiCoder.defaultAbiCoder().encode(
           [
-            'tuple(uint48 saleStartTimestamp, uint48 saleEndTimestamp, address saleTokenHolder, address commitmentToken, address saleToken, address kycVerifier, address saleProceedsReceiver, address protocolFeeReceiver, uint256 minimumCommitment, uint256 maximumCommitment, uint256 minimumTotalCommitment, uint256 maximumTotalCommitment, uint256 saleTokenPrice, uint256 protocolFee, tuple(bool enabled, uint256 start, uint256 cliff, uint256 ratePercentage, uint256 period, address votingTokenLockupPlans) hedgeyLockupParams)',
+            'tuple(uint48 saleStartTimestamp, uint48 saleEndTimestamp, address saleTokenHolder, address commitmentToken, address saleToken, address kycVerifier, address saleProceedsReceiver, address protocolFeeReceiver, uint256 minimumCommitment, uint256 maximumCommitment, uint256 minimumTotalCommitment, uint256 maximumTotalCommitment, uint256 saleTokenPrice, uint256 commitmentTokenProtocolFee, uint256 saleTokenProtocolFee, tuple(bool enabled, uint256 start, uint256 cliff, uint256 ratePercentage, uint256 period, address votingTokenLockupPlans) hedgeyLockupParams)',
           ],
           [savedInitParams],
         );


### PR DESCRIPTION
This PR adds a configurable protocol fee percentage paid by the seller in the fee token. Upon initialization, the contract transfers from the seller and escrows the maximum amount of sale tokens that may be needed. This is the maximum amount of sale tokens that could be sold plus the sale token protocol fee. At the end of the sale, if not all of the sale tokens are sold, the seller gets refunded the leftover amount of sale tokens when the `sellerSettle` function is called.