### PR TITLE
Clock mode configurable

### DIFF
--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -81,6 +81,8 @@ contract VotesERC20StakedV1 is
      * @custom:storage-location erc7201:Decent.VotesERC20Staked.main
      */
     struct VotesERC20StakedStorage {
+        /** @notice The clock mode, true for timestamp, false for blocknumber */
+        bool clockModeTimestamp;
         /** @notice The ERC20 token that users stake */
         IERC20 stakedToken;
         /** @notice Minimum seconds before unstaking allowed */
@@ -167,9 +169,12 @@ contract VotesERC20StakedV1 is
      * @inheritdoc IVotesERC20StakedV1
      */
     function initialize2(
+        bool clockModeTimestamp_,
         uint256 minimumStakingPeriod_,
         address[] calldata rewardsTokens_
     ) public virtual override reinitializer(2) {
+        VotesERC20StakedStorage storage $ = _getVotesERC20StakedStorage();
+        $.clockModeTimestamp = clockModeTimestamp_;
         _updateMinimumStakingPeriod(minimumStakingPeriod_);
         _addRewardsTokens(rewardsTokens_);
     }
@@ -203,12 +208,13 @@ contract VotesERC20StakedV1 is
     function CLOCK_MODE()
         // solhint-disable-previous-line func-name-mixedcase
         public
-        pure
+        view
         virtual
         override(IVotesERC20StakedV1, VotesUpgradeable)
         returns (string memory)
     {
-        return "mode=timestamp";
+        VotesERC20StakedStorage storage $ = _getVotesERC20StakedStorage();
+        return $.clockModeTimestamp ? "mode=timestamp" : "mode=blocknumber&from=default";
     }
 
     // --- View Functions ---
@@ -223,7 +229,8 @@ contract VotesERC20StakedV1 is
         override(IVotesERC20StakedV1, VotesUpgradeable)
         returns (uint48)
     {
-        return uint48(block.timestamp);
+        VotesERC20StakedStorage storage $ = _getVotesERC20StakedStorage();
+        return uint48($.clockModeTimestamp ? block.timestamp : block.number);
     }
 
     /**

--- a/contracts/deployables/erc20/VotesERC20StakedV1.sol
+++ b/contracts/deployables/erc20/VotesERC20StakedV1.sol
@@ -214,7 +214,10 @@ contract VotesERC20StakedV1 is
         returns (string memory)
     {
         VotesERC20StakedStorage storage $ = _getVotesERC20StakedStorage();
-        return $.clockModeTimestamp ? "mode=timestamp" : "mode=blocknumber&from=default";
+        return
+            $.clockModeTimestamp
+                ? "mode=timestamp"
+                : "mode=blocknumber&from=default";
     }
 
     // --- View Functions ---

--- a/contracts/interfaces/decent/deployables/IVotesERC20StakedV1.sol
+++ b/contracts/interfaces/decent/deployables/IVotesERC20StakedV1.sol
@@ -165,10 +165,12 @@ interface IVotesERC20StakedV1 {
      * @notice Completes initialization with metadata, minimum staking period, and rewards tokens (part 2 of 2)
      * @dev Can only be called once during deployment. Sets up the staking token
      * and initial reward tokens. The staking token itself cannot be a reward token.
+     * @param clockModeTimestamp_ The clock mode, true for timestamp, false for blocknumber
      * @param minimumStakingPeriod_ Minimum seconds before unstaking allowed
      * @param rewardsTokens_ Initial array of reward token addresses
      */
     function initialize2(
+        bool clockModeTimestamp_,
         uint256 minimumStakingPeriod_,
         address[] calldata rewardsTokens_
     ) external;
@@ -180,7 +182,7 @@ interface IVotesERC20StakedV1 {
      * @dev Returns "mode=timestamp" indicating timestamp-based timing
      * @return clockMode The clock mode string per EIP-6372
      */
-    function CLOCK_MODE() external pure returns (string memory clockMode);
+    function CLOCK_MODE() external view returns (string memory clockMode);
     // solhint-disable-previous-line func-name-mixedcase
 
     // --- View Functions ---

--- a/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -342,7 +342,7 @@ describe('VotesERC20StakedV1', () => {
 
       const currentTime = await ethers.provider.getBlock('latest').then(b => b!.timestamp);
       const clockTime = await votesERC20Staked.clock();
-      expect(Number(clockTime)).to.be.closeTo(currentTime, 5);
+      expect(Number(clockTime)).to.equal(currentTime);
     });
 
     it('deploys with blocknumber clock mode when false', async () => {

--- a/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -89,6 +89,7 @@ async function deployVotesERC20StakedProxy(
   stakedToken: string,
   minimumStakingPeriod: bigint,
   rewardsTokens: string[],
+  clockModeTimestamp: boolean,
 ): Promise<VotesERC20StakedV1> {
   // Create initialization data with function selector
   const fullInitData = VotesERC20StakedV1__factory.createInterface().encodeFunctionData(
@@ -105,7 +106,11 @@ async function deployVotesERC20StakedProxy(
   );
 
   // Call initialize2
-  await stakingContractInstance.initialize2(true, minimumStakingPeriod, rewardsTokens);
+  await stakingContractInstance.initialize2(
+    clockModeTimestamp,
+    minimumStakingPeriod,
+    rewardsTokens,
+  );
 
   // Return a contract instance connected to the proxy
   return VotesERC20StakedV1__factory.connect(await proxy.getAddress(), owner);
@@ -156,6 +161,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
 
       expect(await votesERC20Staked.name()).to.equal('Staked Mock Voting Token');
@@ -182,6 +188,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
 
       await expect(
@@ -209,6 +216,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
 
       expect(await votesERC20Staked.owner()).to.equal(owner.address);
@@ -228,6 +236,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
     });
 
@@ -278,6 +287,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
     });
 
@@ -299,6 +309,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
     });
 
@@ -315,6 +326,44 @@ describe('VotesERC20StakedV1', () => {
     });
   });
 
+  describe('Clock mode deployment', () => {
+    it('deploys with timestamp clock mode when true', async () => {
+      votesERC20Staked = await deployVotesERC20StakedProxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+        await stakedToken.getAddress(),
+        604800n,
+        [await rewardsTokenA.getAddress(), await rewardsTokenB.getAddress()],
+        true,
+      );
+
+      expect(await votesERC20Staked.CLOCK_MODE()).to.equal('mode=timestamp');
+
+      const currentTime = await ethers.provider.getBlock('latest').then(b => b!.timestamp);
+      const clockTime = await votesERC20Staked.clock();
+      expect(Number(clockTime)).to.be.closeTo(currentTime, 5);
+    });
+
+    it('deploys with blocknumber clock mode when false', async () => {
+      votesERC20Staked = await deployVotesERC20StakedProxy(
+        proxyDeployer,
+        masterCopy,
+        owner,
+        await stakedToken.getAddress(),
+        604800n,
+        [await rewardsTokenA.getAddress(), await rewardsTokenB.getAddress()],
+        false,
+      );
+
+      expect(await votesERC20Staked.CLOCK_MODE()).to.equal('mode=blocknumber&from=default');
+
+      const latestBlockNumber = await ethers.provider.getBlockNumber();
+      const clockValue = await votesERC20Staked.clock();
+      expect(Number(clockValue)).to.equal(latestBlockNumber);
+    });
+  });
+
   describe('Timestamp-based clock functions', () => {
     beforeEach(async () => {
       votesERC20Staked = await deployVotesERC20StakedProxy(
@@ -328,6 +377,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
     });
 
@@ -374,6 +424,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
     });
 
@@ -402,6 +453,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
 
       // Mint 10 staked tokens to alice
@@ -471,6 +523,7 @@ describe('VotesERC20StakedV1', () => {
           await rewardsTokenB.getAddress(),
           await rewardsTokenC.getAddress(),
         ],
+        true,
       );
 
       // Mint 10 staked tokens to alice
@@ -623,6 +676,7 @@ describe('VotesERC20StakedV1', () => {
         await stakedToken.getAddress(),
         604800n,
         [await rewardsTokenA.getAddress(), await rewardsTokenB.getAddress(), nativeAssetAddress],
+        true,
       );
 
       // Mint 10 staked tokens to alice
@@ -844,6 +898,7 @@ describe('VotesERC20StakedV1', () => {
         await stakedToken.getAddress(),
         604800n,
         [await rewardsTokenA.getAddress(), await rewardsTokenB.getAddress(), nativeAssetAddress],
+        true,
       );
 
       // Mint 10 staked tokens to alice
@@ -1145,6 +1200,7 @@ describe('VotesERC20StakedV1', () => {
         await stakedToken.getAddress(),
         604800n,
         [await stakedToken.getAddress(), await rewardsTokenB.getAddress(), nativeAssetAddress],
+        true,
       );
 
       // Mint 100 staked tokens to alice

--- a/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
+++ b/test/unit/deployables/erc20/VotesERC20StakedV1.test.ts
@@ -105,7 +105,7 @@ async function deployVotesERC20StakedProxy(
   );
 
   // Call initialize2
-  await stakingContractInstance.initialize2(minimumStakingPeriod, rewardsTokens);
+  await stakingContractInstance.initialize2(true, minimumStakingPeriod, rewardsTokens);
 
   // Return a contract instance connected to the proxy
   return VotesERC20StakedV1__factory.connect(await proxy.getAddress(), owner);


### PR DESCRIPTION
This PR adds a configurable clock mode (block number or block timestamp) to `VotesERC20StakedV1`. This contract inherits from OpenZeppelin's `VotesUpgradeable` which supports either clock mode: 
https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/governance/utils/VotesUpgradeable.sol

v0 of the Decent contracts were built to use block number for clock mode, and v1 contract were built to use block timestamp.

This contract should be able to be deployed to be used with either version of the contracts, which is why it's being made configurable here.