### PR TITLE
Audit fixes

### DIFF
--- a/contracts/deployables/token-sale/TokenSaleV1.sol
+++ b/contracts/deployables/token-sale/TokenSaleV1.sol
@@ -813,6 +813,7 @@ contract TokenSaleV1 is
         if (rate_ == 0) revert InvalidRate();
         if (rate_ > amount_) revert RateExceedsAmount();
         if (period_ == 0) revert InvalidPeriod();
+        if (cliff_ < start_) revert CliffBeforeStart();
 
         // Calculate vesting end time
         uint256 end = (amount_ % rate_ == 0)

--- a/contracts/interfaces/decent/deployables/ITokenSaleV1.sol
+++ b/contracts/interfaces/decent/deployables/ITokenSaleV1.sol
@@ -76,6 +76,11 @@ interface ITokenSaleV1 {
     error CliffExceedsEnd();
 
     /**
+     * @notice Thrown when Hedgey vesting cliff is before the start time
+     */
+    error CliffBeforeStart();
+
+    /**
      * @notice Thrown when attempting to settle an already settled account
      */
     error AlreadySettled();

--- a/contracts/interfaces/decent/deployables/IVotesERC20StakedV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20StakedV1.sol
@@ -305,7 +305,7 @@ interface IVotesERC20StakedV1 {
 
     /**
      * @notice Adds new reward tokens to the contract
-     * @dev Only callable by owner. Cannot add the staking token as a reward.
+     * @dev Only callable by owner. Note that the staking token may also be a reward token.
      * Duplicate tokens will revert.
      * @param rewardsTokens_ Array of new reward token addresses
      * @custom:access Restricted to owner

--- a/test/unit/deployables/token-sale/TokenSaleV1.test.ts
+++ b/test/unit/deployables/token-sale/TokenSaleV1.test.ts
@@ -508,6 +508,28 @@ describe('TokenSaleV1', () => {
       );
     });
 
+    it('should revert when Hedgey lockup cliff is before start time', async () => {
+      const currentTime = await time.latest();
+      const invalidHedgeyParams = {
+        ...defaultParams,
+        hedgeyLockupParams: {
+          enabled: true,
+          start: BigInt(currentTime + 1_000),
+          cliff: BigInt(currentTime + 999), // cliff < start
+          ratePercentage: ethers.parseEther('0.0025'),
+          period: 10_000,
+          votingTokenLockupPlans: await votingTokenLockupPlans.getAddress(),
+        },
+      };
+
+      await expect(
+        deployTokenSaleProxy(deployer, invalidHedgeyParams),
+      ).to.be.revertedWithCustomError(
+        TokenSaleV1__factory.connect(ethers.ZeroAddress, deployer),
+        'CliffBeforeStart',
+      );
+    });
+
     it('should prevent double initialization', async () => {
       tokenSale = await deployTokenSaleProxy(deployer, defaultParams);
 


### PR DESCRIPTION
This PR addresses two findings from the Halborn audit. The first finding is addressed by updating the natspec documentation, as the contract logic works as intended. It is desired that the staked token may also be added as a rewards token.

**Finding 001**
The documentation states the “staked token itself cannot be added as a reward token,” but _addRewardsTokens() only checks DuplicateRewardsToken() and does not prevent token == stakedToken().


The owner could call addRewardsTokens([stakedToken]) after users have staked. While _distributableRewards() special‑cases this by subtracting totalStaked, the mismatch between stated invariant and code can mislead integrators, off‑chain accounting, or frontends that assume the array never contains the staked asset.


**Finding 003**
The _validateHedgeyParams function in the TokenSaleV1 contract does not check whether the cliff_ parameter is set before the start_ parameter. This allows a vesting schedule to be created where the cliff occurs before the vesting actually begins, which is illogical and could lead to confusion or unintended behavior.


For example, a sale could be initialized with start_ = 1000 and cliff_ = 900, resulting in a cliff that is 100 seconds before vesting starts. This does not align with standard vesting logic, where the cliff should always be at or after the start of vesting.

